### PR TITLE
Backfill start after init-sync at head

### DIFF
--- a/beacon-chain/sync/backfill/service.go
+++ b/beacon-chain/sync/backfill/service.go
@@ -39,6 +39,7 @@ type Service struct {
 	pa              PeerAssigner
 	batchImporter   batchImporter
 	blobStore       *filesystem.BlobStorage
+	initSyncWaiter  func() error
 }
 
 var _ runtime.Service = (*Service)(nil)
@@ -89,6 +90,15 @@ func WithWorkerCount(n int) ServiceOption {
 func WithBatchSize(n uint64) ServiceOption {
 	return func(s *Service) error {
 		s.batchSize = n
+		return nil
+	}
+}
+
+// WithInitSyncWaiter sets a function on the service which will block until init-sync
+// completes for the first time, or returns an error if context is canceled.
+func WithInitSyncWaiter(w func() error) ServiceOption {
+	return func(s *Service) error {
+		s.initSyncWaiter = w
 		return nil
 	}
 }
@@ -261,8 +271,15 @@ func (s *Service) Start() {
 		log.WithError(err).Error("Unable to initialize backfill verifier.")
 		return
 	}
-	s.pool.spawn(ctx, s.nWorkers, clock, s.pa, s.verifier, s.ctxMap, s.newBlobVerifier, s.blobStore)
 
+	if s.initSyncWaiter != nil {
+		log.Info("Backfill service waiting for initial-sync to reach head before starting.")
+		if err := s.initSyncWaiter(); err != nil {
+			log.WithError(err).Error("Error waiting for init-sync to complete.")
+			return
+		}
+	}
+	s.pool.spawn(ctx, s.nWorkers, clock, s.pa, s.verifier, s.ctxMap, s.newBlobVerifier, s.blobStore)
 	s.batchSeq = newBatchSequencer(s.nWorkers, s.ms(s.clock.CurrentSlot()), primitives.Slot(status.LowSlot), primitives.Slot(s.batchSize))
 	if err = s.initBatches(); err != nil {
 		log.WithError(err).Error("Non-recoverable error in backfill service.")


### PR DESCRIPTION
## Problem
Backfill doesn't cooperate with init-sync to preserve rate limit capacity. Making backfill requests concurrently with init-sync requests could be causing peers serving init-sync requests to give init-sync rate limit errors, especially on goerli where some prysm nodes are running with excessively low blob batch limits. We should prioritize init-sync over backfill at node startup so the node can get up to head as soon as possible.

## And so
This PR adds a step to backfill service startup to block on the signal that other services use to wait for init-sync to catch up to head for the first time. Backfill won't spawn the worker pool or begin computing batches until node begins gossip syncing at head.