### PR TITLE
[WIP] Fix slasher min/max span values in bucket when updating more than one chunk per run

### DIFF
--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -526,7 +526,7 @@ func (s *Service) applyAttestationForValidator(
 	// for a validator min or max span, we attempt to update the current chunk
 	// for the source epoch of the attestation. If the update function tells
 	// us we need to proceed to the next chunk, we continue by determining
-	// the start epoch of the next chunk. We exit once no longer need to
+	// the start epoch of the next chunk. We exit once we no longer need to
 	// keep updating chunks.
 	for {
 		chunkIndex = s.params.chunkIndex(startEpoch)
@@ -539,7 +539,7 @@ func (s *Service) applyAttestationForValidator(
 			}
 		}
 
-		keepGoing, err := chunk.Update(
+		keepGoingFromEpoch, keepGoing, err := chunk.Update(
 			chunkIndex,
 			currentEpoch,
 			validatorIndex,
@@ -563,8 +563,10 @@ func (s *Service) applyAttestationForValidator(
 			break
 		}
 
-		// Move to first epoch of next chunk if needed.
-		startEpoch = chunk.NextChunkStartEpoch(startEpoch)
+		// Move to next epoch from next chunk
+		// keepGoingFromEpoch is the first epoch of the next chunk for maxspan
+		// or the last epoch of the previous chunk for minspan
+		startEpoch = keepGoingFromEpoch
 	}
 
 	return nil, nil

--- a/beacon-chain/slasher/doc.go
+++ b/beacon-chain/slasher/doc.go
@@ -119,7 +119,7 @@ For example: For MIN SPAN, validators 256 to 511 included, epochs 8208 to 8223 i
 | validator     511 |   ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞     ∞   |
 \---------------------------------------------------------------------------------------------------------------------/
 
-Chunks are stored into the database a flat array of bytes.
+Chunks are stored into the database as a flat array of bytes.
 For this example, the stored value will be:
 |          validator 256        |           validator 257       |        validator 258          |...|          validator 510        |         validator 511		    |
 [∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,2,2,2,2,2,7,6,5,4,3,2,3,2,∞,∞,∞,2,2,2,2,2,2,2,2,2,2,2,2,∞,∞,∞,∞,...,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞,∞]


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR fixes an issue in the database when updating a min or max span chunk. When the chunk update occurs - whether it was updating to next chunk (maxspan) or to previous chunk (minspan) - the wrong index is being used in the for loop resulting in non-coherent data breaking the slasher implementation.

**Which issues(s) does this PR fix?**
#13658
