### PR TITLE
Add Data Column Gossip Handlers

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "receive_attestation.go",
         "receive_blob.go",
         "receive_block.go",
+        "receive_sidecar.go",
         "service.go",
         "tracked_proposer.go",
         "weak_subjectivity_checks.go",

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -50,6 +50,12 @@ type BlobReceiver interface {
 	ReceiveBlob(context.Context, blocks.VerifiedROBlob) error
 }
 
+// DataColumnReceiver interface defines the methods of chain service for receiving new
+// data columns
+type DataColumnReceiver interface {
+	ReceiveDataColumn(context.Context, *ethpb.DataColumnSidecar) error
+}
+
 // SlashingReceiver interface defines the methods of chain service for receiving validated slashing over the wire.
 type SlashingReceiver interface {
 	ReceiveAttesterSlashing(ctx context.Context, slashings *ethpb.AttesterSlashing)

--- a/beacon-chain/blockchain/receive_sidecar.go
+++ b/beacon-chain/blockchain/receive_sidecar.go
@@ -1,0 +1,12 @@
+package blockchain
+
+import (
+	"context"
+
+	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+)
+
+func (s *Service) ReceiveDataColumn(ctx context.Context, ds *ethpb.DataColumnSidecar) error {
+	// TODO
+	return nil
+}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -628,6 +628,11 @@ func (c *ChainService) ReceiveBlob(_ context.Context, b blocks.VerifiedROBlob) e
 	return nil
 }
 
+// ReceiveDataColumn implements the same method in chain service
+func (c *ChainService) ReceiveDataColumn(_ context.Context, _ *ethpb.DataColumnSidecar) error {
+	return nil
+}
+
 // TargetRootForEpoch mocks the same method in the chain service
 func (c *ChainService) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
 	return c.TargetRoot, nil

--- a/beacon-chain/core/feed/operation/events.go
+++ b/beacon-chain/core/feed/operation/events.go
@@ -32,6 +32,9 @@ const (
 
 	// AttesterSlashingReceived is sent after an attester slashing is received from gossip or rpc
 	AttesterSlashingReceived = 8
+
+	// DataColumnSidecarReceived is sent after a data column sidecar is received from gossip or rpc.
+	DataColumnSidecarReceived = 9
 )
 
 // UnAggregatedAttReceivedData is the data sent with UnaggregatedAttReceived events.
@@ -76,4 +79,8 @@ type ProposerSlashingReceivedData struct {
 // AttesterSlashingReceivedData is the data sent with AttesterSlashingReceived events.
 type AttesterSlashingReceivedData struct {
 	AttesterSlashing *ethpb.AttesterSlashing
+}
+
+type DataColumnSidecarReceivedData struct {
+	DataColumn *ethpb.DataColumnSidecar
 }

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -317,7 +317,7 @@ func TestHostIsResolved(t *testing.T) {
 	// As defined in RFC 2606 , example.org is a
 	// reserved example domain name.
 	exampleHost := "example.org"
-	exampleIP := "93.184.216.34"
+	exampleIP := "93.184.215.34"
 
 	s := &Service{
 		cfg: &Config{

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -317,7 +317,7 @@ func TestHostIsResolved(t *testing.T) {
 	// As defined in RFC 2606 , example.org is a
 	// reserved example domain name.
 	exampleHost := "example.org"
-	exampleIP := "93.184.215.34"
+	exampleIP := "93.184.215.14"
 
 	s := &Service{
 		cfg: &Config{

--- a/beacon-chain/p2p/gossip_topic_mappings.go
+++ b/beacon-chain/p2p/gossip_topic_mappings.go
@@ -22,6 +22,7 @@ var gossipTopicMappings = map[string]proto.Message{
 	SyncCommitteeSubnetTopicFormat:            &ethpb.SyncCommitteeMessage{},
 	BlsToExecutionChangeSubnetTopicFormat:     &ethpb.SignedBLSToExecutionChange{},
 	BlobSubnetTopicFormat:                     &ethpb.BlobSidecar{},
+	DataColumnSubnetTopicFormat:               &ethpb.DataColumnSidecar{},
 }
 
 // GossipTopicMappings is a function to return the assigned data type

--- a/beacon-chain/p2p/pubsub_filter_test.go
+++ b/beacon-chain/p2p/pubsub_filter_test.go
@@ -90,7 +90,7 @@ func TestService_CanSubscribe(t *testing.T) {
 		formatting := []interface{}{digest}
 
 		// Special case for attestation subnets which have a second formatting placeholder.
-		if topic == AttestationSubnetTopicFormat || topic == SyncCommitteeSubnetTopicFormat || topic == BlobSubnetTopicFormat {
+		if topic == AttestationSubnetTopicFormat || topic == SyncCommitteeSubnetTopicFormat || topic == BlobSubnetTopicFormat || topic == DataColumnSubnetTopicFormat {
 			formatting = append(formatting, 0 /* some subnet ID */)
 		}
 

--- a/beacon-chain/p2p/topics.go
+++ b/beacon-chain/p2p/topics.go
@@ -30,6 +30,9 @@ const (
 	GossipBlsToExecutionChangeMessage = "bls_to_execution_change"
 	// GossipBlobSidecarMessage is the name for the blob sidecar message type.
 	GossipBlobSidecarMessage = "blob_sidecar"
+	// GossipDataColumnSidecarMessage is the name for the data column sidecar message type.
+	GossipDataColumnSidecarMessage = "data_column_sidecar"
+
 	// Topic Formats
 	//
 	// AttestationSubnetTopicFormat is the topic format for the attestation subnet.
@@ -52,4 +55,6 @@ const (
 	BlsToExecutionChangeSubnetTopicFormat = GossipProtocolAndDigest + GossipBlsToExecutionChangeMessage
 	// BlobSubnetTopicFormat is the topic format for the blob subnet.
 	BlobSubnetTopicFormat = GossipProtocolAndDigest + GossipBlobSidecarMessage + "_%d"
+	// DataColumnSubnetTopicFormat is the topic format for the data column subnet.
+	DataColumnSubnetTopicFormat = GossipProtocolAndDigest + GossipDataColumnSidecarMessage + "_%d"
 )

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "validate_beacon_blocks.go",
         "validate_blob.go",
         "validate_bls_to_execution_change.go",
+        "validate_data_column_sidecar.go",
         "validate_proposer_slashing.go",
         "validate_sync_committee_message.go",
         "validate_sync_contribution_proof.go",

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "subscriber_beacon_blocks.go",
         "subscriber_blob_sidecar.go",
         "subscriber_bls_to_execution_change.go",
+        "subscriber_data_column_sidecar.go",
         "subscriber_handlers.go",
         "subscriber_sync_committee_message.go",
         "subscriber_sync_contribution_proof.go",

--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -39,6 +39,8 @@ func (s *Service) decodePubsubMessage(msg *pubsub.Message) (ssz.Unmarshaler, err
 		topic = p2p.GossipTypeMapping[reflect.TypeOf(&ethpb.SyncCommitteeMessage{})]
 	case strings.Contains(topic, p2p.GossipBlobSidecarMessage):
 		topic = p2p.GossipTypeMapping[reflect.TypeOf(&ethpb.BlobSidecar{})]
+	case strings.Contains(topic, p2p.GossipDataColumnSidecarMessage):
+		topic = p2p.GossipTypeMapping[reflect.TypeOf(&ethpb.DataColumnSidecar{})]
 	}
 
 	base := p2p.GossipTopicMappings(topic, 0)

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -102,6 +102,7 @@ type config struct {
 type blockchainService interface {
 	blockchain.BlockReceiver
 	blockchain.BlobReceiver
+	blockchain.DataColumnReceiver
 	blockchain.HeadFetcher
 	blockchain.FinalizationFetcher
 	blockchain.ForkFetcher

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -1,0 +1,34 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed"
+	opfeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/operation"
+	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"google.golang.org/protobuf/proto"
+)
+
+func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) error {
+	b, ok := msg.(*ethpb.DataColumnSidecar)
+	if !ok {
+		return fmt.Errorf("message was not type DataColumnSidecar, type=%T", msg)
+	}
+
+	// TODO:Change to new one for data columns
+	s.setSeenBlobIndex(b.SignedBlockHeader.Header.Slot, b.SignedBlockHeader.Header.ProposerIndex, b.ColumnIndex)
+
+	if err := s.cfg.chain.ReceiveDataColumn(ctx, b); err != nil {
+		return err
+	}
+
+	s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
+		Type: opfeed.DataColumnSidecarReceived,
+		Data: &opfeed.DataColumnSidecarReceivedData{
+			DataColumn: b,
+		},
+	})
+
+	return nil
+}

--- a/beacon-chain/sync/validate_data_column_sidecar.go
+++ b/beacon-chain/sync/validate_data_column_sidecar.go
@@ -1,0 +1,110 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	prysmTime "github.com/prysmaticlabs/prysm/v5/time"
+	"github.com/prysmaticlabs/prysm/v5/time/slots"
+)
+
+func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubsub.Message) (pubsub.ValidationResult, error) {
+	receivedTime := prysmTime.Now()
+
+	if pid == s.cfg.p2p.PeerID() {
+		return pubsub.ValidationAccept, nil
+	}
+	if s.cfg.initialSync.Syncing() {
+		return pubsub.ValidationIgnore, nil
+	}
+	if msg.Topic == nil {
+		return pubsub.ValidationReject, errInvalidTopic
+	}
+	m, err := s.decodePubsubMessage(msg)
+	if err != nil {
+		log.WithError(err).Error("Failed to decode message")
+		return pubsub.ValidationReject, err
+	}
+
+	ds, ok := m.(*eth.DataColumnSidecar)
+	if !ok {
+		log.WithField("message", m).Error("Message is not of type *eth.DataColumnSidecar")
+		return pubsub.ValidationReject, errWrongMessage
+	}
+	if ds.ColumnIndex >= params.BeaconConfig().NumberOfColumns {
+		return pubsub.ValidationReject, errors.Errorf("invalid column index provided, got %d", ds.ColumnIndex)
+	}
+	want := fmt.Sprintf("data_column_sidecar_%d", computeSubnetForColumnSidecar(ds.ColumnIndex))
+	if !strings.Contains(*msg.Topic, want) {
+		log.Debug("Column Sidecar index does not match topic")
+		return pubsub.ValidationReject, fmt.Errorf("wrong topic name: %s", *msg.Topic)
+	}
+	if err := slots.VerifyTime(uint64(s.cfg.clock.GenesisTime().Unix()), ds.SignedBlockHeader.Header.Slot, params.BeaconConfig().MaximumGossipClockDisparityDuration()); err != nil {
+		log.WithError(err).Debug("Ignored sidecar: could not verify slot time")
+		return pubsub.ValidationIgnore, nil
+	}
+	cp := s.cfg.chain.FinalizedCheckpt()
+	startSlot, err := slots.EpochStart(cp.Epoch)
+	if err != nil {
+		log.WithError(err).Debug("Ignored column sidecar: could not calculate epoch start slot")
+		return pubsub.ValidationIgnore, nil
+	}
+	if startSlot >= ds.SignedBlockHeader.Header.Slot {
+		err := fmt.Errorf("finalized slot %d greater or equal to block slot %d", startSlot, ds.SignedBlockHeader.Header.Slot)
+		log.Debug(err)
+		return pubsub.ValidationIgnore, err
+	}
+	// Handle sidecar when the parent is unknown.
+	if !s.cfg.chain.HasBlock(ctx, [32]byte(ds.SignedBlockHeader.Header.ParentRoot)) {
+		err := errors.Errorf("unknown parent for data column sidecar with slot %d and parent root %#x", ds.SignedBlockHeader.Header.Slot, ds.SignedBlockHeader.Header.ParentRoot)
+		log.WithError(err).Debug("Could not identify parent for data column sidecar")
+		return pubsub.ValidationIgnore, err
+	}
+	if s.hasBadBlock([32]byte(ds.SignedBlockHeader.Header.ParentRoot)) {
+		bRoot, err := ds.SignedBlockHeader.Header.HashTreeRoot()
+		if err != nil {
+			return pubsub.ValidationIgnore, err
+		}
+		s.setBadBlock(ctx, bRoot)
+		return pubsub.ValidationReject, errors.Errorf("column sidecar with bad parent provided")
+	}
+	parentSlot, err := s.cfg.chain.RecentBlockSlot([32]byte(ds.SignedBlockHeader.Header.ParentRoot))
+	if err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+	if ds.SignedBlockHeader.Header.Slot <= parentSlot {
+		return pubsub.ValidationReject, errors.Errorf("invalid column sidecar slot: %d", ds.SignedBlockHeader.Header.Slot)
+	}
+	if !s.cfg.chain.InForkchoice([32]byte(ds.SignedBlockHeader.Header.ParentRoot)) {
+		return pubsub.ValidationReject, blockchain.ErrNotDescendantOfFinalized
+	}
+	// TODO Verify KZG inclusion proof of data column sidecar
+
+	// TODO Verify KZG proofs of column sidecar
+
+	startTime, err := slots.ToTime(uint64(s.cfg.chain.GenesisTime().Unix()), ds.SignedBlockHeader.Header.Slot)
+	if err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+
+	sinceSlotStartTime := receivedTime.Sub(startTime)
+	validationTime := s.cfg.clock.Now().Sub(receivedTime)
+	fields["sinceSlotStartTime"] = sinceSlotStartTime
+	fields["validationTime"] = validationTime
+	log.WithFields(fields).Debug("Received blob sidecar gossip")
+
+	msg.ValidatorData = vBlobData
+
+	return pubsub.ValidationAccept, nil
+}
+
+func computeSubnetForColumnSidecar(colIdx uint64) uint64 {
+	return colIdx % params.BeaconConfig().DataColumnSidecarSubnetCount
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR adds in support for data column gossip validation. It initializes the validation pipelines for data columns and adds in the respective subscriber. This will allow a peerDAS enabled node to subscribe to data columns. The only things left out are the validation of kzg inclusion proofs and kzg proofs which depend on #13877 . 

This PR also doesn't handle the column event handling in `blockchain`. That will be addressed in a future PR

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
