### PR TITLE
Fix Blob Parent Descendant Check

### DIFF
--- a/beacon-chain/verification/blob.go
+++ b/beacon-chain/verification/blob.go
@@ -247,7 +247,7 @@ func (bv *ROBlobVerifier) SidecarParentSlotLower() (err error) {
 // -- i.e. get_checkpoint_block(store, block_header.parent_root, store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root.
 func (bv *ROBlobVerifier) SidecarDescendsFromFinalized() (err error) {
 	defer bv.recordResult(RequireSidecarDescendsFromFinalized, &err)
-	if !bv.fc.IsCanonical(bv.blob.ParentRoot()) {
+	if !bv.fc.HasNode(bv.blob.ParentRoot()) {
 		return ErrSidecarNotFinalizedDescendent
 	}
 	return nil

--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -358,7 +358,7 @@ func TestSidecarDescendsFromFinalized(t *testing.T) {
 	_, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 1, 1)
 	b := blobs[0]
 	t.Run("not canonical", func(t *testing.T) {
-		ini := Initializer{shared: &sharedResources{fc: &mockForkchoicer{IsCanonicalCB: func(r [32]byte) bool {
+		ini := Initializer{shared: &sharedResources{fc: &mockForkchoicer{HasNodeCB: func(r [32]byte) bool {
 			if b.ParentRoot() != r {
 				t.Error("forkchoice.Slot called with unexpected parent root")
 			}
@@ -369,8 +369,8 @@ func TestSidecarDescendsFromFinalized(t *testing.T) {
 		require.Equal(t, true, v.results.executed(RequireSidecarDescendsFromFinalized))
 		require.NotNil(t, v.results.result(RequireSidecarDescendsFromFinalized))
 	})
-	t.Run("not canonical", func(t *testing.T) {
-		ini := Initializer{shared: &sharedResources{fc: &mockForkchoicer{IsCanonicalCB: func(r [32]byte) bool {
+	t.Run("canonical", func(t *testing.T) {
+		ini := Initializer{shared: &sharedResources{fc: &mockForkchoicer{HasNodeCB: func(r [32]byte) bool {
 			if b.ParentRoot() != r {
 				t.Error("forkchoice.Slot called with unexpected parent root")
 			}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

For blobs we validate that the parent is descended from the last finalized checkpoint. However our blob validation pipeline required that the parent blocks were canonical which is different from what is in the specification and what has been implemented similarly for block validation.

This PR fixes that condition along with its test.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
