### PR TITLE
New blob storage scheme avoiding large base dir count

### DIFF
--- a/beacon-chain/db/filesystem/BUILD.bazel
+++ b/beacon-chain/db/filesystem/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "cache.go",
         "log.go",
         "metrics.go",
+        "migration.go",
         "mock.go",
         "pruner.go",
     ],
@@ -37,6 +38,7 @@ go_test(
     srcs = [
         "blob_test.go",
         "cache_test.go",
+        "migration_test.go",
         "pruner_test.go",
     ],
     embed = [":go_default_library"],

--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,7 @@ const (
 	partExt = "part"
 
 	directoryPermissions = 0700
+	rootPrefixLen        = 4
 )
 
 // BlobStorageOption is a functional option for configuring a BlobStorage.
@@ -321,8 +323,14 @@ func namerForSidecar(sc blocks.VerifiedROBlob) blobNamer {
 	return blobNamer{root: sc.BlockRoot(), index: sc.Index}
 }
 
+func (p blobNamer) groupDir() string {
+	return oneBytePrefix(rootString(p.root))
+}
+
 func (p blobNamer) dir() string {
-	return rootString(p.root)
+	rs := rootString(p.root)
+	parentDir := oneBytePrefix(rs)
+	return filepath.Join(parentDir, rs)
 }
 
 func (p blobNamer) partPath(entropy string) string {
@@ -335,6 +343,11 @@ func (p blobNamer) path() string {
 
 func rootString(root [32]byte) string {
 	return fmt.Sprintf("%#x", root)
+}
+
+func oneBytePrefix(p string) string {
+	// returns eg 0x00 from 0x0002fb4db510b8618b04dc82d023793739c26346a8b02eb73482e24b0fec0555
+	return p[0:rootPrefixLen]
 }
 
 func stringToRoot(str string) ([32]byte, error) {

--- a/beacon-chain/db/filesystem/migration.go
+++ b/beacon-chain/db/filesystem/migration.go
@@ -1,0 +1,61 @@
+package filesystem
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+type directoryMigrator interface {
+	migrate(fs afero.Fs, dirs []string) error
+}
+
+type oneBytePrefixMigrator struct {
+	migrated []string
+}
+
+func (m *oneBytePrefixMigrator) migrate(fs afero.Fs, dirs []string) error {
+	start := time.Now()
+	defer func() {
+		nMigrated := len(m.migrated)
+		if nMigrated > 0 {
+			log.WithField("elapsed", time.Since(start).String()).
+				WithField("dirsMoved", nMigrated).
+				Debug("Migrated blob subdirectories to byte-prefixed format")
+		}
+	}()
+	groups := groupDirsByPrefix(dirs)
+	return m.renameByGroup(fs, groups)
+}
+
+func (m *oneBytePrefixMigrator) renameByGroup(fs afero.Fs, groups map[string][]string) error {
+	for g, sd := range groups {
+		// make the enclosing dir if needed
+		if err := fs.MkdirAll(g, directoryPermissions); err != nil {
+			return err
+		}
+		for _, dir := range sd {
+			dest := filepath.Join(g, dir)
+			// todo: check if directory exists and move files one at a time if so?
+			// that shouldn't be a problem if we migrate in cache warmup and never write to old path.
+			if err := fs.Rename(dir, dest); err != nil {
+				return err
+			}
+			log.WithField("source", dir).WithField("dest", dest).Trace("Migrated legacy blob storage path.")
+			m.migrated = append(m.migrated, dir)
+		}
+	}
+	return nil
+}
+
+func groupDirsByPrefix(dirs []string) map[string][]string {
+	groups := make(map[string][]string)
+	for _, dir := range dirs {
+		if filterLegacy(dir) {
+			key := oneBytePrefix(dir)
+			groups[key] = append(groups[key], dir)
+		}
+	}
+	return groups
+}

--- a/beacon-chain/db/filesystem/migration_test.go
+++ b/beacon-chain/db/filesystem/migration_test.go
@@ -1,0 +1,216 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+	"github.com/spf13/afero"
+)
+
+func testSetupPaths(t *testing.T, fs afero.Fs, paths []migrateBeforeAfter) {
+	for _, ba := range paths {
+		p := ba.before()
+		dir := filepath.Dir(p)
+		require.NoError(t, fs.MkdirAll(dir, directoryPermissions))
+		fh, err := fs.Create(p)
+		require.NoError(t, err)
+		require.NoError(t, fh.Close())
+		// double check that we got the full path correct
+		_, err = fs.Stat(ba.before())
+		require.NoError(t, err)
+	}
+}
+
+func testAssertNewPaths(t *testing.T, fs afero.Fs, paths []migrateBeforeAfter) {
+	for _, ba := range paths {
+		if ba.before() != ba.after() {
+			_, err := fs.Stat(ba.before())
+			require.ErrorIs(t, err, os.ErrNotExist)
+			dir := filepath.Dir(ba.before())
+			_, err = listDir(fs, dir)
+			require.ErrorIs(t, err, os.ErrNotExist)
+		}
+		_, err := fs.Stat(ba.after())
+		require.NoError(t, err)
+	}
+}
+
+type migrateBeforeAfter [2]string
+
+func (ba migrateBeforeAfter) before() string {
+	return ba[0]
+}
+func (ba migrateBeforeAfter) after() string {
+	return ba[1]
+}
+
+func TestOneBytePrefixMigrator(t *testing.T) {
+	cases := []struct {
+		name string
+		plan []migrateBeforeAfter
+		err  error
+	}{
+		{
+			name: "happy path",
+			plan: []migrateBeforeAfter{
+				{
+					"0x0125e54c64c925018c9296965a5b622d9f5ab626c10917860dcfb6aa09a0a00b/0.ssz",
+					"0x01/0x0125e54c64c925018c9296965a5b622d9f5ab626c10917860dcfb6aa09a0a00b/0.ssz",
+				},
+				{
+					"0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/0.ssz",
+					"0x01/0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/0.ssz",
+				},
+				{
+					"0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/1.ssz",
+					"0x01/0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/1.ssz",
+				},
+				{
+					"0x0232521756a0b965eab2c2245d7ad85feaeaf5f427cd14d1a7531f9d555b415c/0.ssz",
+					"0x02/0x0232521756a0b965eab2c2245d7ad85feaeaf5f427cd14d1a7531f9d555b415c/0.ssz",
+				},
+			},
+		},
+		{
+			name: "different roots same prefix",
+			plan: []migrateBeforeAfter{
+				{
+					"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/0.ssz",
+					"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/0.ssz",
+				},
+				{
+					"0xff0774a80664e1667dcd5a18bced866a596b6cef5f351c0f88cd310dd00cb16d/0.ssz",
+					"0xff/0xff0774a80664e1667dcd5a18bced866a596b6cef5f351c0f88cd310dd00cb16d/0.ssz",
+				},
+				{
+					"0x0125e54c64c925018c9296965a5b622d9f5ab626c10917860dcfb6aa09a0a00b/0.ssz",
+					"0x01/0x0125e54c64c925018c9296965a5b622d9f5ab626c10917860dcfb6aa09a0a00b/0.ssz",
+				},
+				{
+					"0x01/0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/0.ssz",
+					"0x01/0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/0.ssz",
+				},
+				{
+					"0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/1.ssz",
+					"0x01/0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/1.ssz",
+				},
+			},
+		},
+		{
+			name: "mix old and new",
+			plan: []migrateBeforeAfter{
+				{
+					"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/0.ssz",
+					"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/0.ssz",
+				},
+				{
+					"0x0125e54c64c925018c9296965a5b622d9f5ab626c10917860dcfb6aa09a0a00b/0.ssz",
+					"0x01/0x0125e54c64c925018c9296965a5b622d9f5ab626c10917860dcfb6aa09a0a00b/0.ssz",
+				},
+				{
+					"0xa0/0xa0000137a809ca8425e03ae6c4244eedc7c0aa37f2735883366bcaf1cca1e3f3/0.ssz",
+					"0xa0/0xa0000137a809ca8425e03ae6c4244eedc7c0aa37f2735883366bcaf1cca1e3f3/0.ssz",
+				},
+				{
+					"0xa0/0xa0000137a809ca8425e03ae6c4244eedc7c0aa37f2735883366bcaf1cca1e3f3/1.ssz",
+					"0xa0/0xa0000137a809ca8425e03ae6c4244eedc7c0aa37f2735883366bcaf1cca1e3f3/1.ssz",
+				},
+				{
+					"0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/0.ssz",
+					"0x01/0x0127dba6fd30fdbb47e73e861d5c6e602b38ac3ddc945bb6a2fc4e10761e9a86/0.ssz",
+				},
+			},
+		},
+		{
+			name: "overwrite existing root dir",
+			plan: []migrateBeforeAfter{
+				{
+					"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/0.ssz",
+					"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/0.ssz",
+				},
+				{
+					"0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/1.ssz",
+					"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb/0.ssz",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fs, _ := NewEphemeralBlobStorageWithFs(t)
+			testSetupPaths(t, fs, c.plan)
+			entries, err := listDir(fs, ".")
+			require.NoError(t, err)
+			m := &oneBytePrefixMigrator{}
+			err = m.migrate(fs, entries)
+			if c.err != nil {
+				require.ErrorIs(t, err, c.err)
+				return
+			}
+			require.NoError(t, err)
+			testAssertNewPaths(t, fs, c.plan)
+		})
+	}
+}
+
+func TestGroupDirsByPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		dirs   []string
+		groups map[string][]string
+	}{
+		{
+			name: "different buckets",
+			dirs: []string{
+				"0x00ff0b18f16d3f22e6386ec3d6718346358089be531cb3715cb61b34a08aca04",
+				"0x0105400af093eeca95c1bf3874e97ec433244dd45222d850fe5ee50e53385f05",
+			},
+			groups: map[string][]string{
+				"0x00": {"0x00ff0b18f16d3f22e6386ec3d6718346358089be531cb3715cb61b34a08aca04"},
+				"0x01": {"0x0105400af093eeca95c1bf3874e97ec433244dd45222d850fe5ee50e53385f05"},
+			},
+		},
+		{
+			name: "same prefix, one bucket",
+			dirs: []string{
+				"0xfff5b975edfa1fbf807afb96e512bfa91eb41f78a9c9999d17f451d0077d3ed8",
+				"0xffff0f4efdd596f39c602c7758d73b7ecf66856fd7649321f78fc8356a2e98b1",
+				"0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb",
+			},
+			groups: map[string][]string{
+				"0xff": {
+					"0xfff5b975edfa1fbf807afb96e512bfa91eb41f78a9c9999d17f451d0077d3ed8",
+					"0xffff0f4efdd596f39c602c7758d73b7ecf66856fd7649321f78fc8356a2e98b1",
+					"0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb",
+				},
+			},
+		},
+		{
+			name: "mix of legacy and new",
+			dirs: []string{
+				"0xfff5b975edfa1fbf807afb96e512bfa91eb41f78a9c9999d17f451d0077d3ed8",
+				"0xff/0xffff0f4efdd596f39c602c7758d73b7ecf66856fd7649321f78fc8356a2e98b1",
+				"0xff/0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb",
+			},
+			groups: map[string][]string{
+				"0xff": {"0xfff5b975edfa1fbf807afb96e512bfa91eb41f78a9c9999d17f451d0077d3ed8"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			groups := groupDirsByPrefix(c.dirs)
+			require.Equal(t, len(c.groups), len(groups))
+			for k, v := range c.groups {
+				got := groups[k]
+				require.Equal(t, len(v), len(got))
+				// compare the lists
+				require.DeepEqual(t, v, got)
+			}
+		})
+	}
+}

--- a/tools/downgrade-blob-storage/main.go
+++ b/tools/downgrade-blob-storage/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var errUsage = errors.New("incorrect usage - missing blob path")
+
+const newLen = 4 // eg '0xff'
+
+func blobPath() (string, error) {
+	if len(os.Args) < 2 {
+		return "", errUsage
+	}
+	return os.Args[1], nil
+}
+
+func usage(err error) {
+	fmt.Printf("%s\n", err.Error())
+	fmt.Println("downgrade-blob-storage: Move blob directories back to old format, without the single byte container directories at the top-level of the directory tree. usage:\n" + os.Args[0] + " <path to blobs dir>")
+}
+
+func main() {
+	bp, err := blobPath()
+	if err != nil {
+		if errors.Is(err, errUsage) {
+			usage(err)
+		}
+		os.Exit(1)
+	}
+	if err := downgrade(bp); err != nil {
+		fmt.Printf("fatal error: %s\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+func downgrade(base string) error {
+	top, err := os.Open(base) // #nosec G304
+	if err != nil {
+		return err
+	}
+	// iterate over top-level blob dir, ie 'blobs' inside prysm's datadir
+	topdirs, err := top.Readdirnames(0)
+	if err != nil {
+		return err
+	}
+	if err := top.Close(); err != nil {
+		return err
+	}
+	nMoved := 0
+	for _, td := range topdirs {
+		// Ignore anything in the old layout.
+		if !filterNew(td) {
+			continue
+		}
+		dir, err := os.Open(filepath.Join(base, td)) // #nosec G304
+		if err != nil {
+			return err
+		}
+		// List the subdirectoress of the short dir containers, eg if td == '0xff'
+		// we want to move all the subdirectories in that dir.
+		subs, err := dir.Readdirnames(0)
+		if err != nil {
+			return err
+		}
+		if err := dir.Close(); err != nil {
+			return err
+		}
+		for _, sd := range subs {
+			// this is the inner layer of directory nesting,
+			// eg if 'td' == '0xff', 'sd' might be something like:
+			// '0xffff875e1d985c5ccb214894983f2428edb271f0f87b68ba7010e4a99df3b5cb'
+			src := filepath.Join(base, td, sd)
+			target := filepath.Join(base, sd)
+			fmt.Printf("moving %s -> %s\n", src, target)
+			if err := os.Rename(src, target); err != nil {
+				return err
+			}
+			nMoved += 1
+		}
+	}
+	fmt.Printf("moved %d directories\n", nMoved)
+	return nil
+}
+
+func filterRoot(s string) bool {
+	return strings.HasPrefix(s, "0x")
+}
+
+func filterNew(s string) bool {
+	return filterRoot(s) && len(s) == newLen
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR changes the naming scheme for blob file storage. Currently the scheme is a single `blobs` directory which contains a subdir for each unique block root, within which we store blobs by their index number, eg:

```blobs/0xff09895e2ff6232ac1ef6f08b1940e0177aaed5d8b682a30574a1cbd3ec6b487/0.ssz```

The problem with this approach is that it leads to a large directory entry for the `blobs` dir, which can cause issues with older filesystems. With this PR, an extra subdir is added to group block root directories by their first byte, eg the directory:

```blobs/0xff09895e2ff6232ac1ef6f08b1940e0177aaed5d8b682a30574a1cbd3ec6b487```

is renamed to:

```blobs/0xff/0xff09895e2ff6232ac1ef6f08b1940e0177aaed5d8b682a30574a1cbd3ec6b487```

In order to minimizes changes to the storage code and reduce the risk of new bugs, we perform a one-time migration of the legacy structure during the blob cache warm up, which runs at node startup. This migration makes the appropriate containing directory for each subdir in the old format (eg `0xff` in the above example) and calls `Rename` to move the existing subdir into the new enclosing directory. On most systems this should be an atomic syscall that should be fairly cheap.

**Which issues(s) does this PR fix?**

Fixes #13880

**Other notes for review**

We're keeping this as a draft PR while we assess whether it makes sense to release before a minor version bump. We would prefer to wait for a version bump because this change is not backwards compatible - the new directory structure won't be understood by nodes running previous releases. It appears the `dir_nlink` ext4 feature flag is enabled by default on modern ext4 systems, so this should only be an issue for users running older kernels.