### PR TITLE
updating post requests that accept ssz to check content type instead …

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -1169,7 +1169,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetPhase0().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Phase0))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1199,7 +1199,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetAltair().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Altair))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1224,7 +1224,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Bellatrix))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1250,7 +1250,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetCapella().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1276,7 +1276,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetDeneb().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Deneb))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1296,7 +1296,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Bellatrix))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1317,7 +1317,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1335,7 +1335,7 @@ func TestPublishBlockSSZ(t *testing.T) {
 		}
 
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte("foo")))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlock(writer, request)
@@ -1531,7 +1531,7 @@ func TestPublishBlindedBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetPhase0().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Phase0))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1561,7 +1561,7 @@ func TestPublishBlindedBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetAltair().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Altair))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1587,7 +1587,7 @@ func TestPublishBlindedBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Bellatrix))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1613,7 +1613,7 @@ func TestPublishBlindedBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedCapella().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1639,7 +1639,7 @@ func TestPublishBlindedBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedDeneb().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Deneb))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1672,7 +1672,7 @@ func TestPublishBlindedBlockSSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1690,7 +1690,7 @@ func TestPublishBlindedBlockSSZ(t *testing.T) {
 		}
 
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte("foo")))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlindedBlock(writer, request)
@@ -1899,7 +1899,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetPhase0().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Phase0))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1929,7 +1929,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetAltair().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Altair))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1954,7 +1954,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Bellatrix))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -1980,7 +1980,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetCapella().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2006,7 +2006,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetDeneb().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Deneb))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2026,7 +2026,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Bellatrix))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2047,7 +2047,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2061,7 +2061,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		}
 
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte(rpctesting.CapellaBlock)))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlockV2(writer, request)
@@ -2078,7 +2078,7 @@ func TestPublishBlockV2SSZ(t *testing.T) {
 		}
 
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte("foo")))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlockV2(writer, request)
@@ -2286,7 +2286,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetPhase0().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Phase0))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2316,7 +2316,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetAltair().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Altair))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2342,7 +2342,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Bellatrix))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2368,7 +2368,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedCapella().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2394,7 +2394,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedDeneb().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Deneb))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2427,7 +2427,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		ssz, err := genericBlock.GetBlindedBellatrix().MarshalSSZ()
 		require.NoError(t, err)
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(ssz))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		request.Header.Set(api.VersionHeader, version.String(version.Capella))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
@@ -2441,7 +2441,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		}
 
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte(rpctesting.BlindedCapellaBlock)))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlockV2(writer, request)
@@ -2458,7 +2458,7 @@ func TestPublishBlindedBlockV2SSZ(t *testing.T) {
 		}
 
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte("foo")))
-		request.Header.Set("Accept", api.OctetStreamMediaType)
+		request.Header.Set("Content-Type", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlindedBlockV2(writer, request)

--- a/network/httputil/BUILD.bazel
+++ b/network/httputil/BUILD.bazel
@@ -22,5 +22,6 @@ go_test(
     deps = [
         "//api:go_default_library",
         "//testing/assert:go_default_library",
+        "//testing/require:go_default_library",
     ],
 )

--- a/network/httputil/reader.go
+++ b/network/httputil/reader.go
@@ -14,40 +14,43 @@ var priorityRegex = regexp.MustCompile(`q=(\d+(?:\.\d+)?)`)
 
 // SszRequested takes a http request and checks to see if it should be requesting a ssz response.
 func SszRequested(req *http.Request) bool {
-	accept := req.Header.Values("Accept")
-	if len(accept) == 0 {
-		return false
-	}
-	types := strings.Split(accept[0], ",")
-	currentType, currentPriority := "", 0.0
-	for _, t := range types {
-		values := strings.Split(t, ";")
-		name := values[0]
-		if name != api.JsonMediaType && name != api.OctetStreamMediaType {
-			continue
+	if req.Method == http.MethodGet {
+		accept := req.Header.Values("Accept")
+		if len(accept) == 0 {
+			return false
 		}
-		// no params specified
-		if len(values) == 1 {
-			priority := 1.0
+		types := strings.Split(accept[0], ",")
+		currentType, currentPriority := "", 0.0
+		for _, t := range types {
+			values := strings.Split(t, ";")
+			name := values[0]
+			if name != api.JsonMediaType && name != api.OctetStreamMediaType {
+				continue
+			}
+			// no params specified
+			if len(values) == 1 {
+				priority := 1.0
+				if priority > currentPriority {
+					currentType, currentPriority = name, priority
+				}
+				continue
+			}
+			params := values[1]
+
+			match := priorityRegex.FindAllStringSubmatch(params, 1)
+			if len(match) != 1 {
+				continue
+			}
+			priority, err := strconv.ParseFloat(match[0][1], 32)
+			if err != nil {
+				return false
+			}
 			if priority > currentPriority {
 				currentType, currentPriority = name, priority
 			}
-			continue
 		}
-		params := values[1]
 
-		match := priorityRegex.FindAllStringSubmatch(params, 1)
-		if len(match) != 1 {
-			continue
-		}
-		priority, err := strconv.ParseFloat(match[0][1], 32)
-		if err != nil {
-			return false
-		}
-		if priority > currentPriority {
-			currentType, currentPriority = name, priority
-		}
+		return currentType == api.OctetStreamMediaType
 	}
-
-	return currentType == api.OctetStreamMediaType
+	return req.Header.Get("Content-Type") == api.OctetStreamMediaType
 }

--- a/network/httputil/reader_test.go
+++ b/network/httputil/reader_test.go
@@ -1,17 +1,20 @@
 package httputil
 
 import (
+	"bytes"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v4/api"
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
+	"github.com/prysmaticlabs/prysm/v4/testing/require"
 )
 
 func TestSSZRequested(t *testing.T) {
 	t.Run("ssz_requested", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{api.OctetStreamMediaType}
 		result := SszRequested(request)
 		assert.Equal(t, true, result)
@@ -25,14 +28,14 @@ func TestSSZRequested(t *testing.T) {
 	})
 
 	t.Run("ssz_content_type_preferred_1", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{fmt.Sprintf("%s;q=0.9,%s", api.JsonMediaType, api.OctetStreamMediaType)}
 		result := SszRequested(request)
 		assert.Equal(t, true, result)
 	})
 
 	t.Run("ssz_content_type_preferred_2", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{fmt.Sprintf("%s;q=0.95,%s;q=0.9", api.OctetStreamMediaType, api.JsonMediaType)}
 		result := SszRequested(request)
 		assert.Equal(t, true, result)
@@ -46,42 +49,72 @@ func TestSSZRequested(t *testing.T) {
 	})
 
 	t.Run("other_params", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{fmt.Sprintf("%s,%s;q=0.9,otherparam=xyz", api.JsonMediaType, api.OctetStreamMediaType)}
 		result := SszRequested(request)
 		assert.Equal(t, false, result)
 	})
 
 	t.Run("no_header", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		result := SszRequested(request)
 		assert.Equal(t, false, result)
 	})
 
 	t.Run("empty_header", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{}
 		result := SszRequested(request)
 		assert.Equal(t, false, result)
 	})
 
 	t.Run("empty_header_value", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{""}
 		result := SszRequested(request)
 		assert.Equal(t, false, result)
 	})
 
 	t.Run("other_content_type", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{"application/other"}
 		result := SszRequested(request)
 		assert.Equal(t, false, result)
 	})
 
 	t.Run("garbage", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example", nil)
 		request.Header["Accept"] = []string{"This is Sparta!!!"}
+		result := SszRequested(request)
+		assert.Equal(t, false, result)
+	})
+
+	t.Run("ssz Post happy path", func(t *testing.T) {
+		var body bytes.Buffer
+		_, err := body.WriteString("something")
+		require.NoError(t, err)
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", &body)
+		request.Header["Content-Type"] = []string{api.OctetStreamMediaType}
+		result := SszRequested(request)
+		assert.Equal(t, true, result)
+	})
+
+	t.Run("ssz Post missing header", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", nil)
+		result := SszRequested(request)
+		assert.Equal(t, false, result)
+	})
+
+	t.Run("ssz Post wrong content type", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", nil)
+		request.Header["Content-Type"] = []string{"application/other"}
+		result := SszRequested(request)
+		assert.Equal(t, false, result)
+	})
+
+	t.Run("ssz Post json content type", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", nil)
+		request.Header["Content-Type"] = []string{api.JsonMediaType}
 		result := SszRequested(request)
 		assert.Equal(t, false, result)
 	})


### PR DESCRIPTION
…of accept header

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
reported by user #shanaq on discord

POST requests should not be using the `Accept` header to interpret incoming ssz data, we should use the `Content-Type` header to check for this instead.

