### PR TITLE
Backfill min slot flag

### DIFF
--- a/beacon-chain/sync/backfill/service.go
+++ b/beacon-chain/sync/backfill/service.go
@@ -307,7 +307,7 @@ func (s *Service) Start() {
 		if ctx.Err() != nil {
 			return
 		}
-		if allComplete := s.updateComplete(); allComplete {
+		if s.updateComplete() {
 			return
 		}
 		s.importBatches(ctx)
@@ -334,11 +334,11 @@ func (s *Service) downscore(b batch) {
 	s.p2p.Peers().Scorers().BadResponsesScorer().Increment(b.blockPid)
 }
 
-func (s *Service) Stop() error {
+func (*Service) Stop() error {
 	return nil
 }
 
-func (s *Service) Status() error {
+func (*Service) Status() error {
 	return nil
 }
 

--- a/beacon-chain/sync/backfill/service.go
+++ b/beacon-chain/sync/backfill/service.go
@@ -118,6 +118,24 @@ func WithVerifierWaiter(viw InitializerWaiter) ServiceOption {
 	}
 }
 
+// WithMinimumSlot allows the user to specify a different backfill minimum slot than the spec default of current - MIN_EPOCHS_FOR_BLOCK_REQUESTS.
+// If this value is greater than current - MIN_EPOCHS_FOR_BLOCK_REQUESTS, it will be ignored with a warning log.
+func WithMinimumSlot(s primitives.Slot) ServiceOption {
+	ms := func(current primitives.Slot) primitives.Slot {
+		specMin := minimumBackfillSlot(current)
+		if s < specMin {
+			return s
+		}
+		log.WithField("userSlot", s).WithField("specMinSlot", specMin).
+			Warn("Ignoring user-specified slot > MIN_EPOCHS_FOR_BLOCK_REQUESTS.")
+		return specMin
+	}
+	return func(s *Service) error {
+		s.ms = ms
+		return nil
+	}
+}
+
 // NewService initializes the backfill Service. Like all implementations of the Service interface,
 // the service won't begin its runloop until Start() is called.
 func NewService(ctx context.Context, su *Store, bStore *filesystem.BlobStorage, cw startup.ClockWaiter, p p2p.P2P, pa PeerAssigner, opts ...ServiceOption) (*Service, error) {

--- a/beacon-chain/sync/backfill/service_test.go
+++ b/beacon-chain/sync/backfill/service_test.go
@@ -29,7 +29,7 @@ func (m mockMinimumSlotter) minimumSlot(_ primitives.Slot) primitives.Slot {
 type mockInitalizerWaiter struct {
 }
 
-func (mi *mockInitalizerWaiter) WaitForInitializer(ctx context.Context) (*verification.Initializer, error) {
+func (*mockInitalizerWaiter) WaitForInitializer(_ context.Context) (*verification.Initializer, error) {
 	return &verification.Initializer{}, nil
 }
 
@@ -67,7 +67,7 @@ func TestServiceInit(t *testing.T) {
 	}
 	go srv.Start()
 	todo := make([]batch, 0)
-	todo = testReadN(t, ctx, pool.todoChan, nWorkers, todo)
+	todo = testReadN(ctx, t, pool.todoChan, nWorkers, todo)
 	require.Equal(t, nWorkers, len(todo))
 	for i := 0; i < remaining; i++ {
 		b := todo[i]
@@ -75,7 +75,7 @@ func TestServiceInit(t *testing.T) {
 			b.state = batchImportable
 		}
 		pool.finishedChan <- b
-		todo = testReadN(t, ctx, pool.todoChan, 1, todo)
+		todo = testReadN(ctx, t, pool.todoChan, 1, todo)
 	}
 	require.Equal(t, remaining+nWorkers, len(todo))
 	for i := remaining; i < remaining+nWorkers; i++ {
@@ -95,7 +95,7 @@ func TestMinimumBackfillSlot(t *testing.T) {
 	require.Equal(t, primitives.Slot(1), minSlot)
 }
 
-func testReadN(t *testing.T, ctx context.Context, c chan batch, n int, into []batch) []batch {
+func testReadN(ctx context.Context, t *testing.T, c chan batch, n int, into []batch) []batch {
 	for i := 0; i < n; i++ {
 		select {
 		case b := <-c:

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -143,6 +143,7 @@ var appFlags = []cli.Flag{
 	bflags.EnableExperimentalBackfill,
 	bflags.BackfillBatchSize,
 	bflags.BackfillWorkerCount,
+	bflags.BackfillOldestSlot,
 }
 
 func init() {

--- a/cmd/beacon-chain/sync/backfill/BUILD.bazel
+++ b/cmd/beacon-chain/sync/backfill/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//beacon-chain/node:go_default_library",
         "//beacon-chain/sync/backfill:go_default_library",
         "//cmd/beacon-chain/sync/backfill/flags:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],
 )

--- a/cmd/beacon-chain/sync/backfill/flags/flags.go
+++ b/cmd/beacon-chain/sync/backfill/flags/flags.go
@@ -35,4 +35,9 @@ var (
 			"This has a multiplicative effect with " + backfillBatchSizeName + ".",
 		Value: 2,
 	}
+	BackfillOldestSlot = &cli.Uint64Flag{
+		Name: "backfill-oldest-slot",
+		Usage: "Specifies the oldest slot that backfill should download. " +
+			"If this value is greater than current_slot - MIN_EPOCHS_FOR_BLOCK_REQUESTS, it will be ignored with a warning log.",
+	}
 )

--- a/cmd/beacon-chain/sync/backfill/options.go
+++ b/cmd/beacon-chain/sync/backfill/options.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/node"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/sync/backfill"
 	"github.com/prysmaticlabs/prysm/v5/cmd/beacon-chain/sync/backfill/flags"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/urfave/cli/v2"
 )
 
@@ -11,11 +12,17 @@ import (
 // from flag parsing.
 func BeaconNodeOptions(c *cli.Context) ([]node.Option, error) {
 	opt := func(node *node.BeaconNode) (err error) {
-		node.BackfillOpts = []backfill.ServiceOption{
+		bno := []backfill.ServiceOption{
 			backfill.WithBatchSize(c.Uint64(flags.BackfillBatchSize.Name)),
 			backfill.WithWorkerCount(c.Int(flags.BackfillWorkerCount.Name)),
 			backfill.WithEnableBackfill(c.Bool(flags.EnableExperimentalBackfill.Name)),
 		}
+		// The zero value of this uint flag would be genesis, so we use IsSet to differentiate nil from zero case.
+		if c.IsSet(flags.BackfillOldestSlot.Name) {
+			uv := c.Uint64(flags.BackfillBatchSize.Name)
+			bno = append(bno, backfill.WithMinimumSlot(primitives.Slot(uv)))
+		}
+		node.BackfillOpts = bno
 		return nil
 	}
 	return []node.Option{opt}, nil

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -140,6 +140,7 @@ var appHelpFlagGroups = []flagGroup{
 			backfill.EnableExperimentalBackfill,
 			backfill.BackfillWorkerCount,
 			backfill.BackfillBatchSize,
+			backfill.BackfillOldestSlot,
 		},
 	},
 	{


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds the ability to control the slot where the backfill operation will be marked complete. This flag only allows specifying a slot that is older than `<current_slot> - MIN_EPOCHS_FOR_BLOCK_REQUESTS`. If the specified slot is newer than that, it will be ignored with a warning log. Setting a value of `0` allows backfilling to genesis.

Note that this flag does not change the behavior of the backfill process with regard to blobs. Blobs outside the retention window still will not be downloaded, as nodes may be unable to find peers capable of serving expired blobs and requiring them to be present would create complexities re peer scoring and delay syncing for the majority of nodes that do not need expired blobs.