### PR TITLE
add log message if in da check at slot end

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -564,14 +564,14 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 	nextSlot := slots.BeginsAt(signed.Block().Slot()+1, s.genesisTime)
 	// Avoid logging if DA check is called after next slot start.
 	if nextSlot.After(time.Now()) {
-		// Defer the Stop method of the timer used by after func for cleanup.
-		defer time.AfterFunc(time.Until(nextSlot), func() {
+		nst := time.AfterFunc(time.Until(nextSlot), func() {
 			if len(missing) == 0 {
 				return
 			}
 			log.WithFields(daCheckLogFields(root, signed, expected, len(missing))).
 				Error("Still waiting for DA check at slot end.")
-		}).Stop()
+		})
+		defer nst.Stop()
 	}
 	for {
 		select {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -568,7 +568,7 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 			if len(missing) == 0 {
 				return
 			}
-			log.WithFields(daCheckLogFields(root, signed, expected, len(missing))).
+			log.WithFields(daCheckLogFields(root, signed.Block().Slot(), expected, len(missing))).
 				Error("Still waiting for DA check at slot end.")
 		})
 		defer nst.Stop()
@@ -591,9 +591,9 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 	}
 }
 
-func daCheckLogFields(root [32]byte, signed interfaces.ReadOnlySignedBeaconBlock, expected, missing int) logrus.Fields {
+func daCheckLogFields(root [32]byte, slot primitives.Slot, expected, missing int) logrus.Fields {
 	return logrus.Fields{
-		"slot":          signed.Block().Slot(),
+		"slot":          slot,
 		"root":          root,
 		"blobsExpected": expected,
 		"blobsWaiting":  missing,

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -93,6 +93,7 @@ type config struct {
 	stateGen                      *stategen.State
 	slasherAttestationsFeed       *event.Feed
 	slasherBlockHeadersFeed       *event.Feed
+	clock                         *startup.Clock
 	stateNotifier                 statefeed.Notifier
 	blobStorage                   *filesystem.BlobStorage
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -93,7 +93,6 @@ type config struct {
 	stateGen                      *stategen.State
 	slasherAttestationsFeed       *event.Feed
 	slasherBlockHeadersFeed       *event.Feed
-	clock                         *startup.Clock
 	stateNotifier                 statefeed.Notifier
 	blobStorage                   *filesystem.BlobStorage
 }


### PR DESCRIPTION

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This changes the DA check so that it will log if the check is running at the end of the slot for the given block, which provides helpful debugging information for blocks with late blobs.