### PR TITLE
Community requested feature flags

### DIFF
--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -95,6 +95,28 @@ var (
 		Name:  "attest-timely",
 		Usage: "Fixes validator can attest timely after current block processes. See #8185 for more details.",
 	}
+	optimisticExecution = &cli.BoolFlag{
+		Name:  "optimistic-execution",
+		Usage: "Allows the beacon to run without a connection to an EL. Useful for nodes without large storage.",
+	}
+	blobsAreAvailable = &cli.BoolFlag{
+		Name:  "blobs-are-available",
+		Usage: "Disables blob gossip, requests, and checks for blob data availability. Useful for nodes without large internet bandwidth.",
+	}
+	allowDeepReorg = &cli.BoolFlag{
+		Name:  "allow-deep-reorg",
+		Usage: "Allow for honest reorgs of arbitrary depth as long as the orphaned chain has less than PROPOSER_SCORE_BOOST.",
+	}
+	withholdAttestations = &cli.BoolFlag{
+		Name:   "withhold_consecutive_attestations",
+		Usage:  "Withhold attestations for consecutive blocks. Useful in conjunction with --allow-deep-reorg.",
+		Hidden: true,
+	}
+	followMajority = &cli.BoolFlag{
+		Name:   "follow-majority",
+		Usage:  "Disable state transition validation and instead follow the attester majority. Useful for systems with low resources.",
+		Hidden: true,
+	}
 	enableSlasherFlag = &cli.BoolFlag{
 		Name:  "slasher",
 		Usage: "Enables a slasher in the beacon node for detecting slashable offenses.",


### PR DESCRIPTION
Following up from internal Slack discussions. This PR implements several of the community requested feature flags.

- Adds a flag `--optimistic-execution` to allow the beacon node to run without an EL connected. Proposers **must** use an external builder. This results in approximately 1.4TB storage reduction in my locally tested node.
- Adds a flag `--blobs-are-available` to disable blob gossip, RPC requests and data availability validation. This results in 70% bandwidth reduction as well as extra 300Gb of storage.
- Adds a flag `--allow-deep-reorgs` which removes the 1-slot limit for the honest reorg feature. It should be safe to reorg longer branches as long as they haven't been voted heavily. This allows for larger MEV extraction if the previous proposers were slow or purposely broadcast their blocks late.

Other flags that are commonly requested are added but since they are not thoroughly tested yet I decided to leave them hidden. For the reviewer: if you think they are safe enough, we can change the visibility.