### PR TITLE
Expand Our TTL for our Message ID Cache

### DIFF
--- a/beacon-chain/p2p/parameter_test.go
+++ b/beacon-chain/p2p/parameter_test.go
@@ -22,7 +22,7 @@ func TestGossipParameters(t *testing.T) {
 	pms := pubsubGossipParam()
 	assert.Equal(t, gossipSubMcacheLen, pms.HistoryLength, "gossipSubMcacheLen")
 	assert.Equal(t, gossipSubMcacheGossip, pms.HistoryGossip, "gossipSubMcacheGossip")
-	assert.Equal(t, gossipSubSeenTTL, int(pubsub.TimeCacheDuration.Milliseconds()/pms.HeartbeatInterval.Milliseconds()), "gossipSubSeenTtl")
+	assert.Equal(t, gossipSubSeenTTL, int(pubsub.TimeCacheDuration.Seconds()), "gossipSubSeenTtl")
 }
 
 func TestFanoutParameters(t *testing.T) {

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -25,7 +25,7 @@ const (
 	// gossip parameters
 	gossipSubMcacheLen    = 6   // number of windows to retain full messages in cache for `IWANT` responses
 	gossipSubMcacheGossip = 3   // number of windows to gossip about
-	gossipSubSeenTTL      = 550 // number of heartbeat intervals to retain message IDs
+	gossipSubSeenTTL      = 768 // number of seconds to retain message IDs ( 2 epochs)
 
 	// fanout ttl
 	gossipSubFanoutTTL = 60000000000 // TTL for fanout maps for topics we are not subscribed to but have published to, in nano seconds
@@ -165,7 +165,8 @@ func pubsubGossipParam() pubsub.GossipSubParams {
 // to configure our message id time-cache rather than instantiating
 // it with a router instance.
 func setPubSubParameters() {
-	pubsub.TimeCacheDuration = 550 * gossipSubHeartbeatInterval
+	seenTtl := 2 * time.Second * time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	pubsub.TimeCacheDuration = seenTtl
 }
 
 // convert from libp2p's internal schema to a compatible prysm protobuf format.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix/ Spec Change

**What does this PR do? Why is it needed?**

Following on from https://github.com/ethereum/consensus-specs/pull/3627 , we expand the seen ttl to address the extended attestation validity conditions brought about from EIP 7045.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**