### PR TITLE
Save invalid blob to temp under new flag

### DIFF
--- a/config/features/config.go
+++ b/config/features/config.go
@@ -74,6 +74,7 @@ type Flags struct {
 	BlobSaveFsync bool
 
 	SaveInvalidBlock bool // SaveInvalidBlock saves invalid block to temp.
+	SaveInvalidBlob  bool // SaveInvalidBlob saves invalid blob to temp.
 
 	// KeystoreImportDebounceInterval specifies the time duration the validator waits to reload new keys if they have
 	// changed on disk. This feature is for advanced use cases only.
@@ -193,6 +194,11 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.Bool(saveInvalidBlockTempFlag.Name) {
 		logEnabled(saveInvalidBlockTempFlag)
 		cfg.SaveInvalidBlock = true
+	}
+
+	if ctx.Bool(saveInvalidBlobTempFlag.Name) {
+		logEnabled(saveInvalidBlobTempFlag)
+		cfg.SaveInvalidBlob = true
 	}
 
 	if ctx.IsSet(disableGRPCConnectionLogging.Name) {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -46,6 +46,10 @@ var (
 		Name:  "save-invalid-block-temp",
 		Usage: "Writes invalid blocks to temp directory.",
 	}
+	saveInvalidBlobTempFlag = &cli.BoolFlag{
+		Name:  "save-invalid-blob-temp",
+		Usage: "Writes invalid blobs to temp directory.",
+	}
 	disableGRPCConnectionLogging = &cli.BoolFlag{
 		Name:  "disable-grpc-connection-logging",
 		Usage: "Disables displaying logs for newly connected grpc clients.",
@@ -201,6 +205,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	enableExperimentalState,
 	writeSSZStateTransitionsFlag,
 	saveInvalidBlockTempFlag,
+	saveInvalidBlobTempFlag,
 	disableGRPCConnectionLogging,
 	HoleskyTestnet,
 	PraterTestnet,


### PR DESCRIPTION
This PR saves an invalid blob to temp under `--save-invalid-blob-temp`. Here the invalid blob is defined by failing `SidecarKzgProofVerified`, we would still perform the proposer signature beforehand to prevent invalid spamming