### PR TITLE
only update head at 10 seconds when validating

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -571,3 +571,9 @@ func (s *Service) inRegularSync() bool {
 	}
 	return fc.HighestReceivedBlockDelay() < params.BeaconConfig().SlotsPerEpoch
 }
+
+// validating returns true if the beacon is tracking some validators that have
+// registered for proposing.
+func (s *Service) validating() bool {
+	return s.cfg.TrackedValidatorsCache.Validating()
+}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -95,7 +95,9 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 				return
 			case slotInterval := <-ticker.C():
 				if slotInterval.Interval > 0 {
-					s.UpdateHead(s.ctx, slotInterval.Slot+1)
+					if s.validating() {
+						s.UpdateHead(s.ctx, slotInterval.Slot+1)
+					}
 				} else {
 					s.cfg.ForkChoiceStore.Lock()
 					if err := s.cfg.ForkChoiceStore.NewSlot(s.ctx, slotInterval.Slot); err != nil {

--- a/beacon-chain/cache/tracked_validators.go
+++ b/beacon-chain/cache/tracked_validators.go
@@ -41,3 +41,9 @@ func (t *TrackedValidatorsCache) Prune() {
 	defer t.Unlock()
 	t.trackedValidators = make(map[primitives.ValidatorIndex]TrackedValidator)
 }
+
+func (t *TrackedValidatorsCache) Validating() bool {
+	t.Lock()
+	defer t.Unlock()
+	return len(t.trackedValidators) > 0
+}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -2703,8 +2703,10 @@ func TestProposer_PrepareBeaconProposer(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			require.Equal(t, false, proposerServer.TrackedValidatorsCache.Validating())
 			val, tracked := proposerServer.TrackedValidatorsCache.Validator(1)
 			require.Equal(t, true, tracked)
+			require.Equal(t, true, proposerServer.TrackedValidatorsCache.Validating())
 			require.Equal(t, primitives.ExecutionAddress(tt.args.request.Recipients[0].FeeRecipient), val.FeeRecipient)
 
 		})


### PR DESCRIPTION
Do not call to update head at 10 seconds if the beacon is not serving validators. 