### PR TITLE
Late block: move checking of empty attribute earlier

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -610,6 +610,13 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	if has {
 		return
 	}
+
+	attribute := s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:])
+	// return early if we are not proposing next slot
+	if attribute.IsEmpty() {
+		return
+	}
+
 	s.headLock.RLock()
 	headBlock, err := s.headBlock()
 	if err != nil {
@@ -620,14 +627,10 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	s.headLock.RUnlock()
 
 	fcuArgs := &fcuConfig{
-		headState: headState,
-		headRoot:  headRoot,
-		headBlock: headBlock,
-	}
-	fcuArgs.attributes = s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:])
-	// return early if we are not proposing next slot
-	if fcuArgs.attributes.IsEmpty() {
-		return
+		headState:  headState,
+		headRoot:   headRoot,
+		headBlock:  headBlock,
+		attributes: attribute,
 	}
 	s.cfg.ForkChoiceStore.RLock()
 	_, err = s.notifyForkchoiceUpdate(ctx, fcuArgs)


### PR DESCRIPTION
In the happy case, validators will not propose the next block. In such scenarios, we will return early due to `attribute.IsEmpty()` being true, eliminating the need to call `s.headBlock()` unless the validator is proposing the next slot. This approach avoids an unnecessary block copy.

Note to the reviewer: Please exercise caution when reviewing any locking mechanisms in this PR, particularly the fork choice lock and head lock. It appears that `s.getPayloadAttribute` may not require locking, but kindly verify this to ensure accuracy.