### PR TITLE
Use proposer index cache for blob verification

### DIFF
--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
     deps = [
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/time:go_default_library",
+        "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native:go_default_library",
         "//config/fieldparams:go_default_library",

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/time"
+	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
@@ -801,4 +802,19 @@ func TestLastActivatedValidatorIndex_OK(t *testing.T) {
 	index, err := LastActivatedValidatorIndex(context.Background(), beaconState)
 	require.NoError(t, err)
 	require.Equal(t, index, primitives.ValidatorIndex(3))
+}
+
+func TestProposerIndexFromCheckpoint(t *testing.T) {
+	e := primitives.Epoch(2)
+	r := [32]byte{'a'}
+	root := [32]byte{'b'}
+	ids := [32]primitives.ValidatorIndex{}
+	slot := primitives.Slot(69) // slot 5 in the Epoch
+	ids[5] = primitives.ValidatorIndex(19)
+	proposerIndicesCache.Set(e, r, ids)
+	c := &forkchoicetypes.Checkpoint{Root: root, Epoch: e - 1}
+	proposerIndicesCache.SetCheckpoint(*c, r)
+	id, err := ProposerIndexAtSlotFromCheckpoint(c, slot)
+	require.NoError(t, err)
+	require.Equal(t, ids[5], id)
 }

--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -431,7 +431,7 @@ func TestSidecarProposerExpected(t *testing.T) {
 	_, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 1, 1)
 	b := blobs[0]
 	t.Run("cached, matches", func(t *testing.T) {
-		ini := Initializer{shared: &sharedResources{pc: &mockProposerCache{ProposerCB: pcReturnsIdx(b.ProposerIndex())}}}
+		ini := Initializer{shared: &sharedResources{pc: &mockProposerCache{ProposerCB: pcReturnsIdx(b.ProposerIndex())}, fc: &mockForkchoicer{TargetRootForEpochCB: fcReturnsTargetRoot([32]byte{})}}}
 		v := ini.NewBlobVerifier(b, GossipSidecarRequirements)
 		require.NoError(t, v.SidecarProposerExpected(ctx))
 		require.Equal(t, true, v.results.executed(RequireSidecarProposerExpected))

--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -438,14 +438,14 @@ func TestSidecarProposerExpected(t *testing.T) {
 		require.NoError(t, v.results.result(RequireSidecarProposerExpected))
 	})
 	t.Run("cached, does not match", func(t *testing.T) {
-		ini := Initializer{shared: &sharedResources{pc: &mockProposerCache{ProposerCB: pcReturnsIdx(b.ProposerIndex() + 1)}}}
+		ini := Initializer{shared: &sharedResources{pc: &mockProposerCache{ProposerCB: pcReturnsIdx(b.ProposerIndex() + 1)}, fc: &mockForkchoicer{TargetRootForEpochCB: fcReturnsTargetRoot([32]byte{})}}}
 		v := ini.NewBlobVerifier(b, GossipSidecarRequirements)
 		require.ErrorIs(t, v.SidecarProposerExpected(ctx), ErrSidecarUnexpectedProposer)
 		require.Equal(t, true, v.results.executed(RequireSidecarProposerExpected))
 		require.NotNil(t, v.results.result(RequireSidecarProposerExpected))
 	})
 	t.Run("not cached, state lookup failure", func(t *testing.T) {
-		ini := Initializer{shared: &sharedResources{sr: sbrNotFound(t, b.ParentRoot()), pc: &mockProposerCache{ProposerCB: pcReturnsNotFound()}}}
+		ini := Initializer{shared: &sharedResources{sr: sbrNotFound(t, b.ParentRoot()), pc: &mockProposerCache{ProposerCB: pcReturnsNotFound()}, fc: &mockForkchoicer{TargetRootForEpochCB: fcReturnsTargetRoot([32]byte{})}}}
 		v := ini.NewBlobVerifier(b, GossipSidecarRequirements)
 		require.ErrorIs(t, v.SidecarProposerExpected(ctx), ErrSidecarUnexpectedProposer)
 		require.Equal(t, true, v.results.executed(RequireSidecarProposerExpected))
@@ -461,7 +461,7 @@ func TestSidecarProposerExpected(t *testing.T) {
 				return b.ProposerIndex(), nil
 			},
 		}
-		ini := Initializer{shared: &sharedResources{sr: sbrForValOverride(b.ProposerIndex(), &ethpb.Validator{}), pc: pc}}
+		ini := Initializer{shared: &sharedResources{sr: sbrForValOverride(b.ProposerIndex(), &ethpb.Validator{}), pc: pc, fc: &mockForkchoicer{TargetRootForEpochCB: fcReturnsTargetRoot([32]byte{})}}}
 		v := ini.NewBlobVerifier(b, GossipSidecarRequirements)
 		require.NoError(t, v.SidecarProposerExpected(ctx))
 		require.Equal(t, true, v.results.executed(RequireSidecarProposerExpected))
@@ -476,7 +476,7 @@ func TestSidecarProposerExpected(t *testing.T) {
 				return b.ProposerIndex() + 1, nil
 			},
 		}
-		ini := Initializer{shared: &sharedResources{sr: sbrForValOverride(b.ProposerIndex(), &ethpb.Validator{}), pc: pc}}
+		ini := Initializer{shared: &sharedResources{sr: sbrForValOverride(b.ProposerIndex(), &ethpb.Validator{}), pc: pc, fc: &mockForkchoicer{TargetRootForEpochCB: fcReturnsTargetRoot([32]byte{})}}}
 		v := ini.NewBlobVerifier(b, GossipSidecarRequirements)
 		require.ErrorIs(t, v.SidecarProposerExpected(ctx), ErrSidecarUnexpectedProposer)
 		require.Equal(t, true, v.results.executed(RequireSidecarProposerExpected))
@@ -491,7 +491,7 @@ func TestSidecarProposerExpected(t *testing.T) {
 				return 0, errors.New("ComputeProposer failed")
 			},
 		}
-		ini := Initializer{shared: &sharedResources{sr: sbrForValOverride(b.ProposerIndex(), &ethpb.Validator{}), pc: pc}}
+		ini := Initializer{shared: &sharedResources{sr: sbrForValOverride(b.ProposerIndex(), &ethpb.Validator{}), pc: pc, fc: &mockForkchoicer{TargetRootForEpochCB: fcReturnsTargetRoot([32]byte{})}}}
 		v := ini.NewBlobVerifier(b, GossipSidecarRequirements)
 		require.ErrorIs(t, v.SidecarProposerExpected(ctx), ErrSidecarUnexpectedProposer)
 		require.Equal(t, true, v.results.executed(RequireSidecarProposerExpected))
@@ -529,6 +529,7 @@ type mockForkchoicer struct {
 	HasNodeCB             func([32]byte) bool
 	IsCanonicalCB         func(root [32]byte) bool
 	SlotCB                func([32]byte) (primitives.Slot, error)
+	TargetRootForEpochCB  func([32]byte, primitives.Epoch) ([32]byte, error)
 }
 
 var _ Forkchoicer = &mockForkchoicer{}
@@ -547,6 +548,16 @@ func (m *mockForkchoicer) IsCanonical(root [32]byte) bool {
 
 func (m *mockForkchoicer) Slot(root [32]byte) (primitives.Slot, error) {
 	return m.SlotCB(root)
+}
+
+func (m *mockForkchoicer) TargetRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+	return m.TargetRootForEpochCB(root, epoch)
+}
+
+func fcReturnsTargetRoot(root [32]byte) func([32]byte, primitives.Epoch) ([32]byte, error) {
+	return func([32]byte, primitives.Epoch) ([32]byte, error) {
+		return root, nil
+	}
 }
 
 type mockSignatureCache struct {
@@ -634,27 +645,27 @@ func (v *validxStateOverride) ValidatorAtIndex(idx primitives.ValidatorIndex) (*
 
 type mockProposerCache struct {
 	ComputeProposerCB func(ctx context.Context, root [32]byte, slot primitives.Slot, pst state.BeaconState) (primitives.ValidatorIndex, error)
-	ProposerCB        func(root [32]byte, slot primitives.Slot) (primitives.ValidatorIndex, bool)
+	ProposerCB        func(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool)
 }
 
 func (p *mockProposerCache) ComputeProposer(ctx context.Context, root [32]byte, slot primitives.Slot, pst state.BeaconState) (primitives.ValidatorIndex, error) {
 	return p.ComputeProposerCB(ctx, root, slot, pst)
 }
 
-func (p *mockProposerCache) Proposer(root [32]byte, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
-	return p.ProposerCB(root, slot)
+func (p *mockProposerCache) Proposer(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
+	return p.ProposerCB(c, slot)
 }
 
 var _ ProposerCache = &mockProposerCache{}
 
-func pcReturnsIdx(idx primitives.ValidatorIndex) func(root [32]byte, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
-	return func(root [32]byte, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
+func pcReturnsIdx(idx primitives.ValidatorIndex) func(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
+	return func(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
 		return idx, true
 	}
 }
 
-func pcReturnsNotFound() func(root [32]byte, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
-	return func(root [32]byte, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
+func pcReturnsNotFound() func(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
+	return func(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
 		return 0, false
 	}
 }

--- a/beacon-chain/verification/cache.go
+++ b/beacon-chain/verification/cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/signing"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/transition"
+	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
@@ -137,7 +138,7 @@ func (c *sigCache) SignatureVerified(sig SignatureData) (bool, error) {
 // across multiple values.
 type ProposerCache interface {
 	ComputeProposer(ctx context.Context, root [32]byte, slot primitives.Slot, pst state.BeaconState) (primitives.ValidatorIndex, error)
-	Proposer(root [32]byte, slot primitives.Slot) (primitives.ValidatorIndex, bool)
+	Proposer(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool)
 }
 
 func newPropCache() *propCache {
@@ -163,7 +164,10 @@ func (*propCache) ComputeProposer(ctx context.Context, parent [32]byte, slot pri
 
 // Proposer returns the validator index if it is found in the cache, along with a boolean indicating
 // whether the value was present, similar to accessing an lru or go map.
-func (*propCache) Proposer(_ [32]byte, _ primitives.Slot) (primitives.ValidatorIndex, bool) {
-	// TODO: replace with potuz' proposer id cache
-	return 0, false
+func (*propCache) Proposer(c *forkchoicetypes.Checkpoint, slot primitives.Slot) (primitives.ValidatorIndex, bool) {
+	id, err := helpers.ProposerIndexAtSlotFromCheckpoint(c, slot)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
 }

--- a/beacon-chain/verification/cache_test.go
+++ b/beacon-chain/verification/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/signing"
+	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/crypto/bls"
@@ -102,7 +103,7 @@ func TestProposerCache(t *testing.T) {
 	st, _ := util.DeterministicGenesisStateDeneb(t, 3)
 
 	pc := newPropCache()
-	_, cached := pc.Proposer([32]byte{}, 1)
+	_, cached := pc.Proposer(&forkchoicetypes.Checkpoint{}, 1)
 	// should not be cached yet
 	require.Equal(t, false, cached)
 
@@ -112,7 +113,7 @@ func TestProposerCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, primitives.ValidatorIndex(expectedIdx), idx)
 
-	idx, cached = pc.Proposer([32]byte{}, 1)
+	idx, cached = pc.Proposer(&forkchoicetypes.Checkpoint{}, 1)
 	// TODO: update this test when we integrate a proposer id cache
 	require.Equal(t, false, cached)
 	require.Equal(t, primitives.ValidatorIndex(0), idx)

--- a/beacon-chain/verification/initializer.go
+++ b/beacon-chain/verification/initializer.go
@@ -20,6 +20,7 @@ type Forkchoicer interface {
 	HasNode([32]byte) bool
 	IsCanonical(root [32]byte) bool
 	Slot([32]byte) (primitives.Slot, error)
+	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 }
 
 // StateByRooter describes a stategen-ish type that can produce arbitrary states by their root


### PR DESCRIPTION
This PR fills in the current proposer cache stub from the verification package to use the proposer index cache in the validator core helpers. 