### PR TITLE
VC: Improve logging in case of fatal error

### DIFF
--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -127,7 +127,8 @@ func main() {
 		Version: version.Version(),
 		Action: func(ctx *cli.Context) error {
 			if err := startNode(ctx); err != nil {
-				return cli.Exit(err.Error(), 1)
+				log.Fatal(err.Error())
+				return err
 			}
 			return nil
 		},

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -261,7 +261,6 @@ func (c *ValidatorClient) initializeFromCLI(cliCtx *cli.Context, router *mux.Rou
 		if isWeb3SignerURLFlagSet {
 			c.wallet = wallet.NewWalletForWeb3Signer()
 		} else {
-			fmt.Println("initializeFromCLI asking for wallet")
 			w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
 				return nil, wallet.ErrNoWalletFound
 			})


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
If running the VC with, for example, a non-existing `--wallet-password-file`, the most useful information (aka, the error message) is actually the less visible on the screen.

Example:

![image](https://github.com/prysmaticlabs/prysm/assets/4943830/c365c33d-e727-4a45-92bd-d9123c9a3060)

After this PR, the log message preventing the VC to run is displayed as `FATAL`.
![image](https://github.com/prysmaticlabs/prysm/assets/4943830/e2f227d0-9a5b-4208-8d98-9c9165c694ce)

**NOTE:** In such a case, the error code is still non-zero.
