### PR TITLE
Fix KZG commitment inclusion proof tag in blob sidecar JSON RPC response

### DIFF
--- a/beacon-chain/rpc/eth/blob/structs.go
+++ b/beacon-chain/rpc/eth/blob/structs.go
@@ -12,5 +12,5 @@ type Sidecar struct {
 	SignedBeaconBlockHeader  *shared.SignedBeaconBlockHeader `json:"signed_block_header"`
 	KzgCommitment            string                          `json:"kzg_commitment"`
 	KzgProof                 string                          `json:"kzg_proof"`
-	CommitmentInclusionProof []string                        `json:"commitment_inclusion_proof"`
+	CommitmentInclusionProof []string                        `json:"kzg_commitment_inclusion_proof"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Renames the blob sidecar field containing the inclusion proof from `commitment_inclusion_proof` to `kzg_commitment_inclusion_proof`, which is the field name in the [beacon API specification](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobSidecars).

Hive was complaining and failing all tests when it came to verifying the blob sidecars from the beacon node, but I've tested with this change and test are not failing anymore due to this issue.

**Which issues(s) does this PR fix?**
No issue number for this afaik.

**Other notes for review**
There are other uses of `commitment_inclusion_proof` but I did not want to touch anything else that was unnecessary.