### PR TITLE
Revise blob sidecar not found log

### DIFF
--- a/beacon-chain/sync/rpc_blob_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v4/monitoring/tracing"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
 
@@ -80,7 +82,10 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 		sc, err := s.cfg.blobStorage.Get(root, idx)
 		if err != nil {
 			if db.IsNotFound(err) {
-				log.WithError(err).Debugf("Peer requested blob sidecar by root which was not found in db, root=%x, index=%d", root, idx)
+				log.WithError(err).WithFields(logrus.Fields{
+					"root":  fmt.Sprintf("%#x", root),
+					"index": idx,
+				}).Debugf("Peer requested blob sidecar by root not found in db")
 				continue
 			}
 			log.WithError(err).Errorf("unexpected db error retrieving BlobSidecar, root=%x, index=%d", root, idx)

--- a/beacon-chain/sync/rpc_blob_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root.go
@@ -80,7 +80,7 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 		sc, err := s.cfg.blobStorage.Get(root, idx)
 		if err != nil {
 			if db.IsNotFound(err) {
-				log.WithError(err).Debugf("BlobSidecar not found in db, root=%x, index=%d", root, idx)
+				log.WithError(err).Debugf("Peer requested blob sidecar by root which was not found in db, root=%x, index=%d", root, idx)
 				continue
 			}
 			log.WithError(err).Errorf("unexpected db error retrieving BlobSidecar, root=%x, index=%d", root, idx)


### PR DESCRIPTION
Revised log messaging to clarify scenarios where a node, despite having the blob sidecar locally, encounters an error serving it to a peer due to the sidecar not being found in the database