### PR TITLE
Set default LocalBlockValueBoost to 10

### DIFF
--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -254,6 +254,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
+	LocalBlockValueBoost:             10,
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

In order to help increase censorship resistance, I propose to change the default LocalBlockValueBoost to 10. This means validators will prioritize local block building unless the bid from the external block builder is 10% or higher than what the validator would receive when building locally.

Looking at ([stats](https://censorship.pics/)), it can be seen that currently 63.7% of external builders are censoring transactions compared to 8.53% of validators who do local block building, so setting a minimum 10% as default can help increase the overall censorship resistance of the network.

It is still easy for validators to opt out of this by manually setting the flag to 0, but many are likely to use the default which could help with censorship resistance for the network.
