### PR TITLE
Revert "pass justified=finalized in Prater (#13695)"

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -290,18 +290,10 @@ func (s *Service) StartFromSavedState(saved state.BeaconState) error {
 	fRoot := s.ensureRootNotZeros(bytesutil.ToBytes32(finalized.Root))
 	s.cfg.ForkChoiceStore.Lock()
 	defer s.cfg.ForkChoiceStore.Unlock()
-	if params.BeaconConfig().ConfigName != params.PraterName {
-		if err := s.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(s.ctx, &forkchoicetypes.Checkpoint{Epoch: justified.Epoch,
-			Root: bytesutil.ToBytes32(justified.Root)}); err != nil {
-			return errors.Wrap(err, "could not update forkchoice's justified checkpoint")
-		}
-	} else {
-		if err := s.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(s.ctx, &forkchoicetypes.Checkpoint{Epoch: finalized.Epoch,
-			Root: bytesutil.ToBytes32(finalized.Root)}); err != nil {
-			return errors.Wrap(err, "could not update forkchoice's justified checkpoint")
-		}
+	if err := s.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(s.ctx, &forkchoicetypes.Checkpoint{Epoch: justified.Epoch,
+		Root: bytesutil.ToBytes32(justified.Root)}); err != nil {
+		return errors.Wrap(err, "could not update forkchoice's justified checkpoint")
 	}
-
 	if err := s.cfg.ForkChoiceStore.UpdateFinalizedCheckpoint(&forkchoicetypes.Checkpoint{Epoch: finalized.Epoch,
 		Root: bytesutil.ToBytes32(finalized.Root)}); err != nil {
 		return errors.Wrap(err, "could not update forkchoice's finalized checkpoint")


### PR DESCRIPTION
This proved useless in Goerli and it's a hack that can be safely removed. I suggest we don't merge this PR (marked as blocked) until mass ejection happens in a couple of weeks. 

With the current #13695 merged, nodes follow the chain and the beacon chain db is correct, while the validators are deadlocked. As soon as the chain justifies they will continue attesting. 

If we merge this PR, the beacon nodes will not be able to follow the chain and will continue sending wrong attestations possibly being banned by peers. 