### PR TITLE
Remove deprecated flags: gossip batch registration and registration cache

### DIFF
--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -12,16 +12,6 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedDisableGossipBatchAggregation = &cli.BoolFlag{
-		Name:   "disable-gossip-batch-aggregation",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
-	deprecatedEnableRegistrationCache = &cli.BoolFlag{
-		Name:   "enable-registration-cache",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
 	deprecatedEnableOptionalEngineMethods = &cli.BoolFlag{
 		Name:   "enable-optional-engine-methods",
 		Usage:  deprecatedUsage,
@@ -62,8 +52,6 @@ var (
 // Deprecated flags for both the beacon node and validator client.
 var deprecatedFlags = []cli.Flag{
 	exampleDeprecatedFeatureFlag,
-	deprecatedDisableGossipBatchAggregation,
-	deprecatedEnableRegistrationCache,
 	deprecatedEnableOptionalEngineMethods,
 	deprecatedDisableBuildBlockParallel,
 	deprecatedDisableReorgLateBlocks,


### PR DESCRIPTION
These flags have been deprecated since March and June last year. I think it's fine to remove them for V5