### PR TITLE
Revert Peer Log Changes

### DIFF
--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -86,7 +86,7 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) ([]libp2p.Op
 		return nil, errors.Wrapf(err, "cannot get ID from public key: %s", ifaceKey.GetPublic().Type().String())
 	}
 
-	log.WithField("peerId", id).Info("Running node with")
+	log.Infof("Running node with peer id of %s ", id.String())
 
 	options := []libp2p.Option{
 		privKeyOption(priKey),

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -315,7 +315,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 	}
 
 	if config.UseFixedPeerIDs {
-		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with")
+		peerId, err := helpers.FindFollowingTextInFile(stdOutFile, "Running node with peer id of ")
 		if err != nil {
 			return fmt.Errorf("could not find peer id: %w", err)
 		}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #13786 , we added QUIC support to prysm. One of the changes included in that was that the peer id would be logged differently. Unfortunately this has broken our E2E setup as it relies on us searching our log file to determine current peer ID. The logging change lead to just a quote `"` being returned. This PR changes it to what it was before.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
