### PR TITLE
Always Set Inprogress Boolean In Cache

### DIFF
--- a/beacon-chain/cache/skip_slot_cache.go
+++ b/beacon-chain/cache/skip_slot_cache.go
@@ -109,10 +109,6 @@ func (c *SkipSlotCache) Get(ctx context.Context, r [32]byte) (state.BeaconState,
 // MarkInProgress a request so that any other similar requests will block on
 // Get until MarkNotInProgress is called.
 func (c *SkipSlotCache) MarkInProgress(r [32]byte) error {
-	if c.disabled {
-		return nil
-	}
-
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -126,10 +122,6 @@ func (c *SkipSlotCache) MarkInProgress(r [32]byte) error {
 // MarkNotInProgress will release the lock on a given request. This should be
 // called after put.
 func (c *SkipSlotCache) MarkNotInProgress(r [32]byte) {
-	if c.disabled {
-		return
-	}
-
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/beacon-chain/cache/skip_slot_cache_test.go
+++ b/beacon-chain/cache/skip_slot_cache_test.go
@@ -2,6 +2,7 @@ package cache_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
@@ -34,4 +35,29 @@ func TestSkipSlotCache_RoundTrip(t *testing.T) {
 	res, err := c.Get(ctx, r)
 	require.NoError(t, err)
 	assert.DeepEqual(t, res.ToProto(), s.ToProto(), "Expected equal protos to return from cache")
+}
+
+func TestSkipSlotCache_DisabledAndEnabled(t *testing.T) {
+	ctx := context.Background()
+	c := cache.NewSkipSlotCache()
+
+	r := [32]byte{'a'}
+	c.Disable()
+
+	require.NoError(t, c.MarkInProgress(r))
+
+	c.Enable()
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		// Get call will only terminate when
+		// it is not longer in progress.
+		obj, err := c.Get(ctx, r)
+		require.NoError(t, err)
+		require.IsNil(t, obj)
+		wg.Done()
+	}()
+
+	c.MarkNotInProgress(r)
+	wg.Wait()
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

For our skip slot cache, we always set the in-progress boolean for a particular root regardless if it is enabled or disabled. This helps avoid wierd edge cases where the skip slot cache is disabled and then enabled which might lead to wierd deadlocks.

**Which issues(s) does this PR fix?**



**Other notes for review**
