### PR TITLE
Beacon API: get blob fix retention cases

### DIFF
--- a/beacon-chain/rpc/eth/blob/BUILD.bazel
+++ b/beacon-chain/rpc/eth/blob/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//beacon-chain/db/filesystem:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/rpc/lookup:go_default_library",
+        "//beacon-chain/rpc/testutil:go_default_library",
         "//beacon-chain/verification:go_default_library",
         "//config/params:go_default_library",
         "//network/httputil:go_default_library",

--- a/beacon-chain/rpc/eth/blob/handlers_test.go
+++ b/beacon-chain/rpc/eth/blob/handlers_test.go
@@ -261,7 +261,7 @@ func TestBlobs(t *testing.T) {
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
 		require.Equal(t, len(resp.Data), 0)
 	})
-	t.Run("outside retention period returns 200 w/empty list ", func(t *testing.T) {
+	t.Run("outside retention period returns 200 w/ empty list ", func(t *testing.T) {
 		u := "http://foo.example/123"
 		request := httptest.NewRequest("GET", u, nil)
 		writer := httptest.NewRecorder()

--- a/beacon-chain/rpc/eth/blob/handlers_test.go
+++ b/beacon-chain/rpc/eth/blob/handlers_test.go
@@ -269,7 +269,7 @@ func TestBlobs(t *testing.T) {
 		moc := &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}}
 		blocker := &lookup.BeaconDbBlocker{
 			ChainInfoFetcher:   moc,
-			GenesisTimeFetcher: moc, // max slot
+			GenesisTimeFetcher: moc, // genesis time is set to 0 here, so it results in current epoch being extremely large
 			BeaconDB:           db,
 			BlobStorage:        bs,
 		}

--- a/beacon-chain/rpc/eth/blob/handlers_test.go
+++ b/beacon-chain/rpc/eth/blob/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/prysmaticlabs/prysm/v4/api/server/structs"
@@ -16,6 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db/filesystem"
 	testDB "github.com/prysmaticlabs/prysm/v4/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/lookup"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/testutil"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/verification"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/network/httputil"
@@ -71,8 +73,11 @@ func TestBlobs(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{Root: blockRoot[:]},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 		s := &Server{
 			Blocker: blocker,
@@ -116,8 +121,11 @@ func TestBlobs(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 		s := &Server{
 			Blocker: blocker,
@@ -137,8 +145,11 @@ func TestBlobs(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{CurrentJustifiedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 		s := &Server{
 			Blocker: blocker,
@@ -157,7 +168,10 @@ func TestBlobs(t *testing.T) {
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
-			BeaconDB:    db,
+			BeaconDB: db,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
 			BlobStorage: bs,
 		}
 		s := &Server{
@@ -177,7 +191,10 @@ func TestBlobs(t *testing.T) {
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
-			BeaconDB:    db,
+			BeaconDB: db,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
 			BlobStorage: bs,
 		}
 		s := &Server{
@@ -198,8 +215,11 @@ func TestBlobs(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 		s := &Server{
 			Blocker: blocker,
@@ -225,8 +245,11 @@ func TestBlobs(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      filesystem.NewEphemeralBlobStorage(t), // new ephemeral storage
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: filesystem.NewEphemeralBlobStorage(t), // new ephemeral storage
 		}
 		s := &Server{
 			Blocker: blocker,
@@ -237,6 +260,81 @@ func TestBlobs(t *testing.T) {
 		resp := &structs.SidecarsResponse{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
 		require.Equal(t, len(resp.Data), 0)
+	})
+	t.Run("outside retention period returns 200 w/empty list ", func(t *testing.T) {
+		u := "http://foo.example/123"
+		request := httptest.NewRequest("GET", u, nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		moc := &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}}
+		blocker := &lookup.BeaconDbBlocker{
+			ChainInfoFetcher:   moc,
+			GenesisTimeFetcher: moc, // max slot
+			BeaconDB:           db,
+			BlobStorage:        bs,
+		}
+		s := &Server{
+			Blocker: blocker,
+		}
+
+		s.Blobs(writer, request)
+
+		assert.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.SidecarsResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		require.Equal(t, 0, len(resp.Data))
+	})
+	t.Run("outside retention period returns 200 w/empty list ", func(t *testing.T) {
+		u := "http://foo.example/123"
+		request := httptest.NewRequest("GET", u, nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		moc := &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}}
+		blocker := &lookup.BeaconDbBlocker{
+			ChainInfoFetcher:   moc,
+			GenesisTimeFetcher: moc, // max slot
+			BeaconDB:           db,
+			BlobStorage:        bs,
+		}
+		s := &Server{
+			Blocker: blocker,
+		}
+
+		s.Blobs(writer, request)
+
+		assert.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.SidecarsResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		require.Equal(t, 0, len(resp.Data))
+	})
+	t.Run("block without commitments returns 200 w/empty list ", func(t *testing.T) {
+		denebBlock, _ := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 333, 0)
+		commitments, err := denebBlock.Block().Body().BlobKzgCommitments()
+		require.NoError(t, err)
+		require.Equal(t, len(commitments), 0)
+		require.NoError(t, db.SaveBlock(context.Background(), denebBlock))
+
+		u := "http://foo.example/333"
+		request := httptest.NewRequest("GET", u, nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		moc := &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}}
+		blocker := &lookup.BeaconDbBlocker{
+			ChainInfoFetcher:   moc,
+			GenesisTimeFetcher: moc, // max slot
+			BeaconDB:           db,
+			BlobStorage:        bs,
+		}
+		s := &Server{
+			Blocker: blocker,
+		}
+
+		s.Blobs(writer, request)
+
+		assert.Equal(t, http.StatusOK, writer.Code)
+		resp := &structs.SidecarsResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		require.Equal(t, 0, len(resp.Data))
 	})
 	t.Run("slot before Deneb fork", func(t *testing.T) {
 		u := "http://foo.example/31"
@@ -282,8 +380,11 @@ func TestBlobs(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		blocker := &lookup.BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &eth.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 		s := &Server{
 			Blocker: blocker,

--- a/beacon-chain/rpc/lookup/blocker_test.go
+++ b/beacon-chain/rpc/lookup/blocker_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	mockChain "github.com/prysmaticlabs/prysm/v4/beacon-chain/blockchain/testing"
@@ -180,8 +181,11 @@ func TestGetBlob(t *testing.T) {
 	t.Run("head", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{Root: blockRoot[:]},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "head", nil)
 		assert.Equal(t, rpcErr == nil, true)
@@ -214,8 +218,11 @@ func TestGetBlob(t *testing.T) {
 	t.Run("finalized", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 
 		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "finalized", nil)
@@ -225,8 +232,11 @@ func TestGetBlob(t *testing.T) {
 	t.Run("justified", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{CurrentJustifiedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 
 		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "justified", nil)
@@ -235,6 +245,9 @@ func TestGetBlob(t *testing.T) {
 	})
 	t.Run("root", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
 			BeaconDB:    db,
 			BlobStorage: bs,
 		}
@@ -244,6 +257,9 @@ func TestGetBlob(t *testing.T) {
 	})
 	t.Run("slot", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
 			BeaconDB:    db,
 			BlobStorage: bs,
 		}
@@ -254,8 +270,11 @@ func TestGetBlob(t *testing.T) {
 	t.Run("one blob only", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      bs,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
 		}
 		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "123", []uint64{2})
 		assert.Equal(t, rpcErr == nil, true)
@@ -270,8 +289,11 @@ func TestGetBlob(t *testing.T) {
 	t.Run("no blobs returns an empty array", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
-			BeaconDB:         db,
-			BlobStorage:      filesystem.NewEphemeralBlobStorage(t),
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: filesystem.NewEphemeralBlobStorage(t),
 		}
 		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "123", nil)
 		assert.Equal(t, rpcErr == nil, true)

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -335,9 +335,10 @@ func (s *Service) Start() {
 		ReplayerBuilder:    ch,
 	}
 	blocker := &lookup.BeaconDbBlocker{
-		BeaconDB:         s.cfg.BeaconDB,
-		ChainInfoFetcher: s.cfg.ChainInfoFetcher,
-		BlobStorage:      s.cfg.BlobStorage,
+		BeaconDB:           s.cfg.BeaconDB,
+		ChainInfoFetcher:   s.cfg.ChainInfoFetcher,
+		GenesisTimeFetcher: s.cfg.GenesisTimeFetcher,
+		BlobStorage:        s.cfg.BlobStorage,
 	}
 	rewardFetcher := &rewards.BlockRewardService{Replayer: ch}
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

fixes the [/eth/v1/beacon/blob_sidecars/{block_id}](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobSidecars) endpoint to handl the additional cases below correctly without a 500 error. currently, we will try to use the root even if the block doesn't exist which doesn't correctly handle all our cases.

- block exists, no commitment, 200 w/ empty list

- block exists, has commitments, inside retention period (greater of protocol- or user-specified) serve then w/ 200 unless we hit an error reading them. we are technically not supposed to import a block to forkchoice unless we have the blobs, so the nuance here is if we can't find the file and we are inside the protocol-defined retention period, then it's actually a 500.


**Which issues(s) does this PR fix?**

related to https://github.com/prysmaticlabs/prysm/issues/13134
