### PR TITLE
Change init sync heursitics

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -569,7 +569,7 @@ func (s *Service) inRegularSync() bool {
 		return true
 	}
 	// If the highest received block is less than 2 blocks away we are in regular sync
-	if currentSlot-fc.HighestReceivedBlockSlot() < primitives.Slot(2) {
+	if currentSlot-highestSlot < primitives.Slot(2) {
 		return true
 	}
 	// At this stage the last block received is from the previous epoch and more than 2 blocks ago.

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -609,7 +609,7 @@ func TestService_inRegularSync(t *testing.T) {
 	require.NoError(t, c.cfg.ForkChoiceStore.InsertNode(ctx, st, blkRoot))
 	require.Equal(t, false, c.inRegularSync())
 
-	c.SetGenesisTime(time.Now().Add(time.Second * time.Duration(-5*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot))))
+	c.SetGenesisTime(time.Now().Add(time.Second * time.Duration(-4*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot))))
 	require.Equal(t, true, c.inRegularSync())
 
 	c.SetGenesisTime(time.Now().Add(time.Second * time.Duration(-1*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot))))


### PR DESCRIPTION
Declare that we are in init sync if everything in this list happens

1) The last synced block is from an epoch prior to the current epoch
2) The last synced block is from at least 3 slots before the current one
3) The last synceed block arrived at least 2 slots after its time to sync. 

cc @nisdas : if we had a way to check this on e2e it would be awesome