### PR TITLE
Use a single rest handler

### DIFF
--- a/validator/client/beacon-api/beacon_api_beacon_chain_client.go
+++ b/validator/client/beacon-api/beacon_api_beacon_chain_client.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"net/http"
 	"reflect"
 	"strconv"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -357,12 +355,7 @@ func (c beaconApiBeaconChainClient) GetValidatorParticipation(ctx context.Contex
 	panic("beaconApiBeaconChainClient.GetValidatorParticipation is not implemented. To use a fallback client, pass a fallback client as the last argument of NewBeaconApiBeaconChainClientWithFallback.")
 }
 
-func NewBeaconApiBeaconChainClientWithFallback(host string, timeout time.Duration, fallbackClient iface.BeaconChainClient) iface.BeaconChainClient {
-	jsonRestHandler := beaconApiJsonRestHandler{
-		httpClient: http.Client{Timeout: timeout},
-		host:       host,
-	}
-
+func NewBeaconApiBeaconChainClientWithFallback(jsonRestHandler JsonRestHandler, fallbackClient iface.BeaconChainClient) iface.BeaconChainClient {
 	return &beaconApiBeaconChainClient{
 		jsonRestHandler:         jsonRestHandler,
 		fallbackClient:          fallbackClient,

--- a/validator/client/beacon-api/beacon_api_node_client.go
+++ b/validator/client/beacon-api/beacon_api_node_client.go
@@ -2,9 +2,7 @@ package beacon_api
 
 import (
 	"context"
-	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -100,12 +98,7 @@ func (c *beaconApiNodeClient) ListPeers(ctx context.Context, in *empty.Empty) (*
 	panic("beaconApiNodeClient.ListPeers is not implemented. To use a fallback client, pass a fallback client as the last argument of NewBeaconApiNodeClientWithFallback.")
 }
 
-func NewNodeClientWithFallback(host string, timeout time.Duration, fallbackClient iface.NodeClient) iface.NodeClient {
-	jsonRestHandler := beaconApiJsonRestHandler{
-		httpClient: http.Client{Timeout: timeout},
-		host:       host,
-	}
-
+func NewNodeClientWithFallback(jsonRestHandler JsonRestHandler, fallbackClient iface.NodeClient) iface.NodeClient {
 	return &beaconApiNodeClient{
 		jsonRestHandler: jsonRestHandler,
 		fallbackClient:  fallbackClient,

--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -2,7 +2,6 @@ package beacon_api
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -23,12 +22,7 @@ type beaconApiValidatorClient struct {
 	prysmBeaconChainCLient  iface.PrysmBeaconChainClient
 }
 
-func NewBeaconApiValidatorClient(host string, timeout time.Duration) iface.ValidatorClient {
-	jsonRestHandler := beaconApiJsonRestHandler{
-		httpClient: http.Client{Timeout: timeout},
-		host:       host,
-	}
-
+func NewBeaconApiValidatorClient(jsonRestHandler JsonRestHandler) iface.ValidatorClient {
 	return &beaconApiValidatorClient{
 		genesisProvider:         beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler},
 		dutiesProvider:          beaconApiDutiesProvider{jsonRestHandler: jsonRestHandler},

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -13,29 +13,29 @@ import (
 )
 
 type JsonRestHandler interface {
-	Get(ctx context.Context, query string, resp interface{}) error
+	Get(ctx context.Context, endpoint string, resp interface{}) error
 	Post(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer, resp interface{}) error
 }
 
-type beaconApiJsonRestHandler struct {
-	httpClient http.Client
-	host       string
+type BeaconApiJsonRestHandler struct {
+	HttpClient http.Client
+	Host       string
 }
 
 // Get sends a GET request and decodes the response body as a JSON object into the passed in object.
 // If an HTTP error is returned, the body is decoded as a DefaultJsonError JSON object and returned as the first return value.
-func (c beaconApiJsonRestHandler) Get(ctx context.Context, endpoint string, resp interface{}) error {
+func (c BeaconApiJsonRestHandler) Get(ctx context.Context, endpoint string, resp interface{}) error {
 	if resp == nil {
 		return errors.New("resp is nil")
 	}
 
-	url := c.host + endpoint
+	url := c.Host + endpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create request for endpoint %s", url)
 	}
 
-	httpResp, err := c.httpClient.Do(req)
+	httpResp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to perform request for endpoint %s", url)
 	}
@@ -50,7 +50,7 @@ func (c beaconApiJsonRestHandler) Get(ctx context.Context, endpoint string, resp
 
 // Post sends a POST request and decodes the response body as a JSON object into the passed in object.
 // If an HTTP error is returned, the body is decoded as a DefaultJsonError JSON object and returned as the first return value.
-func (c beaconApiJsonRestHandler) Post(
+func (c BeaconApiJsonRestHandler) Post(
 	ctx context.Context,
 	apiEndpoint string,
 	headers map[string]string,
@@ -61,7 +61,7 @@ func (c beaconApiJsonRestHandler) Post(
 		return errors.New("data is nil")
 	}
 
-	url := c.host + apiEndpoint
+	url := c.Host + apiEndpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, data)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create request for endpoint %s", url)
@@ -72,7 +72,7 @@ func (c beaconApiJsonRestHandler) Post(
 	}
 	req.Header.Set("Content-Type", api.JsonMediaType)
 
-	httpResp, err := c.httpClient.Do(req)
+	httpResp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to perform request for endpoint %s", url)
 	}

--- a/validator/client/beacon-api/json_rest_handler_test.go
+++ b/validator/client/beacon-api/json_rest_handler_test.go
@@ -40,9 +40,9 @@ func TestGet(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	jsonRestHandler := beaconApiJsonRestHandler{
-		httpClient: http.Client{Timeout: time.Second * 5},
-		host:       server.URL,
+	jsonRestHandler := BeaconApiJsonRestHandler{
+		HttpClient: http.Client{Timeout: time.Second * 5},
+		Host:       server.URL,
 	}
 	resp := &beacon.GetGenesisResponse{}
 	require.NoError(t, jsonRestHandler.Get(ctx, endpoint+"?arg1=abc&arg2=def", resp))
@@ -86,9 +86,9 @@ func TestPost(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	jsonRestHandler := beaconApiJsonRestHandler{
-		httpClient: http.Client{Timeout: time.Second * 5},
-		host:       server.URL,
+	jsonRestHandler := BeaconApiJsonRestHandler{
+		HttpClient: http.Client{Timeout: time.Second * 5},
+		Host:       server.URL,
 	}
 	resp := &beacon.GetGenesisResponse{}
 	require.NoError(t, jsonRestHandler.Post(ctx, endpoint, headers, bytes.NewBuffer(dataBytes), resp))

--- a/validator/client/beacon-api/prysm_beacon_chain_client.go
+++ b/validator/client/beacon-api/prysm_beacon_chain_client.go
@@ -3,11 +3,9 @@ package beacon_api
 import (
 	"context"
 	"fmt"
-	"net/http"
 	neturl "net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/prysm/validator"
@@ -16,12 +14,7 @@ import (
 )
 
 // NewPrysmBeaconChainClient returns implementation of iface.PrysmBeaconChainClient.
-func NewPrysmBeaconChainClient(host string, timeout time.Duration, nodeClient iface.NodeClient) iface.PrysmBeaconChainClient {
-	jsonRestHandler := beaconApiJsonRestHandler{
-		httpClient: http.Client{Timeout: timeout},
-		host:       host,
-	}
-
+func NewPrysmBeaconChainClient(jsonRestHandler JsonRestHandler, nodeClient iface.NodeClient) iface.PrysmBeaconChainClient {
 	return prysmBeaconChainClient{
 		jsonRestHandler: jsonRestHandler,
 		nodeClient:      nodeClient,

--- a/validator/client/beacon-chain-client-factory/beacon_chain_client_factory.go
+++ b/validator/client/beacon-chain-client-factory/beacon_chain_client_factory.go
@@ -9,30 +9,18 @@ import (
 	validatorHelpers "github.com/prysmaticlabs/prysm/v4/validator/helpers"
 )
 
-func NewBeaconChainClient(validatorConn validatorHelpers.NodeConnection) iface.BeaconChainClient {
+func NewBeaconChainClient(validatorConn validatorHelpers.NodeConnection, jsonRestHandler beaconApi.JsonRestHandler) iface.BeaconChainClient {
 	grpcClient := grpcApi.NewGrpcBeaconChainClient(validatorConn.GetGrpcClientConn())
-	featureFlags := features.Get()
-
-	if featureFlags.EnableBeaconRESTApi {
-		return beaconApi.NewBeaconApiBeaconChainClientWithFallback(
-			validatorConn.GetBeaconApiUrl(),
-			validatorConn.GetBeaconApiTimeout(),
-			grpcClient,
-		)
+	if features.Get().EnableBeaconRESTApi {
+		return beaconApi.NewBeaconApiBeaconChainClientWithFallback(jsonRestHandler, grpcClient)
 	} else {
 		return grpcClient
 	}
 }
 
-func NewPrysmBeaconClient(validatorConn validatorHelpers.NodeConnection) iface.PrysmBeaconChainClient {
-	featureFlags := features.Get()
-
-	if featureFlags.EnableBeaconRESTApi {
-		return beaconApi.NewPrysmBeaconChainClient(
-			validatorConn.GetBeaconApiUrl(),
-			validatorConn.GetBeaconApiTimeout(),
-			nodeClientFactory.NewNodeClient(validatorConn),
-		)
+func NewPrysmBeaconClient(validatorConn validatorHelpers.NodeConnection, jsonRestHandler beaconApi.JsonRestHandler) iface.PrysmBeaconChainClient {
+	if features.Get().EnableBeaconRESTApi {
+		return beaconApi.NewPrysmBeaconChainClient(jsonRestHandler, nodeClientFactory.NewNodeClient(validatorConn, jsonRestHandler))
 	} else {
 		return grpcApi.NewGrpcPrysmBeaconChainClient(validatorConn.GetGrpcClientConn())
 	}

--- a/validator/client/node-client-factory/node_client_factory.go
+++ b/validator/client/node-client-factory/node_client_factory.go
@@ -8,12 +8,10 @@ import (
 	validatorHelpers "github.com/prysmaticlabs/prysm/v4/validator/helpers"
 )
 
-func NewNodeClient(validatorConn validatorHelpers.NodeConnection) iface.NodeClient {
+func NewNodeClient(validatorConn validatorHelpers.NodeConnection, jsonRestHandler beaconApi.JsonRestHandler) iface.NodeClient {
 	grpcClient := grpcApi.NewNodeClient(validatorConn.GetGrpcClientConn())
-	featureFlags := features.Get()
-
-	if featureFlags.EnableBeaconRESTApi {
-		return beaconApi.NewNodeClientWithFallback(validatorConn.GetBeaconApiUrl(), validatorConn.GetBeaconApiTimeout(), grpcClient)
+	if features.Get().EnableBeaconRESTApi {
+		return beaconApi.NewNodeClientWithFallback(jsonRestHandler, grpcClient)
 	} else {
 		return grpcClient
 	}

--- a/validator/client/validator-client-factory/validator_client_factory.go
+++ b/validator/client/validator-client-factory/validator_client_factory.go
@@ -8,11 +8,12 @@ import (
 	validatorHelpers "github.com/prysmaticlabs/prysm/v4/validator/helpers"
 )
 
-func NewValidatorClient(validatorConn validatorHelpers.NodeConnection) iface.ValidatorClient {
-	featureFlags := features.Get()
-
-	if featureFlags.EnableBeaconRESTApi {
-		return beaconApi.NewBeaconApiValidatorClient(validatorConn.GetBeaconApiUrl(), validatorConn.GetBeaconApiTimeout())
+func NewValidatorClient(
+	validatorConn validatorHelpers.NodeConnection,
+	jsonRestHandler beaconApi.JsonRestHandler,
+) iface.ValidatorClient {
+	if features.Get().EnableBeaconRESTApi {
+		return beaconApi.NewBeaconApiValidatorClient(jsonRestHandler)
 	} else {
 		return grpcApi.NewGrpcValidatorClient(validatorConn.GetGrpcClientConn())
 	}

--- a/validator/rpc/BUILD.bazel
+++ b/validator/rpc/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//validator/accounts/petnames:go_default_library",
         "//validator/accounts/wallet:go_default_library",
         "//validator/client:go_default_library",
+        "//validator/client/beacon-api:go_default_library",
         "//validator/client/beacon-chain-client-factory:go_default_library",
         "//validator/client/iface:go_default_library",
         "//validator/client/node-client-factory:go_default_library",

--- a/validator/rpc/beacon.go
+++ b/validator/rpc/beacon.go
@@ -1,6 +1,8 @@
 package rpc
 
 import (
+	"net/http"
+
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpcretry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpcopentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
@@ -9,6 +11,7 @@ import (
 	grpcutil "github.com/prysmaticlabs/prysm/v4/api/grpc"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/validator/client"
+	beaconApi "github.com/prysmaticlabs/prysm/v4/validator/client/beacon-api"
 	beaconChainClientFactory "github.com/prysmaticlabs/prysm/v4/validator/client/beacon-chain-client-factory"
 	nodeClientFactory "github.com/prysmaticlabs/prysm/v4/validator/client/node-client-factory"
 	validatorClientFactory "github.com/prysmaticlabs/prysm/v4/validator/client/validator-client-factory"
@@ -51,8 +54,13 @@ func (s *Server) registerBeaconClient() error {
 		s.beaconApiTimeout,
 	)
 
-	s.beaconChainClient = beaconChainClientFactory.NewBeaconChainClient(conn)
-	s.beaconNodeClient = nodeClientFactory.NewNodeClient(conn)
-	s.beaconNodeValidatorClient = validatorClientFactory.NewValidatorClient(conn)
+	restHandler := &beaconApi.BeaconApiJsonRestHandler{
+		HttpClient: http.Client{Timeout: s.beaconApiTimeout},
+		Host:       s.beaconApiEndpoint,
+	}
+	s.beaconChainClient = beaconChainClientFactory.NewBeaconChainClient(conn, restHandler)
+	s.beaconNodeClient = nodeClientFactory.NewNodeClient(conn, restHandler)
+	s.beaconNodeValidatorClient = validatorClientFactory.NewValidatorClient(conn, restHandler)
+
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Changes how we depend on `JsonRestHandler` by reusing the same dependency between several clients.
