### PR TITLE
Use headstate for recent checkpoints

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -18,17 +18,48 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
 
+func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) state.ReadOnlyBeaconState {
+	headEpoch := slots.ToEpoch(s.HeadSlot())
+	if c.Epoch < headEpoch {
+		return nil
+	}
+	if !s.cfg.ForkChoiceStore.IsCanonical([32]byte(c.Root)) {
+		return nil
+	}
+	if c.Epoch == headEpoch {
+		targetSlot, err := s.cfg.ForkChoiceStore.Slot([32]byte(c.Root))
+		if err != nil {
+			return nil
+		}
+		if slots.ToEpoch(targetSlot)+1 < headEpoch {
+			return nil
+		}
+		st, err := s.HeadStateReadOnly(ctx)
+		if err != nil {
+			return nil
+		}
+		return st
+	}
+	slot, err := slots.EpochStart(c.Epoch)
+	if err != nil {
+		return nil
+	}
+	st, err := s.HeadState(ctx)
+	if err != nil {
+		return nil
+	}
+	st, err = transition.ProcessSlotsUsingNextSlotCache(ctx, st, c.Root, slot)
+	if err != nil {
+		return nil
+	}
+	return st
+}
+
 // getAttPreState retrieves the att pre state by either from the cache or the DB.
 func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (state.ReadOnlyBeaconState, error) {
 	// If the attestation is recent and canonical we can use the head state to compute the shuffling.
-	headEpoch := slots.ToEpoch(s.HeadSlot())
-	if c.Epoch == headEpoch {
-		targetSlot, err := s.cfg.ForkChoiceStore.Slot([32]byte(c.Root))
-		if err == nil && slots.ToEpoch(targetSlot)+1 >= headEpoch {
-			if s.cfg.ForkChoiceStore.IsCanonical([32]byte(c.Root)) {
-				return s.HeadStateReadOnly(ctx)
-			}
-		}
+	if st := s.getRecentPreState(ctx, c); st != nil {
+		return st, nil
 	}
 	// Use a multilock to allow scoped holding of a mutex by a checkpoint root + epoch
 	// allowing us to behave smarter in terms of how this function is used concurrently.

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -52,6 +52,9 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 	if err != nil {
 		return nil
 	}
+	if err := s.checkpointStateCache.AddCheckpointState(c, st); err != nil {
+		return nil
+	}
 	return st
 }
 

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -146,6 +146,28 @@ func TestStore_OnAttestation_Ok_DoublyLinkedTree(t *testing.T) {
 	require.NoError(t, service.OnAttestation(ctx, att[0], 0))
 }
 
+func TestService_GetRecentPreState(t *testing.T) {
+	service, _ := minimalTestService(t)
+	ctx := context.Background()
+
+	s, err := util.NewBeaconState()
+	require.NoError(t, err)
+	ckRoot := bytesutil.PadTo([]byte{'A'}, fieldparams.RootLength)
+	cp0 := &ethpb.Checkpoint{Epoch: 0, Root: ckRoot}
+	err = s.SetFinalizedCheckpoint(cp0)
+	require.NoError(t, err)
+
+	st, root, err := prepareForkchoiceState(ctx, 31, [32]byte(ckRoot), [32]byte{}, [32]byte{'R'}, cp0, cp0)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, st, root))
+	service.head = &head{
+		root:  [32]byte(ckRoot),
+		state: s,
+		slot:  31,
+	}
+	require.NotNil(t, service.getRecentPreState(ctx, &ethpb.Checkpoint{Epoch: 1, Root: ckRoot}))
+}
+
 func TestService_GetAttPreState_Concurrency(t *testing.T) {
 	service, _ := minimalTestService(t)
 	ctx := context.Background()


### PR DESCRIPTION
In the event a peer hasn't imported slot 0 and attests for slot 31 as target during slot 0. All prysm nodes that have seen the block in slot 0 and are receiving these attestations, go through the following in `gettAttPrestate`

```
	// If the attestation is recent and canonical we can use the head state to compute the shuffling.
	headEpoch := slots.ToEpoch(s.HeadSlot())
	if c.Epoch == headEpoch {
```
This code path is missed since `c.Epoch > headEpoch`. 

Later in the code we hit:
```
	// Do not process attestations for old non viable checkpoints otherwise
	ok, err := s.cfg.ForkChoiceStore.IsViableForCheckpoint(&forkchoicetypes.Checkpoint{Root: [32]byte(c.Root), Epoch: c.Epoch})
	if err != nil {
		return nil, errors.Wrap(err, "could not check checkpoint condition in forkchoice")
	}
	if !ok {
		return nil, errors.Wrap(ErrNotCheckpoint, fmt.Sprintf("epoch %d root %#x", c.Epoch, c.Root))
	}
```
Forkchoice does not take `c` as viable for checkpoint because the only child (slot 0) does not satisfy the condition in it:
```
	for _, child := range node.children {
		if child.slot > epochStart {
			return true, nil
		}
	}
```
Thus we are flooded with the message 
```
	ErrNotCheckpoint = errors.New("not a checkpoint in forkchoice")
```
This should result in poor attestation performance in slot 0 and inclusion in slot 1. 

This PR implements that if the incoming checkpoint has epoch higher than the current head root and the block is canonical (this can only happen if the checkpoint is the actual headroot) then we return as state the head state advanced to the current slot. 

Reviewer be advised: check about possible performance problems because of the slot processing. 