### PR TITLE
Incorrect eth version on debug fork choice beacon api path

### DIFF
--- a/beacon-chain/rpc/eth/debug/handlers_test.go
+++ b/beacon-chain/rpc/eth/debug/handlers_test.go
@@ -471,7 +471,7 @@ func TestGetForkChoice(t *testing.T) {
 	require.NoError(t, store.UpdateFinalizedCheckpoint(fc))
 	s := &Server{ForkchoiceFetcher: &blockchainmock.ChainService{ForkChoiceStore: store}}
 
-	request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v2/debug/fork_choice", nil)
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/debug/fork_choice", nil)
 	writer := httptest.NewRecorder()
 	writer.Body = &bytes.Buffer{}
 

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -296,7 +296,7 @@ func (s *Service) initializeDebugServerRoutes(debugServer *debug.Server) {
 	s.cfg.Router.HandleFunc("/eth/v1/debug/beacon/states/{state_id}", debugServer.GetBeaconStateSSZ).Methods(http.MethodGet)
 	s.cfg.Router.HandleFunc("/eth/v2/debug/beacon/states/{state_id}", debugServer.GetBeaconStateV2).Methods(http.MethodGet)
 	s.cfg.Router.HandleFunc("/eth/v2/debug/beacon/heads", debugServer.GetForkChoiceHeadsV2).Methods(http.MethodGet)
-	s.cfg.Router.HandleFunc("/eth/v2/debug/fork_choice", debugServer.GetForkChoice).Methods(http.MethodGet)
+	s.cfg.Router.HandleFunc("/eth/v1/debug/fork_choice", debugServer.GetForkChoice).Methods(http.MethodGet)
 }
 
 // prysm internal routes

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -125,7 +125,7 @@ func TestServer_InitializeRoutes(t *testing.T) {
 		"/eth/v1/debug/beacon/states/{state_id}":                     {http.MethodGet},
 		"/eth/v2/debug/beacon/states/{state_id}":                     {http.MethodGet},
 		"/eth/v2/debug/beacon/heads":                                 {http.MethodGet},
-		"/eth/v2/debug/fork_choice":                                  {http.MethodGet},
+		"/eth/v1/debug/fork_choice":                                  {http.MethodGet},
 		"/prysm/v1/beacon/weak_subjectivity":                         {http.MethodGet},
 		"/prysm/node/trusted_peers":                                  {http.MethodGet, http.MethodPost},
 		"/prysm/node/trusted_peers/{peer_id}":                        {http.MethodDelete},


### PR DESCRIPTION

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Revert beacon api path [`/eth/v1/debug/fork_choice`](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Debug/getDebugForkChoice)  back to `v1` from `v2`

**Which issues(s) does this PR fix?**

Fixes #13500