### PR TITLE
Simplify ValidateAttestationTime

### DIFF
--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -197,7 +197,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 					-500 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
 				).Add(200 * time.Millisecond),
 			},
-			wantedErr: "attestation epoch 8 not within current epoch 15 or previous epoch 14",
+			wantedErr: "attestation epoch 8 not within current epoch 15 or previous epoch",
 		},
 		{
 			name: "attestation.slot is well beyond current slot",
@@ -205,7 +205,7 @@ func Test_ValidateAttestationTime(t *testing.T) {
 				attSlot:     1 << 32,
 				genesisTime: prysmTime.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
 			},
-			wantedErr: "which exceeds max allowed value relative to the local clock",
+			wantedErr: "attestation slot 4294967296 not within attestation propagation range of 0 to 15 (current slot)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
ValidateClock in ValidateAttestationTime is useless

The check is that the attSlot is not > than the currentslot + 128 slots.

Later there's a check that the attSlot start time is not > than current slot start time + clockDisparity.

if attSlot > than currentSlot + 128 slots, then the second check would fail anyway.

The lattest check already guarantees that the attSlot cannot be larger than the currentSlot, therefore it may never happen that attEpoch > currentEpoch. We just need to check for Deneb that attEpoch >= currentEpoch - 1.

Removes also some duplicated variables like the attestation epoch being computed twice.

