### PR TITLE
Change goodbye message from rate limited peer to debug verbosity

### DIFF
--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -42,7 +42,7 @@ func (s *Service) goodbyeRPCHandler(_ context.Context, msg interface{}, stream l
 		return fmt.Errorf("wrong message type for goodbye, got %T, wanted *uint64", msg)
 	}
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		log.WithError(err).Warn("Goodbye message from rate-limited peer.")
+		log.WithError(err).Debug("Goodbye message from rate-limited peer.")
 	} else {
 		s.rateLimiter.add(stream, 1)
 	}


### PR DESCRIPTION
More appropriate for debug given the occurrence and lack of control client can do 