### PR TITLE
Fix a few minor nits in protobuf definitions

### DIFF
--- a/proto/engine/v1/execution_engine.proto
+++ b/proto/engine/v1/execution_engine.proto
@@ -215,15 +215,17 @@ message Withdrawal {
 message BlobsBundle {
 	// The KZG commitments of the blobs.
 	repeated bytes kzg_commitments = 1 [(ethereum.eth.ext.ssz_size) = "?,48", (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"];
+
 	// The proofs of the blobs.
 	repeated bytes proofs = 2 [(ethereum.eth.ext.ssz_size) = "?,48", (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"];
+
 	// The blobs itself.
-	repeated bytes blobs = 3 [(ethereum.eth.ext.ssz_size) = "?,131072", (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"];
+	repeated bytes blobs = 3 [(ethereum.eth.ext.ssz_size) = "?,blob.size", (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"];
 }
 
 // Blob contains the data that is to be committed on chain.
 message Blob {
-	// Each blob consists of `BLS_FIELD_ELEMENT`(32) multiplies `FIELD_ELEMENTS_PER_BLOB`(4096)
+	// The blob bytes.
 	bytes data = 1 [(ethereum.eth.ext.ssz_size) = "blob.size"];
 }
 

--- a/proto/eth/v2/beacon_block.proto
+++ b/proto/eth/v2/beacon_block.proto
@@ -331,7 +331,7 @@ message BeaconBlockBodyBellatrix {
   // At most MAX_VOLUNTARY_EXITS.
   repeated v1.SignedVoluntaryExit voluntary_exits = 8 [(ethereum.eth.ext.ssz_max) = "16"];
 
-  // Sync aggregate object to track sync committee votes for light client support. 
+  // Sync aggregate object to track sync committee votes for light client support.
   v1.SyncAggregate sync_aggregate = 9;
 
   // Execution payload: the embedded execution payload of the block [New in Bellatrix]
@@ -523,7 +523,7 @@ message BeaconBlockBodyDeneb {
   // At most MAX_BLS_TO_EXECUTION_CHANGES. New in Capella network upgrade.
   repeated  SignedBLSToExecutionChange bls_to_execution_changes = 11 [(ethereum.eth.ext.ssz_max) = "16"];
 
-  // At most MAX_BLOBS_PER_BLOCK. New in Deneb network upgrade.
+  // At most MAX_BLOB_COMMITMENTS_PER_BLOCK. New in Deneb network upgrade.
   repeated bytes blob_kzg_commitments = 12 [(ethereum.eth.ext.ssz_size) = "?,48", (ethereum.eth.ext.ssz_max)  = "max_blob_commitments.size"];
 }
 

--- a/proto/prysm/v1alpha1/beacon_block.proto
+++ b/proto/prysm/v1alpha1/beacon_block.proto
@@ -710,7 +710,7 @@ message BlindedBeaconBlockBodyDeneb {
     // Execution payload header from the execution chain. New in Bellatrix network upgrade to accommodate MEV interaction.
     ethereum.engine.v1.ExecutionPayloadHeaderDeneb execution_payload_header = 10;
 
-    // At most MAX_BLS_TO_EXECUTION_CHANGES. New in Deneb network upgrade.
+    // At most MAX_BLS_TO_EXECUTION_CHANGES. New in Capella network upgrade.
     repeated SignedBLSToExecutionChange bls_to_execution_changes = 11 [(ethereum.eth.ext.ssz_max) = "16"];
 
     repeated bytes blob_kzg_commitments = 12 [(ethereum.eth.ext.ssz_size) = "?,48", (ethereum.eth.ext.ssz_max)  = "max_blob_commitments.size"];

--- a/proto/ssz_proto_library.bzl
+++ b/proto/ssz_proto_library.bzl
@@ -20,7 +20,7 @@ mainnet = {
     "sync_committee_aggregate_bytes.size": "16",
     "sync_committee_aggregate_bits.type": "github.com/prysmaticlabs/go-bitfield.Bitvector128",
     "withdrawal.size": "16",
-    "blob.size": "131072",
+    "blob.size": "131072",  # BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB
     "logs_bloom.size": "256",
     "extra_data.size": "32",
     "max_blobs_per_block.size": "6",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

* Add blank lines between fields with comments. This is for consistency with other files.
* Use `blob.size` rather than `131072`, might as well since it's defined.
* Replace confusing comment for `Blob`. I get what it's saying but it's strange.
  * `BLS_FIELD_ELEMENT` should be `BYTES_PER_FIELD_ELEMENT`.
  * "multiplies" should have been "multiples of".
  * But even then it doesn't read very well.
*  Comment for commitments should be `MAX_BLOB_COMMITMENTS_PER_BLOCK ` instead of `MAX_BLOBS_PER_BLOCK`.
* Fix comment that says `SignedBLSToExecutionChange` is new to Deneb 😃 
* Add comment describing how `blob.size` is calculated.