### PR TITLE
Download checkpoint sync origin blobs in init-sync

### DIFF
--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//math:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//runtime:go_default_library",
+        "//runtime/version:go_default_library",
         "//time:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

With this PR a checkpoint synced node will fetch blobs for the checkpoint sync origin block in initial-sync before entering round robin sync. This ensures that the node can guarantee availability of the checkpoint sync blobs before participating in the gossip protocol.

**Other notes for review**

We could have fetched blobs from the checkpoint sync provider beacon node instead, but this approach seemed more robust, since it doesn't assume public beacon node apis will provide blobs.