### PR TITLE
Set default fee recipient if tracked val fails

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/time"
@@ -39,6 +40,12 @@ var (
 	})
 )
 
+func setFeeRecipientIfBurnAddress(val *cache.TrackedValidator) {
+	if val.FeeRecipient == primitives.ExecutionAddress([20]byte{}) && val.Index == 0 {
+		val.FeeRecipient = primitives.ExecutionAddress(params.BeaconConfig().DefaultFeeRecipient)
+	}
+}
+
 // This returns the local execution payload of a given slot. The function has full awareness of pre and post merge.
 func (vs *Server) getLocalPayload(ctx context.Context, blk interfaces.ReadOnlyBeaconBlock, st state.BeaconState) (interfaces.ExecutionData, bool, error) {
 	ctx, span := trace.StartSpan(ctx, "ProposerServer.getLocalPayload")
@@ -62,6 +69,7 @@ func (vs *Server) getLocalPayload(ctx context.Context, blk interfaces.ReadOnlyBe
 	if !tracked {
 		logrus.WithFields(logFields).Warn("could not find tracked proposer index")
 	}
+	setFeeRecipientIfBurnAddress(&val)
 
 	var err error
 	if ok && payloadId != [8]byte{} {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
@@ -383,3 +383,16 @@ func TestServer_getTerminalBlockHashIfExists(t *testing.T) {
 		})
 	}
 }
+
+func TestSetFeeRecipientIfBurnAddress(t *testing.T) {
+	val := &cache.TrackedValidator{Index: 1}
+	cfg := params.BeaconConfig().Copy()
+	cfg.DefaultFeeRecipient = common.Address([20]byte{'a'})
+	params.OverrideBeaconConfig(cfg)
+	require.NotEqual(t, common.Address(val.FeeRecipient), params.BeaconConfig().DefaultFeeRecipient)
+	setFeeRecipientIfBurnAddress(val)
+	require.NotEqual(t, common.Address(val.FeeRecipient), params.BeaconConfig().DefaultFeeRecipient)
+	val.Index = 0
+	setFeeRecipientIfBurnAddress(val)
+	require.Equal(t, common.Address(val.FeeRecipient), params.BeaconConfig().DefaultFeeRecipient)
+}


### PR DESCRIPTION
When proposing a block, if the validator is not in the tracked validators cache, set it's fee recipient from the beacon node. 