### PR TITLE
set limit to multiple of burst for goerli

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -171,7 +171,7 @@ var (
 	BlobBatchLimit = &cli.IntFlag{
 		Name:  "blob-batch-limit",
 		Usage: "The amount of blobs the local peer is bounded to request and respond to in a batch.",
-		Value: 64,
+		Value: 16,
 	}
 	// BlobBatchLimitBurstFactor specifies the factor by which blob batch size may increase.
 	BlobBatchLimitBurstFactor = &cli.IntFlag{


### PR DESCRIPTION
Sets the blob rate limit 2x higher than currently deployed goerli nodes. This ramps up the speed of syncing without going over the rate limits of currently deployed nodes.