### PR TITLE
Fix Peer Id Search in E2E

### DIFF
--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -86,7 +86,7 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) ([]libp2p.Op
 		return nil, errors.Wrapf(err, "cannot get ID from public key: %s", ifaceKey.GetPublic().Type().String())
 	}
 
-	log.WithField("peerId", id).Info("Running node with")
+	log.WithField("peerId", id).Info("Running node with id")
 
 	options := []libp2p.Option{
 		privKeyOption(priKey),

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -315,7 +315,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 	}
 
 	if config.UseFixedPeerIDs {
-		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with peerId=")
+		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with id")
 		if err != nil {
 			return fmt.Errorf("could not find peer id: %w", err)
 		}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Fixes the peer id search from our outputted text files. We were searching for a non-existent string which lead to any E2E test using a fixed peer id to fail.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
