### PR TITLE
Rm unused import

### DIFF
--- a/proto/eth/v1/events.proto
+++ b/proto/eth/v1/events.proto
@@ -17,7 +17,6 @@ package ethereum.eth.v1;
 
 import "google/protobuf/descriptor.proto";
 import "proto/eth/ext/options.proto";
-import "proto/engine/v1/execution_engine.proto";
 
 option csharp_namespace = "Ethereum.Eth.V1";
 option go_package = "github.com/prysmaticlabs/prysm/v4/proto/eth/v1";

--- a/proto/eth/v2/beacon_lightclient.proto
+++ b/proto/eth/v2/beacon_lightclient.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 package ethereum.eth.v2;
 
 import "proto/eth/ext/options.proto";
-import "proto/eth/v1/attestation.proto";
 import "proto/eth/v1/beacon_block.proto";
 import "proto/eth/v2/version.proto";
 import "proto/eth/v2/sync_committee.proto";


### PR DESCRIPTION
Fixed warnings for bazel build: 
`proto/eth/v2/beacon_lightclient.proto:19:1: warning: Import proto/eth/v1/attestation.proto is unused`