### PR TITLE
Committee cache rework

### DIFF
--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "active_balance.go",
         "active_balance_disabled.go",  # keep
         "attestation_data.go",
+        "cache.go",
         "checkpoint_state.go",
         "committee.go",
         "committee_disabled.go",  # keep
@@ -49,6 +50,7 @@ go_library(
         "//runtime/version:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_hashicorp_golang_lru//:go_default_library",
+        "@com_github_hashicorp_golang_lru_v2//:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
@@ -93,6 +95,12 @@ go_test(
         "//testing/util:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
+        "@com_github_hashicorp_golang_lru_v2//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@com_github_prometheus_client_model//go:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],

--- a/beacon-chain/cache/cache.go
+++ b/beacon-chain/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"unsafe"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -17,6 +18,24 @@ type lruCache[K comparable, V any] interface {
 	// metrics
 	hitCache()
 	missCache()
+}
+
+func newLRUCache[K comparable, V any]() *lru.Cache[K, V] {
+	cache, err := lru.New[K, V](maxCommitteesCacheSize)
+	if err != nil {
+		panic(fmt.Errorf("%w: %v", ErrNilCache, err))
+	}
+
+	isCacheMissNil, isCacheHitNil := committeeCacheMiss == nil, committeeCacheMiss == nil
+	if isCacheMissNil || isCacheHitNil {
+		panic(fmt.Errorf("%w: isCacheMissNil=<%t>, isCacheHitNil=<%t>",
+			ErrNilMetrics,
+			isCacheHitNil,
+			isCacheHitNil,
+		))
+	}
+
+	return cache
 }
 
 func get[K comparable, V any](c lruCache[K, V], key K) (V, error) {
@@ -57,6 +76,39 @@ func exist[K comparable, V any](c lruCache[K, V], key K) bool {
 }
 
 // comparison helpers
+//
+// isNil is a safeguard when trying to insert key -> value, where value is nil
+//
+// it helps with the confusing Go case where a pointer structure is equal to nil and not flagged by "V == nil"
+// we know that an interface in Go holds two values:
+// var i interface{}       // (type=nil,value=nil)
+// that the nil operator compares the values of type and value to both be nil such as:
+// for i == nil to be true, i should have type==nil and value==nil
+//
+// Unfortunately, in the case of generics when a type any(V), "V == nil" is not always true
+// Picture the following:
+// var b *beaconState              // (type=*beaconState,value=nil)
+// var i interface{}       		   // (type=nil,value=nil)
+//
+// if i != nil {                   // (type=nil,value=nil) != (type=nil,value=nil)
+//
+//		   panic("not nil 1")      // i is in fact nil
+//	}
+//
+// i = p                   		   // assign b to i
+//
+// if i != nil {           		   // (type=*beaconState,value=nil) != (type=nil,value=nil)
+//
+//	      panic("not nil 2")       // panic here
+//	}
+//
+// isNil helps comparing the second 'value' that an interface holds in order to avoid ending up inserting a nil
+// value in cache even though multiple '== nil' have been done before hand.
+// you can see this as a safeguard.
+//
+// Another alternative would be to use the reflect package
+// reflect.ValueOf(v).IsNil()
+// It's way more expensive though (around 3 times more ns/op)
 func isNil[T any](v T) bool {
 	return (*[2]uintptr)(unsafe.Pointer(&v))[1] == 0
 }

--- a/beacon-chain/cache/cache.go
+++ b/beacon-chain/cache/cache.go
@@ -1,0 +1,62 @@
+package cache
+
+import (
+	"unsafe"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// lruCache is a thread-safe size LRU cache.
+type lruCache[K comparable, V any] interface {
+	// Clear the cache
+	Clear()
+
+	// access to cache
+	get() *lru.Cache[K, V]
+
+	// metrics
+	hitCache()
+	missCache()
+}
+
+func get[K comparable, V any](c lruCache[K, V], key K) (V, error) {
+	value, ok := c.get().Get(key)
+	if !ok {
+		c.missCache()
+		var zero V
+		return zero, ErrNotFound
+	}
+	c.hitCache()
+	return value, nil
+}
+
+// method helpers
+func add[K comparable, V any](c lruCache[K, V], key K, value V) error {
+	if isNil(value) {
+		return ErrNilValueProvided
+	}
+	c.get().Add(key, value)
+	return nil
+}
+
+func keys[K comparable, V any](c lruCache[K, V]) []K {
+	return c.get().Keys()
+}
+
+func purge[K comparable, V any](c lruCache[K, V]) {
+	c.get().Purge()
+}
+
+func resize[K comparable, V any](c lruCache[K, V], size int) {
+	c.get().Resize(size)
+}
+
+func exist[K comparable, V any](c lruCache[K, V], key K) bool {
+	_, ok := c.get().Get(key)
+	return ok
+}
+
+// comparison helpers
+func isNil[T any](v T) bool {
+	return (*[2]uintptr)(unsafe.Pointer(&v))[1] == 0
+}

--- a/beacon-chain/cache/cache_test.go
+++ b/beacon-chain/cache/cache_test.go
@@ -1,9 +1,173 @@
 package cache
 
 import (
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
-func TestMain(m *testing.M) {
-	m.Run()
+// generics
+type Key = primitives.Epoch
+type Value = []byte
+
+var (
+	// case setup
+	myCache     lruCache[Key, Value]
+	myCacheOnce sync.Once
+	cacheSetup  = func(t *testing.T) {
+		myCacheOnce.Do(func() {
+			var err error
+			myCache, err = NewTestCache[Key, Value]()
+			if err != nil {
+				t.Fatalf("Error creating cache: %v", err)
+			}
+		})
+		myCache.Clear()
+	}
+
+	// case metrics
+	reg = prometheus.NewPedanticRegistry()
+
+	// case values
+	key   = primitives.Epoch(1)
+	value = []byte("0xaaa")
+)
+
+func TestCache_LRU(t *testing.T) {
+	tests := []struct {
+		name                     string
+		cacheSetup               func(t *testing.T)
+		key                      Key
+		value                    Value
+		expectedValue            Value
+		expectedError            error
+		expectedHitCacheMetrics  float64
+		expectedMissCacheMetrics float64
+	}{
+		{
+			name: "Test adding value returns value",
+			cacheSetup: func(t *testing.T) {
+				cacheSetup(t)
+			},
+			key:                      key,
+			value:                    value,
+			expectedValue:            value,
+			expectedError:            nil,
+			expectedHitCacheMetrics:  1,
+			expectedMissCacheMetrics: 0,
+		},
+		{
+			name: "Test adding nil value returns error",
+			cacheSetup: func(t *testing.T) {
+				cacheSetup(t)
+			},
+			key:                      key,
+			value:                    nil,
+			expectedValue:            nil,
+			expectedError:            ErrNilValueProvided,
+			expectedHitCacheMetrics:  1,
+			expectedMissCacheMetrics: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// test setup
+			test.cacheSetup(t)
+
+			// test values
+			err := add(myCache, test.key, test.value)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Expected error %v, got %v", test.expectedError, err)
+			}
+
+			var item Value
+			item, err = get(myCache, test.key)
+			if item == nil {
+				if !errors.Is(err, ErrNotFound) {
+					t.Errorf("Expected error %v, got %v", ErrNotFound, err)
+				}
+			}
+			require.DeepEqual(t, item, test.expectedValue)
+
+			// test metrics
+			var metrics []*dto.MetricFamily
+			if metrics, err = reg.Gather(); err != nil {
+				t.Error("Gathering failed:", err)
+			}
+			assert.Equal(t, dto.MetricType_COUNTER, metrics[0].GetType())
+			assert.Equal(t, "total_test_cache_hit", metrics[0].GetName())
+			assert.Equal(t, "The number of get requests that are present in the cache.", metrics[0].GetHelp())
+			assert.Equal(t, test.expectedHitCacheMetrics, *metrics[0].GetMetric()[0].Counter.Value)
+
+			assert.Equal(t, dto.MetricType_COUNTER, metrics[1].GetType())
+			assert.Equal(t, "total_test_cache_miss", metrics[1].GetName())
+			assert.Equal(t, "The number of get requests that aren't present in the cache.", metrics[1].GetHelp())
+			assert.Equal(t, test.expectedMissCacheMetrics, *metrics[1].GetMetric()[0].Counter.Value)
+		})
+	}
+}
+
+const (
+	maxTestCacheSize = int(4)
+)
+
+var (
+	testPromCacheHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "total_test_cache_hit",
+		Help: "The number of get requests that are present in the cache.",
+	})
+	testPromCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "total_test_cache_miss",
+		Help: "The number of get requests that aren't present in the cache.",
+	})
+)
+
+type TestCache[K Key, V Value] struct {
+	lru                         *lru.Cache[K, V]
+	promCacheMiss, promCacheHit prometheus.Counter
+}
+
+func NewTestCache[K Key, V Value]() (*TestCache[K, V], error) {
+	cache, err := lru.New[K, V](maxTestCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	if testPromCacheHit == nil || testPromCacheMiss == nil {
+		return nil, err
+	}
+
+	reg.MustRegister(testPromCacheMiss)
+	reg.MustRegister(testPromCacheHit)
+
+	return &TestCache[K, V]{
+		lru:           cache,
+		promCacheMiss: testPromCacheMiss,
+		promCacheHit:  testPromCacheHit,
+	}, nil
+}
+
+func (c *TestCache[K, V]) get() *lru.Cache[K, V] {
+	return c.lru
+}
+
+func (c *TestCache[K, V]) hitCache() {
+	c.promCacheHit.Inc()
+}
+
+func (c *TestCache[K, V]) missCache() {
+	c.promCacheMiss.Inc()
+}
+
+func (c *TestCache[K, V]) Clear() {
+	purge[K, V](c)
 }

--- a/beacon-chain/cache/cache_test.go
+++ b/beacon-chain/cache/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"github.com/stretchr/testify/assert"
@@ -170,4 +171,17 @@ func (c *TestCache[K, V]) missCache() {
 
 func (c *TestCache[K, V]) Clear() {
 	purge[K, V](c)
+}
+
+func Test_isNil(t *testing.T) {
+	var proto interface{}
+	var beaconState *state.BeaconState
+
+	proto = beaconState
+	require.Equal(t, isNil(proto), true)
+	require.Equal(t, confusingIsNil(&proto), false)
+}
+
+func confusingIsNil[T any](arg *T) bool {
+	return arg == nil
 }

--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -5,14 +5,14 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	lruwrpr "github.com/prysmaticlabs/prysm/v5/cache/lru"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/container/slice"
@@ -30,187 +30,218 @@ const (
 )
 
 var (
-	// CommitteeCacheMiss tracks the number of committee requests that aren't present in the cache.
-	CommitteeCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
+	// committeeCacheMiss tracks the number of committee requests that aren't present in the cache.
+	committeeCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "committee_cache_miss",
 		Help: "The number of committee requests that aren't present in the cache.",
 	})
-	// CommitteeCacheHit tracks the number of committee requests that are in the cache.
-	CommitteeCacheHit = promauto.NewCounter(prometheus.CounterOpts{
+	// committeeCacheHit tracks the number of committee requests that are in the cache.
+	committeeCacheHit = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "committee_cache_hit",
 		Help: "The number of committee requests that are present in the cache.",
 	})
 )
 
-// CommitteeCache is a struct with 1 queue for looking up shuffled indices list by seed.
-type CommitteeCache struct {
-	CommitteeCache *lru.Cache
-	lock           sync.RWMutex
-	inProgress     map[string]bool
-	size           int
-}
+var (
+	ErrRequestIndexOutOfBound = errors.New("requested index out of bound")
+)
 
-// committeeKeyFn takes the seed as the key to retrieve shuffled indices of a committee in a given epoch.
-func committeeKeyFn(obj interface{}) (string, error) {
-	info, ok := obj.(*Committees)
-	if !ok {
-		return "", ErrNotCommittee
-	}
-	return key(info.Seed), nil
+// CommitteeCache is a struct with 1 queue for looking up shuffled indices list by seed.
+type CommitteeCache[K string, V Committees] struct {
+	lru                         *lru.Cache[K, V]
+	promCacheMiss, promCacheHit prometheus.Counter
+
+	lock       sync.RWMutex
+	inProgress map[string]bool
+	size       int
 }
 
 // NewCommitteesCache creates a new committee cache for storing/accessing shuffled indices of a committee.
-func NewCommitteesCache() *CommitteeCache {
-	cc := &CommitteeCache{}
-	cc.Clear()
-	return cc
+func NewCommitteesCache[K string, V Committees]() (*CommitteeCache[K, V], error) {
+	cache, err := lru.New[K, V](maxCommitteesCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrNilCache, err)
+	}
+
+	isCacheMissNil, isCacheHitNil := committeeCacheMiss == nil, committeeCacheMiss == nil
+	if isCacheMissNil || isCacheHitNil {
+		return nil,
+			fmt.Errorf("%w: isCacheMissNil=<%t>, isCacheHitNil=<%t>",
+				ErrNilMetrics,
+				isCacheHitNil,
+				isCacheHitNil,
+			)
+	}
+
+	return &CommitteeCache[K, V]{
+		lru:           cache,
+		promCacheMiss: committeeCacheMiss,
+		promCacheHit:  committeeCacheHit,
+		inProgress:    make(map[string]bool),
+	}, nil
 }
 
-// Clear resets the CommitteeCache to its initial state
-func (c *CommitteeCache) Clear() {
+// get returns the underlying lru cache.
+func (c *CommitteeCache[K, V]) get() *lru.Cache[K, V] { //nolint: unused, -- bug in golangci-lint v1.55.2
+	return c.lru
+}
+
+// hitCache increments the cache miss counter.
+func (c *CommitteeCache[K, V]) hitCache() { //nolint: unused, -- bug in golangci-lint v1.55.2
+	c.promCacheHit.Inc()
+}
+
+// missCache increments the cache miss counter.
+func (c *CommitteeCache[K, V]) missCache() { //nolint: unused, -- bug in golangci-lint v1.55.2
+	c.promCacheMiss.Inc()
+}
+
+// Clear the CommitteeCache to its initial state
+func (c *CommitteeCache[K, V]) Clear() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.CommitteeCache = lruwrpr.New(maxCommitteesCacheSize)
+
+	purge[K, V](c)
+	c.compressCommitteeCache()
 	c.inProgress = make(map[string]bool)
-	c.size = maxCommitteesCacheSize
 }
 
+// -------------------------------------------------------------------------------------------------------------------//
+
 // ExpandCommitteeCache expands the size of the committee cache.
-func (c *CommitteeCache) ExpandCommitteeCache() {
+func (c *CommitteeCache[K, V]) ExpandCommitteeCache() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	if c.size == expandedCommitteeCacheSize {
 		return
 	}
-	c.CommitteeCache.Resize(expandedCommitteeCacheSize)
+	resize[K, V](c, expandedCommitteeCacheSize)
 	c.size = expandedCommitteeCacheSize
 	log.Warnf("Expanding committee cache size from %d to %d", maxCommitteesCacheSize, expandedCommitteeCacheSize)
 }
 
+// compressCommitteeCache compresses the size of the committee cache.
+// This method is not thread safe and should be called with a lock.
+func (c *CommitteeCache[K, V]) compressCommitteeCache() {
+	if c.size == maxCommitteesCacheSize {
+		return
+	}
+	resize[K, V](c, maxCommitteesCacheSize)
+	c.size = maxCommitteesCacheSize
+	log.Warnf("Reducing committee cache size from %d to %d", expandedCommitteeCacheSize, maxCommitteesCacheSize)
+}
+
 // CompressCommitteeCache compresses the size of the committee cache.
-func (c *CommitteeCache) CompressCommitteeCache() {
+// This method is thread safe and should be called without a lock.
+func (c *CommitteeCache[K, V]) CompressCommitteeCache() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	if c.size == maxCommitteesCacheSize {
 		return
 	}
-	c.CommitteeCache.Resize(maxCommitteesCacheSize)
+	resize[K, V](c, maxCommitteesCacheSize)
 	c.size = maxCommitteesCacheSize
 	log.Warnf("Reducing committee cache size from %d to %d", expandedCommitteeCacheSize, maxCommitteesCacheSize)
 }
 
 // Committee fetches the shuffled indices by slot and committee index. Every list of indices
 // represent one committee. Returns true if the list exists with slot and committee index. Otherwise returns false, nil.
-func (c *CommitteeCache) Committee(ctx context.Context, slot primitives.Slot, seed [32]byte, index primitives.CommitteeIndex) ([]primitives.ValidatorIndex, error) {
-	if err := c.checkInProgress(ctx, seed); err != nil {
+func (c *CommitteeCache[K, V]) Committee(ctx context.Context, slot primitives.Slot, seed [32]byte, index primitives.CommitteeIndex) ([]primitives.ValidatorIndex, error) {
+	var err error
+	if err = c.checkInProgress(ctx, seed); err != nil {
+		return nil, fmt.Errorf("failed to check progress: %w", err)
+	}
+
+	var item V
+	if item, err = get[K, V](c, K(committeeCachesKey(seed))); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
-
-	obj, exists := c.CommitteeCache.Get(key(seed))
-	if exists {
-		CommitteeCacheHit.Inc()
-	} else {
-		CommitteeCacheMiss.Inc()
-		return nil, nil
-	}
-
-	item, ok := obj.(*Committees)
+	committees, ok := any(item).(Committees)
 	if !ok {
-		return nil, ErrNotCommittee
+		return nil, fmt.Errorf("%v: %w", ErrCast, errNotCommittees)
 	}
 
 	committeeCountPerSlot := uint64(1)
-	if item.CommitteeCount/uint64(params.BeaconConfig().SlotsPerEpoch) > 1 {
-		committeeCountPerSlot = item.CommitteeCount / uint64(params.BeaconConfig().SlotsPerEpoch)
+	if committees.CommitteeCount/uint64(params.BeaconConfig().SlotsPerEpoch) > 1 {
+		committeeCountPerSlot = committees.CommitteeCount / uint64(params.BeaconConfig().SlotsPerEpoch)
 	}
 
 	indexOffSet, err := mathutil.Add64(uint64(index), uint64(slot.ModSlot(params.BeaconConfig().SlotsPerEpoch).Mul(committeeCountPerSlot)))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to calculate indexOffSet: %w", err)
 	}
-	start, end := startEndIndices(item, indexOffSet)
+	start, end := startEndIndices(&committees, indexOffSet)
 
-	if end > uint64(len(item.ShuffledIndices)) || end < start {
-		return nil, errors.New("requested index out of bound")
+	if end > uint64(len(committees.ShuffledIndices)) || end < start {
+		return nil, ErrRequestIndexOutOfBound
 	}
 
-	return item.ShuffledIndices[start:end], nil
+	return committees.ShuffledIndices[start:end], nil
 }
 
 // AddCommitteeShuffledList adds Committee shuffled list object to the cache. T
 // his method also trims the least recently list if the cache size has ready the max cache size limit.
-func (c *CommitteeCache) AddCommitteeShuffledList(ctx context.Context, committees *Committees) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+func (c *CommitteeCache[K, V]) AddCommitteeShuffledList(ctx context.Context, committees *V) error {
 	if err := ctx.Err(); err != nil {
-		return err
+		return fmt.Errorf("failed to continue with context error: %w", err)
 	}
-	key, err := committeeKeyFn(committees)
+
+	key, err := committeeCachesKeyFn[K, V](committees)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to compute committee key fn: %w", err)
 	}
-	_ = c.CommitteeCache.Add(key, committees)
-	return nil
+
+	return add[K, V](c, key, *committees)
 }
 
 // ActiveIndices returns the active indices of a given seed stored in cache.
-func (c *CommitteeCache) ActiveIndices(ctx context.Context, seed [32]byte) ([]primitives.ValidatorIndex, error) {
-	if err := c.checkInProgress(ctx, seed); err != nil {
+func (c *CommitteeCache[K, V]) ActiveIndices(ctx context.Context, seed [32]byte) ([]primitives.ValidatorIndex, error) {
+	var err error
+	if err = c.checkInProgress(ctx, seed); err != nil {
+		return nil, fmt.Errorf("failed to check progress: %w", err)
+	}
+
+	var item V
+	if item, err = get[K, V](c, K(committeeCachesKey(seed))); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
-	obj, exists := c.CommitteeCache.Get(key(seed))
-
-	if exists {
-		CommitteeCacheHit.Inc()
-	} else {
-		CommitteeCacheMiss.Inc()
-		return nil, nil
-	}
-
-	item, ok := obj.(*Committees)
+	committees, ok := any(item).(Committees)
 	if !ok {
-		return nil, ErrNotCommittee
+		return nil, fmt.Errorf("%v: %w", ErrCast, errNotCommittees)
 	}
 
-	return item.SortedIndices, nil
+	return committees.SortedIndices, nil
 }
 
 // ActiveIndicesCount returns the active indices count of a given seed stored in cache.
-func (c *CommitteeCache) ActiveIndicesCount(ctx context.Context, seed [32]byte) (int, error) {
-	if err := c.checkInProgress(ctx, seed); err != nil {
+func (c *CommitteeCache[K, V]) ActiveIndicesCount(ctx context.Context, seed [32]byte) (int, error) {
+	indices, err := c.ActiveIndices(ctx, seed)
+	if err != nil {
 		return 0, err
 	}
 
-	obj, exists := c.CommitteeCache.Get(key(seed))
-	if exists {
-		CommitteeCacheHit.Inc()
-	} else {
-		CommitteeCacheMiss.Inc()
-		return 0, nil
-	}
-
-	item, ok := obj.(*Committees)
-	if !ok {
-		return 0, ErrNotCommittee
-	}
-
-	return len(item.SortedIndices), nil
+	return len(indices), nil
 }
 
 // HasEntry returns true if the committee cache has a value.
-func (c *CommitteeCache) HasEntry(seed string) bool {
-	_, ok := c.CommitteeCache.Get(seed)
-	return ok
+func (c *CommitteeCache[K, V]) HasEntry(seed [32]byte) bool {
+	return exist[K, V](c, K(committeeCachesKey(seed)))
 }
 
 // MarkInProgress a request so that any other similar requests will block on
 // Get until MarkNotInProgress is called.
-func (c *CommitteeCache) MarkInProgress(seed [32]byte) error {
+func (c *CommitteeCache[K, V]) MarkInProgress(seed [32]byte) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	s := key(seed)
+	s := committeeCachesKey(seed)
 	if c.inProgress[s] {
 		return ErrAlreadyInProgress
 	}
@@ -220,10 +251,10 @@ func (c *CommitteeCache) MarkInProgress(seed [32]byte) error {
 
 // MarkNotInProgress will release the lock on a given request. This should be
 // called after put.
-func (c *CommitteeCache) MarkNotInProgress(seed [32]byte) error {
+func (c *CommitteeCache[K, V]) MarkNotInProgress(seed [32]byte) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	s := key(seed)
+	s := committeeCachesKey(seed)
 	delete(c.inProgress, s)
 	return nil
 }
@@ -235,15 +266,7 @@ func startEndIndices(c *Committees, index uint64) (uint64, uint64) {
 	return start, end
 }
 
-// Using seed as source for key to handle reorgs in the same epoch.
-// The seed is derived from state's array of randao mixes and epoch value
-// hashed together. This avoids collisions on different validator set. Spec definition:
-// https://github.com/ethereum/consensus-specs/blob/v0.9.3/specs/core/0_beacon-chain.md#get_seed
-func key(seed [32]byte) string {
-	return string(seed[:])
-}
-
-func (c *CommitteeCache) checkInProgress(ctx context.Context, seed [32]byte) error {
+func (c *CommitteeCache[K, V]) checkInProgress(ctx context.Context, seed [32]byte) error {
 	delay := minDelay
 	// Another identical request may be in progress already. Let's wait until
 	// any in progress request resolves or our timeout is exceeded.
@@ -253,7 +276,7 @@ func (c *CommitteeCache) checkInProgress(ctx context.Context, seed [32]byte) err
 		}
 
 		c.lock.RLock()
-		if !c.inProgress[key(seed)] {
+		if !c.inProgress[committeeCachesKey(seed)] {
 			c.lock.RUnlock()
 			break
 		}
@@ -266,4 +289,28 @@ func (c *CommitteeCache) checkInProgress(ctx context.Context, seed [32]byte) err
 		delay = math.Min(delay, maxDelay)
 	}
 	return nil
+}
+
+// Using seed as source for key to handle reorgs in the same epoch.
+// The seed is derived from state's array of randao mixes and epoch value
+// hashed together. This avoids collisions on different validator set. Spec definition:
+// https://github.com/ethereum/consensus-specs/blob/v0.9.3/specs/core/0_beacon-chain.md#get_seed
+func committeeCachesKey[K string](seed [32]byte) K {
+	return K(seed[:])
+}
+
+// committeeCachesKeyFn takes the seed as the key to retrieve shuffled indices of a committee in a given epoch.
+func committeeCachesKeyFn[K string, V Committees](obj *V) (K, error) {
+	var noKey K
+
+	committees, ok := any(obj).(*Committees)
+	if !ok {
+		return noKey, fmt.Errorf("%v: %w", ErrCast, errNotCommittees)
+	}
+
+	if committees == nil {
+		return noKey, ErrNilValueProvided
+	}
+
+	return committeeCachesKey[K](committees.Seed), nil
 }

--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -57,28 +57,13 @@ type CommitteeCache[K string, V Committees] struct {
 }
 
 // NewCommitteesCache creates a new committee cache for storing/accessing shuffled indices of a committee.
-func NewCommitteesCache[K string, V Committees]() (*CommitteeCache[K, V], error) {
-	cache, err := lru.New[K, V](maxCommitteesCacheSize)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrNilCache, err)
-	}
-
-	isCacheMissNil, isCacheHitNil := committeeCacheMiss == nil, committeeCacheMiss == nil
-	if isCacheMissNil || isCacheHitNil {
-		return nil,
-			fmt.Errorf("%w: isCacheMissNil=<%t>, isCacheHitNil=<%t>",
-				ErrNilMetrics,
-				isCacheHitNil,
-				isCacheHitNil,
-			)
-	}
-
+func NewCommitteesCache[K string, V Committees]() *CommitteeCache[K, V] {
 	return &CommitteeCache[K, V]{
-		lru:           cache,
+		lru:           newLRUCache[K, V](),
 		promCacheMiss: committeeCacheMiss,
 		promCacheHit:  committeeCacheHit,
 		inProgress:    make(map[string]bool),
-	}, nil
+	}
 }
 
 // get returns the underlying lru cache.

--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -106,7 +106,7 @@ func (c *CommitteeCache[K, V]) Clear() {
 	c.inProgress = make(map[string]bool)
 }
 
-// -------------------------------------------------------------------------------------------------------------------//
+// ------------------------------------------------------------------------------------------------------------------ //
 
 // ExpandCommitteeCache expands the size of the committee cache.
 func (c *CommitteeCache[K, V]) ExpandCommitteeCache() {

--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -241,6 +241,7 @@ func (c *CommitteeCache[K, V]) HasEntry(seed [32]byte) bool {
 func (c *CommitteeCache[K, V]) MarkInProgress(seed [32]byte) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	s := committeeCachesKey(seed)
 	if c.inProgress[s] {
 		return ErrAlreadyInProgress
@@ -254,6 +255,7 @@ func (c *CommitteeCache[K, V]) MarkInProgress(seed [32]byte) error {
 func (c *CommitteeCache[K, V]) MarkNotInProgress(seed [32]byte) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	s := committeeCachesKey(seed)
 	delete(c.inProgress, s)
 	return nil
@@ -302,7 +304,6 @@ func committeeCachesKey[K string](seed [32]byte) K {
 // committeeCachesKeyFn takes the seed as the key to retrieve shuffled indices of a committee in a given epoch.
 func committeeCachesKeyFn[K string, V Committees](obj *V) (K, error) {
 	var noKey K
-
 	committees, ok := any(obj).(*Committees)
 	if !ok {
 		return noKey, fmt.Errorf("%v: %w", ErrCast, errNotCommittees)

--- a/beacon-chain/cache/committee_fuzz_test.go
+++ b/beacon-chain/cache/committee_fuzz_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 )
 
+func TestCommitteeKey_Nil(t *testing.T) {
+	var c *Committees
+
+	_, err := committeeCachesKeyFn(c)
+	require.ErrorIs(t, err, ErrNilValueProvided)
+}
+
 func TestCommitteeKeyFuzz_OK(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	c := &Committees{}
@@ -52,9 +59,7 @@ func TestCommitteeCache_FuzzActiveIndices(t *testing.T) {
 
 	for i := 0; i < 100000; i++ {
 		fuzzer.Fuzz(c)
-		err := cache.AddCommitteeShuffledList(context.Background(), c)
-		if err != nil {
-			require.Equal(t, false, !errors.Is(err, ErrNilValueProvided))
+		if err = cache.AddCommitteeShuffledList(context.Background(), c); err != nil {
 			continue
 		}
 

--- a/beacon-chain/cache/committee_fuzz_test.go
+++ b/beacon-chain/cache/committee_fuzz_test.go
@@ -3,6 +3,8 @@
 package cache
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
@@ -22,34 +24,44 @@ func TestCommitteeKeyFuzz_OK(t *testing.T) {
 	}
 }
 
-//func TestCommitteeCache_FuzzCommitteesByEpoch(t *testing.T) {
-//	cache := NewCommitteesCache()
-//	fuzzer := fuzz.NewWithSeed(0)
-//	c := &Committees{}
-//
-//	for i := 0; i < 100000; i++ {
-//		fuzzer.Fuzz(c)
-//		require.NoError(t, cache.AddCommitteeShuffledList(context.Background(), c))
-//		_, err := cache.Committee(context.Background(), 0, c.Seed, 0)
-//		require.NoError(t, err)
-//	}
-//
-//	assert.Equal(t, maxCommitteesCacheSize, len(cache.CommitteeCache.Keys()), "Incorrect key size")
-//}
-//
-//func TestCommitteeCache_FuzzActiveIndices(t *testing.T) {
-//	cache := NewCommitteesCache()
-//	fuzzer := fuzz.NewWithSeed(0)
-//	c := &Committees{}
-//
-//	for i := 0; i < 100000; i++ {
-//		fuzzer.Fuzz(c)
-//		require.NoError(t, cache.AddCommitteeShuffledList(context.Background(), c))
-//
-//		indices, err := cache.ActiveIndices(context.Background(), c.Seed)
-//		require.NoError(t, err)
-//		assert.DeepEqual(t, c.SortedIndices, indices)
-//	}
-//
-//	assert.Equal(t, maxCommitteesCacheSize, len(cache.CommitteeCache.Keys()), "Incorrect key size")
-//}
+func TestCommitteeCache_FuzzCommitteesByEpoch(t *testing.T) {
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
+
+	fuzzer := fuzz.NewWithSeed(0)
+	c := &Committees{}
+
+	for i := 0; i < 100000; i++ {
+		fuzzer.Fuzz(c)
+		err := cache.AddCommitteeShuffledList(context.Background(), c)
+		if err != nil {
+			require.Equal(t, false, !errors.Is(err, ErrNilValueProvided))
+		}
+		_, err = cache.Committee(context.Background(), 0, c.Seed, 0)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, maxCommitteesCacheSize, len(keys[string, Committees](cache)), "Incorrect key size")
+}
+
+func TestCommitteeCache_FuzzActiveIndices(t *testing.T) {
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
+	fuzzer := fuzz.NewWithSeed(0)
+	c := &Committees{}
+
+	for i := 0; i < 100000; i++ {
+		fuzzer.Fuzz(c)
+		err := cache.AddCommitteeShuffledList(context.Background(), c)
+		if err != nil {
+			require.Equal(t, false, !errors.Is(err, ErrNilValueProvided))
+			continue
+		}
+
+		indices, err := cache.ActiveIndices(context.Background(), c.Seed)
+		require.NoError(t, err)
+		assert.DeepEqual(t, c.SortedIndices, indices)
+	}
+
+	assert.Equal(t, maxCommitteesCacheSize, len(keys[string, Committees](cache)), "Incorrect key size")
+}

--- a/beacon-chain/cache/committee_fuzz_test.go
+++ b/beacon-chain/cache/committee_fuzz_test.go
@@ -3,7 +3,6 @@
 package cache
 
 import (
-	"context"
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
@@ -17,40 +16,40 @@ func TestCommitteeKeyFuzz_OK(t *testing.T) {
 
 	for i := 0; i < 100000; i++ {
 		fuzzer.Fuzz(c)
-		k, err := committeeKeyFn(c)
+		k, err := committeeCachesKeyFn(c)
 		require.NoError(t, err)
-		assert.Equal(t, key(c.Seed), k)
+		assert.Equal(t, committeeCachesKey(c.Seed), k)
 	}
 }
 
-func TestCommitteeCache_FuzzCommitteesByEpoch(t *testing.T) {
-	cache := NewCommitteesCache()
-	fuzzer := fuzz.NewWithSeed(0)
-	c := &Committees{}
-
-	for i := 0; i < 100000; i++ {
-		fuzzer.Fuzz(c)
-		require.NoError(t, cache.AddCommitteeShuffledList(context.Background(), c))
-		_, err := cache.Committee(context.Background(), 0, c.Seed, 0)
-		require.NoError(t, err)
-	}
-
-	assert.Equal(t, maxCommitteesCacheSize, len(cache.CommitteeCache.Keys()), "Incorrect key size")
-}
-
-func TestCommitteeCache_FuzzActiveIndices(t *testing.T) {
-	cache := NewCommitteesCache()
-	fuzzer := fuzz.NewWithSeed(0)
-	c := &Committees{}
-
-	for i := 0; i < 100000; i++ {
-		fuzzer.Fuzz(c)
-		require.NoError(t, cache.AddCommitteeShuffledList(context.Background(), c))
-
-		indices, err := cache.ActiveIndices(context.Background(), c.Seed)
-		require.NoError(t, err)
-		assert.DeepEqual(t, c.SortedIndices, indices)
-	}
-
-	assert.Equal(t, maxCommitteesCacheSize, len(cache.CommitteeCache.Keys()), "Incorrect key size")
-}
+//func TestCommitteeCache_FuzzCommitteesByEpoch(t *testing.T) {
+//	cache := NewCommitteesCache()
+//	fuzzer := fuzz.NewWithSeed(0)
+//	c := &Committees{}
+//
+//	for i := 0; i < 100000; i++ {
+//		fuzzer.Fuzz(c)
+//		require.NoError(t, cache.AddCommitteeShuffledList(context.Background(), c))
+//		_, err := cache.Committee(context.Background(), 0, c.Seed, 0)
+//		require.NoError(t, err)
+//	}
+//
+//	assert.Equal(t, maxCommitteesCacheSize, len(cache.CommitteeCache.Keys()), "Incorrect key size")
+//}
+//
+//func TestCommitteeCache_FuzzActiveIndices(t *testing.T) {
+//	cache := NewCommitteesCache()
+//	fuzzer := fuzz.NewWithSeed(0)
+//	c := &Committees{}
+//
+//	for i := 0; i < 100000; i++ {
+//		fuzzer.Fuzz(c)
+//		require.NoError(t, cache.AddCommitteeShuffledList(context.Background(), c))
+//
+//		indices, err := cache.ActiveIndices(context.Background(), c.Seed)
+//		require.NoError(t, err)
+//		assert.DeepEqual(t, c.SortedIndices, indices)
+//	}
+//
+//	assert.Equal(t, maxCommitteesCacheSize, len(cache.CommitteeCache.Keys()), "Incorrect key size")
+//}

--- a/beacon-chain/cache/committee_fuzz_test.go
+++ b/beacon-chain/cache/committee_fuzz_test.go
@@ -32,8 +32,7 @@ func TestCommitteeKeyFuzz_OK(t *testing.T) {
 }
 
 func TestCommitteeCache_FuzzCommitteesByEpoch(t *testing.T) {
-	cache, err := NewCommitteesCache()
-	require.NoError(t, err)
+	cache := NewCommitteesCache()
 
 	fuzzer := fuzz.NewWithSeed(0)
 	c := &Committees{}
@@ -52,14 +51,13 @@ func TestCommitteeCache_FuzzCommitteesByEpoch(t *testing.T) {
 }
 
 func TestCommitteeCache_FuzzActiveIndices(t *testing.T) {
-	cache, err := NewCommitteesCache()
-	require.NoError(t, err)
+	cache := NewCommitteesCache()
 	fuzzer := fuzz.NewWithSeed(0)
 	c := &Committees{}
 
 	for i := 0; i < 100000; i++ {
 		fuzzer.Fuzz(c)
-		if err = cache.AddCommitteeShuffledList(context.Background(), c); err != nil {
+		if err := cache.AddCommitteeShuffledList(context.Background(), c); err != nil {
 			continue
 		}
 

--- a/beacon-chain/cache/committee_test.go
+++ b/beacon-chain/cache/committee_test.go
@@ -23,18 +23,14 @@ func TestCommitteeKeyFn_OK(t *testing.T) {
 		ShuffledIndices: []primitives.ValidatorIndex{1, 2, 3, 4, 5},
 	}
 
-	k, err := committeeKeyFn(item)
+	k, err := committeeCachesKeyFn(item)
 	require.NoError(t, err)
-	assert.Equal(t, key(item.Seed), k)
-}
-
-func TestCommitteeKeyFn_InvalidObj(t *testing.T) {
-	_, err := committeeKeyFn("bad")
-	assert.Equal(t, ErrNotCommittee, err)
+	assert.Equal(t, committeeCachesKey(item.Seed), k)
 }
 
 func TestCommitteeCache_CommitteesByEpoch(t *testing.T) {
-	cache := NewCommitteesCache()
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
 
 	item := &Committees{
 		ShuffledIndices: []primitives.ValidatorIndex{1, 2, 3, 4, 5, 6},
@@ -60,7 +56,8 @@ func TestCommitteeCache_CommitteesByEpoch(t *testing.T) {
 }
 
 func TestCommitteeCache_ActiveIndices(t *testing.T) {
-	cache := NewCommitteesCache()
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
 
 	item := &Committees{Seed: [32]byte{'A'}, SortedIndices: []primitives.ValidatorIndex{1, 2, 3, 4, 5, 6}}
 	indices, err := cache.ActiveIndices(context.Background(), item.Seed)
@@ -77,7 +74,8 @@ func TestCommitteeCache_ActiveIndices(t *testing.T) {
 }
 
 func TestCommitteeCache_ActiveCount(t *testing.T) {
-	cache := NewCommitteesCache()
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
 
 	item := &Committees{Seed: [32]byte{'A'}, SortedIndices: []primitives.ValidatorIndex{1, 2, 3, 4, 5, 6}}
 	count, err := cache.ActiveIndicesCount(context.Background(), item.Seed)
@@ -92,7 +90,8 @@ func TestCommitteeCache_ActiveCount(t *testing.T) {
 }
 
 func TestCommitteeCache_CanRotate(t *testing.T) {
-	cache := NewCommitteesCache()
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
 
 	// Should rotate out all the epochs except 190 through 199.
 	start := 100
@@ -103,22 +102,24 @@ func TestCommitteeCache_CanRotate(t *testing.T) {
 		require.NoError(t, cache.AddCommitteeShuffledList(context.Background(), item))
 	}
 
-	k := cache.CommitteeCache.Keys()
+	k := keys[string, Committees](cache)
 	assert.Equal(t, maxCommitteesCacheSize, len(k))
 
 	sort.Slice(k, func(i, j int) bool {
-		return k[i].(string) < k[j].(string)
+		return k[i] < k[j]
 	})
 	wanted := end - maxCommitteesCacheSize
 	s := bytesutil.ToBytes32([]byte(strconv.Itoa(wanted)))
-	assert.Equal(t, key(s), k[0], "incorrect key received for slot 190")
+	assert.Equal(t, committeeCachesKey(s), k[0], "incorrect key received for slot 190")
 
 	s = bytesutil.ToBytes32([]byte(strconv.Itoa(199)))
-	assert.Equal(t, key(s), k[len(k)-1], "incorrect key received for slot 199")
+	assert.Equal(t, committeeCachesKey(s), k[len(k)-1], "incorrect key received for slot 199")
 }
 
 func TestCommitteeCacheOutOfRange(t *testing.T) {
-	cache := NewCommitteesCache()
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
+
 	seed := bytesutil.ToBytes32([]byte("foo"))
 	comms := &Committees{
 		CommitteeCount:  1,
@@ -126,16 +127,16 @@ func TestCommitteeCacheOutOfRange(t *testing.T) {
 		ShuffledIndices: []primitives.ValidatorIndex{0},
 		SortedIndices:   []primitives.ValidatorIndex{},
 	}
-	key, err := committeeKeyFn(comms)
-	assert.NoError(t, err)
-	_ = cache.CommitteeCache.Add(key, comms)
+	err = cache.AddCommitteeShuffledList(context.Background(), comms)
+	require.NoError(t, err)
 
 	_, err = cache.Committee(context.Background(), 0, seed, math.MaxUint64) // Overflow!
 	require.NotNil(t, err, "Did not fail as expected")
 }
 
 func TestCommitteeCache_DoesNothingWhenCancelledContext(t *testing.T) {
-	cache := NewCommitteesCache()
+	cache, err := NewCommitteesCache()
+	require.NoError(t, err)
 
 	item := &Committees{Seed: [32]byte{'A'}, SortedIndices: []primitives.ValidatorIndex{1, 2, 3, 4, 5, 6}}
 	count, err := cache.ActiveIndicesCount(context.Background(), item.Seed)

--- a/beacon-chain/cache/committees.go
+++ b/beacon-chain/cache/committees.go
@@ -1,14 +1,8 @@
 package cache
 
 import (
-	"errors"
-
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 )
-
-// ErrNotCommittee will be returned when a cache object is not a pointer to
-// a Committee struct.
-var ErrNotCommittee = errors.New("object is not a committee struct")
 
 // Committees defines the shuffled committees seed.
 type Committees struct {

--- a/beacon-chain/cache/error.go
+++ b/beacon-chain/cache/error.go
@@ -3,6 +3,11 @@ package cache
 import "github.com/pkg/errors"
 
 var (
+	// ErrNilCache for when a cache is nil.
+	ErrNilCache = errors.New("cache cannot be nil")
+	// ErrNilMetrics for when cache metrics are nil.
+	ErrNilMetrics = errors.New("cache metrics cannot be nil")
+
 	// ErrNilValueProvided for when we try to put a nil value in a cache.
 	ErrNilValueProvided = errors.New("nil value provided on Put()")
 	// ErrIncorrectType for when the state is of the incorrect type.
@@ -10,8 +15,8 @@ var (
 	// ErrNotFound for cache fetches that return a nil value.
 	ErrNotFound = errors.New("not found in cache")
 	// ErrNonExistingSyncCommitteeKey when sync committee key (root) does not exist in cache.
-	ErrNonExistingSyncCommitteeKey   = errors.New("does not exist sync committee key")
-	errNotSyncCommitteeIndexPosition = errors.New("not syncCommitteeIndexPosition struct")
+	ErrNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
+
 	// ErrNotFoundRegistration when validator registration does not exist in cache.
 	ErrNotFoundRegistration = errors.Wrap(ErrNotFound, "no validator registered")
 
@@ -19,4 +24,11 @@ var (
 	// already in progress. The client should handle this error and wait for the in progress
 	// data to resolve via Get.
 	ErrAlreadyInProgress = errors.New("already in progress")
+
+	// ErrCast for when a cast fails when the cache didn't get the expected type.
+	ErrCast = errors.New("cast failed")
+	// errNotSyncCommitteeIndexPosition for when the cache didn't get the expected type of syncCommitteeIndexPosition.
+	errNotSyncCommitteeIndexPosition = errors.New("not of type SyncCommitteeIndexPosition")
+	// errNotCommittees for when the cache didn't get the expected type of Committee.
+	errNotCommittees = errors.New("not of type Committees")
 )

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -109,7 +109,7 @@ func (s *SyncCommitteeCache) NextPeriodIndexPosition(root [32]byte, valIdx primi
 func (s *SyncCommitteeCache) idxPositionInCommittee(
 	root [32]byte, valIdx primitives.ValidatorIndex,
 ) (*positionInCommittee, error) {
-	obj, exists, err := s.cache.GetByKey(key(root))
+	obj, exists, err := s.cache.GetByKey(committeeCachesKey(root))
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -25,17 +25,9 @@ import (
 )
 
 var (
-	committeeCache       = getCommitteeCacheOrPanic()
+	committeeCache       = cache.NewCommitteesCache()
 	proposerIndicesCache = cache.NewProposerIndicesCache()
 )
-
-func getCommitteeCacheOrPanic() *cache.CommitteeCache[string, cache.Committees] {
-	committeeCache, err := cache.NewCommitteesCache()
-	if err != nil {
-		panic(fmt.Errorf("could not get committee cache: %w", err))
-	}
-	return committeeCache
-}
 
 // SlotCommitteeCount returns the number of beacon committees of a slot. The
 // active validator count is provided as an argument rather than an imported implementation

--- a/beacon-chain/core/helpers/beacon_committee_test.go
+++ b/beacon-chain/core/helpers/beacon_committee_test.go
@@ -456,15 +456,15 @@ func TestUpdateCommitteeCache_CanUpdateAcrossEpochs(t *testing.T) {
 
 	seed, err := Seed(state, e, params.BeaconConfig().DomainBeaconAttester)
 	require.NoError(t, err)
-	require.Equal(t, true, committeeCache.HasEntry(string(seed[:])))
+	require.Equal(t, true, committeeCache.HasEntry(seed))
 
 	nextSeed, err := Seed(state, e+1, params.BeaconConfig().DomainBeaconAttester)
 	require.NoError(t, err)
-	require.Equal(t, false, committeeCache.HasEntry(string(nextSeed[:])))
+	require.Equal(t, false, committeeCache.HasEntry(nextSeed))
 
 	require.NoError(t, UpdateCommitteeCache(context.Background(), state, e+1))
 
-	require.Equal(t, true, committeeCache.HasEntry(string(nextSeed[:])))
+	require.Equal(t, true, committeeCache.HasEntry(nextSeed))
 }
 
 func BenchmarkComputeCommittee300000_WithPreCache(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.1
-	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
+	github.com/hashicorp/golang-lru v1.0.2
 	github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e
 	github.com/holiman/uint256 v1.2.4
 	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20200424224625-be1b05b0b279

--- a/go.sum
+++ b/go.sum
@@ -521,6 +521,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
 github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one line below and remove others.
> Enhancement

**What does this PR do? Why is it needed?**

- This PR reworks the beacon-chain caches implementation by leveraging the latest lru/v2 from Hashicorp.
- It removes the "double lock" case where it'd be blocking in the caller and in the cache.
- It provides better readability, fewer type assertions, and avoids using the pattern interface{} as a function argument.
- Better API: the "seed" cannot be a string in some methods or a [32]byte in others.
- It is more resilient as it prevents the case where a key points to a nil value in the cache.
- It enforces the use of "miss" and "hit" metrics across for the caches implementing the private interface LRUCache for better fine performance tuning

**Which issues(s) does this PR fix?**
#13723 

**Other notes for review**
I will keep opening PRs for the other caches (hashicorp lru) once the implementation is reviewed and accepted by the team.
