### PR TITLE
Slasher: Reduce cold start duration.

### DIFF
--- a/beacon-chain/db/slasherkv/slasher.go
+++ b/beacon-chain/db/slasherkv/slasher.go
@@ -34,17 +34,14 @@ func (s *Store) LastEpochWrittenForValidators(
 	defer span.End()
 
 	attestedEpochs := make([]*slashertypes.AttestedEpochForValidator, 0)
-	encodedIndexes := make([][]byte, len(validatorIndexes))
-
-	for i, validatorIndex := range validatorIndexes {
-		encodedIndexes[i] = encodeValidatorIndex(validatorIndex)
-	}
 
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(attestedEpochsByValidator)
 
-		for i, encodedIndex := range encodedIndexes {
+		for _, validatorIndex := range validatorIndexes {
 			var epoch primitives.Epoch
+
+			encodedIndex := encodeValidatorIndex(validatorIndex)
 
 			if epochBytes := bkt.Get(encodedIndex); epochBytes != nil {
 				if err := epoch.UnmarshalSSZ(epochBytes); err != nil {
@@ -53,7 +50,7 @@ func (s *Store) LastEpochWrittenForValidators(
 			}
 
 			attestedEpoch := &slashertypes.AttestedEpochForValidator{
-				ValidatorIndex: validatorIndexes[i],
+				ValidatorIndex: validatorIndex,
 				Epoch:          epoch,
 			}
 

--- a/beacon-chain/db/slasherkv/slasher.go
+++ b/beacon-chain/db/slasherkv/slasher.go
@@ -39,14 +39,17 @@ func (s *Store) LastEpochWrittenForValidators(
 		bkt := tx.Bucket(attestedEpochsByValidator)
 
 		for _, validatorIndex := range validatorIndexes {
-			var epoch primitives.Epoch
-
 			encodedIndex := encodeValidatorIndex(validatorIndex)
 
-			if epochBytes := bkt.Get(encodedIndex); epochBytes != nil {
-				if err := epoch.UnmarshalSSZ(epochBytes); err != nil {
-					return err
-				}
+			epochBytes := bkt.Get(encodedIndex)
+			if epochBytes == nil {
+				// If there is no epoch for this validator, skip to the next validator.
+				continue
+			}
+
+			var epoch primitives.Epoch
+			if err := epoch.UnmarshalSSZ(epochBytes); err != nil {
+				return err
 			}
 
 			attestedEpoch := &slashertypes.AttestedEpochForValidator{

--- a/beacon-chain/db/slasherkv/slasher_test.go
+++ b/beacon-chain/db/slasherkv/slasher_test.go
@@ -56,18 +56,15 @@ func TestStore_LastEpochWrittenForValidators(t *testing.T) {
 		epochs[i] = primitives.Epoch(i)
 	}
 
-	attestedEpochs, err := beaconDB.LastEpochWrittenForValidators(ctx, indices)
-	require.NoError(t, err)
-	require.Equal(t, true, len(attestedEpochs) == len(indices))
-
-	for _, item := range attestedEpochs {
-		require.Equal(t, primitives.Epoch(0), item.Epoch)
-	}
-
 	epochsByValidator := make(map[primitives.ValidatorIndex]primitives.Epoch, validatorsCount)
 	for i := 0; i < validatorsCount; i++ {
 		epochsByValidator[indices[i]] = epochs[i]
 	}
+
+	// No epochs written for any validators, should return empty list.
+	attestedEpochs, err := beaconDB.LastEpochWrittenForValidators(ctx, indices)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(attestedEpochs))
 
 	err = beaconDB.SaveLastEpochsWrittenForValidators(ctx, epochsByValidator)
 	require.NoError(t, err)

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -81,12 +81,16 @@ type MinSpanChunksSlice struct {
 	data   []uint16
 }
 
+var _ Chunker = (*MinSpanChunksSlice)(nil)
+
 // MaxSpanChunksSlice represents the same data structure as MinSpanChunksSlice however
 // keeps track of validator max spans for slashing detection instead.
 type MaxSpanChunksSlice struct {
 	params *Parameters
 	data   []uint16
 }
+
+var _ Chunker = (*MaxSpanChunksSlice)(nil)
 
 // EmptyMinSpanChunksSlice initializes a min span chunk of length C*K for
 // C = chunkSize and K = validatorChunkSize filled with neutral elements.

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -14,14 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// A struct encapsulating input arguments to
-// functions used for attester slashing detection and
-// loading, saving, and updating min/max span chunks.
-type chunkUpdateArgs struct {
-	chunkIndex   uint64
-	currentEpoch primitives.Epoch
-}
-
 // Chunker defines a struct which represents a slice containing a chunk for K different validator's
 // min/max spans used for surround vote detection in slasher. The interface defines methods used to check
 // if an attestation is slashable for a validator index based on the contents of
@@ -36,7 +28,8 @@ type Chunker interface {
 		attestation *slashertypes.IndexedAttestationWrapper,
 	) (*ethpb.AttesterSlashing, error)
 	Update(
-		args *chunkUpdateArgs,
+		chunkIndex uint64,
+		currentEpoch primitives.Epoch,
 		validatorIndex primitives.ValidatorIndex,
 		startEpoch,
 		newTargetEpoch primitives.Epoch,
@@ -384,21 +377,22 @@ func (m *MaxSpanChunksSlice) CheckSlashable(
 // to update. In our example, we stop at 2, which is still part of chunk 0, so no need
 // to jump to another min span chunks slice to perform updates.
 func (m *MinSpanChunksSlice) Update(
-	args *chunkUpdateArgs,
+	chunkIndex uint64,
+	currentEpoch primitives.Epoch,
 	validatorIndex primitives.ValidatorIndex,
 	startEpoch,
 	newTargetEpoch primitives.Epoch,
 ) (keepGoing bool, err error) {
 	// The lowest epoch we need to update.
 	minEpoch := primitives.Epoch(0)
-	if args.currentEpoch > (m.params.historyLength - 1) {
-		minEpoch = args.currentEpoch - (m.params.historyLength - 1)
+	if currentEpoch > (m.params.historyLength - 1) {
+		minEpoch = currentEpoch - (m.params.historyLength - 1)
 	}
 	epochInChunk := startEpoch
 	// We go down the chunk for the validator, updating every value starting at startEpoch down to minEpoch.
 	// As long as the epoch, e, in the same chunk index and e >= minEpoch, we proceed with
 	// a for loop.
-	for m.params.chunkIndex(epochInChunk) == args.chunkIndex && epochInChunk >= minEpoch {
+	for m.params.chunkIndex(epochInChunk) == chunkIndex && epochInChunk >= minEpoch {
 		var chunkTarget primitives.Epoch
 		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, validatorIndex, epochInChunk)
 		if err != nil {
@@ -433,7 +427,8 @@ func (m *MinSpanChunksSlice) Update(
 // more about how update exactly works, refer to the detailed documentation for the Update function for
 // MinSpanChunksSlice.
 func (m *MaxSpanChunksSlice) Update(
-	args *chunkUpdateArgs,
+	chunkIndex uint64,
+	currentEpoch primitives.Epoch,
 	validatorIndex primitives.ValidatorIndex,
 	startEpoch,
 	newTargetEpoch primitives.Epoch,
@@ -442,7 +437,7 @@ func (m *MaxSpanChunksSlice) Update(
 	// We go down the chunk for the validator, updating every value starting at startEpoch up to
 	// and including the current epoch. As long as the epoch, e, is in the same chunk index and e <= currentEpoch,
 	// we proceed with a for loop.
-	for m.params.chunkIndex(epochInChunk) == args.chunkIndex && epochInChunk <= args.currentEpoch {
+	for m.params.chunkIndex(epochInChunk) == chunkIndex && epochInChunk <= currentEpoch {
 		var chunkTarget primitives.Epoch
 		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, validatorIndex, epochInChunk)
 		if err != nil {
@@ -465,7 +460,7 @@ func (m *MaxSpanChunksSlice) Update(
 	}
 	// If the epoch to update now lies beyond the current chunk, then
 	// continue to the next chunk to update it.
-	keepGoing = epochInChunk <= args.currentEpoch
+	keepGoing = epochInChunk <= currentEpoch
 	return
 }
 

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -127,14 +127,10 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 	source = primitives.Epoch(1)
 	target = primitives.Epoch(2)
 	att = createAttestationWrapperEmptySig(t, source, target, nil, nil)
-	chunkIdx := uint64(0)
+	chunkIndex := uint64(0)
 	startEpoch := target
 	currentEpoch := target
-	args := &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	_, err = chunk.Update(args, validatorIdx, startEpoch, target)
+	_, err = chunk.Update(chunkIndex, currentEpoch, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 
 	// Next up, we create a surrounding vote, but it should NOT be slashable
@@ -209,14 +205,10 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 	source = primitives.Epoch(0)
 	target = primitives.Epoch(3)
 	att = createAttestationWrapperEmptySig(t, source, target, nil, nil)
-	chunkIdx := uint64(0)
+	chunkIndex := uint64(0)
 	startEpoch := source
 	currentEpoch := target
-	args := &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	_, err = chunk.Update(args, validatorIdx, startEpoch, target)
+	_, err = chunk.Update(chunkIndex, currentEpoch, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 
 	// Next up, we create a surrounded vote, but it should NOT be slashable
@@ -288,15 +280,11 @@ func TestMinSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	}
 	chunk := EmptyMinSpanChunksSlice(params)
 	target := primitives.Epoch(3)
-	chunkIdx := uint64(1)
-	validatorIdx := primitives.ValidatorIndex(0)
+	chunkIndex := uint64(1)
+	validatorIndex := primitives.ValidatorIndex(0)
 	startEpoch := target
 	currentEpoch := target
-	args := &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
+	keepGoing, err := chunk.Update(chunkIndex, currentEpoch, validatorIndex, startEpoch, target)
 	require.NoError(t, err)
 
 	// We should keep going! We still have to update the data for chunk index 0.
@@ -306,15 +294,11 @@ func TestMinSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 
 	// Now we update for chunk index 0.
 	chunk = EmptyMinSpanChunksSlice(params)
-	chunkIdx = uint64(0)
-	validatorIdx = primitives.ValidatorIndex(0)
+	chunkIndex = uint64(0)
+	validatorIndex = primitives.ValidatorIndex(0)
 	startEpoch = primitives.Epoch(1)
 	currentEpoch = target
-	args = &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	keepGoing, err = chunk.Update(args, validatorIdx, startEpoch, target)
+	keepGoing, err = chunk.Update(chunkIndex, currentEpoch, validatorIndex, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want = []uint16{3, 2, math.MaxUint16, math.MaxUint16, math.MaxUint16, math.MaxUint16}
@@ -329,15 +313,11 @@ func TestMaxSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	}
 	chunk := EmptyMaxSpanChunksSlice(params)
 	target := primitives.Epoch(3)
-	chunkIdx := uint64(0)
+	chunkIndex := uint64(0)
 	validatorIdx := primitives.ValidatorIndex(0)
 	startEpoch := primitives.Epoch(0)
 	currentEpoch := target
-	args := &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
+	keepGoing, err := chunk.Update(chunkIndex, currentEpoch, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 
 	// We should keep going! We still have to update the data for chunk index 1.
@@ -347,15 +327,11 @@ func TestMaxSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 
 	// Now we update for chunk index 1.
 	chunk = EmptyMaxSpanChunksSlice(params)
-	chunkIdx = uint64(1)
+	chunkIndex = uint64(1)
 	validatorIdx = primitives.ValidatorIndex(0)
 	startEpoch = primitives.Epoch(2)
 	currentEpoch = target
-	args = &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	keepGoing, err = chunk.Update(args, validatorIdx, startEpoch, target)
+	keepGoing, err = chunk.Update(chunkIndex, currentEpoch, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want = []uint16{1, 0, 0, 0, 0, 0}
@@ -393,15 +369,11 @@ func TestMinSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 	}
 	chunk := EmptyMinSpanChunksSlice(params)
 	target := primitives.Epoch(1)
-	chunkIdx := uint64(0)
+	chunkIndex := uint64(0)
 	validatorIdx := primitives.ValidatorIndex(0)
 	startEpoch := target
 	currentEpoch := target
-	args := &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
+	keepGoing, err := chunk.Update(chunkIndex, currentEpoch, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want := []uint16{1, 0, math.MaxUint16, math.MaxUint16, math.MaxUint16, math.MaxUint16}
@@ -416,15 +388,11 @@ func TestMaxSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 	}
 	chunk := EmptyMaxSpanChunksSlice(params)
 	target := primitives.Epoch(3)
-	chunkIdx := uint64(0)
+	chunkIndex := uint64(0)
 	validatorIdx := primitives.ValidatorIndex(0)
 	startEpoch := primitives.Epoch(0)
 	currentEpoch := target
-	args := &chunkUpdateArgs{
-		chunkIndex:   chunkIdx,
-		currentEpoch: currentEpoch,
-	}
-	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
+	keepGoing, err := chunk.Update(chunkIndex, currentEpoch, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want := []uint16{3, 2, 1, 0, 0, 0, 0, 0}

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -458,10 +458,8 @@ func (s *Service) applyAttestationForValidator(
 		}
 
 		keepGoing, err := chunk.Update(
-			&chunkUpdateArgs{
-				chunkIndex:   chunkIndex,
-				currentEpoch: currentEpoch,
-			},
+			chunkIndex,
+			currentEpoch,
 			validatorIndex,
 			startEpoch,
 			targetEpoch,

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -517,14 +517,14 @@ func (s *Service) loadChunks(
 	ctx context.Context,
 	validatorChunkIndex uint64,
 	chunkKind slashertypes.ChunkKind,
-	chunkIndices []uint64,
+	chunkIndexes []uint64,
 ) (map[uint64]Chunker, error) {
 	ctx, span := trace.StartSpan(ctx, "Slasher.loadChunks")
 	defer span.End()
 
-	chunkKeys := make([][]byte, 0, len(chunkIndices))
-	for _, chunkIdx := range chunkIndices {
-		chunkKeys = append(chunkKeys, s.params.flatSliceID(validatorChunkIndex, chunkIdx))
+	chunkKeys := make([][]byte, 0, len(chunkIndexes))
+	for _, chunkIndex := range chunkIndexes {
+		chunkKeys = append(chunkKeys, s.params.flatSliceID(validatorChunkIndex, chunkIndex))
 	}
 
 	rawChunks, chunksExist, err := s.serviceCfg.Database.LoadSlasherChunks(ctx, chunkKind, chunkKeys)
@@ -563,7 +563,7 @@ func (s *Service) loadChunks(
 			return nil, errors.Wrap(err, "could not initialize chunk")
 		}
 
-		chunksByChunkIdx[chunkIndices[i]] = chunk
+		chunksByChunkIdx[chunkIndexes[i]] = chunk
 	}
 
 	return chunksByChunkIdx, nil

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -290,7 +290,7 @@ func (s *Service) epochUpdateForValidator(
 
 		currentChunk, ok := updatedChunks[chunkIndex]
 		if !ok {
-			currentChunk, err = s.getChunk(ctx, chunkKind, validatorChunkIndex, chunkIndex)
+			currentChunk, err = s.getChunkFromDatabase(ctx, chunkKind, validatorChunkIndex, chunkIndex)
 			if err != nil {
 				return errors.Wrap(err, "could not get chunk")
 			}
@@ -409,7 +409,7 @@ func (s *Service) applyAttestationForValidator(
 
 	chunk, ok := chunksByChunkIdx[chunkIndex]
 	if !ok {
-		chunk, err = s.getChunk(ctx, chunkKind, validatorChunkIndex, chunkIndex)
+		chunk, err = s.getChunkFromDatabase(ctx, chunkKind, validatorChunkIndex, chunkIndex)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not get chunk at index %d", chunkIndex)
 		}
@@ -451,7 +451,7 @@ func (s *Service) applyAttestationForValidator(
 
 		chunk, ok := chunksByChunkIdx[chunkIndex]
 		if !ok {
-			chunk, err = s.getChunk(ctx, chunkKind, validatorChunkIndex, chunkIndex)
+			chunk, err = s.getChunkFromDatabase(ctx, chunkKind, validatorChunkIndex, chunkIndex)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not get chunk at index %d", chunkIndex)
 			}
@@ -490,8 +490,8 @@ func (s *Service) applyAttestationForValidator(
 	return nil, nil
 }
 
-// Retrieve a chunk from database from database.
-func (s *Service) getChunk(
+// Retrieve a chunk from database.
+func (s *Service) getChunkFromDatabase(
 	ctx context.Context,
 	chunkKind slashertypes.ChunkKind,
 	validatorChunkIndex uint64,

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -1015,6 +1015,39 @@ func Test_epochUpdateForValidators(t *testing.T) {
 				0: {neutralMax, neutralMax, neutralMax, 55, neutralMax, neutralMax, neutralMax, 55},
 			},
 		},
+		{
+			name:                               "start with some data - high latest updated epoch",
+			chunkSize:                          4,
+			validatorChunkSize:                 2,
+			historyLength:                      12,
+			currentEpoch:                       16,
+			validatorChunkIndex:                21,
+			latestUpdatedEpochByValidatorIndex: map[primitives.ValidatorIndex]primitives.Epoch{42: 2, 43: 3},
+			initialMinChunkByChunkIndex: map[uint64][]uint16{
+				// | validator 42 |  validator 43 |
+				0: {55, 55, 55, 55, 55, 55, 55, 55},
+				1: {66, 66, 66, 66, 66, 66, 66, 66},
+				2: {77, 77, 77, 77, 77, 77, 77, 77},
+			},
+			expectedMinChunkByChunkIndex: map[uint64][]uint16{
+				// |                  validator 42                |                  validator 43                 |
+				0: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+				1: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+				2: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+			},
+			initialMaxChunkByChunkIndex: map[uint64][]uint16{
+				// | validator 42 |  validator 43 |
+				0: {55, 55, 55, 55, 55, 55, 55, 55},
+				1: {66, 66, 66, 66, 66, 66, 66, 66},
+				2: {77, 77, 77, 77, 77, 77, 77, 77},
+			},
+			expectedMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |                  validator 42                |                  validator 43                 |
+				0: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+				1: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+				2: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -834,55 +834,260 @@ func Test_processQueuedAttestations_OverlappingChunkIndices(t *testing.T) {
 }
 
 func Test_epochUpdateForValidators(t *testing.T) {
-	ctx := context.Background()
-	slasherDB := dbtest.SetupSlasherDB(t)
+	neutralMin, neutralMax := uint16(65535), uint16(0)
 
-	// Check if the chunk at chunk index already exists in-memory.
-	s := &Service{
-		params: &Parameters{
-			chunkSize:          2, // 2 epochs in a chunk.
-			validatorChunkSize: 2, // 2 validators in a chunk.
-			historyLength:      4,
+	testCases := []struct {
+		name                               string
+		chunkSize                          uint64
+		validatorChunkSize                 uint64
+		historyLength                      primitives.Epoch
+		currentEpoch                       primitives.Epoch
+		validatorChunkIndex                uint64
+		latestUpdatedEpochByValidatorIndex map[primitives.ValidatorIndex]primitives.Epoch
+		initialMinChunkByChunkIndex        map[uint64][]uint16
+		expectedMinChunkByChunkIndex       map[uint64][]uint16
+		initialMaxChunkByChunkIndex        map[uint64][]uint16
+		expectedMaxChunkByChunkIndex       map[uint64][]uint16
+	}{
+		{
+			name:                               "start with no data - first chunk",
+			chunkSize:                          4,
+			validatorChunkSize:                 2,
+			historyLength:                      8,
+			currentEpoch:                       2,
+			validatorChunkIndex:                21,
+			latestUpdatedEpochByValidatorIndex: nil,
+			initialMinChunkByChunkIndex:        nil,
+			expectedMinChunkByChunkIndex: map[uint64][]uint16{
+				// |                  validator 42                |                   validator 43                |
+				0: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+			},
+			initialMaxChunkByChunkIndex: nil,
+			expectedMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |                  validator 42                |                   validator 43                |
+				0: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+			},
 		},
-		serviceCfg:                     &ServiceConfig{Database: slasherDB},
-		latestEpochWrittenForValidator: map[primitives.ValidatorIndex]primitives.Epoch{},
+		{
+			name:                               "start with no data - second chunk",
+			chunkSize:                          4,
+			validatorChunkSize:                 2,
+			historyLength:                      8,
+			currentEpoch:                       5,
+			validatorChunkIndex:                21,
+			latestUpdatedEpochByValidatorIndex: nil,
+			initialMinChunkByChunkIndex:        nil,
+			expectedMinChunkByChunkIndex: map[uint64][]uint16{
+				// |                  validator 42                |                   validator 43                |
+				0: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+				1: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+			},
+			initialMaxChunkByChunkIndex: nil,
+			expectedMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |                  validator 42                |                   validator 43                |
+				0: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+				1: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+			},
+		},
+		{
+			name:                               "start with some data - first chunk",
+			chunkSize:                          4,
+			validatorChunkSize:                 2,
+			historyLength:                      8,
+			currentEpoch:                       2,
+			validatorChunkIndex:                21,
+			latestUpdatedEpochByValidatorIndex: map[primitives.ValidatorIndex]primitives.Epoch{42: 0, 43: 1},
+			initialMinChunkByChunkIndex: map[uint64][]uint16{
+				// |    validator 42    |   validator 43    |
+				0: {14, 9999, 9999, 9999, 15, 16, 9999, 9999},
+			},
+			expectedMinChunkByChunkIndex: map[uint64][]uint16{
+				// |           validator 42         |      validator 43       |
+				0: {14, neutralMin, neutralMin, 9999, 15, 16, neutralMin, 9999},
+			},
+			initialMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |    validator 42    |  validator 43     |
+				0: {70, 9999, 9999, 9999, 71, 72, 9999, 9999},
+			},
+			expectedMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |          validator 42          |      validator 43        |
+				0: {70, neutralMax, neutralMax, 9999, 71, 72, neutralMax, 9999},
+			},
+		},
+		{
+			name:                               "start with some data - second chunk",
+			chunkSize:                          4,
+			validatorChunkSize:                 2,
+			historyLength:                      8,
+			currentEpoch:                       5,
+			validatorChunkIndex:                21,
+			latestUpdatedEpochByValidatorIndex: map[primitives.ValidatorIndex]primitives.Epoch{42: 1, 43: 2},
+			initialMinChunkByChunkIndex: map[uint64][]uint16{
+				// |   validator 42   |  validator 43   |
+				0: {14, 13, 9999, 9999, 15, 16, 17, 9999},
+			},
+			expectedMinChunkByChunkIndex: map[uint64][]uint16{
+				// |         validator 42         |     validator 43      |
+				0: {14, 13, neutralMin, neutralMin, 15, 16, 17, neutralMin},
+
+				// |                  validator 42                |                   validator 43                |
+				1: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+			},
+			initialMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |   validator 42   |   validator 43  |
+				0: {70, 69, 9999, 9999, 71, 72, 73, 9999},
+			},
+			expectedMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |         validator 42         |      validator 43     |
+				0: {70, 69, neutralMax, neutralMax, 71, 72, 73, neutralMax},
+
+				// |                  validator 42                |                   validator 43                |
+				1: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+			},
+		},
+		{
+			name:                               "start with some data - third chunk",
+			chunkSize:                          4,
+			validatorChunkSize:                 2,
+			historyLength:                      12,
+			currentEpoch:                       9,
+			validatorChunkIndex:                21,
+			latestUpdatedEpochByValidatorIndex: map[primitives.ValidatorIndex]primitives.Epoch{42: 5, 43: 6},
+			initialMinChunkByChunkIndex: map[uint64][]uint16{
+				// |   validator 42   |  validator 43   |
+				1: {14, 13, 9999, 9999, 15, 16, 17, 9999},
+			},
+			expectedMinChunkByChunkIndex: map[uint64][]uint16{
+				// |         validator 42         |     validator 43      |
+				1: {14, 13, neutralMin, neutralMin, 15, 16, 17, neutralMin},
+
+				// |                  validator 42                |                   validator 43                |
+				2: {neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin, neutralMin},
+			},
+			initialMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |   validator 42   |   validator 43  |
+				1: {70, 69, 9999, 9999, 71, 72, 73, 9999},
+			},
+			expectedMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |         validator 42         |      validator 43     |
+				1: {70, 69, neutralMax, neutralMax, 71, 72, 73, neutralMax},
+
+				// |                  validator 42                |                   validator 43                |
+				2: {neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax, neutralMax},
+			},
+		},
+		{
+			name:                               "start with some data - third chunk - wrap to first chunk",
+			chunkSize:                          4,
+			validatorChunkSize:                 2,
+			historyLength:                      12,
+			currentEpoch:                       14,
+			validatorChunkIndex:                21,
+			latestUpdatedEpochByValidatorIndex: map[primitives.ValidatorIndex]primitives.Epoch{42: 9, 43: 10},
+			initialMinChunkByChunkIndex: map[uint64][]uint16{
+				// | validator 42 |  validator 43 |
+				0: {55, 55, 55, 55, 55, 55, 55, 55},
+				1: {66, 66, 66, 66, 66, 66, 66, 66},
+
+				// |   validator 42   |   validator 43  |
+				2: {77, 77, 9999, 9999, 77, 77, 77, 9999},
+			},
+			expectedMinChunkByChunkIndex: map[uint64][]uint16{
+				// |        validator 42          |      validator 43     |
+				2: {77, 77, neutralMin, neutralMin, 77, 77, 77, neutralMin},
+
+				// |             validator 42             |             validator 43              |
+				0: {neutralMin, neutralMin, neutralMin, 55, neutralMin, neutralMin, neutralMin, 55},
+			},
+			initialMaxChunkByChunkIndex: map[uint64][]uint16{
+				// | validator 42 |  validator 43 |
+				0: {55, 55, 55, 55, 55, 55, 55, 55},
+				1: {66, 66, 66, 66, 66, 66, 66, 66},
+
+				// |   validator 42   |   validator 43  |
+				2: {77, 77, 9999, 9999, 77, 77, 77, 9999},
+			},
+			expectedMaxChunkByChunkIndex: map[uint64][]uint16{
+				// |        validator 42          |      validator 43     |
+				2: {77, 77, neutralMax, neutralMax, 77, 77, 77, neutralMax},
+
+				// |             validator 42             |             validator 43              |
+				0: {neutralMax, neutralMax, neutralMax, 55, neutralMax, neutralMax, neutralMax, 55},
+			},
+		},
 	}
 
-	t.Run("no update if no latest written epoch", func(t *testing.T) {
-		currentEpoch := primitives.Epoch(3)
-		// No last written epoch for both validators.
-		s.latestEpochWrittenForValidator = map[primitives.ValidatorIndex]primitives.Epoch{}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context.
+			ctx := context.Background()
 
-		// Because the validators have no recorded latest epoch written, we expect
-		// no chunks to be loaded nor updated to.
-		updatedChunks, err := s.updatedChunkByChunkIndex(
-			ctx, slashertypes.MinSpan, currentEpoch, 0, // validatorChunkIndex
-		)
-		require.NoError(t, err)
-		require.Equal(t, 0, len(updatedChunks))
-	})
+			// Initialize the slasher database.
+			slasherDB := dbtest.SetupSlasherDB(t)
 
-	t.Run("update from latest written epoch", func(t *testing.T) {
-		currentEpoch := primitives.Epoch(3)
+			// Intialize the slasher service.
+			service := &Service{
+				params: &Parameters{
+					chunkSize:          tt.chunkSize,
+					validatorChunkSize: tt.validatorChunkSize,
+					historyLength:      tt.historyLength,
+				},
+				serviceCfg:                     &ServiceConfig{Database: slasherDB},
+				latestEpochWrittenForValidator: tt.latestUpdatedEpochByValidatorIndex,
+			}
 
-		// Set the latest written epoch for validators to current epoch - 1.
-		latestWrittenEpoch := currentEpoch - 1
-		s.latestEpochWrittenForValidator = map[primitives.ValidatorIndex]primitives.Epoch{
-			1: latestWrittenEpoch,
-			2: latestWrittenEpoch,
-		}
+			// Save min initial chunks if they exist.
+			if tt.initialMinChunkByChunkIndex != nil {
+				minChunkerByChunkerIndex := map[uint64]Chunker{}
+				for chunkIndex, minChunk := range tt.initialMinChunkByChunkIndex {
+					minChunkerByChunkerIndex[chunkIndex] = &MinSpanChunksSlice{data: minChunk}
+				}
 
-		// Because the latest written epoch for the input validators is == 2, we expect
-		// that we will update all epochs from 2 up to 3 (the current epoch). This is all
-		// safe contained in chunk index 1.
-		updatedChunks, err := s.updatedChunkByChunkIndex(
-			ctx, slashertypes.MinSpan, currentEpoch, 0, // validatorChunkIndex,
-		)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(updatedChunks))
-		_, ok := updatedChunks[1]
-		require.Equal(t, true, ok)
-	})
+				err := service.saveUpdatedChunks(ctx, minChunkerByChunkerIndex, slashertypes.MinSpan, tt.validatorChunkIndex)
+				require.NoError(t, err)
+			}
+
+			// Save max initial chunks if they exist.
+			if tt.initialMaxChunkByChunkIndex != nil {
+				maxChunkerByChunkerIndex := map[uint64]Chunker{}
+				for chunkIndex, maxChunk := range tt.initialMaxChunkByChunkIndex {
+					maxChunkerByChunkerIndex[chunkIndex] = &MaxSpanChunksSlice{data: maxChunk}
+				}
+
+				err := service.saveUpdatedChunks(ctx, maxChunkerByChunkerIndex, slashertypes.MaxSpan, tt.validatorChunkIndex)
+				require.NoError(t, err)
+			}
+
+			// Get chunks.
+			actualMinChunkByChunkIndex, err := service.updatedChunkByChunkIndex(
+				ctx, slashertypes.MinSpan, tt.currentEpoch, tt.validatorChunkIndex,
+			)
+
+			// Compare the actual and expected chunks.
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expectedMinChunkByChunkIndex), len(actualMinChunkByChunkIndex))
+			for chunkIndex, expectedMinChunk := range tt.expectedMinChunkByChunkIndex {
+				actualMinChunk, ok := actualMinChunkByChunkIndex[chunkIndex]
+				require.Equal(t, true, ok)
+				require.Equal(t, len(expectedMinChunk), len(actualMinChunk.Chunk()))
+				require.DeepSSZEqual(t, expectedMinChunk, actualMinChunk.Chunk())
+			}
+
+			actualMaxChunkByChunkIndex, err := service.updatedChunkByChunkIndex(
+				ctx, slashertypes.MaxSpan, tt.currentEpoch, tt.validatorChunkIndex,
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expectedMaxChunkByChunkIndex), len(actualMaxChunkByChunkIndex))
+			for chunkIndex, expectedMaxChunk := range tt.expectedMaxChunkByChunkIndex {
+				actualMaxChunk, ok := actualMaxChunkByChunkIndex[chunkIndex]
+				require.Equal(t, true, ok)
+				require.Equal(t, len(expectedMaxChunk), len(actualMaxChunk.Chunk()))
+				require.DeepSSZEqual(t, expectedMaxChunk, actualMaxChunk.Chunk())
+			}
+
+		})
+	}
 }
 
 func Test_applyAttestationForValidator_MinSpanChunk(t *testing.T) {

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -849,34 +849,20 @@ func Test_epochUpdateForValidators(t *testing.T) {
 	}
 
 	t.Run("no update if no latest written epoch", func(t *testing.T) {
-		validators := []primitives.ValidatorIndex{
-			1, 2,
-		}
 		currentEpoch := primitives.Epoch(3)
 		// No last written epoch for both validators.
 		s.latestEpochWrittenForValidator = map[primitives.ValidatorIndex]primitives.Epoch{}
 
 		// Because the validators have no recorded latest epoch written, we expect
 		// no chunks to be loaded nor updated to.
-		updatedChunks := make(map[uint64]Chunker)
-		for _, valIdx := range validators {
-			err := s.loadAndUpdateChunks(
-				ctx,
-				updatedChunks,
-				slashertypes.MinSpan,
-				currentEpoch,
-				0, // validatorChunkIndex
-				valIdx,
-			)
-			require.NoError(t, err)
-		}
+		updatedChunks, err := s.updatedChunkByChunkIndex(
+			ctx, slashertypes.MinSpan, currentEpoch, 0, // validatorChunkIndex
+		)
+		require.NoError(t, err)
 		require.Equal(t, 0, len(updatedChunks))
 	})
 
 	t.Run("update from latest written epoch", func(t *testing.T) {
-		validators := []primitives.ValidatorIndex{
-			1, 2,
-		}
 		currentEpoch := primitives.Epoch(3)
 
 		// Set the latest written epoch for validators to current epoch - 1.
@@ -889,18 +875,10 @@ func Test_epochUpdateForValidators(t *testing.T) {
 		// Because the latest written epoch for the input validators is == 2, we expect
 		// that we will update all epochs from 2 up to 3 (the current epoch). This is all
 		// safe contained in chunk index 1.
-		updatedChunks := make(map[uint64]Chunker)
-		for _, valIdx := range validators {
-			err := s.loadAndUpdateChunks(
-				ctx,
-				updatedChunks,
-				slashertypes.MinSpan,
-				currentEpoch,
-				0, // validatorChunkIndex,
-				valIdx,
-			)
-			require.NoError(t, err)
-		}
+		updatedChunks, err := s.updatedChunkByChunkIndex(
+			ctx, slashertypes.MinSpan, currentEpoch, 0, // validatorChunkIndex,
+		)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(updatedChunks))
 		_, ok := updatedChunks[1]
 		require.Equal(t, true, ok)

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -860,12 +860,12 @@ func Test_epochUpdateForValidators(t *testing.T) {
 		// no chunks to be loaded nor updated to.
 		updatedChunks := make(map[uint64]Chunker)
 		for _, valIdx := range validators {
-			err := s.epochUpdateForValidator(
+			err := s.loadAndUpdateChunks(
 				ctx,
 				updatedChunks,
-				0, // validatorChunkIndex
 				slashertypes.MinSpan,
 				currentEpoch,
+				0, // validatorChunkIndex
 				valIdx,
 			)
 			require.NoError(t, err)
@@ -891,12 +891,12 @@ func Test_epochUpdateForValidators(t *testing.T) {
 		// safe contained in chunk index 1.
 		updatedChunks := make(map[uint64]Chunker)
 		for _, valIdx := range validators {
-			err := s.epochUpdateForValidator(
+			err := s.loadAndUpdateChunks(
 				ctx,
 				updatedChunks,
-				0, // validatorChunkIndex,
 				slashertypes.MinSpan,
 				currentEpoch,
+				0, // validatorChunkIndex,
 				valIdx,
 			)
 			require.NoError(t, err)


### PR DESCRIPTION
**Please read commit by commit.**

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Improve slasher cold boot duration.

Before this commit, on a slasher cold boot (aka, without any db),
the `updatedChunkByChunkIndex` function looped for all validators
AND for all epochs between the genesis epoch and the current epoch.

This could take several dozen of minutes, and it is useless since the
min/max spans are actually a circular buffer with a limited lenght.
Cells of min/max spans can be overwritten (with the same value)
plenty of times.

After this commit, the `updatedChunkByChunkIndex` function loops
for all validators AND AT MOST `historyLength` lenght.
Every cell of min/max spans are written AT MOST once.

Time needed for slasher boot goes from `O(nm`) to "only" `O(m)`, where:
- `n` is the number of epochs since the genesis.
- `m` is the number of validators.

**Which issues(s) does this PR fix?**
