### PR TITLE
Display prune log if total pruned > 0

### DIFF
--- a/beacon-chain/db/filesystem/pruner.go
+++ b/beacon-chain/db/filesystem/pruner.go
@@ -81,12 +81,14 @@ func (p *blobPruner) prune(pruneBefore primitives.Slot) error {
 		}()
 	} else {
 		defer func() {
-			log.WithFields(log.Fields{
-				"upToEpoch":    slots.ToEpoch(pruneBefore),
-				"duration":     time.Since(start).String(),
-				"filesRemoved": totalPruned,
-			}).Debug("Pruned old blobs")
-			blobsPrunedCounter.Add(float64(totalPruned))
+			if totalPruned > 0 {
+				log.WithFields(log.Fields{
+					"upToEpoch":    slots.ToEpoch(pruneBefore),
+					"duration":     time.Since(start).String(),
+					"filesRemoved": totalPruned,
+				}).Debug("Pruned old blobs")
+				blobsPrunedCounter.Add(float64(totalPruned))
+			}
 		}()
 	}
 


### PR DESCRIPTION
This behavior introduced in [https://github.com/prysmaticlabs/prysm/pull/13417](https://github.com/prysmaticlabs/prysm/pull/13417) was later reverted. The latest PR reinstates the #13417 behavior, which prunes only if greater than 0.