### PR TITLE
Remove deprecated aggregate parallel flag

### DIFF
--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -28,11 +28,6 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedAggregateParallel = &cli.BoolFlag{
-		Name:   "aggregate-parallel",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
 	deprecatedEnableOptionalEngineMethods = &cli.BoolFlag{
 		Name:   "enable-optional-engine-methods",
 		Usage:  deprecatedUsage,
@@ -76,7 +71,6 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisableGossipBatchAggregation,
 	deprecatedBuildBlockParallel,
 	deprecatedEnableRegistrationCache,
-	deprecatedAggregateParallel,
 	deprecatedEnableOptionalEngineMethods,
 	deprecatedDisableBuildBlockParallel,
 	deprecatedDisableReorgLateBlocks,


### PR DESCRIPTION
This has been there for one major release. We can remove it now for the next release