### PR TITLE
validator client should set beacon API endpoint in configurations

### DIFF
--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -660,6 +660,8 @@ func (c *ValidatorClient) registerRPCService(router *mux.Router) error {
 		ClientGrpcRetryDelay:     grpcRetryDelay,
 		ClientGrpcHeaders:        strings.Split(grpcHeaders, ","),
 		ClientWithCert:           clientCert,
+		BeaconApiTimeout:         time.Second * 30,
+		BeaconApiEndpoint:        c.cliCtx.String(flags.BeaconRESTApiProviderFlag.Name),
 		Router:                   router,
 	})
 	return c.services.RegisterService(server)

--- a/validator/rpc/server.go
+++ b/validator/rpc/server.go
@@ -53,6 +53,8 @@ type Config struct {
 	GenesisFetcher           client.GenesisFetcher
 	WalletInitializedFeed    *event.Feed
 	NodeGatewayEndpoint      string
+	BeaconApiEndpoint        string
+	BeaconApiTimeout         time.Duration
 	Router                   *mux.Router
 	Wallet                   *wallet.Wallet
 }
@@ -130,6 +132,8 @@ func NewServer(ctx context.Context, cfg *Config) *Server {
 		validatorMonitoringPort:  cfg.ValidatorMonitoringPort,
 		validatorGatewayHost:     cfg.ValidatorGatewayHost,
 		validatorGatewayPort:     cfg.ValidatorGatewayPort,
+		beaconApiTimeout:         cfg.BeaconApiTimeout,
+		beaconApiEndpoint:        cfg.BeaconApiEndpoint,
 		router:                   cfg.Router,
 	}
 	// immediately register routes to override any catchalls


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Running validator client in rest mode with `--enable-beacon-rest-api` with the web UI causes the following error 
![image](https://github.com/prysmaticlabs/prysm/assets/90280386/353af159-5f79-4f5f-a9c6-b17983063795)
this is due to the beacon API endpoint not being set. by setting these settings during registration it should fix the issue.

