### PR TITLE
Fix minor issue in blsToExecChange message validator

### DIFF
--- a/beacon-chain/p2p/message_id.go
+++ b/beacon-chain/p2p/message_id.go
@@ -83,7 +83,7 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 	decodedData, err := encoder.DecodeSnappy(pmsg.Data, gossipPubSubSize)
 	if err != nil {
 		totalLength, err := math.AddInt(
-			len(params.BeaconConfig().MessageDomainValidSnappy),
+			len(params.BeaconConfig().MessageDomainInvalidSnappy),
 			len(topicLenBytes),
 			topicLen,
 			len(pmsg.Data),

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -517,7 +517,7 @@ func (f *blocksFetcher) requestBlobs(ctx context.Context, req *p2ppb.BlobSidecar
 		"capacity": f.rateLimiter.Remaining(pid.String()),
 		"score":    f.p2p.Peers().Scorers().BlockProviderScorer().FormatScorePretty(pid),
 	}).Debug("Requesting blobs")
-	// We're intentionally abusing the block rate limit here, treating blob requests as if they were blob requests.
+	// We're intentionally abusing the block rate limit here, treating blob requests as if they were block requests.
 	// Since blob requests take more bandwidth than blocks, we should improve how we account for the different kinds
 	// of requests, more in proportion to the cost of serving them.
 	if f.rateLimiter.Remaining(pid.String()) < int64(req.Count) {

--- a/beacon-chain/sync/validate_bls_to_execution_change.go
+++ b/beacon-chain/sync/validate_bls_to_execution_change.go
@@ -38,6 +38,9 @@ func (s *Service) validateBlsToExecutionChange(ctx context.Context, pid peer.ID,
 	}
 
 	// Check that the validator hasn't submitted a previous execution change.
+	if blsChange.Message == nil {
+		return pubsub.ValidationReject, errNilMessage
+	}
 	if s.cfg.blsToExecPool.ValidatorExists(blsChange.Message.ValidatorIndex) {
 		return pubsub.ValidationIgnore, nil
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

* Small fix in `postAltairMsgID` which used the wrong domain when calculating length; was using `ValidSnappy` in length calculation and using `InvalidSnappy` later. It doesn't make a difference though because both domains are the same length, four bytes. Just fixing to fix.
* Fix a typo in a comment about blob requests.
* The primary reason for this PR: check that `blsChange.Message` isn't `nil` before derefencing it. The gossip topic message validators, like this one, will recover from any panic. So Prysm won't crash, but it will print an annoying panic stack trace to the console.
