### PR TITLE
Use ROForkchoice in blob verifier

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -742,7 +742,7 @@ func (b *BeaconNode) registerSyncService(initialSyncComplete chan struct{}) erro
 		regularsync.WithInitialSyncComplete(initialSyncComplete),
 		regularsync.WithStateNotifier(b),
 		regularsync.WithBlobStorage(b.BlobStorage),
-		regularsync.WithVerifierWaiter(verification.NewInitializerWaiter(b.clockWaiter, b.forkChoicer, b.stateGen)),
+		regularsync.WithVerifierWaiter(verification.NewInitializerWaiter(b.clockWaiter, forkchoice.NewROForkChoice(b.forkChoicer), b.stateGen)),
 	)
 	return b.services.RegisterService(rs)
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**
The sync package should use the ROForkchoice type to ensure it only accesses fast forkchoice methods in a threadsafe fashion.  Background on ROForkchoice: https://github.com/prysmaticlabs/prysm/pull/13244