### PR TITLE
Add metric for data availability wait time

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -182,6 +182,10 @@ var (
 		Name: "chain_service_processing_milliseconds",
 		Help: "Total time to call a chain service in ReceiveBlock()",
 	})
+	dataAvabilityWaitedTime = promauto.NewSummary(prometheus.SummaryOpts{
+		Name: "da_waited_time_milliseconds",
+		Help: "Total time to wait for a data availability check in ReceiveBlock(), a node is blocked during this time",
+	})
 	processAttsElapsedTime = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "process_attestations_milliseconds",

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -209,6 +209,7 @@ func (s *Service) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySig
 
 	timeWithoutDaWait := time.Since(receivedTime) - daWaitedTime
 	chainServiceProcessingTime.Observe(float64(timeWithoutDaWait.Milliseconds()))
+	dataAvabilityWaitedTime.Observe(float64(daWaitedTime.Milliseconds()))
 
 	return nil
 }


### PR DESCRIPTION
This PR introduces a valuable metric: data availability wait time. This metric measures the duration a node is blocked at `ReceiveBlock`, making it crucial to monitor.