### PR TITLE
P2P: Add QUIC support

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -707,6 +707,7 @@ func (b *BeaconNode) registerP2P(cliCtx *cli.Context) error {
 		PrivateKey:           cliCtx.String(cmd.P2PPrivKey.Name),
 		StaticPeerID:         cliCtx.Bool(cmd.P2PStaticID.Name),
 		MetaDataDir:          cliCtx.String(cmd.P2PMetadata.Name),
+		QUICPort:             cliCtx.Uint(cmd.P2PQUICPort.Name),
 		TCPPort:              cliCtx.Uint(cmd.P2PTCPPort.Name),
 		UDPPort:              cliCtx.Uint(cmd.P2PUDPPort.Name),
 		MaxPeers:             cliCtx.Uint(cmd.P2PMaxPeers.Name),

--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -90,6 +90,7 @@ go_library(
         "@com_github_libp2p_go_libp2p//core/peerstore:go_default_library",
         "@com_github_libp2p_go_libp2p//core/protocol:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/security/noise:go_default_library",
+        "@com_github_libp2p_go_libp2p//p2p/transport/quic:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/transport/tcp:go_default_library",
         "@com_github_libp2p_go_libp2p_mplex//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",

--- a/beacon-chain/p2p/config.go
+++ b/beacon-chain/p2p/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	PrivateKey           string
 	DataDir              string
 	MetaDataDir          string
+	QUICPort             uint
 	TCPPort              uint
 	UDPPort              uint
 	MaxPeers             uint

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -457,7 +457,7 @@ func convertToSingleMultiAddr(node *enode.Node) (ma.Multiaddr, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get peer id")
 	}
-	return multiAddressBuilderWithID(node.IP(), "tcp", uint(node.TCP()), id)
+	return multiAddressBuilderWithID(node.IP(), tcp, uint(node.TCP()), id)
 }
 
 func convertToUdpMultiAddr(node *enode.Node) ([]ma.Multiaddr, error) {
@@ -475,14 +475,14 @@ func convertToUdpMultiAddr(node *enode.Node) ([]ma.Multiaddr, error) {
 	var ip4 enr.IPv4
 	var ip6 enr.IPv6
 	if node.Load(&ip4) == nil {
-		address, ipErr := multiAddressBuilderWithID(net.IP(ip4), "udp", uint(node.UDP()), id)
+		address, ipErr := multiAddressBuilderWithID(net.IP(ip4), udp, uint(node.UDP()), id)
 		if ipErr != nil {
 			return nil, errors.Wrap(ipErr, "could not build IPv4 address")
 		}
 		addresses = append(addresses, address)
 	}
 	if node.Load(&ip6) == nil {
-		address, ipErr := multiAddressBuilderWithID(net.IP(ip6), "udp", uint(node.UDP()), id)
+		address, ipErr := multiAddressBuilderWithID(net.IP(ip6), udp, uint(node.UDP()), id)
 		if ipErr != nil {
 			return nil, errors.Wrap(ipErr, "could not build IPv6 address")
 		}

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -321,7 +321,7 @@ func (s *Service) filterPeer(node *enode.Node) bool {
 		return false
 	}
 
-	if len(multiAddrs) == 0 {
+	if peerData == nil || len(multiAddrs) == 0 {
 		return false
 	}
 
@@ -476,12 +476,8 @@ func convertToAddrInfo(node *enode.Node) (*peer.AddrInfo, []ma.Multiaddr, error)
 		return nil, nil, errors.Wrapf(err, "could not convert to peer info: %v", multiAddrs)
 	}
 
-	if len(infos) > 1 {
-		return nil, nil, errors.Errorf("infos contains %v elements, expected not more than 1", len(infos))
-	}
-
-	if len(infos) == 0 {
-		return nil, multiAddrs, nil
+	if len(infos) != 1 {
+		return nil, nil, errors.Errorf("infos contains %v elements, expected exactly 1", len(infos))
 	}
 
 	return &infos[0], multiAddrs, nil

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -400,7 +400,7 @@ func PeersFromStringAddrs(addrs []string) ([]ma.Multiaddr, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not get enode from string")
 		}
-		nodeAddrs, err := convertToMultiAddrs(enodeAddr)
+		nodeAddrs, err := retrieveMultiAddrsFromNode(enodeAddr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not get multiaddr")
 		}
@@ -449,7 +449,7 @@ func convertToMultiAddr(nodes []*enode.Node) []ma.Multiaddr {
 		}
 
 		// Get up to two multiaddrs (TCP and QUIC) for each node.
-		nodeMultiAddrs, err := convertToMultiAddrs(node)
+		nodeMultiAddrs, err := retrieveMultiAddrsFromNode(node)
 		if err != nil {
 			log.WithError(err).Errorf("Could not convert to multiAddr node %s", node)
 			continue
@@ -462,7 +462,7 @@ func convertToMultiAddr(nodes []*enode.Node) []ma.Multiaddr {
 }
 
 func convertToAddrInfo(node *enode.Node) (*peer.AddrInfo, []ma.Multiaddr, error) {
-	multiAddrs, err := convertToMultiAddrs(node)
+	multiAddrs, err := retrieveMultiAddrsFromNode(node)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -487,11 +487,11 @@ func convertToAddrInfo(node *enode.Node) (*peer.AddrInfo, []ma.Multiaddr, error)
 	return &infos[0], multiAddrs, nil
 }
 
-// convertToMultiAddrs converts an enode.Node to a list of multiaddrs.
+// retrieveMultiAddrsFromNode converts an enode.Node to a list of multiaddrs.
 // If the node has a both a QUIC and a TCP port set in their ENR, then
 // the multiaddr corresponding to the QUIC port is added first, followed
 // by the multiaddr corresponding to the TCP port.
-func convertToMultiAddrs(node *enode.Node) ([]ma.Multiaddr, error) {
+func retrieveMultiAddrsFromNode(node *enode.Node) ([]ma.Multiaddr, error) {
 	multiaddrs := make([]ma.Multiaddr, 0, 2)
 
 	// Retrieve the node public key.

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -457,7 +457,7 @@ func convertToSingleMultiAddr(node *enode.Node) (ma.Multiaddr, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get peer id")
 	}
-	return multiAddressBuilderWithID(node.IP().String(), "tcp", uint(node.TCP()), id)
+	return multiAddressBuilderWithID(node.IP(), "tcp", uint(node.TCP()), id)
 }
 
 func convertToUdpMultiAddr(node *enode.Node) ([]ma.Multiaddr, error) {
@@ -475,14 +475,14 @@ func convertToUdpMultiAddr(node *enode.Node) ([]ma.Multiaddr, error) {
 	var ip4 enr.IPv4
 	var ip6 enr.IPv6
 	if node.Load(&ip4) == nil {
-		address, ipErr := multiAddressBuilderWithID(net.IP(ip4).String(), "udp", uint(node.UDP()), id)
+		address, ipErr := multiAddressBuilderWithID(net.IP(ip4), "udp", uint(node.UDP()), id)
 		if ipErr != nil {
 			return nil, errors.Wrap(ipErr, "could not build IPv4 address")
 		}
 		addresses = append(addresses, address)
 	}
 	if node.Load(&ip6) == nil {
-		address, ipErr := multiAddressBuilderWithID(net.IP(ip6).String(), "udp", uint(node.UDP()), id)
+		address, ipErr := multiAddressBuilderWithID(net.IP(ip6), "udp", uint(node.UDP()), id)
 		if ipErr != nil {
 			return nil, errors.Wrap(ipErr, "could not build IPv6 address")
 		}

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -166,8 +166,9 @@ func TestCreateLocalNode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Define ports.
 			const (
-				udpPort = 2000
-				tcpPort = 3000
+				udpPort  = 2000
+				tcpPort  = 3000
+				quicPort = 3000
 			)
 
 			// Create a private key.
@@ -180,7 +181,7 @@ func TestCreateLocalNode(t *testing.T) {
 				cfg:                   tt.cfg,
 			}
 
-			localNode, err := service.createLocalNode(privKey, address, udpPort, tcpPort)
+			localNode, err := service.createLocalNode(privKey, address, udpPort, tcpPort, quicPort)
 			if tt.expectedError {
 				require.NotNil(t, err)
 				return
@@ -237,7 +238,7 @@ func TestMultiAddrsConversion_InvalidIPAddr(t *testing.T) {
 		genesisTime:           time.Now(),
 		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
 	}
-	node, err := s.createLocalNode(pkey, addr, 0, 0)
+	node, err := s.createLocalNode(pkey, addr, 0, 0, 0)
 	require.NoError(t, err)
 	multiAddr := convertToMultiAddr([]*enode.Node{node.Node()})
 	assert.Equal(t, 0, len(multiAddr), "Invalid ip address converted successfully")
@@ -248,8 +249,9 @@ func TestMultiAddrConversion_OK(t *testing.T) {
 	ipAddr, pkey := createAddrAndPrivKey(t)
 	s := &Service{
 		cfg: &Config{
-			TCPPort: 0,
-			UDPPort: 0,
+			UDPPort:  2000,
+			TCPPort:  3000,
+			QUICPort: 3000,
 		},
 		genesisTime:           time.Now(),
 		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -104,7 +104,7 @@ func TestStartDiscv5_DifferentForkDigests(t *testing.T) {
 
 	for _, node := range nodes {
 		if s.filterPeer(node) {
-			nodeAddrs, err := convertToMultiAddrs(node)
+			nodeAddrs, err := retrieveMultiAddrsFromNode(node)
 			require.NoError(t, err)
 			addrs = append(addrs, nodeAddrs...)
 		}
@@ -195,7 +195,7 @@ func TestStartDiscv5_SameForkDigests_DifferentNextForkData(t *testing.T) {
 
 	for _, node := range nodes {
 		if s.filterPeer(node) {
-			nodeAddrs, err := convertToMultiAddrs(node)
+			nodeAddrs, err := retrieveMultiAddrsFromNode(node)
 			require.NoError(t, err)
 			addrs = append(addrs, nodeAddrs...)
 		}

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 func TestStartDiscv5_DifferentForkDigests(t *testing.T) {
-	port := 2000
+	const port = 2000
+
 	ipAddr, pkey := createAddrAndPrivKey(t)
 	genesisTime := time.Now()
 	genesisValidatorsRoot := make([]byte, fieldparams.RootLength)
@@ -53,7 +54,7 @@ func TestStartDiscv5_DifferentForkDigests(t *testing.T) {
 
 	var listeners []*discover.UDPv5
 	for i := 1; i <= 5; i++ {
-		port = 3000 + i
+		port := 3000 + i
 		cfg.UDPPort = uint(port)
 		ipAddr, pkey := createAddrAndPrivKey(t)
 
@@ -98,13 +99,14 @@ func TestStartDiscv5_DifferentForkDigests(t *testing.T) {
 	s.genesisTime = genesisTime
 	s.genesisValidatorsRoot = make([]byte, 32)
 	s.dv5Listener = lastListener
-	var addrs []ma.Multiaddr
 
-	for _, n := range nodes {
-		if s.filterPeer(n) {
-			addr, err := convertToSingleMultiAddr(n)
+	addrs := make([]ma.Multiaddr, 0)
+
+	for _, node := range nodes {
+		if s.filterPeer(node) {
+			nodeAddrs, err := convertToMultiAddrs(node)
 			require.NoError(t, err)
-			addrs = append(addrs, addr)
+			addrs = append(addrs, nodeAddrs...)
 		}
 	}
 
@@ -114,10 +116,11 @@ func TestStartDiscv5_DifferentForkDigests(t *testing.T) {
 }
 
 func TestStartDiscv5_SameForkDigests_DifferentNextForkData(t *testing.T) {
+	const port = 2000
+
 	params.SetupTestConfigCleanup(t)
 	hook := logTest.NewGlobal()
 	logrus.SetLevel(logrus.TraceLevel)
-	port := 2000
 	ipAddr, pkey := createAddrAndPrivKey(t)
 	genesisTime := time.Now()
 	genesisValidatorsRoot := make([]byte, 32)
@@ -138,7 +141,7 @@ func TestStartDiscv5_SameForkDigests_DifferentNextForkData(t *testing.T) {
 
 	var listeners []*discover.UDPv5
 	for i := 1; i <= 5; i++ {
-		port = 3000 + i
+		port := 3000 + i
 		cfg.UDPPort = uint(port)
 		ipAddr, pkey := createAddrAndPrivKey(t)
 
@@ -188,13 +191,13 @@ func TestStartDiscv5_SameForkDigests_DifferentNextForkData(t *testing.T) {
 	s.genesisTime = genesisTime
 	s.genesisValidatorsRoot = make([]byte, 32)
 	s.dv5Listener = lastListener
-	var addrs []ma.Multiaddr
+	addrs := make([]ma.Multiaddr, 0, len(nodes))
 
-	for _, n := range nodes {
-		if s.filterPeer(n) {
-			addr, err := convertToSingleMultiAddr(n)
+	for _, node := range nodes {
+		if s.filterPeer(node) {
+			nodeAddrs, err := convertToMultiAddrs(node)
 			require.NoError(t, err)
-			addrs = append(addrs, addr)
+			addrs = append(addrs, nodeAddrs...)
 		}
 	}
 	if len(addrs) == 0 {

--- a/beacon-chain/p2p/log.go
+++ b/beacon-chain/p2p/log.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"net"
 	"strconv"
 	"strings"
 
@@ -29,7 +30,7 @@ func logIPAddr(id peer.ID, addrs ...ma.Multiaddr) {
 
 func logExternalIPAddr(id peer.ID, addr string, port uint) {
 	if addr != "" {
-		multiAddr, err := MultiAddressBuilder(addr, port)
+		multiAddr, err := MultiAddressBuilder(net.ParseIP(addr), port)
 		if err != nil {
 			log.WithError(err).Error("Could not create multiaddress")
 			return

--- a/beacon-chain/p2p/log.go
+++ b/beacon-chain/p2p/log.go
@@ -13,32 +13,32 @@ import (
 var log = logrus.WithField("prefix", "p2p")
 
 func logIPAddr(id peer.ID, addrs ...ma.Multiaddr) {
-	var correctAddr ma.Multiaddr
 	for _, addr := range addrs {
-		if strings.Contains(addr.String(), "/ip4/") || strings.Contains(addr.String(), "/ip6/") {
-			correctAddr = addr
-			break
+		if !(strings.Contains(addr.String(), "/ip4/") || strings.Contains(addr.String(), "/ip6/")) {
+			continue
 		}
-	}
-	if correctAddr != nil {
+
 		log.WithField(
 			"multiAddr",
-			correctAddr.String()+"/p2p/"+id.String(),
+			addr.String()+"/p2p/"+id.String(),
 		).Info("Node started p2p server")
 	}
 }
 
-func logExternalIPAddr(id peer.ID, addr string, port uint) {
+func logExternalIPAddr(id peer.ID, addr string, tcpPort, quicPort uint) {
 	if addr != "" {
-		multiAddr, err := MultiAddressBuilder(net.ParseIP(addr), port)
+		multiAddrs, err := MultiAddressBuilder(net.ParseIP(addr), tcpPort, quicPort)
 		if err != nil {
 			log.WithError(err).Error("Could not create multiaddress")
 			return
 		}
-		log.WithField(
-			"multiAddr",
-			multiAddr.String()+"/p2p/"+id.String(),
-		).Info("Node started external p2p server")
+
+		for _, multiAddr := range multiAddrs {
+			log.WithField(
+				"multiAddr",
+				multiAddr.String()+"/p2p/"+id.String(),
+			).Info("Node started external p2p server")
+		}
 	}
 }
 

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -11,7 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
-	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	libp2ptcp "github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	gomplex "github.com/libp2p/go-mplex"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
@@ -67,7 +67,7 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) ([]libp2p.Op
 		libp2p.ListenAddrs(listen),
 		libp2p.UserAgent(version.BuildData()),
 		libp2p.ConnectionGater(s),
-		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(libp2ptcp.NewTCPTransport),
 		libp2p.DefaultMuxers,
 		libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport),
 		libp2p.Security(noise.ID, noise.New),

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -60,7 +60,7 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) ([]libp2p.Op
 		return nil, errors.Wrapf(err, "cannot get ID from public key: %s", ifaceKey.GetPublic().Type().String())
 	}
 
-	log.Infof("Running node with peer id of %s ", id)
+	log.WithField("peerId", id).Info("Running node with")
 
 	options := []libp2p.Option{
 		privKeyOption(priKey),

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -89,7 +89,7 @@ func TestIPV6Support(t *testing.T) {
 	lNode := enode.NewLocalNode(db, key)
 	mockIPV6 := net.IP{0xff, 0x02, 0xAA, 0, 0x1F, 0, 0x2E, 0, 0, 0x36, 0x45, 0, 0, 0, 0, 0x02}
 	lNode.Set(enr.IP(mockIPV6))
-	mas, err := convertToMultiAddrs(lNode.Node())
+	mas, err := retrieveMultiAddrsFromNode(lNode.Node())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	mock "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
@@ -127,5 +128,57 @@ func TestDefaultMultiplexers(t *testing.T) {
 
 	assert.Equal(t, protocol.ID("/yamux/1.0.0"), cfg.Muxers[0].ID)
 	assert.Equal(t, protocol.ID("/mplex/6.7.0"), cfg.Muxers[1].ID)
+}
 
+func TestMultiAddressBuilderWithID(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ip       net.IP
+		protocol internetProtocol
+		port     uint
+		id       string
+
+		expectedMultiaddrStr string
+	}{
+		{
+			name:     "UDP",
+			ip:       net.IPv4(192, 168, 0, 1),
+			protocol: udp,
+			port:     5678,
+			id:       "0025080212210204fb1ebb1aa467527d34306a4794a5171d6516405e720b909b7f816d63aef96a",
+
+			expectedMultiaddrStr: "/ip4/192.168.0.1/udp/5678/p2p/16Uiu2HAkum7hhuMpWqFj3yNLcmQBGmThmqw2ohaCRThXQuKU9ohs",
+		},
+		{
+			name:     "TCP",
+			ip:       net.IPv4(192, 168, 0, 1),
+			protocol: tcp,
+			port:     5678,
+			id:       "0025080212210204fb1ebb1aa467527d34306a4794a5171d6516405e720b909b7f816d63aef96a",
+
+			expectedMultiaddrStr: "/ip4/192.168.0.1/tcp/5678/p2p/16Uiu2HAkum7hhuMpWqFj3yNLcmQBGmThmqw2ohaCRThXQuKU9ohs",
+		},
+		{
+			name:     "QUIC",
+			ip:       net.IPv4(192, 168, 0, 1),
+			protocol: quic,
+			port:     5678,
+			id:       "0025080212210204fb1ebb1aa467527d34306a4794a5171d6516405e720b909b7f816d63aef96a",
+
+			expectedMultiaddrStr: "/ip4/192.168.0.1/udp/5678/quic-v1/p2p/16Uiu2HAkum7hhuMpWqFj3yNLcmQBGmThmqw2ohaCRThXQuKU9ohs",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := hex.DecodeString(tt.id)
+			require.NoError(t, err)
+
+			actualMultiaddr, err := multiAddressBuilderWithID(tt.ip, tt.protocol, tt.port, peer.ID(id))
+			require.NoError(t, err)
+
+			actualMultiaddrStr := actualMultiaddr.String()
+			require.Equal(t, tt.expectedMultiaddrStr, actualMultiaddrStr)
+		})
+	}
 }

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -89,21 +89,24 @@ func TestIPV6Support(t *testing.T) {
 	lNode := enode.NewLocalNode(db, key)
 	mockIPV6 := net.IP{0xff, 0x02, 0xAA, 0, 0x1F, 0, 0x2E, 0, 0, 0x36, 0x45, 0, 0, 0, 0, 0x02}
 	lNode.Set(enr.IP(mockIPV6))
-	ma, err := convertToSingleMultiAddr(lNode.Node())
+	mas, err := convertToMultiAddrs(lNode.Node())
 	if err != nil {
 		t.Fatal(err)
 	}
-	ipv6Exists := false
-	for _, p := range ma.Protocols() {
-		if p.Name == "ip4" {
-			t.Error("Got ip4 address instead of ip6")
+
+	for _, ma := range mas {
+		ipv6Exists := false
+		for _, p := range ma.Protocols() {
+			if p.Name == "ip4" {
+				t.Error("Got ip4 address instead of ip6")
+			}
+			if p.Name == "ip6" {
+				ipv6Exists = true
+			}
 		}
-		if p.Name == "ip6" {
-			ipv6Exists = true
+		if !ipv6Exists {
+			t.Error("Multiaddress did not have ipv6 protocol")
 		}
-	}
-	if !ipv6Exists {
-		t.Error("Multiaddress did not have ipv6 protocol")
 	}
 }
 
@@ -111,8 +114,9 @@ func TestDefaultMultiplexers(t *testing.T) {
 	var cfg libp2p.Config
 	_ = cfg
 	p2pCfg := &Config{
-		TCPPort:       2000,
 		UDPPort:       2000,
+		TCPPort:       3000,
+		QUICPort:      3000,
 		StateNotifier: &mock.MockStateNotifier{},
 	}
 	svc := &Service{cfg: p2pCfg}

--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -449,6 +450,32 @@ func (p *Status) InboundConnected() []peer.ID {
 	return peers
 }
 
+// InboundConnectedTCP returns the current batch of inbound peers that are connected using TCP.
+func (p *Status) InboundConnectedTCP() []peer.ID {
+	p.store.RLock()
+	defer p.store.RUnlock()
+	peers := make([]peer.ID, 0)
+	for pid, peerData := range p.store.Peers() {
+		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirInbound && strings.Contains(peerData.Address.String(), "tcp") {
+			peers = append(peers, pid)
+		}
+	}
+	return peers
+}
+
+// InboundConnectedTCP returns the current batch of inbound peers that are connected using QUIC.
+func (p *Status) InboundConnectedQUIC() []peer.ID {
+	p.store.RLock()
+	defer p.store.RUnlock()
+	peers := make([]peer.ID, 0)
+	for pid, peerData := range p.store.Peers() {
+		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirInbound && strings.Contains(peerData.Address.String(), "quic") {
+			peers = append(peers, pid)
+		}
+	}
+	return peers
+}
+
 // Outbound returns the current batch of outbound peers.
 func (p *Status) Outbound() []peer.ID {
 	p.store.RLock()
@@ -475,7 +502,33 @@ func (p *Status) OutboundConnected() []peer.ID {
 	return peers
 }
 
-// Active returns the peers that are connecting or connected.
+// OutboundConnected returns the current batch of outbound peers that are connected using TCP.
+func (p *Status) OutboundConnectedTCP() []peer.ID {
+	p.store.RLock()
+	defer p.store.RUnlock()
+	peers := make([]peer.ID, 0)
+	for pid, peerData := range p.store.Peers() {
+		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirOutbound && strings.Contains(peerData.Address.String(), "tcp") {
+			peers = append(peers, pid)
+		}
+	}
+	return peers
+}
+
+// OutboundConnected returns the current batch of outbound peers that are connected using QUIC.
+func (p *Status) OutboundConnectedQUIC() []peer.ID {
+	p.store.RLock()
+	defer p.store.RUnlock()
+	peers := make([]peer.ID, 0)
+	for pid, peerData := range p.store.Peers() {
+		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirOutbound && strings.Contains(peerData.Address.String(), "quic") {
+			peers = append(peers, pid)
+		}
+	}
+	return peers
+}
+
+// Active returns the peers that are active (connecting or connected).
 func (p *Status) Active() []peer.ID {
 	p.store.RLock()
 	defer p.store.RUnlock()
@@ -514,7 +567,7 @@ func (p *Status) Disconnected() []peer.ID {
 	return peers
 }
 
-// Inactive returns the peers that are disconnecting or disconnected.
+// Inactive returns the peers that are inactive (disconnecting or disconnected).
 func (p *Status) Inactive() []peer.ID {
 	p.store.RLock()
 	defer p.store.RUnlock()

--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -77,6 +77,13 @@ const (
 	MaxBackOffDuration = 5000
 )
 
+type InternetProtocol string
+
+const (
+	TCP  = "tcp"
+	QUIC = "quic"
+)
+
 // Status is the structure holding the peer status information.
 type Status struct {
 	ctx       context.Context
@@ -450,26 +457,13 @@ func (p *Status) InboundConnected() []peer.ID {
 	return peers
 }
 
-// InboundConnectedTCP returns the current batch of inbound peers that are connected using TCP.
-func (p *Status) InboundConnectedTCP() []peer.ID {
+// InboundConnectedWithProtocol returns the current batch of inbound peers that are connected with a given protocol.
+func (p *Status) InboundConnectedWithProtocol(protocol InternetProtocol) []peer.ID {
 	p.store.RLock()
 	defer p.store.RUnlock()
 	peers := make([]peer.ID, 0)
 	for pid, peerData := range p.store.Peers() {
-		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirInbound && strings.Contains(peerData.Address.String(), "tcp") {
-			peers = append(peers, pid)
-		}
-	}
-	return peers
-}
-
-// InboundConnectedTCP returns the current batch of inbound peers that are connected using QUIC.
-func (p *Status) InboundConnectedQUIC() []peer.ID {
-	p.store.RLock()
-	defer p.store.RUnlock()
-	peers := make([]peer.ID, 0)
-	for pid, peerData := range p.store.Peers() {
-		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirInbound && strings.Contains(peerData.Address.String(), "quic") {
+		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirInbound && strings.Contains(peerData.Address.String(), string(protocol)) {
 			peers = append(peers, pid)
 		}
 	}
@@ -502,26 +496,13 @@ func (p *Status) OutboundConnected() []peer.ID {
 	return peers
 }
 
-// OutboundConnected returns the current batch of outbound peers that are connected using TCP.
-func (p *Status) OutboundConnectedTCP() []peer.ID {
+// OutboundConnectedWithProtocol returns the current batch of outbound peers that are connected with a given protocol.
+func (p *Status) OutboundConnectedWithProtocol(protocol InternetProtocol) []peer.ID {
 	p.store.RLock()
 	defer p.store.RUnlock()
 	peers := make([]peer.ID, 0)
 	for pid, peerData := range p.store.Peers() {
-		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirOutbound && strings.Contains(peerData.Address.String(), "tcp") {
-			peers = append(peers, pid)
-		}
-	}
-	return peers
-}
-
-// OutboundConnected returns the current batch of outbound peers that are connected using QUIC.
-func (p *Status) OutboundConnectedQUIC() []peer.ID {
-	p.store.RLock()
-	defer p.store.RUnlock()
-	peers := make([]peer.ID, 0)
-	for pid, peerData := range p.store.Peers() {
-		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirOutbound && strings.Contains(peerData.Address.String(), "quic") {
+		if peerData.ConnState == PeerConnected && peerData.Direction == network.DirOutbound && strings.Contains(peerData.Address.String(), string(protocol)) {
 			peers = append(peers, pid)
 		}
 	}

--- a/beacon-chain/p2p/peers/status_test.go
+++ b/beacon-chain/p2p/peers/status_test.go
@@ -1111,6 +1111,74 @@ func TestInbound(t *testing.T) {
 	assert.Equal(t, inbound.String(), result[0].String())
 }
 
+func TestInboundConnected(t *testing.T) {
+	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
+		PeerLimit: 30,
+		ScorerParams: &scorers.Config{
+			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
+				Threshold: 0,
+			},
+		},
+	})
+
+	addr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
+	require.NoError(t, err)
+	inbound := createPeer(t, p, addr, network.DirInbound, peers.PeerConnected)
+	createPeer(t, p, addr, network.DirInbound, peers.PeerConnecting)
+
+	result := p.InboundConnected()
+	require.Equal(t, 1, len(result))
+	assert.Equal(t, inbound.String(), result[0].String())
+}
+
+func TestInboundConnectedTCP(t *testing.T) {
+	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
+		PeerLimit: 30,
+		ScorerParams: &scorers.Config{
+			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
+				Threshold: 0,
+			},
+		},
+	})
+
+	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
+	require.NoError(t, err)
+
+	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
+	require.NoError(t, err)
+
+	inboundTCP := createPeer(t, p, addrTCP, network.DirInbound, peers.PeerConnected)
+	createPeer(t, p, addrQUIC, network.DirInbound, peers.PeerConnected)
+
+	result := p.InboundConnectedTCP()
+	require.Equal(t, 1, len(result))
+	assert.Equal(t, inboundTCP.String(), result[0].String())
+}
+
+func TestInboundConnectedQUIC(t *testing.T) {
+	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
+		PeerLimit: 30,
+		ScorerParams: &scorers.Config{
+			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
+				Threshold: 0,
+			},
+		},
+	})
+
+	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
+	require.NoError(t, err)
+
+	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
+	require.NoError(t, err)
+
+	inboundQUIC := createPeer(t, p, addrQUIC, network.DirInbound, peers.PeerConnected)
+	createPeer(t, p, addrTCP, network.DirInbound, peers.PeerConnected)
+
+	result := p.InboundConnectedQUIC()
+	require.Equal(t, 1, len(result))
+	assert.Equal(t, inboundQUIC.String(), result[0].String())
+}
+
 func TestOutbound(t *testing.T) {
 	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
 		PeerLimit: 30,
@@ -1128,6 +1196,74 @@ func TestOutbound(t *testing.T) {
 	result := p.Outbound()
 	require.Equal(t, 1, len(result))
 	assert.Equal(t, outbound.String(), result[0].String())
+}
+
+func TestOutboundConnected(t *testing.T) {
+	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
+		PeerLimit: 30,
+		ScorerParams: &scorers.Config{
+			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
+				Threshold: 0,
+			},
+		},
+	})
+
+	addr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
+	require.NoError(t, err)
+	inbound := createPeer(t, p, addr, network.DirOutbound, peers.PeerConnected)
+	createPeer(t, p, addr, network.DirOutbound, peers.PeerConnecting)
+
+	result := p.OutboundConnected()
+	require.Equal(t, 1, len(result))
+	assert.Equal(t, inbound.String(), result[0].String())
+}
+
+func TestOutbondConnectedTCP(t *testing.T) {
+	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
+		PeerLimit: 30,
+		ScorerParams: &scorers.Config{
+			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
+				Threshold: 0,
+			},
+		},
+	})
+
+	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
+	require.NoError(t, err)
+
+	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
+	require.NoError(t, err)
+
+	outboundTCP := createPeer(t, p, addrTCP, network.DirOutbound, peers.PeerConnected)
+	createPeer(t, p, addrQUIC, network.DirOutbound, peers.PeerConnected)
+
+	result := p.OutboundConnectedTCP()
+	require.Equal(t, 1, len(result))
+	assert.Equal(t, outboundTCP.String(), result[0].String())
+}
+
+func TestOutboundConnectedQUIC(t *testing.T) {
+	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
+		PeerLimit: 30,
+		ScorerParams: &scorers.Config{
+			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
+				Threshold: 0,
+			},
+		},
+	})
+
+	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
+	require.NoError(t, err)
+
+	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
+	require.NoError(t, err)
+
+	outboundQUIC := createPeer(t, p, addrQUIC, network.DirOutbound, peers.PeerConnected)
+	createPeer(t, p, addrTCP, network.DirOutbound, peers.PeerConnected)
+
+	result := p.OutboundConnectedQUIC()
+	require.Equal(t, 1, len(result))
+	assert.Equal(t, outboundQUIC.String(), result[0].String())
 }
 
 // addPeer is a helper to add a peer with a given connection state)

--- a/beacon-chain/p2p/peers/status_test.go
+++ b/beacon-chain/p2p/peers/status_test.go
@@ -1131,7 +1131,7 @@ func TestInboundConnected(t *testing.T) {
 	assert.Equal(t, inbound.String(), result[0].String())
 }
 
-func TestInboundConnectedTCP(t *testing.T) {
+func TestInboundConnectedWithProtocol(t *testing.T) {
 	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
 		PeerLimit: 30,
 		ScorerParams: &scorers.Config{
@@ -1141,42 +1141,55 @@ func TestInboundConnectedTCP(t *testing.T) {
 		},
 	})
 
-	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
-	require.NoError(t, err)
+	addrsTCP := []string{
+		"/ip4/127.0.0.1/tcp/33333",
+		"/ip4/127.0.0.2/tcp/44444",
+	}
 
-	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
-	require.NoError(t, err)
+	addrsQUIC := []string{
+		"/ip4/192.168.1.3/udp/13000/quic-v1",
+		"/ip4/192.168.1.4/udp/14000/quic-v1",
+		"/ip4/192.168.1.5/udp/14000/quic-v1",
+	}
 
-	inboundTCP := createPeer(t, p, addrTCP, network.DirInbound, peers.PeerConnected)
-	createPeer(t, p, addrQUIC, network.DirInbound, peers.PeerConnected)
+	expectedTCP := make(map[string]bool, len(addrsTCP))
+	for _, addr := range addrsTCP {
+		multiaddr, err := ma.NewMultiaddr(addr)
+		require.NoError(t, err)
 
-	result := p.InboundConnectedTCP()
-	require.Equal(t, 1, len(result))
-	assert.Equal(t, inboundTCP.String(), result[0].String())
-}
+		peer := createPeer(t, p, multiaddr, network.DirInbound, peers.PeerConnected)
+		expectedTCP[peer.String()] = true
+	}
 
-func TestInboundConnectedQUIC(t *testing.T) {
-	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
-		PeerLimit: 30,
-		ScorerParams: &scorers.Config{
-			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
-				Threshold: 0,
-			},
-		},
-	})
+	expectedQUIC := make(map[string]bool, len(addrsQUIC))
+	for _, addr := range addrsQUIC {
+		multiaddr, err := ma.NewMultiaddr(addr)
+		require.NoError(t, err)
 
-	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
-	require.NoError(t, err)
+		peer := createPeer(t, p, multiaddr, network.DirInbound, peers.PeerConnected)
+		expectedQUIC[peer.String()] = true
+	}
 
-	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
-	require.NoError(t, err)
+	// TCP
+	// ---
 
-	inboundQUIC := createPeer(t, p, addrQUIC, network.DirInbound, peers.PeerConnected)
-	createPeer(t, p, addrTCP, network.DirInbound, peers.PeerConnected)
+	actualTCP := p.InboundConnectedWithProtocol(peers.TCP)
+	require.Equal(t, len(expectedTCP), len(actualTCP))
 
-	result := p.InboundConnectedQUIC()
-	require.Equal(t, 1, len(result))
-	assert.Equal(t, inboundQUIC.String(), result[0].String())
+	for _, actualPeer := range actualTCP {
+		_, ok := expectedTCP[actualPeer.String()]
+		require.Equal(t, true, ok)
+	}
+
+	// QUIC
+	// ----
+	actualQUIC := p.InboundConnectedWithProtocol(peers.QUIC)
+	require.Equal(t, len(expectedQUIC), len(actualQUIC))
+
+	for _, actualPeer := range actualQUIC {
+		_, ok := expectedQUIC[actualPeer.String()]
+		require.Equal(t, true, ok)
+	}
 }
 
 func TestOutbound(t *testing.T) {
@@ -1218,7 +1231,7 @@ func TestOutboundConnected(t *testing.T) {
 	assert.Equal(t, inbound.String(), result[0].String())
 }
 
-func TestOutbondConnectedTCP(t *testing.T) {
+func TestOutboundConnectedWithProtocol(t *testing.T) {
 	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
 		PeerLimit: 30,
 		ScorerParams: &scorers.Config{
@@ -1228,42 +1241,55 @@ func TestOutbondConnectedTCP(t *testing.T) {
 		},
 	})
 
-	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
-	require.NoError(t, err)
+	addrsTCP := []string{
+		"/ip4/127.0.0.1/tcp/33333",
+		"/ip4/127.0.0.2/tcp/44444",
+	}
 
-	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
-	require.NoError(t, err)
+	addrsQUIC := []string{
+		"/ip4/192.168.1.3/udp/13000/quic-v1",
+		"/ip4/192.168.1.4/udp/14000/quic-v1",
+		"/ip4/192.168.1.5/udp/14000/quic-v1",
+	}
 
-	outboundTCP := createPeer(t, p, addrTCP, network.DirOutbound, peers.PeerConnected)
-	createPeer(t, p, addrQUIC, network.DirOutbound, peers.PeerConnected)
+	expectedTCP := make(map[string]bool, len(addrsTCP))
+	for _, addr := range addrsTCP {
+		multiaddr, err := ma.NewMultiaddr(addr)
+		require.NoError(t, err)
 
-	result := p.OutboundConnectedTCP()
-	require.Equal(t, 1, len(result))
-	assert.Equal(t, outboundTCP.String(), result[0].String())
-}
+		peer := createPeer(t, p, multiaddr, network.DirOutbound, peers.PeerConnected)
+		expectedTCP[peer.String()] = true
+	}
 
-func TestOutboundConnectedQUIC(t *testing.T) {
-	p := peers.NewStatus(context.Background(), &peers.StatusConfig{
-		PeerLimit: 30,
-		ScorerParams: &scorers.Config{
-			BadResponsesScorerConfig: &scorers.BadResponsesScorerConfig{
-				Threshold: 0,
-			},
-		},
-	})
+	expectedQUIC := make(map[string]bool, len(addrsQUIC))
+	for _, addr := range addrsQUIC {
+		multiaddr, err := ma.NewMultiaddr(addr)
+		require.NoError(t, err)
 
-	addrQUIC, err := ma.NewMultiaddr("/ip4/192.168.1.3/udp/13000/quic-v1")
-	require.NoError(t, err)
+		peer := createPeer(t, p, multiaddr, network.DirOutbound, peers.PeerConnected)
+		expectedQUIC[peer.String()] = true
+	}
 
-	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/33333")
-	require.NoError(t, err)
+	// TCP
+	// ---
 
-	outboundQUIC := createPeer(t, p, addrQUIC, network.DirOutbound, peers.PeerConnected)
-	createPeer(t, p, addrTCP, network.DirOutbound, peers.PeerConnected)
+	actualTCP := p.OutboundConnectedWithProtocol(peers.TCP)
+	require.Equal(t, len(expectedTCP), len(actualTCP))
 
-	result := p.OutboundConnectedQUIC()
-	require.Equal(t, 1, len(result))
-	assert.Equal(t, outboundQUIC.String(), result[0].String())
+	for _, actualPeer := range actualTCP {
+		_, ok := expectedTCP[actualPeer.String()]
+		require.Equal(t, true, ok)
+	}
+
+	// QUIC
+	// ----
+	actualQUIC := p.OutboundConnectedWithProtocol(peers.QUIC)
+	require.Equal(t, len(expectedQUIC), len(actualQUIC))
+
+	for _, actualPeer := range actualQUIC {
+		_, ok := expectedQUIC[actualPeer.String()]
+		require.Equal(t, true, ok)
+	}
 }
 
 // addPeer is a helper to add a peer with a given connection state)

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -235,10 +235,10 @@ func (s *Service) Start() {
 	async.RunEvery(s.ctx, time.Duration(params.BeaconConfig().RespTimeout)*time.Second, s.updateMetrics)
 	async.RunEvery(s.ctx, refreshRate, s.RefreshENR)
 	async.RunEvery(s.ctx, 1*time.Minute, func() {
-		inboundQUICCount := len(s.peers.InboundConnectedQUIC())
-		inboundTCPCount := len(s.peers.InboundConnectedTCP())
-		outboundQUICCount := len(s.peers.OutboundConnectedQUIC())
-		outboundTCPCount := len(s.peers.OutboundConnectedTCP())
+		inboundQUICCount := len(s.peers.InboundConnectedWithProtocol(peers.QUIC))
+		inboundTCPCount := len(s.peers.InboundConnectedWithProtocol(peers.TCP))
+		outboundQUICCount := len(s.peers.OutboundConnectedWithProtocol(peers.QUIC))
+		outboundTCPCount := len(s.peers.OutboundConnectedWithProtocol(peers.TCP))
 		total := inboundQUICCount + inboundTCPCount + outboundQUICCount + outboundTCPCount
 
 		log.WithFields(logrus.Fields{

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -216,7 +216,7 @@ func (s *Service) Start() {
 	if len(s.cfg.StaticPeers) > 0 {
 		addrs, err := PeersFromStringAddrs(s.cfg.StaticPeers)
 		if err != nil {
-			log.WithError(err).Error("Could not connect to static peer")
+			log.WithError(err).Error("could not convert ENR to multiaddr")
 		}
 		// Set trusted peers for those that are provided as static addresses.
 		pids := peerIdsFromMultiAddrs(addrs)

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -235,11 +235,19 @@ func (s *Service) Start() {
 	async.RunEvery(s.ctx, time.Duration(params.BeaconConfig().RespTimeout)*time.Second, s.updateMetrics)
 	async.RunEvery(s.ctx, refreshRate, s.RefreshENR)
 	async.RunEvery(s.ctx, 1*time.Minute, func() {
+		inboundQUICCount := len(s.peers.InboundConnectedQUIC())
+		inboundTCPCount := len(s.peers.InboundConnectedTCP())
+		outboundQUICCount := len(s.peers.OutboundConnectedQUIC())
+		outboundTCPCount := len(s.peers.OutboundConnectedTCP())
+		total := inboundQUICCount + inboundTCPCount + outboundQUICCount + outboundTCPCount
+
 		log.WithFields(logrus.Fields{
-			"inbound":     len(s.peers.InboundConnected()),
-			"outbound":    len(s.peers.OutboundConnected()),
-			"activePeers": len(s.peers.Active()),
-		}).Info("Peer summary")
+			"inboundQUIC":  inboundQUICCount,
+			"inboundTCP":   inboundTCPCount,
+			"outboundQUIC": outboundQUICCount,
+			"outboundTCP":  outboundTCPCount,
+			"total":        total,
+		}).Info("Connected peers")
 	})
 
 	multiAddrs := s.host.Network().ListenAddresses()

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/peers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/peers/scorers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/types"
+	"github.com/prysmaticlabs/prysm/v5/config/features"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	leakybucket "github.com/prysmaticlabs/prysm/v5/container/leaky-bucket"
 	prysmnetwork "github.com/prysmaticlabs/prysm/v5/network"
@@ -241,13 +242,18 @@ func (s *Service) Start() {
 		outboundTCPCount := len(s.peers.OutboundConnectedWithProtocol(peers.TCP))
 		total := inboundQUICCount + inboundTCPCount + outboundQUICCount + outboundTCPCount
 
-		log.WithFields(logrus.Fields{
-			"inboundQUIC":  inboundQUICCount,
-			"inboundTCP":   inboundTCPCount,
-			"outboundQUIC": outboundQUICCount,
-			"outboundTCP":  outboundTCPCount,
-			"total":        total,
-		}).Info("Connected peers")
+		fields := logrus.Fields{
+			"inboundTCP":  inboundTCPCount,
+			"outboundTCP": outboundTCPCount,
+			"total":       total,
+		}
+
+		if features.Get().EnableQUIC {
+			fields["inboundQUIC"] = inboundQUICCount
+			fields["outboundQUIC"] = outboundQUICCount
+		}
+
+		log.WithFields(fields).Info("Connected peers")
 	})
 
 	multiAddrs := s.host.Network().ListenAddresses()

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -247,9 +247,10 @@ func (s *Service) Start() {
 
 	p2pHostAddress := s.cfg.HostAddress
 	p2pTCPPort := s.cfg.TCPPort
+	p2pQUICPort := s.cfg.QUICPort
 
 	if p2pHostAddress != "" {
-		logExternalIPAddr(s.host.ID(), p2pHostAddress, p2pTCPPort)
+		logExternalIPAddr(s.host.ID(), p2pHostAddress, p2pTCPPort, p2pQUICPort)
 		verifyConnectivity(p2pHostAddress, p2pTCPPort, "tcp")
 	}
 

--- a/beacon-chain/p2p/service_test.go
+++ b/beacon-chain/p2p/service_test.go
@@ -102,8 +102,9 @@ func TestService_Start_OnlyStartsOnce(t *testing.T) {
 
 	cs := startup.NewClockSynchronizer()
 	cfg := &Config{
-		TCPPort:     2000,
 		UDPPort:     2000,
+		TCPPort:     3000,
+		QUICPort:    3000,
 		ClockWaiter: cs,
 	}
 	s, err := NewService(context.Background(), cfg)
@@ -147,8 +148,9 @@ func TestService_Start_NoDiscoverFlag(t *testing.T) {
 
 	cs := startup.NewClockSynchronizer()
 	cfg := &Config{
-		TCPPort:       2000,
 		UDPPort:       2000,
+		TCPPort:       3000,
+		QUICPort:      3000,
 		StateNotifier: &mock.MockStateNotifier{},
 		NoDiscovery:   true, // <-- no s.dv5Listener is created
 		ClockWaiter:   cs,

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -93,6 +93,11 @@ func (s *Service) FindPeersWithSubnet(ctx context.Context, topic string,
 			if err != nil {
 				continue
 			}
+
+			if info == nil {
+				continue
+			}
+
 			wg.Add(1)
 			go func() {
 				if err := s.connectWithPeer(ctx, *info); err != nil {

--- a/beacon-chain/p2p/subnets_test.go
+++ b/beacon-chain/p2p/subnets_test.go
@@ -66,7 +66,7 @@ func TestStartDiscV5_FindPeersWithSubnet(t *testing.T) {
 	genesisTime := time.Now()
 
 	bootNodeService := &Service{
-		cfg:                   &Config{TCPPort: 2000, UDPPort: 3000},
+		cfg:                   &Config{UDPPort: 2000, TCPPort: 3000, QUICPort: 3000},
 		genesisTime:           genesisTime,
 		genesisValidatorsRoot: genesisValidatorsRoot,
 	}
@@ -89,8 +89,9 @@ func TestStartDiscV5_FindPeersWithSubnet(t *testing.T) {
 		service, err := NewService(ctx, &Config{
 			Discv5BootStrapAddrs: []string{bootNodeENR},
 			MaxPeers:             30,
-			TCPPort:              uint(2000 + i),
-			UDPPort:              uint(3000 + i),
+			UDPPort:              uint(2000 + i),
+			TCPPort:              uint(3000 + i),
+			QUICPort:             uint(3000 + i),
 		})
 
 		require.NoError(t, err)
@@ -133,8 +134,9 @@ func TestStartDiscV5_FindPeersWithSubnet(t *testing.T) {
 	cfg := &Config{
 		Discv5BootStrapAddrs: []string{bootNodeENR},
 		MaxPeers:             30,
-		TCPPort:              2010,
-		UDPPort:              3010,
+		UDPPort:              2010,
+		TCPPort:              3010,
+		QUICPort:             3010,
 	}
 
 	service, err := NewService(ctx, cfg)

--- a/beacon-chain/p2p/watch_peers.go
+++ b/beacon-chain/p2p/watch_peers.go
@@ -50,7 +50,7 @@ func ensurePeerConnections(ctx context.Context, h host.Host, peers *peers.Status
 		c := h.Network().ConnsToPeer(p.ID)
 		if len(c) == 0 {
 			if err := connectWithTimeout(ctx, h, p); err != nil {
-				log.WithField("peer", p.ID).WithField("addrs", p.Addrs).WithError(err).Errorf("Failed to reconnect to peer")
+				log.WithField("peer", p.ID).WithField("addrs", p.Addrs).WithError(err).Errorf("failed to reconnect to peer")
 				continue
 			}
 		}

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -142,7 +142,13 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 		// it successfully writes a response. We don't blindly call
 		// Close here because we may have only written a partial
 		// response.
+		// About the special case for quic-v1, please see:
+		// https://github.com/quic-go/quic-go/issues/3291
 		defer func() {
+			if strings.Contains(stream.Conn().RemoteMultiaddr().String(), "quic-v1") {
+				time.Sleep(2 * time.Second)
+			}
+
 			_err := stream.Reset()
 			_ = _err
 		}()

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -90,6 +90,7 @@ var appFlags = []cli.Flag{
 	cmd.StaticPeers,
 	cmd.RelayNode,
 	cmd.P2PUDPPort,
+	cmd.P2PQUICPort,
 	cmd.P2PTCPPort,
 	cmd.P2PIP,
 	cmd.P2PHost,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -55,6 +55,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.BootstrapNode,
 			cmd.RelayNode,
 			cmd.P2PUDPPort,
+			cmd.P2PQUICPort,
 			cmd.P2PTCPPort,
 			cmd.DataDirFlag,
 			cmd.VerbosityFlag,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -113,13 +113,19 @@ var (
 	// P2PUDPPort defines the port to be used by discv5.
 	P2PUDPPort = &cli.IntFlag{
 		Name:  "p2p-udp-port",
-		Usage: "The port used by discv5.",
+		Usage: "The UDP port used by the discovery service discv5.",
 		Value: 12000,
 	}
-	// P2PTCPPort defines the port to be used by libp2p.
+	// P2PQUICPort defines the QUIC port to be used by libp2p.
+	P2PQUICPort = &cli.IntFlag{
+		Name:  "p2p-quic-port",
+		Usage: "The QUIC port used by libp2p.",
+		Value: 13000,
+	}
+	// P2PTCPPort defines the TCP port to be used by libp2p.
 	P2PTCPPort = &cli.IntFlag{
 		Name:  "p2p-tcp-port",
-		Usage: "The port used by libp2p.",
+		Usage: "The TCP port used by libp2p.",
 		Value: 13000,
 	}
 	// P2PIP defines the local IP to be used by libp2p.

--- a/cmd/prysmctl/p2p/BUILD.bazel
+++ b/cmd/prysmctl/p2p/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_libp2p_go_libp2p//core/protocol:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/security/noise:go_default_library",
+        "@com_github_libp2p_go_libp2p//p2p/transport/quic:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/transport/tcp:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_fastssz//:go_default_library",

--- a/cmd/prysmctl/p2p/client.go
+++ b/cmd/prysmctl/p2p/client.go
@@ -53,7 +53,7 @@ func newClient(beaconEndpoints []string, clientPort uint) (*client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not set up p2p metadata")
 	}
-	listen, err := p2p.MultiAddressBuilder(ipAdd.String(), clientPort)
+	listen, err := p2p.MultiAddressBuilder(ipAdd, clientPort)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not set up listening multiaddr")
 	}

--- a/cmd/prysmctl/p2p/client.go
+++ b/cmd/prysmctl/p2p/client.go
@@ -14,7 +14,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
-	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	libp2pquic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	libp2ptcp "github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/pkg/errors"
 	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/go-bitfield"
@@ -43,7 +44,7 @@ type client struct {
 	nodeClient   pb.NodeClient
 }
 
-func newClient(beaconEndpoints []string, clientPort uint) (*client, error) {
+func newClient(beaconEndpoints []string, tcpPort, quicPort uint) (*client, error) {
 	ipAdd := ipAddr()
 	priv, err := privKey()
 	if err != nil {
@@ -53,15 +54,16 @@ func newClient(beaconEndpoints []string, clientPort uint) (*client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not set up p2p metadata")
 	}
-	listen, err := p2p.MultiAddressBuilder(ipAdd, clientPort)
+	multiaddrs, err := p2p.MultiAddressBuilder(ipAdd, tcpPort, quicPort)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not set up listening multiaddr")
 	}
 	options := []libp2p.Option{
 		privKeyOption(priv),
-		libp2p.ListenAddrs(listen),
+		libp2p.ListenAddrs(multiaddrs...),
 		libp2p.UserAgent(version.BuildData()),
-		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(libp2pquic.NewTransport),
+		libp2p.Transport(libp2ptcp.NewTCPTransport),
 	}
 	options = append(options, libp2p.Security(noise.ID, noise.New))
 	options = append(options, libp2p.Ping(false))

--- a/cmd/prysmctl/p2p/request_blobs.go
+++ b/cmd/prysmctl/p2p/request_blobs.go
@@ -22,11 +22,12 @@ import (
 )
 
 var requestBlobsFlags = struct {
-	Peers        string
-	ClientPort   uint
-	APIEndpoints string
-	StartSlot    uint64
-	Count        uint64
+	Peers          string
+	ClientPortTCP  uint
+	ClientPortQUIC uint
+	APIEndpoints   string
+	StartSlot      uint64
+	Count          uint64
 }{}
 
 var requestBlobsCmd = &cli.Command{
@@ -47,9 +48,16 @@ var requestBlobsCmd = &cli.Command{
 			Value:       "",
 		},
 		&cli.UintFlag{
-			Name:        "client-port",
-			Usage:       "port to use for the client as a libp2p host",
-			Destination: &requestBlobsFlags.ClientPort,
+			Name:        "client-port-tcp",
+			Aliases:     []string{"client-port"},
+			Usage:       "TCP port to use for the client as a libp2p host",
+			Destination: &requestBlobsFlags.ClientPortTCP,
+			Value:       13001,
+		},
+		&cli.UintFlag{
+			Name:        "client-port-quic",
+			Usage:       "QUIC port to use for the client as a libp2p host",
+			Destination: &requestBlobsFlags.ClientPortQUIC,
 			Value:       13001,
 		},
 		&cli.StringFlag{
@@ -60,13 +68,13 @@ var requestBlobsCmd = &cli.Command{
 		},
 		&cli.Uint64Flag{
 			Name:        "start-slot",
-			Usage:       "start slot for blocks by range request. If unset, will use start_slot(current_epoch-1)",
+			Usage:       "start slot for blobs by range request. If unset, will use start_slot(current_epoch-1)",
 			Destination: &requestBlobsFlags.StartSlot,
 			Value:       0,
 		},
 		&cli.Uint64Flag{
 			Name:        "count",
-			Usage:       "number of blocks to request, (default 32)",
+			Usage:       "number of blobs to request, (default 32)",
 			Destination: &requestBlobsFlags.Count,
 			Value:       32,
 		},
@@ -90,7 +98,7 @@ func cliActionRequestBlobs(cliCtx *cli.Context) error {
 		allAPIEndpoints = strings.Split(requestBlobsFlags.APIEndpoints, ",")
 	}
 	var err error
-	c, err := newClient(allAPIEndpoints, requestBlobsFlags.ClientPort)
+	c, err := newClient(allAPIEndpoints, requestBlobsFlags.ClientPortTCP, requestBlobsFlags.ClientPortQUIC)
 	if err != nil {
 		return err
 	}

--- a/cmd/prysmctl/p2p/request_blocks.go
+++ b/cmd/prysmctl/p2p/request_blocks.go
@@ -23,13 +23,14 @@ import (
 )
 
 var requestBlocksFlags = struct {
-	Network      string
-	Peers        string
-	ClientPort   uint
-	APIEndpoints string
-	StartSlot    uint64
-	Count        uint64
-	Step         uint64
+	Network        string
+	Peers          string
+	ClientPortTCP  uint
+	ClientPortQUIC uint
+	APIEndpoints   string
+	StartSlot      uint64
+	Count          uint64
+	Step           uint64
 }{}
 
 var requestBlocksCmd = &cli.Command{
@@ -56,9 +57,16 @@ var requestBlocksCmd = &cli.Command{
 			Value:       "",
 		},
 		&cli.UintFlag{
-			Name:        "client-port",
-			Usage:       "port to use for the client as a libp2p host",
-			Destination: &requestBlocksFlags.ClientPort,
+			Name:        "client-port-tcp",
+			Aliases:     []string{"client-port"},
+			Usage:       "TCP port to use for the client as a libp2p host",
+			Destination: &requestBlocksFlags.ClientPortTCP,
+			Value:       13001,
+		},
+		&cli.UintFlag{
+			Name:        "client-port-quic",
+			Usage:       "QUIC port to use for the client as a libp2p host",
+			Destination: &requestBlocksFlags.ClientPortQUIC,
 			Value:       13001,
 		},
 		&cli.StringFlag{
@@ -120,7 +128,7 @@ func cliActionRequestBlocks(cliCtx *cli.Context) error {
 		allAPIEndpoints = strings.Split(requestBlocksFlags.APIEndpoints, ",")
 	}
 	var err error
-	c, err := newClient(allAPIEndpoints, requestBlocksFlags.ClientPort)
+	c, err := newClient(allAPIEndpoints, requestBlocksFlags.ClientPortTCP, requestBlocksFlags.ClientPortQUIC)
 	if err != nil {
 		return err
 	}

--- a/cmd/prysmctl/p2p/request_blocks.go
+++ b/cmd/prysmctl/p2p/request_blocks.go
@@ -23,6 +23,7 @@ import (
 )
 
 var requestBlocksFlags = struct {
+	Network      string
 	Peers        string
 	ClientPort   uint
 	APIEndpoints string
@@ -42,6 +43,12 @@ var requestBlocksCmd = &cli.Command{
 	},
 	Flags: []cli.Flag{
 		cmd.ChainConfigFileFlag,
+		&cli.StringFlag{
+			Name:        "network",
+			Usage:       "network to run on (mainnet, sepolia, holesky)",
+			Destination: &requestBlocksFlags.Network,
+			Value:       "mainnet",
+		},
 		&cli.StringFlag{
 			Name:        "peer-multiaddrs",
 			Usage:       "comma-separated, peer multiaddr(s) to connect to for p2p requests",
@@ -82,6 +89,21 @@ var requestBlocksCmd = &cli.Command{
 }
 
 func cliActionRequestBlocks(cliCtx *cli.Context) error {
+	switch requestBlocksFlags.Network {
+	case params.SepoliaName:
+		if err := params.SetActive(params.SepoliaConfig()); err != nil {
+			log.Fatal(err)
+		}
+	case params.HoleskyName:
+		if err := params.SetActive(params.HoleskyConfig()); err != nil {
+			log.Fatal(err)
+		}
+	case params.MainnetName:
+		// Do nothing
+	default:
+		log.Fatalf("Unknown network provided: %s", requestBlocksFlags.Network)
+	}
+
 	if cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
 		chainConfigFileName := cliCtx.String(cmd.ChainConfigFileFlag.Name)
 		if err := params.LoadChainConfigFile(chainConfigFileName, nil); err != nil {

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -42,6 +42,7 @@ type Flags struct {
 	WriteSSZStateTransitions            bool // WriteSSZStateTransitions to tmp directory.
 	EnablePeerScorer                    bool // EnablePeerScorer enables experimental peer scoring in p2p.
 	EnableLightClient                   bool // EnableLightClient enables light client APIs.
+	EnableQUIC                          bool // EnableQUIC specifies whether to enable QUIC transport for libp2p.
 	WriteWalletPasswordOnWebOnboarding  bool // WriteWalletPasswordOnWebOnboarding writes the password to disk after Prysm web signup.
 	EnableDoppelGanger                  bool // EnableDoppelGanger enables doppelganger protection on startup for the validator.
 	EnableHistoricalSpaceRepresentation bool // EnableHistoricalSpaceRepresentation enables the saving of registry validators in separate buckets to save space
@@ -264,6 +265,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.IsSet(BlobSaveFsync.Name) {
 		logEnabled(BlobSaveFsync)
 		cfg.BlobSaveFsync = true
+	}
+	if ctx.IsSet(EnableQUIC.Name) {
+		logEnabled(EnableQUIC)
+		cfg.EnableQUIC = true
 	}
 
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -171,6 +171,11 @@ var (
 		Name:  "blob-save-fsync",
 		Usage: "Forces new blob files to be fysnc'd before continuing, ensuring durable blob writes.",
 	}
+	// EnableQUIC enables connection using the QUIC protocol for peers which support it.
+	EnableQUIC = &cli.BoolFlag{
+		Name:  "enable-quic",
+		Usage: "Enables connection using the QUIC protocol for peers which support it.",
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -229,6 +234,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	DisableRegistrationCache,
 	EnableLightClient,
 	BlobSaveFsync,
+	EnableQUIC,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -182,6 +182,7 @@ var (
 var devModeFlags = []cli.Flag{
 	enableExperimentalState,
 	backfill.EnableExperimentalBackfill,
+	EnableQUIC,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -109,8 +109,8 @@ var (
 	}
 	enableDoppelGangerProtection = &cli.BoolFlag{
 		Name: "enable-doppelganger",
-		Usage: `Enables the validator to perform a doppelganger check.
-		This is not "a foolproof method to find duplicate instances in the network.
+		Usage: `Enables the validator to perform a doppelganger check. 
+		This is not a foolproof method to find duplicate instances in the network. 
 		Your validator will still be vulnerable if it is being run in unsafe configurations.`,
 	}
 	disableStakinContractCheck = &cli.BoolFlag{

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -313,7 +313,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 	}
 
 	if config.UseFixedPeerIDs {
-		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with peer id of ")
+		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with peerId=")
 		if err != nil {
 			return fmt.Errorf("could not find peer id: %w", err)
 		}

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -257,6 +257,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 		fmt.Sprintf("--%s=%s", flags.ExecutionJWTSecretFlag.Name, jwtPath),
 		fmt.Sprintf("--%s=%d", flags.MinSyncPeers.Name, 1),
 		fmt.Sprintf("--%s=%d", cmdshared.P2PUDPPort.Name, e2e.TestParams.Ports.PrysmBeaconNodeUDPPort+index),
+		fmt.Sprintf("--%s=%d", cmdshared.P2PQUICPort.Name, e2e.TestParams.Ports.PrysmBeaconNodeQUICPort+index),
 		fmt.Sprintf("--%s=%d", cmdshared.P2PTCPPort.Name, e2e.TestParams.Ports.PrysmBeaconNodeTCPPort+index),
 		fmt.Sprintf("--%s=%d", cmdshared.P2PMaxPeers.Name, expectedNumOfPeers),
 		fmt.Sprintf("--%s=%d", flags.MonitoringPortFlag.Name, e2e.TestParams.Ports.PrysmBeaconNodeMetricsPort+index),

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -276,6 +276,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 		"--" + cmdshared.ForceClearDB.Name,
 		"--" + cmdshared.AcceptTosFlag.Name,
 		"--" + flags.EnableDebugRPCEndpoints.Name,
+		"--" + features.EnableQUIC.Name,
 	}
 	if config.UsePprof {
 		args = append(args, "--pprof", fmt.Sprintf("--pprofport=%d", e2e.TestParams.Ports.PrysmBeaconNodePprofPort+index))

--- a/testing/endtoend/params/params.go
+++ b/testing/endtoend/params/params.go
@@ -46,6 +46,7 @@ type ports struct {
 	Eth1ProxyPort                   int
 	PrysmBeaconNodeRPCPort          int
 	PrysmBeaconNodeUDPPort          int
+	PrysmBeaconNodeQUICPort         int
 	PrysmBeaconNodeTCPPort          int
 	PrysmBeaconNodeGatewayPort      int
 	PrysmBeaconNodeMetricsPort      int
@@ -144,10 +145,11 @@ const (
 
 	PrysmBeaconNodeRPCPort     = 4150
 	PrysmBeaconNodeUDPPort     = PrysmBeaconNodeRPCPort + portSpan
-	PrysmBeaconNodeTCPPort     = PrysmBeaconNodeRPCPort + 2*portSpan
-	PrysmBeaconNodeGatewayPort = PrysmBeaconNodeRPCPort + 3*portSpan
-	PrysmBeaconNodeMetricsPort = PrysmBeaconNodeRPCPort + 4*portSpan
-	PrysmBeaconNodePprofPort   = PrysmBeaconNodeRPCPort + 5*portSpan
+	PrysmBeaconNodeQUICPort    = PrysmBeaconNodeRPCPort + 2*portSpan
+	PrysmBeaconNodeTCPPort     = PrysmBeaconNodeRPCPort + 3*portSpan
+	PrysmBeaconNodeGatewayPort = PrysmBeaconNodeRPCPort + 4*portSpan
+	PrysmBeaconNodeMetricsPort = PrysmBeaconNodeRPCPort + 5*portSpan
+	PrysmBeaconNodePprofPort   = PrysmBeaconNodeRPCPort + 6*portSpan
 
 	LighthouseBeaconNodeP2PPort     = 5150
 	LighthouseBeaconNodeHTTPPort    = LighthouseBeaconNodeP2PPort + portSpan
@@ -330,6 +332,10 @@ func initializeStandardPorts(shardCount, shardIndex int, ports *ports, existingR
 	if err != nil {
 		return err
 	}
+	beaconNodeQUICPort, err := port(PrysmBeaconNodeQUICPort, shardCount, shardIndex, existingRegistrations)
+	if err != nil {
+		return err
+	}
 	beaconNodeTCPPort, err := port(PrysmBeaconNodeTCPPort, shardCount, shardIndex, existingRegistrations)
 	if err != nil {
 		return err
@@ -367,6 +373,7 @@ func initializeStandardPorts(shardCount, shardIndex int, ports *ports, existingR
 	ports.Eth1ProxyPort = eth1ProxyPort
 	ports.PrysmBeaconNodeRPCPort = beaconNodeRPCPort
 	ports.PrysmBeaconNodeUDPPort = beaconNodeUDPPort
+	ports.PrysmBeaconNodeQUICPort = beaconNodeQUICPort
 	ports.PrysmBeaconNodeTCPPort = beaconNodeTCPPort
 	ports.PrysmBeaconNodeGatewayPort = beaconNodeGatewayPort
 	ports.PrysmBeaconNodeMetricsPort = beaconNodeMetricsPort

--- a/testing/endtoend/params/params_test.go
+++ b/testing/endtoend/params/params_test.go
@@ -30,7 +30,7 @@ func TestStandardPorts(t *testing.T) {
 	var existingRegistrations []int
 	testPorts := &ports{}
 	assert.NoError(t, initializeStandardPorts(2, 0, testPorts, &existingRegistrations))
-	assert.Equal(t, 16, len(existingRegistrations))
+	assert.Equal(t, 17, len(existingRegistrations))
 	assert.NotEqual(t, 0, testPorts.PrysmBeaconNodeGatewayPort)
 	assert.NotEqual(t, 0, testPorts.PrysmBeaconNodeTCPPort)
 	assert.NotEqual(t, 0, testPorts.JaegerTracingPort)


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This pull request adds the QUIC protocol support. For more information about the QUIC protocol, and how it is supported into libp2p, please checkout [here](https://docs.libp2p.io/concepts/transports/quic/).

This PR adds a new `--p2p-quic-port (default: 13000)` flag.
```
--p2p-quic-port value The QUIC port used by libp2p. (default: 13000)
```

This new feature is hidden behind the `--enable-quic` feature flag:
```
features OPTIONS:
   ...
   --enable-quic                             Enables connection using the QUIC protocol for peers which support it. (default: false)
   ...
```
P2P ports are now:
```
ALREADY EXISTING:
--p2p-udp-port value   The UDP port used by the discovery service discv5. (default: 12000)
--p2p-tcp-port value   The TCP port used by libp2p. (default: 13000)

NEW:
--p2p-quic-port value  The QUIC port used by libp2p. (default: 13000)
```

Now, port `13000` is used as both default port for libp2p TCP and QUIC(UDP).

When starting the beacon node, the following log is displayed:
```
INFO p2p: Started discovery v5 ENR=enr:-Mq4QMhhoVSzFFpYC3zDKE24nQndTXw8lXtReLAqd1ddTGcHEwnzBgcKeASZyjtzogf7h_Zluie8CNhBdfjNOzycCyaGAY6AcM_qh2F0dG5ldHOIAAAAAAAAAACEZXRoMpBprg6ZBQFwAP__________gmlkgnY0gmlwhF4QcmaEcXVpY4IyyIlzZWNwMjU2azGhAxaMhBX-x4-CvNk5PkOUEcuv8cCFVh9UnscPj--TtQpLiHN5bmNuZXRzAIN0Y3CCMsiDdWRwgi7g
```

The corresponding decoded ENR is the following:
(Note the new `quic` entry.)
![image](https://github.com/prysmaticlabs/prysm/assets/4943830/c3d6fdea-3199-4e57-ac6b-61ef1c513d33)


When starting a new node, the following logs are displayed:
```
ALREADY EXISTING:
INFO p2p: Node started p2p server multiAddr=/ip4/172.18.0.3/tcp/13000/p2p/16Uiu2HAmEB1bM8P23R5Ptx9XU8bFMvh3hvNPqnSdkQWnsrGXzCdp

NEW:
INFO p2p: Node started p2p server multiAddr=/ip4/172.18.0.3/udp/13000/quic-v1/p2p/16Uiu2HAmEB1bM8P23R5Ptx9XU8bFMvh3hvNPqnSdkQWnsrGXzCdp
```

If using the `--p2p-host-ip` flag:

```
ALREADY EXISTING:
INFO p2p: Node started external p2p server multiAddr=/ip4/94.16.114.102/tcp/13000/p2p/16Uiu2HAmEB1bM8P23R5Ptx9XU8bFMvh3hvNPqnSdkQWnsrGXzCdp

NEW:
INFO p2p: Node started external p2p server multiAddr=/ip4/94.16.114.102/udp/13000/quic-v1/p2p/16Uiu2HAmEB1bM8P23R5Ptx9XU8bFMvh3hvNPqnSdkQWnsrGXzCdp
```

Every minute, the following log is displayed, showing the number of inbound/outbound TCP/QUIC peers.

```
INFO p2p: Connected peers inboundQUIC=10 inboundTCP=3 outboundQUIC=3 outboundTCP=57 total=73
```

Below is represented an extract of the beacon API call to  `<ip-address>:3500/eth/v1/beacon/genesis`:

Only four items are retained in the extract:
- 1 TCP / Outbound
- 1 TCP / Inbound
- 1 QUIC / Outbound
- 1 QUIC / Inbound

Outbound / Inbound is represented in the `direction` field.
TCP / QUIC is represented in the `last_seen_p2p_address` field.

```
{
  "data": [
...
    {
      "peer_id": "16Uiu2HAkxVmsQQtNCvgADvdEFZUw1hq6rVBxZ3hb4bNt7jDYJAgp",
      "enr": "enr:-Ly4QM65O2LrfDEEmk-eH08SbTgD4c-TqJduC4-Q2CqE1UwpDpDewwwUz0oRV7lwC6_NlEWiOMaQoHNJJOPt98X8lhsWh2F0dG5ldHOIAAAAAAAAgAGEZXRoMpBprg6ZBQFwAP__________gmlkgnY0gmlwhMIhKIyJc2VjcDI1NmsxoQItoAsu0kuhTEY5ewhZLhu83v0zSnoin7O_p4U6_ULO4YhzeW5jbmV0cwSDdGNwgiMsg3VkcIIjLA",
      "last_seen_p2p_address": "/ip4/194.33.40.140/tcp/9004",
      "state": "connected",
      "direction": "outbound"
    },
...
    {
      "peer_id": "16Uiu2HAm3GPSjdiaAkCbr1qafWAojzepodknQCoZfFbR5k5b92LL",
      "enr": "",
      "last_seen_p2p_address": "/ip4/168.119.10.116/tcp/16741",
      "state": "connected",
      "direction": "inbound"
    },
...
    {
      "peer_id": "16Uiu2HAmFiyzWcJedxXkeca5btmqPD7MYKsuUmKkd1RzaVfZX5KH",
      "enr": "enr:-MW4QGIXCYuk2GRAkumwtfHj_NhEYZRB0W_qO19jgmZMK7vqX9zPEANC05iLtu5dB22asvlJCg8hKSDMvqKCv580ds6ByYdhdHRuZXRziAAAAAAAABgAhGV0aDKQaa4OmQUBcAD__________4JpZIJ2NIJpcIRKMkPehHF1aWOCIymJc2VjcDI1NmsxoQMtmPqbx98SSU8z8FXOpdD1hesW3rvogahgJpn9jUGjpIhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA",
      "last_seen_p2p_address": "/ip4/74.50.67.222/udp/9001/quic-v1",
      "state": "connected",
      "direction": "outbound"
    },
...
    {
      "peer_id": "16Uiu2HAkyiEJirC3Efo7NcAnHhVqZVREDWGiCRMUtE6FN36ARC2V",
      "enr": "",
      "last_seen_p2p_address": "/ip4/80.249.120.20/udp/9001/quic-v1",
      "state": "connected",
      "direction": "inbound"
    },
...
  ]
}
```

Decoded ENR of the TCP/Outbound peer is represented as:
(No `quic` entry in present the ENR.)
![image](https://github.com/prysmaticlabs/prysm/assets/4943830/09c63ee8-6e8e-4952-81a5-b1c62f6d6931)

Decoded ENR of the QUIC/Outbound peer is represented as:
(The `quic` entry is present in the ENR.)
![image](https://github.com/prysmaticlabs/prysm/assets/4943830/b68e9dca-f1b1-4dc3-a22d-d7fd9e1650cc)

**Note:**
When an outbound peer supports both the TCP and the QUIC protocols, then Prysm favors the QUIC protocol.