### PR TITLE
Only process blocks which haven't been processed

### DIFF
--- a/beacon-chain/das/cache.go
+++ b/beacon-chain/das/cache.go
@@ -103,7 +103,7 @@ func (e *cacheEntry) filter(root [32]byte, kc safeCommitmentArray) ([]blocks.ROB
 	return scs, nil
 }
 
-// safeCommitemntArray is a fixed size array of commitment byte slices. This is helpful for avoiding
+// safeCommitmentArray is a fixed size array of commitment byte slices. This is helpful for avoiding
 // gratuitous bounds checks.
 type safeCommitmentArray [fieldparams.MaxBlobsPerBlock][]byte
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -110,7 +110,7 @@ func validateRangeRequest(r *pb.BeaconBlocksByRangeRequest, current primitives.S
 	if rp.start > maxStart {
 		return rangeParams{}, p2ptypes.ErrInvalidRequest
 	}
-	rp.end, err = rp.start.SafeAdd((rp.size - 1))
+	rp.end, err = rp.start.SafeAdd(rp.size - 1)
 	if err != nil {
 		return rangeParams{}, p2ptypes.ErrInvalidRequest
 	}

--- a/consensus-types/blocks/roblock.go
+++ b/consensus-types/blocks/roblock.go
@@ -81,7 +81,7 @@ type BlockWithROBlobs struct {
 	Blobs []ROBlob
 }
 
-// BlockWithROBlobsSlice gives convnenient access to getting a slice of just the ROBlocks,
+// BlockWithROBlobsSlice gives convenient access to getting a slice of just the ROBlocks,
 // and defines sorting helpers.
 type BlockWithROBlobsSlice []BlockWithROBlobs
 

--- a/container/trie/sparse_merkle.go
+++ b/container/trie/sparse_merkle.go
@@ -250,7 +250,7 @@ func (m *SparseMerkleTrie) Copy() *SparseMerkleTrie {
 
 // NumOfItems returns the num of items stored in
 // the sparse merkle trie. We handle a special case
-// where if there is only one item stored and it is a
+// where if there is only one item stored and it is an
 // empty 32-byte root.
 func (m *SparseMerkleTrie) NumOfItems() int {
 	var zeroBytes [32]byte

--- a/testing/util/deneb.go
+++ b/testing/util/deneb.go
@@ -188,7 +188,7 @@ func ExtendBlocksPlusBlobs(t *testing.T, blks []blocks.ROBlock, size int) ([]blo
 	return blks, blobs
 }
 
-// HackDenebForkEpoch is helpful for tests that need to set up cases where the deneb fork has passed.
+// HackDenebMaxuint is helpful for tests that need to set up cases where the deneb fork has passed.
 // We have unit tests that assert our config matches the upstream config, where the next fork is always
 // set to MaxUint64 until the fork epoch is formally set. This creates an issue for tests that want to
 // work with slots that are defined to be after deneb because converting the max epoch to a slot leads


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR fixes a mistake which will reprocess `BlockWithBlobs` that have already been processed. I believe this is an accident, but the error handling for `errBlockAlreadyProcessed` gives me some doubts.

* Replace `data.bwb` (processed & unprocessed) with `bwb` (unprocessed).
* Remove switch case for handling already processed block; this is impossible now, right?

https://github.com/prysmaticlabs/prysm/blob/0e043d55b4e71257d40675903c38b0940723f8ac/beacon-chain/sync/initial-sync/round_robin.go#L162-L176

Also, unrelated to the primary purpose of this PR:

* Fix a few typos.
* Update a few comments to fix function names.
* Redo error format string that I find a little awkward.
* Replace `parent` with `parent.Root()` in error format.
  * Not sure if this would have worked properly before.
  * I think it would have printed the whole block.
* Remove some excess parenthesis.