### PR TITLE
Delete invalid blob at block processing

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -387,7 +387,10 @@ func (s *Service) removeInvalidBlockAndState(ctx context.Context, blkRoots [][32
 			// This is an irreparable condition, it would me a justified or finalized block has become invalid.
 			return err
 		}
-		// TODO: Remove blob here
+		if err := s.blobStorage.Remove(root); err != nil {
+			// Blobs may not exist for some blocks, leading to deletion failures. Log such errors at debug level.
+			log.WithError(err).Debug("Could not remove blob from blob storage")
+		}
 	}
 	return nil
 }

--- a/beacon-chain/blockchain/setup_test.go
+++ b/beacon-chain/blockchain/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache/depositcache"
 	statefeed "github.com/prysmaticlabs/prysm/v4/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db/filesystem"
 	testDB "github.com/prysmaticlabs/prysm/v4/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice"
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/doubly-linked-tree"
@@ -116,6 +117,7 @@ func minimalTestService(t *testing.T, opts ...Option) (*Service, *testServiceReq
 		WithBLSToExecPool(req.blsPool),
 		WithDepositCache(dc),
 		WithTrackedValidatorsCache(cache.NewTrackedValidatorsCache()),
+		WithBlobStorage(filesystem.NewEphemeralBlobStorage(t)),
 	}
 	// append the variadic opts so they override the defaults by being processed afterwards
 	opts = append(defOpts, opts...)

--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -185,6 +185,12 @@ func (bs *BlobStorage) Get(root [32]byte, idx uint64) (blocks.VerifiedROBlob, er
 	return verification.BlobSidecarNoop(ro)
 }
 
+// Remove removes all blobs for a given root.
+func (bs *BlobStorage) Remove(root [32]byte) error {
+	rootDir := blobNamer{root: root}.dir()
+	return bs.fs.RemoveAll(rootDir)
+}
+
 // Indices generates a bitmap representing which BlobSidecar.Index values are present on disk for a given root.
 // This value can be compared to the commitments observed in a block to determine which indices need to be found
 // on the network to confirm data availability.

--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -73,6 +73,21 @@ func TestBlobStorage_SaveBlobData(t *testing.T) {
 		require.NoError(t, err)
 		require.DeepSSZEqual(t, expected, actual)
 	})
+
+	t.Run("round trip write, read and delete", func(t *testing.T) {
+		bs := NewEphemeralBlobStorage(t)
+		err := bs.Save(testSidecars[0])
+		require.NoError(t, err)
+
+		expected := testSidecars[0]
+		actual, err := bs.Get(expected.BlockRoot(), expected.Index)
+		require.NoError(t, err)
+		require.DeepSSZEqual(t, expected, actual)
+
+		require.NoError(t, bs.Remove(expected.BlockRoot()))
+		_, err = bs.Get(expected.BlockRoot(), expected.Index)
+		require.ErrorContains(t, "file does not exist", err)
+	})
 }
 
 // pollUntil polls a condition function until it returns true or a timeout is reached.


### PR DESCRIPTION
Simultaneously delete invalid blobs and blocks during block processing. Since a block might not have an associated blob, logging blob deletion failures at the debug level is appropriate. Note that this is a rare occurrence.