### PR TITLE
[WIP] Add broadcast equivocating blocks

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//beacon-chain/operations/slashings:go_default_library",
         "//beacon-chain/operations/voluntaryexits:go_default_library",
         "//beacon-chain/p2p:go_default_library",
+        "//beacon-chain/slasher/types:go_default_library",
         "//beacon-chain/startup:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",

--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -109,6 +109,14 @@ func WithSlashingPool(p slashings.PoolManager) Option {
 	}
 }
 
+// WithSlasherDB to check slashing objects
+func WithSlasherDB(sDB db.SlasherDatabase) Option {
+	return func(s *Service) error {
+		s.cfg.SlasherDB = sDB
+		return nil
+	}
+}
+
 // WithBLSToExecPool to keep track of BLS to Execution address changes.
 func WithBLSToExecPool(p blstoexec.PoolManager) Option {
 	return func(s *Service) error {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -87,7 +87,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 		}
 	}
 
-	if err := s.broadcastDoubleBlockProposals(ctx, signed, blockRoot); err != nil {
+	if err := s.broadcastDoubleBlockProposals(ctx, cfg.signed, cfg.blockRoot); err != nil {
 		return errors.Wrap(err, "could not broadcast equivocating blocks to the network")
 	}
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+	slashertypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/slasher/types"
 	"time"
 
 	"github.com/pkg/errors"
@@ -85,6 +86,12 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 			return errors.Wrap(err, "could not set optimistic block to valid")
 		}
 	}
+
+	// Broadcast equivocating blocks to the network if any.
+	if err := s.broadcastDoubleBlockProposals(ctx, signed, blockRoot); err != nil {
+		return errors.Wrap(err, "could not broadcast equivocating blocks to the network")
+	}
+
 	start := time.Now()
 	cfg.headRoot, err = s.cfg.ForkChoiceStore.Head(ctx)
 	if err != nil {
@@ -101,6 +108,36 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	}
 	if err := s.sendFCU(cfg, fcuArgs); err != nil {
 		return errors.Wrap(err, "could not send FCU to engine")
+	}
+	return nil
+}
+
+func (s *Service) broadcastDoubleBlockProposals(ctx context.Context, signed interfaces.ReadOnlySignedBeaconBlock, blockRoot [32]byte) error {
+	header, err := signed.Header()
+	if err != nil {
+		return errors.Wrap(err, "could not get block header")
+	}
+	proposals := []*slashertypes.SignedBlockHeaderWrapper{{
+		SignedBeaconBlockHeader: header,
+		SigningRoot:             blockRoot,
+	}}
+	// check if there are any slashable double proposals
+	proposerSlashings, err := s.cfg.SlasherDB.CheckDoubleBlockProposals(ctx, proposals)
+	if err != nil {
+		return errors.Wrap(err, "could not check double block proposals")
+	}
+	if len(proposerSlashings) > 0 {
+		// we can only have one entry here as we only check for double proposals for a one and only one block header
+		proposerSlashing := proposerSlashings[0]
+		// transform to protobuf object
+		proposerSlashingProto := ethpb.ProposerSlashing{
+			Header_1: proposerSlashing.Header_1,
+			Header_2: proposerSlashing.Header_2,
+		}
+		// broadcast over the network
+		if err := s.cfg.P2p.Broadcast(ctx, &proposerSlashingProto); err != nil {
+			return errors.Wrap(err, "could not broadcast slashing object")
+		}
 	}
 	return nil
 }

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -87,7 +87,6 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 		}
 	}
 
-	// Broadcast equivocating blocks to the network if any.
 	if err := s.broadcastDoubleBlockProposals(ctx, signed, blockRoot); err != nil {
 		return errors.Wrap(err, "could not broadcast equivocating blocks to the network")
 	}
@@ -112,6 +111,8 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	return nil
 }
 
+// broadcastDoubleBlockProposals checks if the given block is a double block proposal (equivocating block) and broadcasts it to the network if it is
+// returns an error if the process fails to check whether the block is a double block proposal or if the broadcast fails
 func (s *Service) broadcastDoubleBlockProposals(ctx context.Context, signed interfaces.ReadOnlySignedBeaconBlock, blockRoot [32]byte) error {
 	header, err := signed.Header()
 	if err != nil {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -86,6 +86,7 @@ type config struct {
 	AttService              *attestations.Service
 	StateGen                *stategen.State
 	SlasherAttestationsFeed *event.Feed
+	SlasherDB               db.SlasherDatabase
 	WeakSubjectivityCheckpt *ethpb.Checkpoint
 	BlockFetcher            execution.POWBlockFetcher
 	FinalizedStateAtStartUp state.BeaconState

--- a/beacon-chain/blockchain/setup_test.go
+++ b/beacon-chain/blockchain/setup_test.go
@@ -78,6 +78,7 @@ type testServiceRequirements struct {
 	attSrv  *attestations.Service
 	blsPool *blstoexec.Pool
 	dc      *depositcache.DepositCache
+	sDB     db.SlasherDatabase
 }
 
 func minimalTestService(t *testing.T, opts ...Option) (*Service, *testServiceRequirements) {
@@ -94,6 +95,7 @@ func minimalTestService(t *testing.T, opts ...Option) (*Service, *testServiceReq
 	blsPool := blstoexec.NewPool()
 	dc, err := depositcache.New()
 	require.NoError(t, err)
+	sDB := testDB.SetupSlasherDB(t)
 	req := &testServiceRequirements{
 		ctx:     ctx,
 		db:      beaconDB,
@@ -105,6 +107,7 @@ func minimalTestService(t *testing.T, opts ...Option) (*Service, *testServiceReq
 		attSrv:  attSrv,
 		blsPool: blsPool,
 		dc:      dc,
+		sDB:     sDB,
 	}
 	defOpts := []Option{WithDatabase(req.db),
 		WithStateNotifier(req.notif),
@@ -112,6 +115,7 @@ func minimalTestService(t *testing.T, opts ...Option) (*Service, *testServiceReq
 		WithForkChoiceStore(req.fcs),
 		WithClockSynchronizer(req.cs),
 		WithAttestationPool(req.attPool),
+		WithSlasherDB(req.sDB),
 		WithAttestationService(req.attSrv),
 		WithBLSToExecPool(req.blsPool),
 		WithDepositCache(dc),

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -657,6 +657,7 @@ func (b *BeaconNode) registerBlockchainService(fc forkchoice.ForkChoicer, gs *st
 		blockchain.WithAttestationService(attService),
 		blockchain.WithStateGen(b.stateGen),
 		blockchain.WithSlasherAttestationsFeed(b.slasherAttestationsFeed),
+		blockchain.WithSlasherDB(b.slasherDB),
 		blockchain.WithFinalizedStateAtStartUp(b.finalizedStateAtStartUp),
 		blockchain.WithClockSynchronizer(gs),
 		blockchain.WithSyncComplete(syncComplete),


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
Prysm runs with an optional `slasher` service that flags equivocating blocks. This PR allows the beacon chain to flag such a block when validating a new block for each slot and broadcast it to the network.
I reuse the same logic provided by `db.SlasherDatabase` by injecting exposing its instance in the bc cfg. 

**Which issues(s) does this PR fix?**
#13088
