### PR TITLE
Reduce Lookahead Steps Parameter

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -29,7 +29,7 @@ const (
 	skippedMachineTimeout = 10 * staleEpochTimeout
 	// lookaheadSteps is a limit on how many forward steps are loaded into queue.
 	// Each step is managed by assigned finite state machine. Must be >= 2.
-	lookaheadSteps = 8
+	lookaheadSteps = 4
 	// noRequiredPeersErrMaxRetries defines number of retries when no required peers are found.
 	noRequiredPeersErrMaxRetries = 1000
 	// noRequiredPeersErrRefreshInterval defines interval for which queue will be paused before


### PR DESCRIPTION
**What type of PR is this?**

Constant Adjustment

**What does this PR do? Why is it needed?**

Due to deneb coming up along with blocks being much bigger in general than 4 years ago, it is better for the network for prysm nodes syncing to sync 4 batches at a time rather than 8. This allows less wasted bandwidth in the event of bad/missed batches.
 
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
