### PR TITLE
ssz interop write: only capture invalid block

### DIFF
--- a/beacon-chain/core/transition/BUILD.bazel
+++ b/beacon-chain/core/transition/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//beacon-chain/core/execution:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/time:go_default_library",
-        "//beacon-chain/core/transition/interop:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native:go_default_library",

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/altair"
 	b "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/transition/interop"
 	v "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	field_params "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
@@ -57,9 +56,6 @@ func ExecuteStateTransitionNoVerifyAnySig(
 	ctx, span := trace.StartSpan(ctx, "core.state.ExecuteStateTransitionNoVerifyAnySig")
 	defer span.End()
 	var err error
-
-	interop.WriteBlockToDisk(signed, false /* Has the block failed */)
-	interop.WriteStateToDisk(st)
 
 	parentRoot := signed.Block().ParentRoot()
 	st, err = ProcessSlotsUsingNextSlotCache(ctx, st, parentRoot[:], signed.Block().Slot())

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -40,7 +40,7 @@ var (
 	}
 	writeSSZStateTransitionsFlag = &cli.BoolFlag{
 		Name:  "interop-write-ssz-state-transitions",
-		Usage: "Writes SSZ states to disk after attempted state transitio.",
+		Usage: "Writes failed SSZ block to disk after attempted importing block and state transition.",
 	}
 	disableGRPCConnectionLogging = &cli.BoolFlag{
 		Name:  "disable-grpc-connection-logging",


### PR DESCRIPTION
When using `--interop-write-ssz-state-transitions`, the goal is to save failed blocks to disk for debugging purposes. Valid blocks and states are already stored on disk and can be accessed through the beacon-api so there's no need to capture them directly using this flag. Storing every state for every slot is costly, with each state taking up approximately 175MB. This PR modifies the behavior of `interop-write-ssz-state-transitions` to only save invalid blocks to disk, thereby optimizing storage. This is achieved by removing `interop.WriteBlockToDisk` and `interop.WriteStateToDisk` calls in `ExecuteStateTransitionNoVerifyAnySig`.