### PR TITLE
Don't return error that can be internally handled

### DIFF
--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -25,8 +25,7 @@ func TestBlobStorage_SaveBlobData(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("no error for duplicate", func(t *testing.T) {
-		fs, bs, err := NewEphemeralBlobStorageWithFs(t)
-		require.NoError(t, err)
+		fs, bs := NewEphemeralBlobStorageWithFs(t)
 		existingSidecar := testSidecars[0]
 
 		blobPath := namerForSidecar(existingSidecar).path()
@@ -130,8 +129,7 @@ func TestBlobStorage_SaveBlobData(t *testing.T) {
 // pollUntil polls a condition function until it returns true or a timeout is reached.
 
 func TestBlobIndicesBounds(t *testing.T) {
-	fs, bs, err := NewEphemeralBlobStorageWithFs(t)
-	require.NoError(t, err)
+	fs, bs := NewEphemeralBlobStorageWithFs(t)
 	root := [32]byte{}
 
 	okIdx := uint64(fieldparams.MaxBlobsPerBlock - 1)
@@ -162,8 +160,7 @@ func writeFakeSSZ(t *testing.T, fs afero.Fs, root [32]byte, idx uint64) {
 
 func TestBlobStoragePrune(t *testing.T) {
 	currentSlot := primitives.Slot(200000)
-	fs, bs, err := NewEphemeralBlobStorageWithFs(t)
-	require.NoError(t, err)
+	fs, bs := NewEphemeralBlobStorageWithFs(t)
 
 	t.Run("PruneOne", func(t *testing.T) {
 		_, sidecars := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 300, fieldparams.MaxBlobsPerBlock)
@@ -219,8 +216,7 @@ func TestBlobStoragePrune(t *testing.T) {
 
 func BenchmarkPruning(b *testing.B) {
 	var t *testing.T
-	_, bs, err := NewEphemeralBlobStorageWithFs(t)
-	require.NoError(t, err)
+	_, bs := NewEphemeralBlobStorageWithFs(t)
 
 	blockQty := 10000
 	currentSlot := primitives.Slot(150000)

--- a/beacon-chain/db/filesystem/mock.go
+++ b/beacon-chain/db/filesystem/mock.go
@@ -21,13 +21,13 @@ func NewEphemeralBlobStorage(t testing.TB) *BlobStorage {
 
 // NewEphemeralBlobStorageWithFs can be used by tests that want access to the virtual filesystem
 // in order to interact with it outside the parameters of the BlobStorage api.
-func NewEphemeralBlobStorageWithFs(t testing.TB) (afero.Fs, *BlobStorage, error) {
+func NewEphemeralBlobStorageWithFs(t testing.TB) (afero.Fs, *BlobStorage) {
 	fs := afero.NewMemMapFs()
 	pruner, err := newBlobPruner(fs, params.BeaconConfig().MinEpochsForBlobsSidecarsRequest, withWarmedCache())
 	if err != nil {
 		t.Fatal("test setup issue", err)
 	}
-	return fs, &BlobStorage{fs: fs, pruner: pruner}, nil
+	return fs, &BlobStorage{fs: fs, pruner: pruner}
 }
 
 type BlobMocker struct {

--- a/beacon-chain/db/filesystem/pruner_test.go
+++ b/beacon-chain/db/filesystem/pruner_test.go
@@ -51,8 +51,7 @@ func TestTryPruneDir_CachedExpired(t *testing.T) {
 		require.Equal(t, 0, pruned)
 	})
 	t.Run("blobs to delete", func(t *testing.T) {
-		fs, bs, err := NewEphemeralBlobStorageWithFs(t)
-		require.NoError(t, err)
+		fs, bs := NewEphemeralBlobStorageWithFs(t)
 		var slot primitives.Slot = 0
 		_, sidecars := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, slot, 2)
 		scs, err := verification.BlobSidecarSliceNoop(sidecars)
@@ -83,8 +82,7 @@ func TestTryPruneDir_CachedExpired(t *testing.T) {
 
 func TestTryPruneDir_SlotFromFile(t *testing.T) {
 	t.Run("expired blobs deleted", func(t *testing.T) {
-		fs, bs, err := NewEphemeralBlobStorageWithFs(t)
-		require.NoError(t, err)
+		fs, bs := NewEphemeralBlobStorageWithFs(t)
 		var slot primitives.Slot = 0
 		_, sidecars := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, slot, 2)
 		scs, err := verification.BlobSidecarSliceNoop(sidecars)
@@ -116,8 +114,7 @@ func TestTryPruneDir_SlotFromFile(t *testing.T) {
 		require.Equal(t, 0, len(files))
 	})
 	t.Run("not expired, intact", func(t *testing.T) {
-		fs, bs, err := NewEphemeralBlobStorageWithFs(t)
-		require.NoError(t, err)
+		fs, bs := NewEphemeralBlobStorageWithFs(t)
 		// Set slot equal to the window size, so it should be retained.
 		slot := bs.pruner.windowSize
 		_, sidecars := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, slot, 2)
@@ -184,8 +181,7 @@ func TestSlotFromFile(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("slot %d", c.slot), func(t *testing.T) {
-			fs, bs, err := NewEphemeralBlobStorageWithFs(t)
-			require.NoError(t, err)
+			fs, bs := NewEphemeralBlobStorageWithFs(t)
 			_, sidecars := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, c.slot, 1)
 			sc, err := verification.BlobSidecarNoop(sidecars[0])
 			require.NoError(t, err)

--- a/beacon-chain/rpc/lookup/blocker_test.go
+++ b/beacon-chain/rpc/lookup/blocker_test.go
@@ -164,8 +164,7 @@ func TestGetBlob(t *testing.T) {
 	db := testDB.SetupDB(t)
 	denebBlock, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 123, 4)
 	require.NoError(t, db.SaveBlock(context.Background(), denebBlock))
-	_, bs, err := filesystem.NewEphemeralBlobStorageWithFs(t)
-	require.NoError(t, err)
+	_, bs := filesystem.NewEphemeralBlobStorageWithFs(t)
 	testSidecars, err := verification.BlobSidecarSliceNoop(blobs)
 	require.NoError(t, err)
 	for i := range testSidecars {


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Trivial change to remove a useless error return so callers don't need to handle it.