### PR TITLE
fix 1-worker underflow; lower default batch size

### DIFF
--- a/beacon-chain/sync/backfill/batcher.go
+++ b/beacon-chain/sync/backfill/batcher.go
@@ -79,6 +79,10 @@ func (c *batchSequencer) update(b batch) {
 		// so we want to copy c to a, then on i=3, d to b, then on i=4 e to c.
 		c.seq[i-done] = c.seq[i]
 	}
+	if done == 1 && len(c.seq) == 1 {
+		c.seq[0] = c.batcher.beforeBatch(c.seq[0])
+		return
+	}
 	// Overwrite the moved batches with the next ones in the sequence.
 	// Continuing the example in the comment above, len(c.seq)==5, done=2, so i=3.
 	// We want to replace index 3 with the batch that should be processed after index 2,

--- a/cmd/beacon-chain/sync/backfill/flags/flags.go
+++ b/cmd/beacon-chain/sync/backfill/flags/flags.go
@@ -22,7 +22,7 @@ var (
 		Usage: "Number of blocks per backfill batch. " +
 			"A larger number will request more blocks at once from peers, but also consume more system memory to " +
 			"hold batches in memory during processing. This has a multiplicative effect with " + backfillWorkerCountName + ".",
-		Value: 64,
+		Value: 32,
 	}
 	// BackfillWorkerCount allows users to tune the number of concurrent backfill batches to download, to maximize
 	// network utilization at the cost of higher memory.


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix
Other

**What does this PR do? Why is it needed?**

This PR fixes a panic that occurs soon after the first backfill batch completes, if the backfill worker count flag is set to 1 (`--backfill-worker-count=1`).

Also, the default value for `--backfill-batch-size` is lowered from 64 to 32, based on testing in mainnet where it was observed that this value led to a healthier mix of peer implementations, due to the higher batch size triggering rate limits more frequently for some peer implementations. 