### PR TITLE
Use retention period when fetching blobs

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -299,6 +299,11 @@ func (bs *BlobStorage) Clear() error {
 	return nil
 }
 
+// WithinRetentionPeriod checks if the requested epoch is within the blob retention period.
+func (bs *BlobStorage) WithinRetentionPeriod(requested, current primitives.Epoch) bool {
+	return requested+bs.retentionEpochs >= current
+}
+
 type blobNamer struct {
 	root  [32]byte
 	index uint64

--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -248,3 +248,45 @@ func TestNewBlobStorage(t *testing.T) {
 	_, err = NewBlobStorage(WithBasePath(path.Join(t.TempDir(), "good")))
 	require.NoError(t, err)
 }
+
+func TestConfig_WithinRetentionPeriod(t *testing.T) {
+	retention := primitives.Epoch(16)
+	storage := &BlobStorage{retentionEpochs: retention}
+
+	cases := []struct {
+		name      string
+		requested primitives.Epoch
+		current   primitives.Epoch
+		within    bool
+	}{
+		{
+			name:      "before",
+			requested: 0,
+			current:   retention + 1,
+			within:    false,
+		},
+		{
+			name:      "same",
+			requested: 0,
+			current:   0,
+			within:    true,
+		},
+		{
+			name:      "boundary",
+			requested: 0,
+			current:   retention,
+			within:    true,
+		},
+		{
+			name:      "one less",
+			requested: retention - 1,
+			current:   retention,
+			within:    true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.within, storage.WithinRetentionPeriod(c.requested, c.current))
+		})
+	}
+}

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -223,7 +223,7 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 		return nil, &core.RpcError{Err: errors.Wrap(err, "failed to retrieve block from db"), Reason: core.Internal}
 	}
 	// if block is not in the retention window  return 200 w/ empty list
-	if !params.WithinDAPeriod(slots.ToEpoch(b.Block().Slot()), slots.ToEpoch(p.GenesisTimeFetcher.CurrentSlot())) {
+	if !p.BlobStorage.WithinRetentionPeriod(slots.ToEpoch(b.Block().Slot()), slots.ToEpoch(p.GenesisTimeFetcher.CurrentSlot())) {
 		return make([]*blocks.VerifiedROBlob, 0), nil
 	}
 	commitments, err := b.Block().Body().BlobKzgCommitments()


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Blobs endpoint uses data availability period (which is always equal `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`) instead of retention period to determine if it should return early with no blobs.

**Which issues(s) does this PR fix?**

Fixes #13853
