### PR TITLE
Fix get validator endpoint for empty query parameters

### DIFF
--- a/validator/rpc/handlers_beacon.go
+++ b/validator/rpc/handlers_beacon.go
@@ -158,25 +158,31 @@ func (s *Server) GetValidators(w http.ResponseWriter, r *http.Request) {
 	}
 	pageToken := r.URL.Query().Get("page_token")
 	publicKeys := r.URL.Query()["public_keys"]
-	pubkeys := make([][]byte, len(publicKeys))
+	pubkeys := make([][]byte, 0)
 	for i, key := range publicKeys {
-		var pk []byte
+		if key == "" {
+			continue
+		}
 		if strings.HasPrefix(key, "0x") {
 			k, ok := shared.ValidateHex(w, fmt.Sprintf("PublicKeys[%d]", i), key, fieldparams.BLSPubkeyLength)
 			if !ok {
 				return
 			}
-			pk = bytesutil.SafeCopyBytes(k)
+			pubkeys = append(pubkeys, bytesutil.SafeCopyBytes(k))
 		} else {
 			data, err := base64.StdEncoding.DecodeString(key)
 			if err != nil {
 				httputil.HandleError(w, errors.Wrap(err, "Failed to decode base64").Error(), http.StatusBadRequest)
 				return
 			}
-			pk = bytesutil.SafeCopyBytes(data)
+			pubkeys = append(pubkeys, bytesutil.SafeCopyBytes(data))
 		}
-		pubkeys[i] = pk
 	}
+	if len(pubkeys) == 0 {
+		httputil.HandleError(w, "no pubkeys provided", http.StatusBadRequest)
+		return
+	}
+	log.Infof("Pubkeys! %v", pubkeys)
 	req := &ethpb.ListValidatorsRequest{
 		PublicKeys: pubkeys,
 		PageSize:   int32(ps),

--- a/validator/rpc/handlers_beacon.go
+++ b/validator/rpc/handlers_beacon.go
@@ -182,7 +182,6 @@ func (s *Server) GetValidators(w http.ResponseWriter, r *http.Request) {
 		httputil.HandleError(w, "no pubkeys provided", http.StatusBadRequest)
 		return
 	}
-	log.Infof("Pubkeys! %v", pubkeys)
 	req := &ethpb.ListValidatorsRequest{
 		PublicKeys: pubkeys,
 		PageSize:   int32(ps),

--- a/validator/rpc/handlers_beacon_test.go
+++ b/validator/rpc/handlers_beacon_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/testing/assert"
@@ -101,4 +102,155 @@ func TestGetBeaconStatus_OK(t *testing.T) {
 		},
 	}
 	assert.DeepEqual(t, want, resp)
+}
+
+func TestServer_GetValidators(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		expectedReq *ethpb.ListValidatorsRequest
+		chainResp   *ethpb.Validators
+		want        *ValidatorsResponse
+		wantCode    int
+		wantErr     string
+	}{
+		{
+			name:     "happypath on page_size, page_token, public_keys",
+			wantCode: http.StatusOK,
+			query:    "page_size=4&page_token=0&public_keys=0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4",
+			expectedReq: func() *ethpb.ListValidatorsRequest {
+				b, err := hexutil.Decode("0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4")
+				require.NoError(t, err)
+				pubkeys := [][]byte{b}
+				return &ethpb.ListValidatorsRequest{
+					PublicKeys: pubkeys,
+					PageSize:   int32(4),
+					PageToken:  "0",
+				}
+			}(),
+			chainResp: func() *ethpb.Validators {
+				b, err := hexutil.Decode("0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4")
+				require.NoError(t, err)
+				return &ethpb.Validators{
+					Epoch: 0,
+					ValidatorList: []*ethpb.Validators_ValidatorContainer{
+						{
+							Index: 0,
+							Validator: &ethpb.Validator{
+								PublicKey: b,
+							},
+						},
+					},
+					NextPageToken: "0",
+					TotalSize:     0,
+				}
+			}(),
+			want: &ValidatorsResponse{
+				Epoch: 0,
+				ValidatorList: []*ValidatorContainer{
+					{
+						Index: 0,
+						Validator: &Validator{
+							PublicKey:                  "0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4",
+							WithdrawalCredentials:      "0x",
+							EffectiveBalance:           0,
+							Slashed:                    false,
+							ActivationEligibilityEpoch: 0,
+							ActivationEpoch:            0,
+							ExitEpoch:                  0,
+							WithdrawableEpoch:          0,
+						},
+					},
+				},
+				NextPageToken: "0",
+				TotalSize:     0,
+			},
+		},
+		{
+			name:     "extra public key that's empty still returns correct response",
+			wantCode: http.StatusOK,
+			query:    "page_size=4&page_token=0&public_keys=0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4&public_keys=",
+			expectedReq: func() *ethpb.ListValidatorsRequest {
+				b, err := hexutil.Decode("0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4")
+				require.NoError(t, err)
+				pubkeys := [][]byte{b}
+				return &ethpb.ListValidatorsRequest{
+					PublicKeys: pubkeys,
+					PageSize:   int32(4),
+					PageToken:  "0",
+				}
+			}(),
+			chainResp: func() *ethpb.Validators {
+				b, err := hexutil.Decode("0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4")
+				require.NoError(t, err)
+				return &ethpb.Validators{
+					Epoch: 0,
+					ValidatorList: []*ethpb.Validators_ValidatorContainer{
+						{
+							Index: 0,
+							Validator: &ethpb.Validator{
+								PublicKey: b,
+							},
+						},
+					},
+					NextPageToken: "0",
+					TotalSize:     0,
+				}
+			}(),
+			want: &ValidatorsResponse{
+				Epoch: 0,
+				ValidatorList: []*ValidatorContainer{
+					{
+						Index: 0,
+						Validator: &Validator{
+							PublicKey:                  "0x855ae9c6184d6edd46351b375f16f541b2d33b0ed0da9be4571b13938588aee840ba606a946f0e8023ae3a4b2a43b4d4",
+							WithdrawalCredentials:      "0x",
+							EffectiveBalance:           0,
+							Slashed:                    false,
+							ActivationEligibilityEpoch: 0,
+							ActivationEpoch:            0,
+							ExitEpoch:                  0,
+							WithdrawableEpoch:          0,
+						},
+					},
+				},
+				NextPageToken: "0",
+				TotalSize:     0,
+			},
+		},
+		{
+			name:     "no public keys passed results in error",
+			wantCode: http.StatusBadRequest,
+			query:    "page_size=4&page_token=0&public_keys=",
+			wantErr:  "no pubkeys provided",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			beaconChainClient := validatormock.NewMockBeaconChainClient(ctrl)
+			if tt.wantErr == "" {
+				beaconChainClient.EXPECT().ListValidators(
+					gomock.Any(), // ctx
+					tt.expectedReq,
+				).Return(tt.chainResp, nil)
+			}
+			s := &Server{
+				beaconChainClient: beaconChainClient,
+			}
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v2/validator/beacon/validators?%s", tt.query), http.NoBody)
+			wr := httptest.NewRecorder()
+			wr.Body = &bytes.Buffer{}
+			s.GetValidators(wr, req)
+			require.Equal(t, tt.wantCode, wr.Code)
+			if tt.wantErr != "" {
+				require.StringContains(t, tt.wantErr, string(wr.Body.Bytes()))
+			} else {
+				resp := &ValidatorsResponse{}
+				require.NoError(t, json.Unmarshal(wr.Body.Bytes(), resp))
+
+				require.DeepEqual(t, resp, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

Running validator client in rest mode with `--enable-beacon-rest-api` with the web UI causes the following error
![image](https://github.com/prysmaticlabs/prysm/assets/90280386/b95c72e5-b6e5-43e6-9cb1-903b798ae6b8)
This is caused by a poor handling of the query parameters for rest. This PR introduces some fixes.