### PR TITLE
Use read only validators in Beacon API

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_validator.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_validator.go
@@ -369,16 +369,7 @@ func decodeIds(w http.ResponseWriter, st state.BeaconState, rawIds []string, ign
 func valsFromIds(w http.ResponseWriter, st state.BeaconState, ids []primitives.ValidatorIndex) ([]state.ReadOnlyValidator, bool) {
 	var vals []state.ReadOnlyValidator
 	if len(ids) == 0 {
-		allVals := st.Validators()
-		vals = make([]state.ReadOnlyValidator, len(allVals))
-		for i, val := range allVals {
-			readOnlyVal, err := statenative.NewValidator(val)
-			if err != nil {
-				httputil.HandleError(w, "Could not convert validator: "+err.Error(), http.StatusInternalServerError)
-				return nil, false
-			}
-			vals[i] = readOnlyVal
-		}
+		vals = st.ValidatorsReadOnly()
 	} else {
 		vals = make([]state.ReadOnlyValidator, 0, len(ids))
 		for _, id := range ids {

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -118,6 +118,7 @@ type ReadOnlyValidator interface {
 // ReadOnlyValidators defines a struct which only has read access to validators methods.
 type ReadOnlyValidators interface {
 	Validators() []*ethpb.Validator
+	ValidatorsReadOnly() []ReadOnlyValidator
 	ValidatorAtIndex(idx primitives.ValidatorIndex) (*ethpb.Validator, error)
 	ValidatorAtIndexReadOnly(idx primitives.ValidatorIndex) (ReadOnlyValidator, error)
 	ValidatorIndexByPubkey(key [fieldparams.BLSPubkeyLength]byte) (primitives.ValidatorIndex, bool)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This is a simplified version of https://github.com/prysmaticlabs/prysm/pull/13782, applying `ReadOnlyValidators()` only to Beacon API, which speeds up fetching all validators ~3x
