### PR TITLE
Separate block/blob rate limits

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -626,12 +626,12 @@ func TestBlocksFetcher_WaitForBandwidth(t *testing.T) {
 	vr := [32]byte{}
 	fetcher.chain = &mock.ChainService{Genesis: gt, ValidatorsRoot: vr}
 	start := time.Now()
-	assert.NoError(t, fetcher.waitForBandwidth(p2.PeerID(), 10))
+	assert.NoError(t, fetcher.waitForBandwidth(p2.PeerID(), 10, fetcher.rateLimiter))
 	dur := time.Since(start)
 	assert.Equal(t, true, dur < time.Millisecond, "waited excessively for bandwidth")
 	fetcher.rateLimiter.Add(p2.PeerID().String(), int64(req.Count*burstFactor))
 	start = time.Now()
-	assert.NoError(t, fetcher.waitForBandwidth(p2.PeerID(), req.Count))
+	assert.NoError(t, fetcher.waitForBandwidth(p2.PeerID(), req.Count, fetcher.rateLimiter))
 	dur = time.Since(start)
 	assert.Equal(t, float64(5), dur.Truncate(1*time.Second).Seconds(), "waited excessively for bandwidth")
 }

--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -43,8 +43,8 @@ func newRateLimiter(p2pProvider p2p.P2P) *limiter {
 	allowedBlocksBurst := int64(flags.Get().BlockBatchLimitBurstFactor * flags.Get().BlockBatchLimit)
 
 	// Initialize blob limits.
-	allowedBlobsPerSecond := float64(flags.Get().BlobBatchLimit)
-	allowedBlobsBurst := int64(flags.Get().BlobBatchLimitBurstFactor * flags.Get().BlobBatchLimit)
+	allowedBlobsPerSecond := float64(flags.Get().BlobServingBatchLimit)
+	allowedBlobsBurst := int64(flags.Get().BlobBatchLimitBurstFactor * flags.Get().BlobServingBatchLimit)
 
 	// Set topic map for all rpc topics.
 	topicMap := make(map[string]*leakybucket.Collector, len(p2p.RPCTopicMappings))

--- a/beacon-chain/sync/rpc_blob_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root.go
@@ -58,7 +58,7 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 	// Sort the identifiers so that requests for the same blob root will be adjacent, minimizing db lookups.
 	sort.Sort(blobIdents)
 
-	batchSize := flags.Get().BlobBatchLimit
+	batchSize := flags.Get().BlobServingBatchLimit
 	var ticker *time.Ticker
 	if len(blobIdents) > batchSize {
 		ticker = time.NewTicker(time.Second)

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -167,11 +167,16 @@ var (
 		Usage: "The factor by which block batch limit may increase on burst.",
 		Value: 2,
 	}
+	BlobServingBatchLimit = &cli.IntFlag{
+		Name:  "blob-batch-limit",
+		Usage: "Maximum number of blob slots for the server to allow in a batch.",
+		Value: 64,
+	}
 	// BlobBatchLimit specifies the requested blob batch size.
 	BlobBatchLimit = &cli.IntFlag{
 		Name:  "blob-batch-limit",
-		Usage: "The amount of blobs the local peer is bounded to request and respond to in a batch.",
-		Value: 64,
+		Usage: "Max number of blob slots to request in a batch.",
+		Value: 16,
 	}
 	// BlobBatchLimitBurstFactor specifies the factor by which blob batch size may increase.
 	BlobBatchLimitBurstFactor = &cli.IntFlag{

--- a/cmd/beacon-chain/flags/config.go
+++ b/cmd/beacon-chain/flags/config.go
@@ -14,6 +14,7 @@ type GlobalFlags struct {
 	BlockBatchLimit            int
 	BlockBatchLimitBurstFactor int
 	BlobBatchLimit             int
+	BlobServingBatchLimit      int
 	BlobBatchLimitBurstFactor  int
 }
 
@@ -43,6 +44,7 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg.BlockBatchLimit = ctx.Int(BlockBatchLimit.Name)
 	cfg.BlockBatchLimitBurstFactor = ctx.Int(BlockBatchLimitBurstFactor.Name)
 	cfg.BlobBatchLimit = ctx.Int(BlobBatchLimit.Name)
+	cfg.BlobServingBatchLimit = ctx.Int(BlobServingBatchLimit.Name)
 	cfg.BlobBatchLimitBurstFactor = ctx.Int(BlobBatchLimitBurstFactor.Name)
 	cfg.MinimumPeersPerSubnet = ctx.Int(MinPeersPerSubnet.Name)
 	configureMinimumPeers(ctx, cfg)

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -57,7 +57,7 @@ var appFlags = []cli.Flag{
 	flags.SetGCPercent,
 	flags.BlockBatchLimit,
 	flags.BlockBatchLimitBurstFactor,
-	flags.BlobBatchLimit,
+	flags.BlobServingBatchLimit,
 	flags.BlobBatchLimitBurstFactor,
 	flags.InteropMockEth1DataVotesFlag,
 	flags.InteropNumValidatorsFlag,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -114,6 +114,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.BlockBatchLimit,
 			flags.BlockBatchLimitBurstFactor,
 			flags.BlobBatchLimit,
+			flags.BlobServingBatchLimit,
 			flags.BlobBatchLimitBurstFactor,
 			flags.EnableDebugRPCEndpoints,
 			flags.SubscribeToAllSubnets,

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -269,6 +269,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 		fmt.Sprintf("--%s=%d", flags.BlockBatchLimitBurstFactor.Name, 8),
 		fmt.Sprintf("--%s=%d", flags.BlobBatchLimitBurstFactor.Name, 16),
 		fmt.Sprintf("--%s=%d", flags.BlobBatchLimit.Name, 256),
+		fmt.Sprintf("--%s=%d", flags.BlobServingBatchLimit.Name, 256),
 		fmt.Sprintf("--%s=%s", cmdshared.ChainConfigFileFlag.Name, cfgPath),
 		"--" + cmdshared.ValidatorMonitorIndicesFlag.Name + "=1",
 		"--" + cmdshared.ValidatorMonitorIndicesFlag.Name + "=2",


### PR DESCRIPTION
We need to be able to separately tune serving and requesting blob rate limits to deal with a situation where servers are currently tuned lower than requesters need to be. Separating these 2 parameters into flags allows us to tune up the serving side before tuning up the requesting side.

This PR also changes blob requests to use their own rate limiter instead of doubling up on the block rate limiter.