### PR TITLE
`e2e`: Expected log `Running node with peerId=` -> `Running node with`.

### DIFF
--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -315,7 +315,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 	}
 
 	if config.UseFixedPeerIDs {
-		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with peerId=")
+		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with")
 		if err != nil {
 			return fmt.Errorf("could not find peer id: %w", err)
 		}


### PR DESCRIPTION
Rationale:
The `FindFollowingTextInFile` seems to have troubles with `logrus` fields.

