### PR TITLE
Capitalize Aggregated Unaggregated Attestations Log

### DIFF
--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -42,7 +42,7 @@ func (s *Service) prepareForkChoiceAtts() {
 			switch slotInterval.Interval {
 			case 0:
 				duration := time.Since(t)
-				log.WithField("Duration", duration).Debug("aggregated unaggregated attestations")
+				log.WithField("Duration", duration).Debug("Aggregated unaggregated attestations")
 				batchForkChoiceAttsT1.Observe(float64(duration.Milliseconds()))
 			case 1:
 				batchForkChoiceAttsT2.Observe(float64(time.Since(t).Milliseconds()))


### PR DESCRIPTION
`Aggregated Unaggregated Attestations` is the only log I've seen that's not capitalized. Consistency will be nice here