### PR TITLE
Extend Broadcast Window For Attestations

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -137,7 +137,9 @@ func (s *Service) internalBroadcastAttestation(ctx context.Context, subnet uint6
 	// In the event our attestation is outdated and beyond the
 	// acceptable threshold, we exit early and do not broadcast it.
 	currSlot := slots.CurrentSlot(uint64(s.genesisTime.Unix()))
-	if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch < currSlot {
+	currEpoch := slots.ToEpoch(currSlot)
+	attEpoch := slots.ToEpoch(att.Data.Slot)
+	if attEpoch+1 < currEpoch {
 		log.WithFields(logrus.Fields{
 			"attestationSlot": att.Data.Slot,
 			"currentSlot":     currSlot,


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

With EIP7045, attestations are valid from both the current and previous epoch. Our broadcast method chooses to filter out attestations which are beyond 32 slots. With Deneb this would be unnecessarily rejection valid attestations. This PR fixes it.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
