### PR TITLE
Add Support For Discovery Of Column Subnets

### DIFF
--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "active_balance_disabled.go",  # keep
         "attestation_data.go",
         "checkpoint_state.go",
+        "column_subnet_ids.go",
         "committee.go",
         "committee_disabled.go",  # keep
         "committees.go",

--- a/beacon-chain/cache/column_subnet_ids.go
+++ b/beacon-chain/cache/column_subnet_ids.go
@@ -33,23 +33,23 @@ func (s *columnSubnetIDs) GetColumnSubnets() ([]uint64, bool, time.Time) {
 
 	id, duration, ok := s.colSubCache.GetWithExpiration(columnKey)
 	if !ok {
-		return []uint64{}, ok, time.Time{}
+		return nil, false, time.Time{}
 	}
 	// Retrieve indices from the cache.
 	idxs, ok := id.([]uint64)
 	if !ok {
-		return []uint64{}, ok, time.Time{}
+		return nil, false, time.Time{}
 	}
 
 	return idxs, ok, duration
 }
 
 // AddColumnSubnets adds the relevant data column subnets.
-func (s *columnSubnetIDs) AddColumnSubnets(comIndex []uint64) {
-	s.colSubLock.RLock()
-	defer s.colSubLock.RUnlock()
+func (s *columnSubnetIDs) AddColumnSubnets(colIdx []uint64) {
+	s.colSubLock.Lock()
+	defer s.colSubLock.Unlock()
 
-	s.colSubCache.Set(columnKey, comIndex, 0)
+	s.colSubCache.Set(columnKey, colIdx, 0)
 }
 
 // EmptyAllCaches empties out all the related caches and flushes any stored
@@ -58,8 +58,8 @@ func (s *columnSubnetIDs) AddColumnSubnets(comIndex []uint64) {
 // separately.
 func (s *columnSubnetIDs) EmptyAllCaches() {
 	// Clear the cache.
-
 	s.colSubLock.Lock()
+	defer s.colSubLock.Unlock()
+
 	s.colSubCache.Flush()
-	s.colSubLock.Unlock()
 }

--- a/beacon-chain/cache/column_subnet_ids.go
+++ b/beacon-chain/cache/column_subnet_ids.go
@@ -1,0 +1,65 @@
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+)
+
+type columnSubnetIDs struct {
+	colSubCache *cache.Cache
+	colSubLock  sync.RWMutex
+}
+
+// ColumnSubnetIDs for column subnet participants
+var ColumnSubnetIDs = newColumnSubnetIDs()
+
+const columnKey = "columns"
+
+func newColumnSubnetIDs() *columnSubnetIDs {
+	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+	// Set the default duration of a column subnet subscription as the column expiry period.
+	subLength := epochDuration * time.Duration(params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest)
+	persistentCache := cache.New(subLength*time.Second, epochDuration*time.Second)
+	return &columnSubnetIDs{colSubCache: persistentCache}
+}
+
+// GetColumnSubnets retrieves the data column subnets.
+func (s *columnSubnetIDs) GetColumnSubnets() ([]uint64, bool, time.Time) {
+	s.colSubLock.RLock()
+	defer s.colSubLock.RUnlock()
+
+	id, duration, ok := s.colSubCache.GetWithExpiration(columnKey)
+	if !ok {
+		return []uint64{}, ok, time.Time{}
+	}
+	// Retrieve indices from the cache.
+	idxs, ok := id.([]uint64)
+	if !ok {
+		return []uint64{}, ok, time.Time{}
+	}
+
+	return idxs, ok, duration
+}
+
+// AddColumnSubnets adds the relevant data column subnets.
+func (s *columnSubnetIDs) AddColumnSubnets(comIndex []uint64) {
+	s.colSubLock.RLock()
+	defer s.colSubLock.RUnlock()
+
+	s.colSubCache.Set(columnKey, comIndex, 0)
+}
+
+// EmptyAllCaches empties out all the related caches and flushes any stored
+// entries on them. This should only ever be used for testing, in normal
+// production, handling of the relevant subnets for each role is done
+// separately.
+func (s *columnSubnetIDs) EmptyAllCaches() {
+	// Clear the cache.
+
+	s.colSubLock.Lock()
+	s.colSubCache.Flush()
+	s.colSubLock.Unlock()
+}

--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//consensus-types/primitives:go_default_library",
         "//consensus-types/wrapper:go_default_library",
         "//container/leaky-bucket:go_default_library",
+        "//container/slice:go_default_library",
         "//crypto/ecdsa:go_default_library",
         "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -45,10 +45,10 @@ type quicProtocol uint16
 // quicProtocol is the "quic" key, which holds the QUIC port of the node.
 func (quicProtocol) ENRKey() string { return "quic" }
 
-// RefreshENR uses an epoch to refresh the enr entry for our node
-// with the tracked committee ids for the epoch, allowing our node
-// to be dynamically discoverable by others given our tracked committee ids.
-func (s *Service) RefreshENR() {
+// UpdateLocalSubnets checks that we are tracking our local persistent subnets for a variety of gossip topics.
+// This routine checks for our attestation, sync committee and data column subnets and updates them if they have
+// been rotated.
+func (s *Service) UpdateLocalSubnets() {
 	// return early if discv5 isnt running
 	if s.dv5Listener == nil || !s.isInitialized() {
 		return

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -58,6 +58,10 @@ func (s *Service) RefreshENR() {
 		log.WithError(err).Error("Could not initialize persistent subnets")
 		return
 	}
+	if err := initializePersistentColumnSubnets(s.dv5Listener.LocalNode().ID()); err != nil {
+		log.WithError(err).Error("Could not initialize persistent column subnets")
+		return
+	}
 
 	bitV := bitfield.NewBitvector64()
 	committees := cache.SubnetIDs.GetAllSubnets()

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -45,10 +45,10 @@ type quicProtocol uint16
 // quicProtocol is the "quic" key, which holds the QUIC port of the node.
 func (quicProtocol) ENRKey() string { return "quic" }
 
-// UpdateLocalSubnets checks that we are tracking our local persistent subnets for a variety of gossip topics.
+// RefreshPersistentSubnets checks that we are tracking our local persistent subnets for a variety of gossip topics.
 // This routine checks for our attestation, sync committee and data column subnets and updates them if they have
 // been rotated.
-func (s *Service) UpdateLocalSubnets() {
+func (s *Service) RefreshPersistentSubnets() {
 	// return early if discv5 isnt running
 	if s.dv5Listener == nil || !s.isInitialized() {
 		return

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -601,7 +601,7 @@ func TestRefreshENR_ForkBoundaries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.svcBuilder(t)
-			s.UpdateLocalSubnets()
+			s.RefreshPersistentSubnets()
 			tt.postValidation(t, s)
 			s.dv5Listener.Close()
 			cache.SubnetIDs.EmptyAllCaches()

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -601,7 +601,7 @@ func TestRefreshENR_ForkBoundaries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := tt.svcBuilder(t)
-			s.RefreshENR()
+			s.UpdateLocalSubnets()
 			tt.postValidation(t, s)
 			s.dv5Listener.Close()
 			cache.SubnetIDs.EmptyAllCaches()

--- a/beacon-chain/p2p/interfaces.go
+++ b/beacon-chain/p2p/interfaces.go
@@ -82,7 +82,7 @@ type PeerManager interface {
 	Host() host.Host
 	ENR() *enr.Record
 	DiscoveryAddresses() ([]multiaddr.Multiaddr, error)
-	RefreshENR()
+	UpdateLocalSubnets()
 	FindPeersWithSubnet(ctx context.Context, topic string, subIndex uint64, threshold int) (bool, error)
 	AddPingMethod(reqFunc func(ctx context.Context, id peer.ID) error)
 }

--- a/beacon-chain/p2p/interfaces.go
+++ b/beacon-chain/p2p/interfaces.go
@@ -82,7 +82,7 @@ type PeerManager interface {
 	Host() host.Host
 	ENR() *enr.Record
 	DiscoveryAddresses() ([]multiaddr.Multiaddr, error)
-	UpdateLocalSubnets()
+	RefreshPersistentSubnets()
 	FindPeersWithSubnet(ctx context.Context, topic string, subIndex uint64, threshold int) (bool, error)
 	AddPingMethod(reqFunc func(ctx context.Context, id peer.ID) error)
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -226,7 +226,7 @@ func (s *Service) Start() {
 	}
 	// Initialize metadata according to the
 	// current epoch.
-	s.UpdateLocalSubnets()
+	s.RefreshPersistentSubnets()
 
 	// Periodic functions.
 	async.RunEvery(s.ctx, params.BeaconConfig().TtfbTimeoutDuration(), func() {
@@ -234,7 +234,7 @@ func (s *Service) Start() {
 	})
 	async.RunEvery(s.ctx, 30*time.Minute, s.Peers().Prune)
 	async.RunEvery(s.ctx, time.Duration(params.BeaconConfig().RespTimeout)*time.Second, s.updateMetrics)
-	async.RunEvery(s.ctx, refreshRate, s.UpdateLocalSubnets)
+	async.RunEvery(s.ctx, refreshRate, s.RefreshPersistentSubnets)
 	async.RunEvery(s.ctx, 1*time.Minute, func() {
 		inboundQUICCount := len(s.peers.InboundConnectedWithProtocol(peers.QUIC))
 		inboundTCPCount := len(s.peers.InboundConnectedWithProtocol(peers.TCP))

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -226,7 +226,7 @@ func (s *Service) Start() {
 	}
 	// Initialize metadata according to the
 	// current epoch.
-	s.RefreshENR()
+	s.UpdateLocalSubnets()
 
 	// Periodic functions.
 	async.RunEvery(s.ctx, params.BeaconConfig().TtfbTimeoutDuration(), func() {
@@ -234,7 +234,7 @@ func (s *Service) Start() {
 	})
 	async.RunEvery(s.ctx, 30*time.Minute, s.Peers().Prune)
 	async.RunEvery(s.ctx, time.Duration(params.BeaconConfig().RespTimeout)*time.Second, s.updateMetrics)
-	async.RunEvery(s.ctx, refreshRate, s.RefreshENR)
+	async.RunEvery(s.ctx, refreshRate, s.UpdateLocalSubnets)
 	async.RunEvery(s.ctx, 1*time.Minute, func() {
 		inboundQUICCount := len(s.peers.InboundConnectedWithProtocol(peers.QUIC))
 		inboundTCPCount := len(s.peers.InboundConnectedWithProtocol(peers.TCP))

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -265,8 +265,12 @@ func computeSubscribedColumnSubnets(nodeID enode.ID) ([]uint64, error) {
 		}
 		subs = append(subs, sub)
 	}
-	if len(subs) != int(subnetsPerNode) {
-		return nil, errors.Errorf("inconsistent subnet assignment: %d vs %d", len(subs), subnetsPerNode)
+	isubnetsPerNode, err := mathutil.Int(subnetsPerNode)
+	if err != nil {
+		return nil, err
+	}
+	if len(subs) != isubnetsPerNode {
+		return nil, errors.Errorf("inconsistent subnet assignment: %d vs %d", len(subs), isubnetsPerNode)
 	}
 	return subs, nil
 }

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/wrapper"
+	"github.com/prysmaticlabs/prysm/v5/container/slice"
 	"github.com/prysmaticlabs/prysm/v5/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	mathutil "github.com/prysmaticlabs/prysm/v5/math"
@@ -202,6 +203,19 @@ func initializePersistentSubnets(id enode.ID, epoch primitives.Epoch) error {
 	return nil
 }
 
+func initializePersistentColumnSubnets(id enode.ID) error {
+	_, ok, expTime := cache.ColumnSubnetIDs.GetColumnSubnets()
+	if ok && expTime.After(time.Now()) {
+		return nil
+	}
+	subs, err := computeSubscribedColumnSubnets(id)
+	if err != nil {
+		return err
+	}
+	cache.ColumnSubnetIDs.AddColumnSubnets(subs)
+	return nil
+}
+
 // Spec pseudocode definition:
 //
 // def compute_subscribed_subnets(node_id: NodeID, epoch: Epoch) -> Sequence[SubnetID]:
@@ -217,6 +231,42 @@ func computeSubscribedSubnets(nodeID enode.ID, epoch primitives.Epoch) ([]uint64
 			return nil, err
 		}
 		subs = append(subs, sub)
+	}
+	return subs, nil
+}
+
+func computeCustodyColumns(nodeID enode.ID) ([]uint64, error) {
+	subs, err := computeSubscribedColumnSubnets(nodeID)
+	if err != nil {
+		return nil, err
+	}
+	colsPerSub := params.BeaconConfig().NumberOfColumns / params.BeaconConfig().DataColumnSidecarSubnetCount
+	colIdxs := []uint64{}
+	for _, sub := range subs {
+		for i := uint64(0); i < colsPerSub; i++ {
+			colId := params.BeaconConfig().DataColumnSidecarSubnetCount*i + sub
+			colIdxs = append(colIdxs, colId)
+		}
+	}
+	return colIdxs, nil
+}
+
+func computeSubscribedColumnSubnets(nodeID enode.ID) ([]uint64, error) {
+	subnetsPerNode := params.BeaconConfig().CustodyRequirement
+	subs := make([]uint64, 0, subnetsPerNode)
+
+	for i := uint64(0); i < subnetsPerNode; i++ {
+		sub, err := computeSubscribedColumnSubnet(nodeID, i)
+		if err != nil {
+			return nil, err
+		}
+		if slice.IsInUint64(sub, subs) {
+			continue
+		}
+		subs = append(subs, sub)
+	}
+	if len(subs) != int(subnetsPerNode) {
+		return nil, errors.Errorf("inconsistent subnet assignment: %d vs %d", len(subs), subnetsPerNode)
 	}
 	return subs, nil
 }
@@ -244,6 +294,16 @@ func computeSubscribedSubnet(nodeID enode.ID, epoch primitives.Epoch, index uint
 	}
 	subnet := (uint64(permutatedPrefix) + index) % params.BeaconConfig().AttestationSubnetCount
 	return subnet, nil
+}
+
+func computeSubscribedColumnSubnet(nodeID enode.ID, index uint64) (uint64, error) {
+	num := uint256.NewInt(0).SetBytes(nodeID.Bytes())
+	num = num.Add(num, uint256.NewInt(index))
+	num64bit := num.Uint64()
+	byteNum := bytesutil.Uint64ToBytesLittleEndian(num64bit)
+	hashedObj := hash.Hash(byteNum)
+	subnetID := bytesutil.FromBytes8(hashedObj[:8]) % params.BeaconConfig().DataColumnSidecarSubnetCount
+	return subnetID, nil
 }
 
 func computeSubscriptionExpirationTime(nodeID enode.ID, epoch primitives.Epoch) time.Duration {

--- a/beacon-chain/p2p/testing/fuzz_p2p.go
+++ b/beacon-chain/p2p/testing/fuzz_p2p.go
@@ -66,7 +66,7 @@ func (_ *FakeP2P) FindPeersWithSubnet(_ context.Context, _ string, _ uint64, _ i
 }
 
 // RefreshENR mocks the p2p func.
-func (_ *FakeP2P) RefreshENR() {}
+func (_ *FakeP2P) UpdateLocalSubnets() {}
 
 // LeaveTopic -- fake.
 func (_ *FakeP2P) LeaveTopic(_ string) error {

--- a/beacon-chain/p2p/testing/fuzz_p2p.go
+++ b/beacon-chain/p2p/testing/fuzz_p2p.go
@@ -66,7 +66,7 @@ func (_ *FakeP2P) FindPeersWithSubnet(_ context.Context, _ string, _ uint64, _ i
 }
 
 // RefreshENR mocks the p2p func.
-func (_ *FakeP2P) UpdateLocalSubnets() {}
+func (_ *FakeP2P) RefreshPersistentSubnets() {}
 
 // LeaveTopic -- fake.
 func (_ *FakeP2P) LeaveTopic(_ string) error {

--- a/beacon-chain/p2p/testing/mock_peermanager.go
+++ b/beacon-chain/p2p/testing/mock_peermanager.go
@@ -48,7 +48,7 @@ func (m MockPeerManager) DiscoveryAddresses() ([]multiaddr.Multiaddr, error) {
 }
 
 // RefreshENR .
-func (_ MockPeerManager) RefreshENR() {}
+func (_ MockPeerManager) UpdateLocalSubnets() {}
 
 // FindPeersWithSubnet .
 func (_ MockPeerManager) FindPeersWithSubnet(_ context.Context, _ string, _ uint64, _ int) (bool, error) {

--- a/beacon-chain/p2p/testing/mock_peermanager.go
+++ b/beacon-chain/p2p/testing/mock_peermanager.go
@@ -48,7 +48,7 @@ func (m MockPeerManager) DiscoveryAddresses() ([]multiaddr.Multiaddr, error) {
 }
 
 // RefreshENR .
-func (_ MockPeerManager) UpdateLocalSubnets() {}
+func (_ MockPeerManager) RefreshPersistentSubnets() {}
 
 // FindPeersWithSubnet .
 func (_ MockPeerManager) FindPeersWithSubnet(_ context.Context, _ string, _ uint64, _ int) (bool, error) {

--- a/beacon-chain/p2p/testing/p2p.go
+++ b/beacon-chain/p2p/testing/p2p.go
@@ -361,7 +361,7 @@ func (_ *TestP2P) FindPeersWithSubnet(_ context.Context, _ string, _ uint64, _ i
 }
 
 // RefreshENR mocks the p2p func.
-func (_ *TestP2P) RefreshENR() {}
+func (_ *TestP2P) UpdateLocalSubnets() {}
 
 // ForkDigest mocks the p2p func.
 func (p *TestP2P) ForkDigest() ([4]byte, error) {

--- a/beacon-chain/p2p/testing/p2p.go
+++ b/beacon-chain/p2p/testing/p2p.go
@@ -361,7 +361,7 @@ func (_ *TestP2P) FindPeersWithSubnet(_ context.Context, _ string, _ uint64, _ i
 }
 
 // RefreshENR mocks the p2p func.
-func (_ *TestP2P) UpdateLocalSubnets() {}
+func (_ *TestP2P) RefreshPersistentSubnets() {}
 
 // ForkDigest mocks the p2p func.
 func (p *TestP2P) ForkDigest() ([4]byte, error) {

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -145,6 +145,9 @@ func (s *Service) registerSubscribers(epoch primitives.Epoch, digest [4]byte) {
 			params.BeaconConfig().BlobsidecarSubnetCount,
 		)
 	}
+	if features.Get().EnablePeerDAS {
+		// TODO: Subscribe to persistent column subnets here
+	}
 }
 
 // subscribe to a given topic with a given validator and subscription handler.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR allows a peer to compute its assigned custody column subnets and record the entries in a cache. Using these values a node can now subscribe to its custodied gossip subnets. The subscription of these subnets requires the implementation and support of the gossip validation pipeline for data columns. This will come up in a follow up PR

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
