### PR TITLE
BN: Move  `--db-backup-output-dir` as a deprecated flag.

### DIFF
--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -62,7 +62,6 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.TracingEndpointFlag,
 			cmd.TraceSampleFractionFlag,
 			cmd.MonitoringHostFlag,
-			cmd.BackupWebhookOutputDir,
 			flags.MonitoringPortFlag,
 			cmd.DisableMonitoringFlag,
 			cmd.MaxGoroutines,
@@ -183,6 +182,12 @@ var appHelpFlagGroups = []flagGroup{
 			genesis.StatePath,
 			flags.InteropGenesisTimeFlag,
 			flags.InteropNumValidatorsFlag,
+		},
+	},
+	{
+		Name: "deprecated",
+		Flags: []cli.Flag{
+			cmd.BackupWebhookOutputDir,
 		},
 	},
 }


### PR DESCRIPTION
**What type of PR is this?**
Bug fix 

**What does this PR do? Why is it needed?**
No functional change.

New `--help` output:
```
...
interop OPTIONS:
   --genesis-state value           Load a genesis state from ssz file. Testnet genesis files can be found in the eth2-clients/eth2-testnets repository on github.
   --interop-genesis-time value    Specify the genesis time for interop genesis state generation. Must be used with --interop-num-validators (default: 0)
   --interop-num-validators value  Specify number of genesis validators to generate for interop. Must be used with --interop-genesis-time (default: 0)

deprecated OPTIONS:
   --db-backup-output-dir value  Output directory for db backups.
```

I do not remove this flag not to break compatibility.

An other PR in documentation will remove the section for BN DB backup.

**Which issues(s) does this PR fix?**
Fixes #13449
