### PR TITLE
Fix blob batch verifier pointer receiver

### DIFF
--- a/beacon-chain/sync/backfill/blobs.go
+++ b/beacon-chain/sync/backfill/blobs.go
@@ -112,7 +112,7 @@ func (bbv *blobBatchVerifier) newVerifier(rb blocks.ROBlob) verification.BlobVer
 	return m[rb.Index]
 }
 
-func (bbv blobBatchVerifier) VerifiedROBlobs(_ context.Context, blk blocks.ROBlock, _ []blocks.ROBlob) ([]blocks.VerifiedROBlob, error) {
+func (bbv *blobBatchVerifier) VerifiedROBlobs(_ context.Context, blk blocks.ROBlock, _ []blocks.ROBlob) ([]blocks.VerifiedROBlob, error) {
 	m, ok := bbv.verifiers[blk.Root()]
 	if !ok {
 		return nil, errors.Wrapf(verification.ErrMissingVerification, "no record of verifiers for root %#x", blk.Root())


### PR DESCRIPTION
`blobBatchVerifier` should be a pointer receiver for `VerifiedROBlobs` like `newVerifier`. The value is 2 pointers so this is just an aesthetic issue that shows up as a warning in people's IDE