### PR TITLE
Save invalid block to temp `save-invalid-block-temp`

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -108,6 +108,7 @@ go_library(
         "//crypto/rand:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//encoding/ssz/equality:go_default_library",
+        "//io/file:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//network/forks:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -2,10 +2,16 @@ package sync
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path"
 
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/transition/interop"
+	"github.com/prysmaticlabs/prysm/v5/config/features"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
+	"github.com/prysmaticlabs/prysm/v5/io/file"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -33,7 +39,10 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 			if r != [32]byte{} {
 				s.setBadBlock(ctx, r) // Setting head block as bad.
 			} else {
+				// TODO(13721): Remove this once we can deprecate the flag.
 				interop.WriteBlockToDisk(signed, true /*failed*/)
+
+				saveInvalidBlockToTemp(signed)
 				s.setBadBlock(ctx, root)
 			}
 		}
@@ -44,4 +53,22 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 		return err
 	}
 	return err
+}
+
+// WriteInvalidBlockToDisk as a block ssz. Writes to temp directory.
+func saveInvalidBlockToTemp(block interfaces.ReadOnlySignedBeaconBlock) {
+	if !features.Get().SaveInvalidBlock {
+		return
+	}
+	filename := fmt.Sprintf("beacon_block_%d.ssz", block.Block().Slot())
+	fp := path.Join(os.TempDir(), filename)
+	log.Warnf("Writing invalid block to disk at %s", fp)
+	enc, err := block.MarshalSSZ()
+	if err != nil {
+		log.WithError(err).Error("Failed to ssz encode block")
+		return
+	}
+	if err := file.WriteFile(fp, enc); err != nil {
+		log.WithError(err).Error("Failed to write to disk")
+	}
 }

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -72,6 +72,9 @@ type Flags struct {
 	PrepareAllPayloads bool // PrepareAllPayloads informs the engine to prepare a block on every slot.
 	// BlobSaveFsync requires blob saving to block on fsync to ensure blobs are durably persisted before passing DA.
 	BlobSaveFsync bool
+
+	SaveInvalidBlock bool // SaveInvalidBlock saves invalid block to temp.
+
 	// KeystoreImportDebounceInterval specifies the time duration the validator waits to reload new keys if they have
 	// changed on disk. This feature is for advanced use cases only.
 	KeystoreImportDebounceInterval time.Duration
@@ -185,6 +188,11 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.Bool(writeSSZStateTransitionsFlag.Name) {
 		logEnabled(writeSSZStateTransitionsFlag)
 		cfg.WriteSSZStateTransitions = true
+	}
+
+	if ctx.Bool(saveInvalidBlockTempFlag.Name) {
+		logEnabled(saveInvalidBlockTempFlag)
+		cfg.SaveInvalidBlock = true
 	}
 
 	if ctx.IsSet(disableGRPCConnectionLogging.Name) {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -42,6 +42,10 @@ var (
 		Name:  "interop-write-ssz-state-transitions",
 		Usage: "Writes SSZ states to disk after attempted state transitio.",
 	}
+	saveInvalidBlockTempFlag = &cli.BoolFlag{
+		Name:  "save-invalid-block-temp",
+		Usage: "Writes invalid blocks to temp directory.",
+	}
 	disableGRPCConnectionLogging = &cli.BoolFlag{
 		Name:  "disable-grpc-connection-logging",
 		Usage: "Disables displaying logs for newly connected grpc clients.",
@@ -196,6 +200,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	devModeFlag,
 	enableExperimentalState,
 	writeSSZStateTransitionsFlag,
+	saveInvalidBlockTempFlag,
 	disableGRPCConnectionLogging,
 	HoleskyTestnet,
 	PraterTestnet,


### PR DESCRIPTION
Add the new flag `--save-invalid-block-temp` to save invalid gossip and received blocks to a temporary folder. This will be useful for the Deneb hard fork happening in one day. The choice of a feature flag and a temporary folder was made for their simplicity and minimal manual intervention. If necessary, we can later switch to a regular flag and a user-specified folder.