### PR TITLE
Remove deprecated late reorg flag

### DIFF
--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -17,11 +17,6 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedEnableReorgLateBlocks = &cli.BoolFlag{
-		Name:   "enable-reorg-late-blocks",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
 	deprecatedDisableGossipBatchAggregation = &cli.BoolFlag{
 		Name:   "disable-gossip-batch-aggregation",
 		Usage:  deprecatedUsage,
@@ -84,7 +79,6 @@ var (
 var deprecatedFlags = []cli.Flag{
 	exampleDeprecatedFeatureFlag,
 	deprecatedDisableVecHTR,
-	deprecatedEnableReorgLateBlocks,
 	deprecatedDisableGossipBatchAggregation,
 	deprecatedBuildBlockParallel,
 	deprecatedEnableRegistrationCache,


### PR DESCRIPTION
This has been there for one major release. We can remove it now for the next release