### PR TITLE
Prune dangling blob

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -304,7 +304,8 @@ func (bs *BlobStorage) processFolder(folder string, pruneBefore primitives.Slot)
 	}
 
 	if slot == 0 {
-		return 0, fmt.Errorf("no blob files found in folder %s", folder)
+		log.WithField("folder", folder).Warn("Could not find slot for folder")
+		return 0, nil
 	}
 
 	var num int

--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -214,6 +214,21 @@ func TestBlobStoragePrune(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 4, len(remainingFolders))
 	})
+	t.Run("Prune dangling blob", func(t *testing.T) {
+		_, sidecars := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 300, fieldparams.MaxBlobsPerBlock)
+		testSidecars, err := verification.BlobSidecarSliceNoop(sidecars)
+		require.NoError(t, err)
+
+		for _, sidecar := range testSidecars[1:] {
+			require.NoError(t, bs.Save(sidecar))
+		}
+
+		require.NoError(t, bs.Prune(currentSlot-bs.retentionSlots))
+
+		remainingFolders, err := afero.ReadDir(fs, ".")
+		require.NoError(t, err)
+		require.Equal(t, 0, len(remainingFolders))
+	})
 }
 
 func BenchmarkPruning(b *testing.B) {

--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -211,7 +211,7 @@ func TestBlobStoragePrune(t *testing.T) {
 	})
 	t.Run("PruneMany", func(t *testing.T) {
 		blockQty := 10
-		slot := primitives.Slot(0)
+		slot := primitives.Slot(1)
 
 		for j := 0; j <= blockQty; j++ {
 			root := bytesutil.ToBytes32(bytesutil.ToBytes(uint64(slot), 32))


### PR DESCRIPTION
If a folder lacks a blob with index 0, the following error will persist indefinitely. Therefore, we should examine all potential blobs and prune accordingly.
```
[2024-01-05 09:41:51] ERROR failed to prune blobs from slot 267809 error=failed to process folder 0xc55288171d8ba959d1614327e20df7f11cb0742eadec907ba48fee19ad7b2157: open /Users/t/devnet12/blobs/0xc55288171d8ba959d1614327e20df7f11cb0742eadec907ba48fee19ad7b2157/0.ssz: no such file or directory
```