### PR TITLE
Fix pending block/blob zero peer edge case

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -192,6 +192,8 @@ func (s *Service) hasPeer() bool {
 	return len(s.cfg.p2p.Peers().Connected()) > 0
 }
 
+var errNoPeersForPending = errors.New("no suitable peers to process pending block queue, delaying")
+
 // processAndBroadcastBlock validates, processes, and broadcasts a block.
 // part of the function is to request missing blobs from peers if the block contains kzg commitments.
 func (s *Service) processAndBroadcastBlock(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock, blkRoot [32]byte) error {
@@ -202,10 +204,21 @@ func (s *Service) processAndBroadcastBlock(ctx context.Context, b interfaces.Rea
 		}
 	}
 
-	peers := s.getBestPeers()
-	peerCount := len(peers)
-	if peerCount > 0 {
-		if err := s.requestPendingBlobs(ctx, b, blkRoot, peers[rand.NewGenerator().Int()%peerCount]); err != nil {
+	commitmentCount, err := commitmentsForBlock(b)
+	if err != nil {
+		return err
+	}
+	request, err := s.constructPendingBlobsRequest(ctx, blkRoot, commitmentCount)
+	if err != nil {
+		return err
+	}
+	if len(request) > 0 {
+		peers := s.getBestPeers()
+		peerCount := len(peers)
+		if peerCount == 0 {
+			return errors.Wrapf(errNoPeersForPending, "block root=%#x", blkRoot)
+		}
+		if err := s.sendAndSaveBlobSidecars(ctx, request, peers[rand.NewGenerator().Int()%peerCount], b); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -204,11 +204,7 @@ func (s *Service) processAndBroadcastBlock(ctx context.Context, b interfaces.Rea
 		}
 	}
 
-	commitmentCount, err := commitmentsForBlock(b)
-	if err != nil {
-		return err
-	}
-	request, err := s.constructPendingBlobsRequest(ctx, blkRoot, commitmentCount)
+	request, err := s.pendingBlobsRequestForBlock(blkRoot, b)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -31,7 +31,7 @@ import (
 	leakybucket "github.com/prysmaticlabs/prysm/v5/container/leaky-bucket"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
-	"github.com/prysmaticlabs/prysm/v5/proto/eth/v2"
+	eth "github.com/prysmaticlabs/prysm/v5/proto/eth/v2"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/testing/assert"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
@@ -370,12 +370,16 @@ func TestRequestPendingBlobs(t *testing.T) {
 	t.Run("old block should not fail", func(t *testing.T) {
 		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 		require.NoError(t, err)
-		require.NoError(t, s.requestPendingBlobs(context.Background(), b, [32]byte{}, "test"))
+		cc, err := commitmentsForBlock(b)
+		require.NoError(t, err)
+		require.NoError(t, s.requestPendingBlobs(context.Background(), b, [32]byte{}, cc, "test"))
 	})
 	t.Run("empty commitment block should not fail", func(t *testing.T) {
 		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 		require.NoError(t, err)
-		require.NoError(t, s.requestPendingBlobs(context.Background(), b, [32]byte{}, "test"))
+		cc, err := commitmentsForBlock(b)
+		require.NoError(t, err)
+		require.NoError(t, s.requestPendingBlobs(context.Background(), b, [32]byte{}, cc, "test"))
 	})
 	t.Run("unsupported protocol", func(t *testing.T) {
 		p1 := p2ptest.NewTestP2P(t)
@@ -406,7 +410,9 @@ func TestRequestPendingBlobs(t *testing.T) {
 		b.Block.Body.BlobKzgCommitments = make([][]byte, 1)
 		b1, err := blocks.NewSignedBeaconBlock(b)
 		require.NoError(t, err)
-		require.ErrorContains(t, "protocols not supported", s.requestPendingBlobs(context.Background(), b1, [32]byte{}, p2.PeerID()))
+		cc, err := commitmentsForBlock(b1)
+		require.NoError(t, err)
+		require.ErrorContains(t, "protocols not supported", s.requestPendingBlobs(context.Background(), b1, [32]byte{}, cc, p2.PeerID()))
 	})
 }
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -157,6 +157,7 @@ type Service struct {
 	verifierWaiter                   *verification.InitializerWaiter
 	newBlobVerifier                  verification.NewBlobVerifier
 	availableBlocker                 coverage.AvailableBlocker
+	ctxMap                           ContextByteVersions
 }
 
 // NewService initializes new regular sync service.
@@ -295,6 +296,15 @@ func (s *Service) waitForChainStart() {
 	s.cfg.clock = clock
 	startTime := clock.GenesisTime()
 	log.WithField("starttime", startTime).Debug("Received state initialized event")
+
+	ctxMap, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
+	if err != nil {
+		log.WithError(err).WithField("genesis_validator_root", clock.GenesisValidatorsRoot()).
+			Error("sync service failed to initialize context version map")
+		return
+	}
+	s.ctxMap = ctxMap
+
 	// Register respective rpc handlers at state initialized event.
 	s.registerRPCHandlers()
 	// Wait for chainstart in separate routine.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

There appears to be an edge case where the pending block queue can send a block to ReceiveBlock without requesting blobs first. The pending block broadcast code tries to fetch any necessary blobs before calling ReceiveBlock and broadcasting, but will silently skip the blob fetch if there are no connected peers. ~~I believe this could cause a deadlock when coupled with a Resync.~~ I no longer think there's a deadlock, but it does generally cause the syncing process to get messy and gets the pending block wedged in da check for at least 3 slots before Resync can do its job.

~~This PR also removes blob fetching from the step where the batch of pending blocks is retrieved, deferring that work until broadcast time. This is to simplify the flow, whereas today we could have blobs requested in multiple places with unclear timing consquences due to asyncrony in adding fetched blocks to the queue before blobs are retrieved, and pending queue task spawning new goroutines on a timer. It also allows the blob request to be balanced to a different peer and prevents requesting excess amounts of blobs when processing the batch of multiple blocks.~~

**Which issues(s) does this PR fix?**

unclear if this will fix the issue so I won't mark it as fixed for now.