### PR TITLE
exit blob fetching for cp block if outside retention

### DIFF
--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "//beacon-chain/das:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/filesystem:go_default_library",
+        "//beacon-chain/db/kv:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/p2p:go_default_library",
         "//beacon-chain/p2p/peers:go_default_library",

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -316,6 +316,9 @@ func (s *Service) fetchOriginBlobs(pids []peer.ID) error {
 		log.WithField("root", fmt.Sprintf("%#x", r)).Error("Block for checkpoint sync origin root not found in db")
 		return err
 	}
+	if !params.WithinDAPeriod(slots.ToEpoch(blk.Block().Slot()), slots.ToEpoch(s.clock.CurrentSlot())) {
+		return nil
+	}
 	rob, err := blocks.NewROBlockWithRoot(blk, r)
 	if err != nil {
 		return err


### PR DESCRIPTION

**What type of PR is this?**
Bug fix


**What does this PR do? Why is it needed?**

If the checkpoint sync origin is outside the blob retention epoch, we will have pruned its blobs. This creates a false positive where we think we need to fetch the blobs, but since they are outside the retention period, we may not be able to get them from peers.

This PR exits the checkpoint block blob fetching routine if the checkpoint block slot is outside the retention period.
