### PR TITLE
Enhance block by root log

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -79,13 +79,6 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 			seen := s.seenPendingBlocks[bRoot]
 			s.pendingQueueLock.RUnlock()
 			if !seen {
-				// Pending attestation's missing block has not arrived yet.
-				log.WithFields(logrus.Fields{
-					"currentSlot": s.cfg.clock.CurrentSlot(),
-					"attSlot":     attestations[0].Message.Aggregate.Data.Slot,
-					"attCount":    len(attestations),
-					"blockRoot":   hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
-				}).Debug("Requesting block for pending attestation")
 				pendingRoots = append(pendingRoots, bRoot)
 			}
 		}

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -53,7 +53,7 @@ func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 	a := &ethpb.AggregateAttestationAndProof{Aggregate: &ethpb.Attestation{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{Root: make([]byte, 32)}}}}
 	r.blkRootToPendingAtts[[32]byte{'A'}] = []*ethpb.SignedAggregateAttestationAndProof{{Message: a}}
 	require.NoError(t, r.processPendingAtts(context.Background()))
-	require.LogsContain(t, hook, "Requesting block for pending attestation")
+	require.LogsContain(t, hook, "Requesting block by root")
 }
 
 func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -126,7 +126,6 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			// Request parent block if not in the pending queue and not in the database.
 			isParentBlockInDB := s.cfg.beaconDB.HasBlock(ctx, parentRoot)
 			if !inPendingQueue && !isParentBlockInDB && s.hasPeer() {
-				log.WithFields(logrus.Fields{"currentSlot": b.Block().Slot(), "parentRoot": hex.EncodeToString(parentRoot[:])}).Debug("Requesting parent block")
 				parentRoots = append(parentRoots, parentRoot)
 				continue
 			}
@@ -283,6 +282,8 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 		r := roots[i]
 		if s.seenPendingBlocks[r] || s.cfg.chain.BlockBeingSynced(r) {
 			roots = append(roots[:i], roots[i+1:]...)
+		} else {
+			log.WithField("blockRoot", fmt.Sprintf("%#x", r)).Debug("Requesting block by root")
 		}
 	}
 	s.pendingQueueLock.RUnlock()


### PR DESCRIPTION
Currently, if a block's parent or attestation head vote is not in the database, the beacon node logs a request message for it. This message can be either "**Requesting block for pending attestation**" or "**Requesting parent block**"'. However, these logs are misleading because they are generated before the requested root is filtered by `s.seenPendingBlocks[r] || s.cfg.chain.BlockBeingSynced(r)`. It would be more accurate to log these messages after applying the filter. Although logging later in the function means losing information like `attSlot`, `attCount`, or `slot`, these details are likely irrelevant for a debug log, and changing the debug log format should not be a concern...