### PR TITLE
Change example.org DNS record

### DIFF
--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -317,7 +317,7 @@ func TestHostIsResolved(t *testing.T) {
 	// As defined in RFC 2606 , example.org is a
 	// reserved example domain name.
 	exampleHost := "example.org"
-	exampleIP := "93.184.216.34"
+	exampleIP := "93.184.215.14"
 
 	s := &Service{
 		cfg: &Config{


### PR DESCRIPTION
**What type of PR is this?**


Bug fix

DNS record has changed for example.org causing tests to fail.

A longer term fix might be changing this to a domain record prysm controls
