### PR TITLE
fix handling of goodbye messages for limited peers

### DIFF
--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -42,9 +42,10 @@ func (s *Service) goodbyeRPCHandler(_ context.Context, msg interface{}, stream l
 		return fmt.Errorf("wrong message type for goodbye, got %T, wanted *uint64", msg)
 	}
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		return err
+		log.WithError(err).Warn("Goodbye message from rate-limited peer.")
+	} else {
+		s.rateLimiter.add(stream, 1)
 	}
-	s.rateLimiter.add(stream, 1)
 	log := log.WithField("Reason", goodbyeMessage(*m))
 	log.WithField("peer", stream.Conn().RemotePeer()).Trace("Peer has sent a goodbye message")
 	s.cfg.p2p.Peers().SetNextValidTime(stream.Conn().RemotePeer(), goodByeBackoff(*m))


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

I've noticed these rate limit errors on the goodbye topic:
```[2024-03-20 18:11:17] DEBUG sync: Could not handle p2p RPC (ptr) error=rate limited peer=16Uiu2HAm34cymQmtLYvFQJd5jzW1fYE4xcUPyW4LRmBxGhLfsR4U topic=/eth2/beacon_chain/req/goodbye/1/ssz_snappy```

I'm assuming what's happening here is that we rate limit a peer, and they choose to disconnect with us as a result, at which point they can send us a (optional) goodbye message, and we then raise this error saying "you can't call my goodbye rpc, you are rate limited". The problem is this prevents us from correctly handling the disconnect as implemented in the goodbye rpc handler. Since we're about to disconnect the peer with a reconnect backoff anyway, we should allow this to proceed and just log the faintly interesting fact that the peer is already rate limited.

