### PR TITLE
Do not log zero sync committee messages

### DIFF
--- a/validator/client/log.go
+++ b/validator/client/log.go
@@ -138,7 +138,9 @@ func (v *validator) LogSubmittedAtts(slot primitives.Slot) {
 
 // LogSubmittedSyncCommitteeMessages logs info about submitted sync committee messages.
 func (v *validator) LogSubmittedSyncCommitteeMessages() {
-	log.WithField("messages", v.syncCommitteeStats.totalMessagesSubmitted).Debug("Submitted sync committee messages successfully to beacon node")
-	// Reset the amount.
-	atomic.StoreUint64(&v.syncCommitteeStats.totalMessagesSubmitted, 0)
+	if v.syncCommitteeStats.totalMessagesSubmitted > 0 {
+		log.WithField("messages", v.syncCommitteeStats.totalMessagesSubmitted).Debug("Submitted sync committee messages successfully to beacon node")
+		// Reset the amount.
+		atomic.StoreUint64(&v.syncCommitteeStats.totalMessagesSubmitted, 0)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

`msg="Submitted sync committee messages successfully to beacon node" messages=0` log is completely useless
