### PR TITLE
Optimize Adding Dirty Indices

### DIFF
--- a/beacon-chain/state/state-native/setters_misc.go
+++ b/beacon-chain/state/state-native/setters_misc.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/stateutil"
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/container/slice"
 	"github.com/prysmaticlabs/prysm/v5/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
@@ -198,9 +199,14 @@ func (b *BeaconState) addDirtyIndices(index types.FieldIndex, indices []uint64) 
 		return
 	}
 	totalIndicesLen := len(b.dirtyIndices[index]) + len(indices)
+	// Reduce duplicates to verify that these are indeed unique.
+	if totalIndicesLen > indicesLimit {
+		b.dirtyIndices[index] = slice.SetUint64(b.dirtyIndices[index])
+	}
+	totalIndicesLen = len(b.dirtyIndices[index]) + len(indices)
 	if totalIndicesLen > indicesLimit {
 		b.rebuildTrie[index] = true
-		b.dirtyIndices[index] = []uint64{}
+		b.dirtyIndices[index] = make([]uint64, 0, indicesLimit)
 	} else {
 		b.dirtyIndices[index] = append(b.dirtyIndices[index], indices...)
 	}

--- a/beacon-chain/state/state-native/setters_misc.go
+++ b/beacon-chain/state/state-native/setters_misc.go
@@ -202,8 +202,8 @@ func (b *BeaconState) addDirtyIndices(index types.FieldIndex, indices []uint64) 
 	// Reduce duplicates to verify that these are indeed unique.
 	if totalIndicesLen > indicesLimit {
 		b.dirtyIndices[index] = slice.SetUint64(b.dirtyIndices[index])
+		totalIndicesLen = len(b.dirtyIndices[index]) + len(indices)
 	}
-	totalIndicesLen = len(b.dirtyIndices[index]) + len(indices)
 	if totalIndicesLen > indicesLimit {
 		b.rebuildTrie[index] = true
 		b.dirtyIndices[index] = make([]uint64, 0, indicesLimit)

--- a/container/slice/slice.go
+++ b/container/slice/slice.go
@@ -94,7 +94,7 @@ func UnionUint64(s ...[]uint64) []uint64 {
 // values from the provided list of indices.
 func SetUint64(a []uint64) []uint64 {
 	// Remove duplicates indices.
-	intMap := map[uint64]bool{}
+	intMap := make(map[uint64]bool, len(a))
 	cleanedIndices := make([]uint64, 0, len(a))
 	for _, idx := range a {
 		if intMap[idx] {


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

We optimize how we add dirty indices for a particular field. In the event we do hit our indices limit, we attempt to remove duplicates before determining whether or not to rebuild the trie. This helps in prevent us from unnecessarily rebuilding a whole field trie. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
