### PR TITLE
Log da block root in hex

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -594,7 +594,7 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 func daCheckLogFields(root [32]byte, slot primitives.Slot, expected, missing int) logrus.Fields {
 	return logrus.Fields{
 		"slot":          slot,
-		"root":          root,
+		"root":          fmt.Sprintf("%#x", root),
 		"blobsExpected": expected,
 		"blobsWaiting":  missing,
 	}


### PR DESCRIPTION
Logging DA block root in hex so it's more readable

`Mar 21 09:23:23 t beacon-chain[1002098]: time="2024-03-21 09:23:23" level=error msg="Still waiting for DA check at slot end." blobsExpected=6 blobsWaiting=6 prefix=blockchain root=[0 227 89 28 9 157 91 149 221 20 236 163 60 205 170 26 210 157 250 150 115 236 122 252 192 154 175 201 86 164 60 51] slot=8684514`