### PR TITLE
Slasher: Fixes double votes false positive and attester slashings duplication.

### DIFF
--- a/beacon-chain/db/slasherkv/slasher.go
+++ b/beacon-chain/db/slasherkv/slasher.go
@@ -189,10 +189,10 @@ func (s *Store) CheckAttesterDoubleVotes(
 
 					// Build the proof of double vote.
 					slashAtt := &slashertypes.AttesterDoubleVote{
-						ValidatorIndex:         primitives.ValidatorIndex(valIdx),
-						Target:                 attToProcess.IndexedAttestation.Data.Target.Epoch,
-						PrevAttestationWrapper: existingAttRecord,
-						AttestationWrapper:     attToProcess,
+						ValidatorIndex: primitives.ValidatorIndex(valIdx),
+						Target:         attToProcess.IndexedAttestation.Data.Target.Epoch,
+						Wrapper_1:      existingAttRecord,
+						Wrapper_2:      attToProcess,
 					}
 
 					localDoubleVotes = append(localDoubleVotes, slashAtt)

--- a/beacon-chain/db/slasherkv/slasher_test.go
+++ b/beacon-chain/db/slasherkv/slasher_test.go
@@ -93,28 +93,28 @@ func TestStore_CheckAttesterDoubleVotes(t *testing.T) {
 
 	wanted := []*slashertypes.AttesterDoubleVote{
 		{
-			ValidatorIndex:         0,
-			Target:                 3,
-			PrevAttestationWrapper: createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{1}),
-			AttestationWrapper:     createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{2}),
+			ValidatorIndex: 0,
+			Target:         3,
+			Wrapper_1:      createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{1}),
+			Wrapper_2:      createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{2}),
 		},
 		{
-			ValidatorIndex:         1,
-			Target:                 3,
-			PrevAttestationWrapper: createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{1}),
-			AttestationWrapper:     createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{2}),
+			ValidatorIndex: 1,
+			Target:         3,
+			Wrapper_1:      createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{1}),
+			Wrapper_2:      createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{2}),
 		},
 		{
-			ValidatorIndex:         2,
-			Target:                 4,
-			PrevAttestationWrapper: createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{3}),
-			AttestationWrapper:     createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{4}),
+			ValidatorIndex: 2,
+			Target:         4,
+			Wrapper_1:      createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{3}),
+			Wrapper_2:      createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{4}),
 		},
 		{
-			ValidatorIndex:         3,
-			Target:                 4,
-			PrevAttestationWrapper: createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{3}),
-			AttestationWrapper:     createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{4}),
+			ValidatorIndex: 3,
+			Target:         4,
+			Wrapper_1:      createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{3}),
+			Wrapper_2:      createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{4}),
 		},
 	}
 	doubleVotes, err := beaconDB.CheckAttesterDoubleVotes(ctx, slashableAtts)
@@ -126,8 +126,8 @@ func TestStore_CheckAttesterDoubleVotes(t *testing.T) {
 	for i, double := range doubleVotes {
 		require.DeepEqual(t, wanted[i].ValidatorIndex, double.ValidatorIndex)
 		require.DeepEqual(t, wanted[i].Target, double.Target)
-		require.DeepEqual(t, wanted[i].PrevAttestationWrapper, double.PrevAttestationWrapper)
-		require.DeepEqual(t, wanted[i].AttestationWrapper, double.AttestationWrapper)
+		require.DeepEqual(t, wanted[i].Wrapper_1, double.Wrapper_1)
+		require.DeepEqual(t, wanted[i].Wrapper_2, double.Wrapper_2)
 	}
 }
 

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -166,8 +166,8 @@ func (s *Service) checkDoubleVotes(
 	for _, doubleVote := range doubleVotes {
 		doubleVotesTotal.Inc()
 
-		wrapper_1 := doubleVote.PrevAttestationWrapper
-		wrapper_2 := doubleVote.AttestationWrapper
+		wrapper_1 := doubleVote.Wrapper_1
+		wrapper_2 := doubleVote.Wrapper_2
 
 		slashing := &ethpb.AttesterSlashing{
 			Attestation_1: wrapper_1.IndexedAttestation,

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -69,31 +69,30 @@ func Test_processAttestations(t *testing.T) {
 				},
 			},
 		},
-		// Uncomment when https://github.com/prysmaticlabs/prysm/issues/13590 is fixed
-		// {
-		// 	name: "Same target with different signing roots - two steps",
-		// 	steps: []*step{
-		// 		{
-		// 			currentEpoch: 4,
-		// 			attestationsInfo: []*attestationInfo{
-		// 				{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
-		// 			},
-		// 			expectedSlashingsInfo: nil,
-		// 		},
-		// 		{
-		// 			currentEpoch: 4,
-		// 			attestationsInfo: []*attestationInfo{
-		// 				{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
-		// 			},
-		// 			expectedSlashingsInfo: []*slashingInfo{
-		// 				{
-		// 					attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
-		// 					attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		{
+			name: "Same target with different signing roots - two steps",
+			steps: []*step{
+				{
+					currentEpoch: 4,
+					attestationsInfo: []*attestationInfo{
+						{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
+					},
+					expectedSlashingsInfo: nil,
+				},
+				{
+					currentEpoch: 4,
+					attestationsInfo: []*attestationInfo{
+						{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
+					},
+					expectedSlashingsInfo: []*slashingInfo{
+						{
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
+							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
+						},
+					},
+				},
+			},
+		},
 		{
 			name: "Same target with same signing roots - single step",
 			steps: []*step{
@@ -273,31 +272,30 @@ func Test_processAttestations(t *testing.T) {
 				},
 			},
 		},
-		// Uncomment when https://github.com/prysmaticlabs/prysm/issues/13590 is fixed
-		// {
-		// 	name: "Detects double vote, (source 1, target 2), (source 0, target 2) - two steps",
-		// 	steps: []*step{
-		// 		{
-		// 			currentEpoch: 4,
-		// 			attestationsInfo: []*attestationInfo{
-		// 				{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 			},
-		// 			expectedSlashingsInfo: nil,
-		// 		},
-		// 		{
-		// 			currentEpoch: 4,
-		// 			attestationsInfo: []*attestationInfo{
-		// 				{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 			},
-		// 			expectedSlashingsInfo: []*slashingInfo{
-		// 				{
-		// 					attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 					attestationInfo_2: &attestationInfo{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		{
+			name: "Detects double vote, (source 1, target 2), (source 0, target 2) - two steps",
+			steps: []*step{
+				{
+					currentEpoch: 4,
+					attestationsInfo: []*attestationInfo{
+						{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+					},
+					expectedSlashingsInfo: nil,
+				},
+				{
+					currentEpoch: 4,
+					attestationsInfo: []*attestationInfo{
+						{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+					},
+					expectedSlashingsInfo: []*slashingInfo{
+						{
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+						},
+					},
+				},
+			},
+		},
 		{
 			name: "Not slashable, surrounding but non-overlapping attesting indices within same validator chunk index - single step",
 			steps: []*step{

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -144,20 +144,20 @@ func Test_processAttestations(t *testing.T) {
 					},
 					expectedSlashingsInfo: []*slashingInfo{
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 					},
 				},
@@ -180,20 +180,20 @@ func Test_processAttestations(t *testing.T) {
 					},
 					expectedSlashingsInfo: []*slashingInfo{
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 					},
 				},
@@ -258,12 +258,12 @@ func Test_processAttestations(t *testing.T) {
 					},
 					expectedSlashingsInfo: []*slashingInfo{
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
+							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
 					},
 				},

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -299,57 +299,6 @@ func Test_processAttestations(t *testing.T) {
 		// 	},
 		// },
 		{
-			name: "Detects surrounded vote (source 0, target 3), (source 1, target 2) - single step",
-			steps: []*step{
-				{
-					currentEpoch: 4,
-					attestationsInfo: []*attestationInfo{
-						{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-					},
-					expectedSlashingsInfo: []*slashingInfo{
-						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
-						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
-					},
-				},
-			},
-		},
-		// Uncomment when https://github.com/prysmaticlabs/prysm/issues/13591 is fixed
-		// {
-		// 	name: "Detects surrounded vote (source 0, target 3), (source 1, target 2) - two steps",
-		// 	steps: []*step{
-		// 		{
-		// 			currentEpoch: 4,
-		// 			attestationsInfo: []*attestationInfo{
-		// 				{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 			},
-		// 			expectedSlashingsInfo: nil,
-		// 		},
-		// 		{
-		// 			currentEpoch: 4,
-		// 			attestationsInfo: []*attestationInfo{
-		// 				{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 			},
-		// 			expectedSlashingsInfo: []*slashingInfo{
-		// 				{
-		// 					attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 					attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 				},
-		// 				{
-		// 					attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 					attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		{
 			name: "Detects double vote, (source 1, target 2), (source 0, target 2) - single step",
 			steps: []*step{
 				{

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -12,6 +12,7 @@ import (
 	slashingsmock "github.com/prysmaticlabs/prysm/v4/beacon-chain/operations/slashings/mock"
 	slashertypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/startup"
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/crypto/bls"
@@ -64,10 +65,6 @@ func Test_processAttestations(t *testing.T) {
 							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
 							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
 						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
-							attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
-						},
 					},
 				},
 			},
@@ -89,10 +86,6 @@ func Test_processAttestations(t *testing.T) {
 		// 				{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
 		// 			},
 		// 			expectedSlashingsInfo: []*slashingInfo{
-		// 				{
-		// 					attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
-		// 					attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
-		// 				},
 		// 				{
 		// 					attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{1}},
 		// 					attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: []byte{2}},
@@ -147,18 +140,6 @@ func Test_processAttestations(t *testing.T) {
 							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
 					},
 				},
 			},
@@ -183,18 +164,6 @@ func Test_processAttestations(t *testing.T) {
 							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
 					},
 				},
 			},
@@ -210,10 +179,6 @@ func Test_processAttestations(t *testing.T) {
 						{source: 0, target: 1000, indices: []uint64{0}, beaconBlockRoot: nil},
 					},
 					expectedSlashingsInfo: []*slashingInfo{
-						{
-							attestationInfo_1: &attestationInfo{source: 0, target: 1000, indices: []uint64{0}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 50, target: 51, indices: []uint64{0}, beaconBlockRoot: nil},
-						},
 						{
 							attestationInfo_1: &attestationInfo{source: 0, target: 1000, indices: []uint64{0}, beaconBlockRoot: nil},
 							attestationInfo_2: &attestationInfo{source: 50, target: 51, indices: []uint64{0}, beaconBlockRoot: nil},
@@ -261,10 +226,6 @@ func Test_processAttestations(t *testing.T) {
 							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 						},
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
 					},
 				},
 			},
@@ -290,10 +251,6 @@ func Test_processAttestations(t *testing.T) {
 		// 					attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 		// 					attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 		// 				},
-		// 				{
-		// 					attestationInfo_1: &attestationInfo{source: 0, target: 3, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 					attestationInfo_2: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 				},
 		// 			},
 		// 		},
 		// 	},
@@ -308,10 +265,6 @@ func Test_processAttestations(t *testing.T) {
 						{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 					},
 					expectedSlashingsInfo: []*slashingInfo{
-						{
-							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-							attestationInfo_2: &attestationInfo{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-						},
 						{
 							attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 							attestationInfo_2: &attestationInfo{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
@@ -337,10 +290,6 @@ func Test_processAttestations(t *testing.T) {
 		// 				{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 		// 			},
 		// 			expectedSlashingsInfo: []*slashingInfo{
-		// 				{
-		// 					attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 					attestationInfo_2: &attestationInfo{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
-		// 				},
 		// 				{
 		// 					attestationInfo_1: &attestationInfo{source: 1, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
 		// 					attestationInfo_2: &attestationInfo{source: 0, target: 2, indices: []uint64{0, 1}, beaconBlockRoot: nil},
@@ -697,10 +646,11 @@ func Test_processAttestations(t *testing.T) {
 				}
 
 				// Build expected attester slashings.
-				expectedSlashings := make([]*ethpb.AttesterSlashing, 0, len(step.expectedSlashingsInfo))
+				expectedSlashings := make(map[[fieldparams.RootLength]byte]*ethpb.AttesterSlashing, len(step.expectedSlashingsInfo))
+
 				for _, slashingInfo := range step.expectedSlashingsInfo {
 					// Create attestations.
-					attestation_1 := createAttestationWrapper(
+					wrapper_1 := createAttestationWrapper(
 						t,
 						domain,
 						privateKeys,
@@ -710,7 +660,7 @@ func Test_processAttestations(t *testing.T) {
 						slashingInfo.attestationInfo_1.beaconBlockRoot,
 					)
 
-					attestation_2 := createAttestationWrapper(
+					wrapper_2 := createAttestationWrapper(
 						t,
 						domain,
 						privateKeys,
@@ -721,13 +671,16 @@ func Test_processAttestations(t *testing.T) {
 					)
 
 					// Create the attester slashing.
-					attesterSlashing := &ethpb.AttesterSlashing{
-						Attestation_1: attestation_1.IndexedAttestation,
-						Attestation_2: attestation_2.IndexedAttestation,
+					expectedSlashing := &ethpb.AttesterSlashing{
+						Attestation_1: wrapper_1.IndexedAttestation,
+						Attestation_2: wrapper_2.IndexedAttestation,
 					}
 
-					// Add the attester slashing to the list.
-					expectedSlashings = append(expectedSlashings, attesterSlashing)
+					root, err := expectedSlashing.HashTreeRoot()
+					require.NoError(t, err, "failed to hash tree root")
+
+					// Add the attester slashing to the map.
+					expectedSlashings[root] = expectedSlashing
 				}
 
 				// Get the currentSlot for the current epoch.
@@ -738,7 +691,18 @@ func Test_processAttestations(t *testing.T) {
 				processedSlashings := slasherService.processAttestations(ctx, attestationWrappers, currentSlot)
 
 				// Check the processed slashings correspond to the expected slashings.
-				assert.DeepSSZEqual(t, expectedSlashings, processedSlashings)
+				require.Equal(t, len(expectedSlashings), len(processedSlashings), "processed slashings count not equal to expected")
+
+				for root := range expectedSlashings {
+					// Check the expected slashing is in the processed slashings.
+					processedSlashing, ok := processedSlashings[root]
+					require.Equal(t, true, ok, "processed slashing not found")
+
+					// Check the root matches
+					controlRoot, err := processedSlashing.HashTreeRoot()
+					require.NoError(t, err, "failed to hash tree root")
+					require.Equal(t, root, controlRoot, "root not equal")
+				}
 			}
 		})
 	}
@@ -1060,49 +1024,6 @@ func Test_applyAttestationForValidator_MaxSpanChunk(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, slashing)
-}
-
-func Test_checkDoubleVotes_SlashableAttestationsOnDisk(t *testing.T) {
-	slasherDB := dbtest.SetupSlasherDB(t)
-	ctx := context.Background()
-	// For a list of input attestations, check that we can
-	// indeed check there could exist a double vote offense
-	// within the list with respect to previous entries in the db.
-	prevAtts := []*slashertypes.IndexedAttestationWrapper{
-		createAttestationWrapperEmptySig(t, 0, 1, []uint64{1, 2}, []byte{1}),
-		createAttestationWrapperEmptySig(t, 0, 2, []uint64{1, 2}, []byte{1}),
-	}
-	srv, err := New(context.Background(),
-		&ServiceConfig{
-			Database:      slasherDB,
-			StateNotifier: &mock.MockStateNotifier{},
-			ClockWaiter:   startup.NewClockSynchronizer(),
-		})
-	require.NoError(t, err)
-
-	err = slasherDB.SaveAttestationRecordsForValidators(ctx, prevAtts)
-	require.NoError(t, err)
-
-	prev1 := createAttestationWrapperEmptySig(t, 0, 2, []uint64{1, 2}, []byte{1})
-	cur1 := createAttestationWrapperEmptySig(t, 0, 2, []uint64{1, 2}, []byte{2})
-	prev2 := createAttestationWrapperEmptySig(t, 0, 2, []uint64{1, 2}, []byte{1})
-	cur2 := createAttestationWrapperEmptySig(t, 0, 2, []uint64{1, 2}, []byte{2})
-	wanted := []*ethpb.AttesterSlashing{
-		{
-			Attestation_1: prev1.IndexedAttestation,
-			Attestation_2: cur1.IndexedAttestation,
-		},
-		{
-			Attestation_1: prev2.IndexedAttestation,
-			Attestation_2: cur2.IndexedAttestation,
-		},
-	}
-	newAtts := []*slashertypes.IndexedAttestationWrapper{
-		createAttestationWrapperEmptySig(t, 0, 2, []uint64{1, 2}, []byte{2}), // Different signing root.
-	}
-	slashings, err := srv.checkDoubleVotes(ctx, newAtts)
-	require.NoError(t, err)
-	require.DeepEqual(t, wanted, slashings)
 }
 
 func Test_loadChunks_MinSpans(t *testing.T) {

--- a/beacon-chain/slasher/process_slashings_test.go
+++ b/beacon-chain/slasher/process_slashings_test.go
@@ -10,6 +10,7 @@ import (
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/doubly-linked-tree"
 	slashingsmock "github.com/prysmaticlabs/prysm/v4/beacon-chain/operations/slashings/mock"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
@@ -75,11 +76,16 @@ func TestService_processAttesterSlashings(t *testing.T) {
 		firstAtt.Signature = signature.Marshal()
 		secondAtt.Signature = make([]byte, 96)
 
-		slashings := []*ethpb.AttesterSlashing{
-			{
-				Attestation_1: firstAtt,
-				Attestation_2: secondAtt,
-			},
+		slashing := &ethpb.AttesterSlashing{
+			Attestation_1: firstAtt,
+			Attestation_2: secondAtt,
+		}
+
+		root, err := slashing.HashTreeRoot()
+		require.NoError(tt, err, "failed to hash tree root")
+
+		slashings := map[[fieldparams.RootLength]byte]*ethpb.AttesterSlashing{
+			root: slashing,
 		}
 
 		_, err = s.processAttesterSlashings(ctx, slashings)
@@ -94,11 +100,16 @@ func TestService_processAttesterSlashings(t *testing.T) {
 		firstAtt.Signature = make([]byte, 96)
 		secondAtt.Signature = signature.Marshal()
 
-		slashings := []*ethpb.AttesterSlashing{
-			{
-				Attestation_1: firstAtt,
-				Attestation_2: secondAtt,
-			},
+		slashing := &ethpb.AttesterSlashing{
+			Attestation_1: firstAtt,
+			Attestation_2: secondAtt,
+		}
+
+		root, err := slashing.HashTreeRoot()
+		require.NoError(tt, err, "failed to hash tree root")
+
+		slashings := map[[fieldparams.RootLength]byte]*ethpb.AttesterSlashing{
+			root: slashing,
 		}
 
 		_, err = s.processAttesterSlashings(ctx, slashings)
@@ -113,11 +124,16 @@ func TestService_processAttesterSlashings(t *testing.T) {
 		firstAtt.Signature = signature.Marshal()
 		secondAtt.Signature = signature.Marshal()
 
-		slashings := []*ethpb.AttesterSlashing{
-			{
-				Attestation_1: firstAtt,
-				Attestation_2: secondAtt,
-			},
+		slashing := &ethpb.AttesterSlashing{
+			Attestation_1: firstAtt,
+			Attestation_2: secondAtt,
+		}
+
+		root, err := slashing.HashTreeRoot()
+		require.NoError(tt, err, "failed to hash tree root")
+
+		slashings := map[[fieldparams.RootLength]byte]*ethpb.AttesterSlashing{
+			root: slashing,
 		}
 
 		_, err = s.processAttesterSlashings(ctx, slashings)

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	slashertypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/slasher/types"
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
@@ -107,7 +108,7 @@ func (s *Service) processAttestations(
 	ctx context.Context,
 	attestations []*slashertypes.IndexedAttestationWrapper,
 	currentSlot primitives.Slot,
-) []*ethpb.AttesterSlashing {
+) map[[fieldparams.RootLength]byte]*ethpb.AttesterSlashing {
 	// Get the current epoch from the current slot.
 	currentEpoch := slots.ToEpoch(currentSlot)
 

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -139,14 +139,6 @@ func (s *Service) processAttestations(
 		"attsQueueSize":   queuedAttestationsCount,
 	}).Info("Processing queued attestations for slashing detection")
 
-	// Save the attestation records to our database.
-	// If multiple attestations are provided for the same validator index + target epoch combination,
-	// then the first (validator index + target epoch) => signing root) link is kept into the database.
-	if err := s.serviceCfg.Database.SaveAttestationRecordsForValidators(ctx, validAttestations); err != nil {
-		log.WithError(err).Error(couldNotSaveAttRecord)
-		return nil
-	}
-
 	// Check for attestatinos slashings (double, sourrounding, surrounded votes).
 	slashings, err := s.checkSlashableAttestations(ctx, currentEpoch, validAttestations)
 	if err != nil {

--- a/beacon-chain/slasher/types/types.go
+++ b/beacon-chain/slasher/types/types.go
@@ -24,10 +24,10 @@ type IndexedAttestationWrapper struct {
 // AttesterDoubleVote represents a double vote instance
 // which is a slashable event for attesters.
 type AttesterDoubleVote struct {
-	Target                 primitives.Epoch
-	ValidatorIndex         primitives.ValidatorIndex
-	PrevAttestationWrapper *IndexedAttestationWrapper
-	AttestationWrapper     *IndexedAttestationWrapper
+	Target         primitives.Epoch
+	ValidatorIndex primitives.ValidatorIndex
+	Wrapper_1      *IndexedAttestationWrapper
+	Wrapper_2      *IndexedAttestationWrapper
 }
 
 // DoubleBlockProposal containing an incoming and an existing proposal's signing root.

--- a/testing/slasher/simulator/BUILD.bazel
+++ b/testing/slasher/simulator/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//time/slots:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )


### PR DESCRIPTION
Please read this PR commit by commit.

**What type of PR is this?**
Bug fix

This pull requests fixes 2 bugs:

**Double votes false positive**
- For a given validator, when two different attestations with the same target epochs are received by the slasher **in the same batch**, the slasher detects them as a slashable offence. ==> ✅
- However, for a given validator, when two different attestations with the same target epochs are received by the slasher **in two different batches**, the slasher does **not** detect any slashable offence. ==> ❌. This PR fixes this point.

**Redondant attester slashing objects sent**
When an equivocating attestation is detected, then the same attester slashing object is sent multiple times. The number of copies of the same object depends of the number of validators actually slashable. This PR ensure that each attester slashing object is sent exactly once.

**Which issues(s) does this PR fix?**

- https://github.com/prysmaticlabs/prysm/issues/13590
- https://github.com/prysmaticlabs/prysm/issues/13592