### PR TITLE
avoid part path collisions with mem addr entropy

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -115,7 +115,7 @@ func (bs *BlobStorage) Save(sidecar blocks.VerifiedROBlob) error {
 	if err := bs.fs.MkdirAll(fname.dir(), directoryPermissions); err != nil {
 		return err
 	}
-	partPath := fname.partPath()
+	partPath := fname.partPath(fmt.Sprintf("%p", sidecarData))
 
 	partialMoved := false
 	// Ensure the partial file is deleted.
@@ -257,16 +257,12 @@ func (p blobNamer) dir() string {
 	return rootString(p.root)
 }
 
-func (p blobNamer) fname(ext string) string {
-	return path.Join(p.dir(), fmt.Sprintf("%d.%s", p.index, ext))
-}
-
-func (p blobNamer) partPath() string {
-	return p.fname(partExt)
+func (p blobNamer) partPath(entropy string) string {
+	return path.Join(p.dir(), fmt.Sprintf("%s-%d.%s", entropy, p.index, partExt))
 }
 
 func (p blobNamer) path() string {
-	return p.fname(sszExt)
+	return path.Join(p.dir(), fmt.Sprintf("%d.%s", p.index, sszExt))
 }
 
 func rootString(root [32]byte) string {


### PR DESCRIPTION


**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

We have observed blob sidecars being truncated. My theory is that this is due to a race when 2 of the same blob sidecar are concurrently written and the second calls `Create`, which opens the same path with `O_TRUNC`.
