### PR TITLE
Add metrics to track pending attestations

### DIFF
--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -150,6 +150,10 @@ var (
 			Help: "Time to verify gossiped blob sidecars",
 		},
 	)
+	pendingAttCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "gossip_pending_attestations_total",
+		Help: "increased when receiving a new pending attestation",
+	})
 
 	// Sync committee verification performance.
 	syncMessagesForUnknownBlocks = promauto.NewCounter(

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -177,6 +177,7 @@ func (s *Service) savePendingAtt(att *ethpb.SignedAggregateAttestationAndProof) 
 
 	_, ok := s.blkRootToPendingAtts[root]
 	if !ok {
+		pendingAttCount.Inc()
 		s.blkRootToPendingAtts[root] = []*ethpb.SignedAggregateAttestationAndProof{att}
 		return
 	}
@@ -187,6 +188,7 @@ func (s *Service) savePendingAtt(att *ethpb.SignedAggregateAttestationAndProof) 
 			return
 		}
 	}
+	pendingAttCount.Inc()
 	s.blkRootToPendingAtts[root] = append(s.blkRootToPendingAtts[root], att)
 }
 


### PR DESCRIPTION
This adds two counters to keep track of how many pending attestations the node has seen