### PR TITLE
Get the right head state when proposing a failed reorg

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -2875,7 +2875,7 @@ func TestProposer_GetParentHeadState(t *testing.T) {
 		StateGen:          stategen.New(db, doublylinkedtree.New()),
 	}
 	t.Run("failed reorg", func(tt *testing.T) {
-		head, err := proposerServer.getParentHeadState(ctx, 1, parentRoot, headRoot)
+		head, err := proposerServer.getParentStateFromReorgData(ctx, 1, parentRoot, headRoot)
 		require.NoError(t, err)
 		st := parentState.Copy()
 		st, err = transition.ProcessSlots(ctx, st, st.Slot()+1)
@@ -2892,7 +2892,7 @@ func TestProposer_GetParentHeadState(t *testing.T) {
 
 	t.Run("no reorg", func(tt *testing.T) {
 		require.NoError(t, transition.UpdateNextSlotCache(ctx, headRoot[:], headState))
-		head, err := proposerServer.getParentHeadState(ctx, 1, headRoot, headRoot)
+		head, err := proposerServer.getParentStateFromReorgData(ctx, 1, headRoot, headRoot)
 		require.NoError(t, err)
 		st := headState.Copy()
 		st, err = transition.ProcessSlots(ctx, st, st.Slot()+1)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -2859,3 +2859,51 @@ func TestProposer_GetFeeRecipientByPubKey(t *testing.T) {
 
 	require.Equal(t, common.HexToAddress("0x055Fb65722E7b2455012BFEBf6177F1D2e9728D8").Hex(), common.BytesToAddress(resp.FeeRecipient).Hex())
 }
+
+func TestProposer_GetParentHeadState(t *testing.T) {
+	db := dbutil.SetupDB(t)
+	ctx := context.Background()
+
+	parentState, parentRoot, _ := util.DeterministicGenesisStateWithGenesisBlock(t, ctx, db, 100)
+	headState, headRoot, _ := util.DeterministicGenesisStateWithGenesisBlock(t, ctx, db, 50)
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, parentRoot[:], parentState))
+
+	proposerServer := &Server{
+		ChainStartFetcher: &mockExecution.Chain{},
+		Eth1InfoFetcher:   &mockExecution.Chain{},
+		Eth1BlockFetcher:  &mockExecution.Chain{},
+		StateGen:          stategen.New(db, doublylinkedtree.New()),
+	}
+	t.Run("failed reorg", func(tt *testing.T) {
+		head, err := proposerServer.getParentHeadState(ctx, 1, parentRoot, headRoot)
+		require.NoError(t, err)
+		st := parentState.Copy()
+		st, err = transition.ProcessSlots(ctx, st, st.Slot()+1)
+		require.NoError(t, err)
+		str, err := st.StateRootAtIndex(0)
+		require.NoError(t, err)
+		headStr, err := head.StateRootAtIndex(0)
+		require.NoError(t, err)
+		genesisStr, err := headState.StateRootAtIndex(0)
+		require.NoError(t, err)
+		require.Equal(t, [32]byte(str), [32]byte(headStr))
+		require.NotEqual(t, [32]byte(str), [32]byte(genesisStr))
+	})
+
+	t.Run("no reorg", func(tt *testing.T) {
+		require.NoError(t, transition.UpdateNextSlotCache(ctx, headRoot[:], headState))
+		head, err := proposerServer.getParentHeadState(ctx, 1, headRoot, headRoot)
+		require.NoError(t, err)
+		st := headState.Copy()
+		st, err = transition.ProcessSlots(ctx, st, st.Slot()+1)
+		require.NoError(t, err)
+		str, err := st.StateRootAtIndex(0)
+		require.NoError(t, err)
+		headStr, err := head.StateRootAtIndex(0)
+		require.NoError(t, err)
+		genesisStr, err := parentState.StateRootAtIndex(0)
+		require.NoError(t, err)
+		require.Equal(t, [32]byte(str), [32]byte(headStr))
+		require.NotEqual(t, [32]byte(str), [32]byte(genesisStr))
+	})
+}


### PR DESCRIPTION
This fixes the following bug:

The node is about to propose block N+1. It syncs block N, based on N-1, and is late, the node head remains being N-1 and will attempt a reorg. If at the beginning of the slot N+1 the node N has shown to be strong, the node relents and starts building a local payload immediately on top of N. 

The node obtains the blockroot of N from forkchoice and requests the corresponding state advanced to N+1. 
If the node **also** has a cache miss (in the NSC) then the node will advance the **head** state to N+1. Here's the bug since this would produce the state based from N-1, instead of N as we want. 

cc @nisdas 