### PR TITLE
Update aggregate atts t1 bucket values

### DIFF
--- a/beacon-chain/operations/attestations/metrics.go
+++ b/beacon-chain/operations/attestations/metrics.go
@@ -34,7 +34,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "aggregate_attestations_t1",
 			Help:    "Captures times of attestation aggregation in milliseconds during the first interval per slot",
-			Buckets: []float64{100, 200, 500, 1000, 1500, 2000, 2500, 3500},
+			Buckets: []float64{10, 20, 50, 100, 200, 300, 500, 1000},
 		},
 	)
 	batchForkChoiceAttsT2 = promauto.NewHistogram(


### PR DESCRIPTION
Since aggregate parallel has been default, we never updated the bucket values. Aggregate parallel yields ~5-10x im provements. On my node it's always the first bucket:
```
# TYPE aggregate_attestations_t1 histogram
aggregate_attestations_t1_bucket{le="100"} 64229
aggregate_attestations_t1_bucket{le="200"} 64238
aggregate_attestations_t1_bucket{le="500"} 64239
aggregate_attestations_t1_bucket{le="1000"} 64240
aggregate_attestations_t1_bucket{le="1500"} 64240
aggregate_attestations_t1_bucket{le="2000"} 64240
aggregate_attestations_t1_bucket{le="2500"} 64240
aggregate_attestations_t1_bucket{le="3500"} 64240
aggregate_attestations_t1_bucket{le="+Inf"} 64240


Feb 10 16:38:42 t beacon-chain[527495]: time="2024-02-10 16:38:42" level=debug msg="Aggregated unaggregated attestations" Duration=29.257958ms prefix="pool/attestations"
Feb 10 16:38:54 t beacon-chain[527495]: time="2024-02-10 16:38:54" level=debug msg="Aggregated unaggregated attestations" Duration=28.394571ms prefix="pool/attestations"
Feb 10 16:39:06 t beacon-chain[527495]: time="2024-02-10 16:39:06" level=debug msg="Aggregated unaggregated attestations" Duration=24.710014ms prefix="pool/attestations"
Feb 10 16:39:18 t beacon-chain[527495]: time="2024-02-10 16:39:18" level=debug msg="Aggregated unaggregated attestations" Duration=21.40579ms prefix="pool/attestations"
Feb 10 16:39:30 t beacon-chain[527495]: time="2024-02-10 16:39:30" level=debug msg="Aggregated unaggregated attestations" Duration=23.543603ms prefix="pool/attestations"
Feb 10 16:39:42 t beacon-chain[527495]: time="2024-02-10 16:39:42" level=debug msg="Aggregated unaggregated attestations" Duration=19.682172ms prefix="pool/attestations"
Feb 10 16:39:54 t beacon-chain[527495]: time="2024-02-10 16:39:54" level=debug msg="Aggregated unaggregated attestations" Duration=19.233089ms prefix="pool/attestations"
Feb 10 16:40:06 t beacon-chain[527495]: time="2024-02-10 16:40:06" level=debug msg="Aggregated unaggregated attestations" Duration=21.423413ms prefix="pool/attestations"
Feb 10 16:40:18 t beacon-chain[527495]: time="2024-02-10 16:40:18" level=debug msg="Aggregated unaggregated attestations" Duration=19.230622ms prefix="pool/attestations"
Feb 10 16:40:30 t beacon-chain[527495]: time="2024-02-10 16:40:30" level=debug msg="Aggregated unaggregated attestations" Duration=22.474415ms prefix="pool/attestations"
Feb 10 16:40:42 t beacon-chain[527495]: time="2024-02-10 16:40:42" level=debug msg="Aggregated unaggregated attestations" Duration=20.971846ms prefix="pool/attestations"
Feb 10 16:40:54 t beacon-chain[527495]: time="2024-02-10 16:40:54" level=debug msg="Aggregated unaggregated attestations" Duration=27.605794ms prefix="pool/attestations"
Feb 10 16:41:06 t beacon-chain[527495]: time="2024-02-10 16:41:06" level=debug msg="Aggregated unaggregated attestations" Duration=21.936237ms prefix="pool/attestations"
Feb 10 16:41:18 t beacon-chain[527495]: time="2024-02-10 16:41:18" level=debug msg="Aggregated unaggregated attestations" Duration=17.090841ms prefix="pool/attestations"
Feb 10 16:41:30 t beacon-chain[527495]: time="2024-02-10 16:41:30" level=debug msg="Aggregated unaggregated attestations" Duration=17.199515ms prefix="pool/attestations"
Feb 10 16:41:42 t beacon-chain[527495]: time="2024-02-10 16:41:42" level=debug msg="Aggregated unaggregated attestations" Duration=17.948511ms prefix="pool/attestations"
Feb 10 16:41:54 t beacon-chain[527495]: time="2024-02-10 16:41:54" level=debug msg="Aggregated unaggregated attestations" Duration=16.483889ms prefix="pool/attestations"
Feb 10 16:42:06 t beacon-chain[527495]: time="2024-02-10 16:42:06" level=debug msg="Aggregated unaggregated attestations" Duration=48.543085ms prefix="pool/attestations"
Feb 10 16:42:18 t beacon-chain[527495]: time="2024-02-10 16:42:18" level=debug msg="Aggregated unaggregated attestations" Duration=49.335646ms prefix="pool/attestations"
Feb 10 16:42:30 t beacon-chain[527495]: time="2024-02-10 16:42:30" level=debug msg="Aggregated unaggregated attestations" Duration=42.525172ms prefix="pool/attestations"
Feb 10 16:42:42 t beacon-chain[527495]: time="2024-02-10 16:42:42" level=debug msg="Aggregated unaggregated attestations" Duration=39.024606ms prefix="pool/attestations"
Feb 10 16:42:54 t beacon-chain[527495]: time="2024-02-10 16:42:54" level=debug msg="Aggregated unaggregated attestations" Duration=49.515792ms prefix="pool/attestations"
Feb 10 16:43:06 t beacon-chain[527495]: time="2024-02-10 16:43:06" level=debug msg="Aggregated unaggregated attestations" Duration=46.994882ms prefix="pool/attestations"
Feb 10 16:43:18 t beacon-chain[527495]: time="2024-02-10 16:43:18" level=debug msg="Aggregated unaggregated attestations" Duration=39.974745ms prefix="pool/attestations"
Feb 10 16:43:30 t beacon-chain[527495]: time="2024-02-10 16:43:30" level=debug msg="Aggregated unaggregated attestations" Duration=41.212505ms prefix="pool/attestations"
```