### PR TITLE
call fsync between part file write and rename

### DIFF
--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -108,7 +108,7 @@ func TestBlobStorage_SaveBlobData(t *testing.T) {
 		// to be empty. This test ensures that several routines can safely save the same blob at the
 		// same time. This isn't ideal behavior from the caller, but should be handled safely anyway.
 		// See https://github.com/prysmaticlabs/prysm/pull/13648
-		b, err := NewBlobStorage(t.TempDir())
+		b, err := NewBlobStorage(WithBasePath(t.TempDir()))
 		require.NoError(t, err)
 		blob := testSidecars[0]
 
@@ -268,6 +268,8 @@ func BenchmarkPruning(b *testing.B) {
 }
 
 func TestNewBlobStorage(t *testing.T) {
-	_, err := NewBlobStorage(path.Join(t.TempDir(), "good"))
+	_, err := NewBlobStorage()
+	require.ErrorIs(t, err, errNoBasePath)
+	_, err = NewBlobStorage(WithBasePath(path.Join(t.TempDir(), "good")))
 	require.NoError(t, err)
 }

--- a/beacon-chain/node/options.go
+++ b/beacon-chain/node/options.go
@@ -43,6 +43,15 @@ func WithBlobStorage(bs *filesystem.BlobStorage) Option {
 	}
 }
 
+// WithBlobStorageOptions appends 1 or more filesystem.BlobStorageOption on the beacon node,
+// to be used when initializing blob storage.
+func WithBlobStorageOptions(opt ...filesystem.BlobStorageOption) Option {
+	return func(bn *BeaconNode) error {
+		bn.BlobStorageOptions = append(bn.BlobStorageOptions, opt...)
+		return nil
+	}
+}
+
 // WithBlobRetentionEpochs sets the blobRetentionEpochs value, used in kv store initialization.
 func WithBlobRetentionEpochs(e primitives.Epoch) Option {
 	return func(bn *BeaconNode) error {

--- a/cmd/beacon-chain/storage/options.go
+++ b/cmd/beacon-chain/storage/options.go
@@ -35,11 +35,10 @@ func BeaconNodeOptions(c *cli.Context) ([]node.Option, error) {
 	if err != nil {
 		return nil, err
 	}
-	bs, err := filesystem.NewBlobStorage(blobStoragePath(c), filesystem.WithBlobRetentionEpochs(e))
-	if err != nil {
-		return nil, err
-	}
-	return []node.Option{node.WithBlobStorage(bs), node.WithBlobRetentionEpochs(e)}, nil
+	opts := []node.Option{node.WithBlobStorageOptions(
+		filesystem.WithBlobRetentionEpochs(e), filesystem.WithBasePath(blobStoragePath(c)),
+	)}
+	return opts, nil
 }
 
 func blobStoragePath(c *cli.Context) string {

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -69,7 +69,8 @@ type Flags struct {
 	EnableEIP4881                bool // EnableEIP4881 specifies whether to use the deposit tree from EIP4881
 
 	PrepareAllPayloads bool // PrepareAllPayloads informs the engine to prepare a block on every slot.
-
+	// BlobSaveFsync requires blob saving to block on fsync to ensure blobs are durably persisted before passing DA.
+	BlobSaveFsync bool
 	// KeystoreImportDebounceInterval specifies the time duration the validator waits to reload new keys if they have
 	// changed on disk. This feature is for advanced use cases only.
 	KeystoreImportDebounceInterval time.Duration
@@ -245,6 +246,11 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(EnableLightClient)
 		cfg.EnableLightClient = true
 	}
+	if ctx.IsSet(BlobSaveFsync.Name) {
+		logEnabled(BlobSaveFsync)
+		cfg.BlobSaveFsync = true
+	}
+
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
 	Init(cfg)
 	return nil

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -149,11 +149,15 @@ var (
 		Name:  "disable-resource-manager",
 		Usage: "Disables running the libp2p resource manager.",
 	}
-
 	// DisableRegistrationCache a flag for disabling the validator registration cache and use db instead.
 	DisableRegistrationCache = &cli.BoolFlag{
 		Name:  "disable-registration-cache",
 		Usage: "Temporary flag for disabling the validator registration cache instead of using the DB. Note: registrations do not clear on restart while using the DB.",
+	}
+	// BlobSaveFsync enforces durable filesystem writes for use cases where blob availability is critical.
+	BlobSaveFsync = &cli.BoolFlag{
+		Name:  "blob-save-fsync",
+		Usage: "Forces new blob files to be fysnc'd before continuing, ensuring durable blob writes.",
 	}
 )
 
@@ -209,6 +213,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	disableResourceManager,
 	DisableRegistrationCache,
 	EnableLightClient,
+	BlobSaveFsync,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR adds a feature flag `--blob-save-fsync`. When this flag is set, the blob storage code will call fsync after writing blob data to the `.part` file, before renaming the part file to the `.ssz` file.

This can be used by node operators who want extra reassurance that zero-length blob files won't be written, particularly in the event of a node restart.