### PR TITLE
Revert "set limit to multiple of burst for goerli (#13544)"

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -171,7 +171,7 @@ var (
 	BlobBatchLimit = &cli.IntFlag{
 		Name:  "blob-batch-limit",
 		Usage: "The amount of blobs the local peer is bounded to request and respond to in a batch.",
-		Value: 16,
+		Value: 64,
 	}
 	// BlobBatchLimitBurstFactor specifies the factor by which blob batch size may increase.
 	BlobBatchLimitBurstFactor = &cli.IntFlag{


### PR DESCRIPTION
This reverts commit 373c853d17300a0a96e3ceca0ebb77683b6ebc1f.

setting the limit to a value lower than the block batch size does not work because the request code doesn't know how to deal with it.