### PR TITLE
adds a metric to track blob sig cache lookups

### DIFF
--- a/beacon-chain/verification/BUILD.bazel
+++ b/beacon-chain/verification/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "fake.go",
         "initializer.go",
         "interface.go",
+        "metrics.go",
         "mock.go",
         "result.go",
     ],
@@ -35,6 +36,8 @@ go_library(
         "//time/slots:go_default_library",
         "@com_github_hashicorp_golang_lru//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/beacon-chain/verification/blob.go
+++ b/beacon-chain/verification/blob.go
@@ -190,12 +190,15 @@ func (bv *ROBlobVerifier) ValidProposerSignature(ctx context.Context) (err error
 	// First check if there is a cached verification that can be reused.
 	seen, err := bv.sc.SignatureVerified(sd)
 	if seen {
+		blobVerifiationProposerSignatureCache.WithLabelValues("hit-valid").Inc()
 		if err != nil {
 			log.WithFields(logging.BlobFields(bv.blob)).WithError(err).Debug("reusing failed proposer signature validation from cache")
+			blobVerifiationProposerSignatureCache.WithLabelValues("hit-invalid").Inc()
 			return ErrInvalidProposerSignature
 		}
 		return nil
 	}
+	blobVerifiationProposerSignatureCache.WithLabelValues("miss").Inc()
 
 	// Retrieve the parent state to fallback to full verification.
 	parent, err := bv.parentState(ctx)

--- a/beacon-chain/verification/metrics.go
+++ b/beacon-chain/verification/metrics.go
@@ -1,0 +1,16 @@
+package verification
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	blobVerifiationProposerSignatureCache = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "blob_verification_proposer_signature_cache",
+			Help: "BlobSidecar proposer signature cache result.",
+		},
+		[]string{"result"},
+	)
+)


### PR DESCRIPTION

**What type of PR is this?**

Feature


**What does this PR do? Why is it needed?**

The blob verification package uses a proposer signature cache to avoid re-verifying the same signature over the same block root multiple times. This PR adds a metric to keep track of how often this cache has a miss, a hit for a valid signature, and a hit for invalid signatures.