### PR TITLE
Backfill throttling

### DIFF
--- a/beacon-chain/sync/backfill/batch_test.go
+++ b/beacon-chain/sync/backfill/batch_test.go
@@ -1,8 +1,11 @@
 package backfill
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 )
@@ -18,4 +21,23 @@ func TestSortBatchDesc(t *testing.T) {
 	for i := range orderOut {
 		require.Equal(t, orderOut[i], batches[i].end)
 	}
+}
+
+func TestWaitUntilReady(t *testing.T) {
+	b := batch{}.withState(batchErrRetryable)
+	require.Equal(t, time.Time{}, b.retryAfter)
+	var got time.Duration
+	wur := batchBlockUntil
+	var errDerp = errors.New("derp")
+	batchBlockUntil = func(_ context.Context, ur time.Duration, _ batch) error {
+		got = ur
+		return errDerp
+	}
+	// retries counter and timestamp are set when we mark the batch for sequencing, if it is in the retry state
+	b = b.withState(batchSequenced)
+	require.ErrorIs(t, b.waitUntilReady(context.Background()), errDerp)
+	require.Equal(t, true, retryDelay-b.retryAfter.Sub(time.Now()) < time.Millisecond)
+	require.Equal(t, true, got < retryDelay && got > retryDelay-time.Millisecond)
+	require.Equal(t, 1, b.retries)
+	batchBlockUntil = wur
 }

--- a/beacon-chain/sync/backfill/pool.go
+++ b/beacon-chain/sync/backfill/pool.go
@@ -143,6 +143,17 @@ func (p *p2pBatchWorkerPool) batchRouter(pa PeerAssigner) {
 			return
 		}
 		for _, pid := range assigned {
+			// Wait to retry a failed batch to avoid hammering peers
+			// if we've hit a state where batches will consistently fail.
+			// Avoids spamming requests and logs.
+			if todo[0].retries > 0 {
+				untilRetry := time.Until(todo[0].retryAfter)
+				if untilRetry > time.Millisecond {
+					log.WithFields(todo[0].logFields()).WithField("untilRetry", untilRetry.String()).
+						Debug("Sleeping for retry backoff delay")
+					time.Sleep(untilRetry)
+				}
+			}
 			busy[pid] = true
 			todo[0].busy = pid
 			p.toWorkers <- todo[0].withPeer(pid)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

If backfill gets wedged (for instance what happened with the finalized index bug we fixed in the last release) it can retry the latest batch in a hot loop. I'm worried that if there is some backfill bug or network condition that causes a batch to continually fail, this could spam peers with requests and create a lot of log volume.

So this PR adds a delay of 1 second before retrying a failed batch. This is a blunt tool to quickly make the current situation a bit safer before we update backfill to share rate limiting functionality with init sync.