### PR TITLE
Revert "set limit to multiple of burst for goerli"

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -171,7 +171,7 @@ var (
 	BlobBatchLimit = &cli.IntFlag{
 		Name:  "blob-batch-limit",
 		Usage: "The amount of blobs the local peer is bounded to request and respond to in a batch.",
-		Value: 16,
+		Value: 64,
 	}
 	// BlobBatchLimitBurstFactor specifies the factor by which blob batch size may increase.
 	BlobBatchLimitBurstFactor = &cli.IntFlag{


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#13544

Discussed offline that the original change does not solve a problem we detected in testnets. 