### PR TITLE
Refactor beacon-chain/core/helpers tests to be black box

### DIFF
--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -50,6 +50,8 @@ go_test(
         "attestation_test.go",
         "beacon_committee_test.go",
         "block_test.go",
+        "private_access_fuzz_noop_test.go",  # keep
+        "private_access_test.go",
         "randao_test.go",
         "rewards_penalties_test.go",
         "shuffle_test.go",

--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -140,7 +140,7 @@ func BeaconCommittee(
 	}
 	count := committeesPerSlot * uint64(params.BeaconConfig().SlotsPerEpoch)
 
-	return computeCommittee(validatorIndices, seed, indexOffset, count)
+	return ComputeCommittee(validatorIndices, seed, indexOffset, count)
 }
 
 // CommitteeAssignmentContainer represents a committee list, committee index, and to be attested slot for a given epoch.
@@ -359,7 +359,7 @@ func UpdateProposerIndicesInCache(ctx context.Context, state state.ReadOnlyBeaco
 	if err != nil {
 		return err
 	}
-	proposerIndices, err := precomputeProposerIndices(state, indices, epoch)
+	proposerIndices, err := PrecomputeProposerIndices(state, indices, epoch)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ func ClearCache() {
 	balanceCache.Clear()
 }
 
-// computeCommittee returns the requested shuffled committee out of the total committees using
+// ComputeCommittee returns the requested shuffled committee out of the total committees using
 // validator indices and seed.
 //
 // Spec pseudocode definition:
@@ -424,7 +424,7 @@ func ClearCache() {
 //	  start = (len(indices) * index) // count
 //	  end = (len(indices) * uint64(index + 1)) // count
 //	  return [indices[compute_shuffled_index(uint64(i), uint64(len(indices)), seed)] for i in range(start, end)]
-func computeCommittee(
+func ComputeCommittee(
 	indices []primitives.ValidatorIndex,
 	seed [32]byte,
 	index, count uint64,
@@ -451,9 +451,9 @@ func computeCommittee(
 	return shuffledList[start:end], nil
 }
 
-// This computes proposer indices of the current epoch and returns a list of proposer indices,
+// PrecomputeProposerIndices computes proposer indices of the current epoch and returns a list of proposer indices,
 // the index of the list represents the slot number.
-func precomputeProposerIndices(state state.ReadOnlyBeaconState, activeIndices []primitives.ValidatorIndex, e primitives.Epoch) ([]primitives.ValidatorIndex, error) {
+func PrecomputeProposerIndices(state state.ReadOnlyBeaconState, activeIndices []primitives.ValidatorIndex, e primitives.Epoch) ([]primitives.ValidatorIndex, error) {
 	hashFunc := hash.CustomSHA256Hasher()
 	proposerIndices := make([]primitives.ValidatorIndex, params.BeaconConfig().SlotsPerEpoch)
 

--- a/beacon-chain/core/helpers/private_access_fuzz_noop_test.go
+++ b/beacon-chain/core/helpers/private_access_fuzz_noop_test.go
@@ -1,0 +1,17 @@
+//go:build fuzz
+
+package helpers
+
+import "github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
+
+func CommitteeCache() *cache.FakeCommitteeCache {
+	return committeeCache
+}
+
+func SyncCommitteeCache() *cache.FakeSyncCommitteeCache {
+	return syncCommitteeCache
+}
+
+func ProposerIndicesCache() *cache.FakeProposerIndicesCache {
+	return proposerIndicesCache
+}

--- a/beacon-chain/core/helpers/private_access_test.go
+++ b/beacon-chain/core/helpers/private_access_test.go
@@ -1,0 +1,17 @@
+//go:build !fuzz
+
+package helpers
+
+import "github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
+
+func CommitteeCache() *cache.CommitteeCache {
+	return committeeCache
+}
+
+func SyncCommitteeCache() *cache.SyncCommitteeCache {
+	return syncCommitteeCache
+}
+
+func ProposerIndicesCache() *cache.ProposerIndicesCache {
+	return proposerIndicesCache
+}

--- a/beacon-chain/core/helpers/randao_test.go
+++ b/beacon-chain/core/helpers/randao_test.go
@@ -1,9 +1,10 @@
-package helpers
+package helpers_test
 
 import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	state_native "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
@@ -40,10 +41,10 @@ func TestRandaoMix_OK(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		require.NoError(t, state.SetSlot(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(test.epoch+1))))
-		mix, err := RandaoMix(state, test.epoch)
+		mix, err := helpers.RandaoMix(state, test.epoch)
 		require.NoError(t, err)
 		assert.DeepEqual(t, test.randaoMix, mix, "Incorrect randao mix")
 	}
@@ -76,10 +77,10 @@ func TestRandaoMix_CopyOK(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		require.NoError(t, state.SetSlot(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(test.epoch+1))))
-		mix, err := RandaoMix(state, test.epoch)
+		mix, err := helpers.RandaoMix(state, test.epoch)
 		require.NoError(t, err)
 		uniqueNumber := uint64(params.BeaconConfig().EpochsPerHistoricalVector.Add(1000))
 		binary.LittleEndian.PutUint64(mix, uniqueNumber)
@@ -92,7 +93,7 @@ func TestRandaoMix_CopyOK(t *testing.T) {
 }
 
 func TestGenerateSeed_OK(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	randaoMixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
 	for i := 0; i < len(randaoMixes); i++ {
@@ -107,7 +108,7 @@ func TestGenerateSeed_OK(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	got, err := Seed(state, 10, params.BeaconConfig().DomainBeaconAttester)
+	got, err := helpers.Seed(state, 10, params.BeaconConfig().DomainBeaconAttester)
 	require.NoError(t, err)
 
 	wanted := [32]byte{102, 82, 23, 40, 226, 79, 171, 11, 203, 23, 175, 7, 88, 202, 80,

--- a/beacon-chain/core/helpers/rewards_penalties_test.go
+++ b/beacon-chain/core/helpers/rewards_penalties_test.go
@@ -1,9 +1,10 @@
-package helpers
+package helpers_test
 
 import (
 	"math"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/time"
 	state_native "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestTotalBalance_OK(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Validators: []*ethpb.Validator{
 		{EffectiveBalance: 27 * 1e9}, {EffectiveBalance: 28 * 1e9},
@@ -22,19 +23,19 @@ func TestTotalBalance_OK(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	balance := TotalBalance(state, []primitives.ValidatorIndex{0, 1, 2, 3})
+	balance := helpers.TotalBalance(state, []primitives.ValidatorIndex{0, 1, 2, 3})
 	wanted := state.Validators()[0].EffectiveBalance + state.Validators()[1].EffectiveBalance +
 		state.Validators()[2].EffectiveBalance + state.Validators()[3].EffectiveBalance
 	assert.Equal(t, wanted, balance, "Incorrect TotalBalance")
 }
 
 func TestTotalBalance_ReturnsEffectiveBalanceIncrement(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Validators: []*ethpb.Validator{}})
 	require.NoError(t, err)
 
-	balance := TotalBalance(state, []primitives.ValidatorIndex{})
+	balance := helpers.TotalBalance(state, []primitives.ValidatorIndex{})
 	wanted := params.BeaconConfig().EffectiveBalanceIncrement
 	assert.Equal(t, wanted, balance, "Incorrect TotalBalance")
 }
@@ -51,7 +52,7 @@ func TestGetBalance_OK(t *testing.T) {
 		{i: 2, b: []uint64{0, 0, 0}},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Balances: test.b})
 		require.NoError(t, err)
@@ -68,7 +69,7 @@ func TestTotalActiveBalance(t *testing.T) {
 		{10000},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		validators := make([]*ethpb.Validator, 0)
 		for i := 0; i < test.vCount; i++ {
@@ -76,7 +77,7 @@ func TestTotalActiveBalance(t *testing.T) {
 		}
 		state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Validators: validators})
 		require.NoError(t, err)
-		bal, err := TotalActiveBalance(state)
+		bal, err := helpers.TotalActiveBalance(state)
 		require.NoError(t, err)
 		require.Equal(t, uint64(test.vCount)*params.BeaconConfig().MaxEffectiveBalance, bal)
 	}
@@ -91,7 +92,7 @@ func TestTotalActiveBal_ReturnMin(t *testing.T) {
 		{10000},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		validators := make([]*ethpb.Validator, 0)
 		for i := 0; i < test.vCount; i++ {
@@ -99,7 +100,7 @@ func TestTotalActiveBal_ReturnMin(t *testing.T) {
 		}
 		state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Validators: validators})
 		require.NoError(t, err)
-		bal, err := TotalActiveBalance(state)
+		bal, err := helpers.TotalActiveBalance(state)
 		require.NoError(t, err)
 		require.Equal(t, params.BeaconConfig().EffectiveBalanceIncrement, bal)
 	}
@@ -115,7 +116,7 @@ func TestTotalActiveBalance_WithCache(t *testing.T) {
 		{vCount: 10000, wantCount: 10000},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		validators := make([]*ethpb.Validator, 0)
 		for i := 0; i < test.vCount; i++ {
@@ -123,7 +124,7 @@ func TestTotalActiveBalance_WithCache(t *testing.T) {
 		}
 		state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{Validators: validators})
 		require.NoError(t, err)
-		bal, err := TotalActiveBalance(state)
+		bal, err := helpers.TotalActiveBalance(state)
 		require.NoError(t, err)
 		require.Equal(t, uint64(test.wantCount)*params.BeaconConfig().MaxEffectiveBalance, bal)
 	}
@@ -141,7 +142,7 @@ func TestIncreaseBalance_OK(t *testing.T) {
 		{i: 2, b: []uint64{27 * 1e9, 28 * 1e9, 32 * 1e9}, nb: 33 * 1e9, eb: 65 * 1e9},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 			Validators: []*ethpb.Validator{
@@ -149,7 +150,7 @@ func TestIncreaseBalance_OK(t *testing.T) {
 			Balances: test.b,
 		})
 		require.NoError(t, err)
-		require.NoError(t, IncreaseBalance(state, test.i, test.nb))
+		require.NoError(t, helpers.IncreaseBalance(state, test.i, test.nb))
 		assert.Equal(t, test.eb, state.Balances()[test.i], "Incorrect Validator balance")
 	}
 }
@@ -167,7 +168,7 @@ func TestDecreaseBalance_OK(t *testing.T) {
 		{i: 3, b: []uint64{27 * 1e9, 28 * 1e9, 1, 28 * 1e9}, nb: 28 * 1e9, eb: 0},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 			Validators: []*ethpb.Validator{
@@ -175,13 +176,13 @@ func TestDecreaseBalance_OK(t *testing.T) {
 			Balances: test.b,
 		})
 		require.NoError(t, err)
-		require.NoError(t, DecreaseBalance(state, test.i, test.nb))
+		require.NoError(t, helpers.DecreaseBalance(state, test.i, test.nb))
 		assert.Equal(t, test.eb, state.Balances()[test.i], "Incorrect Validator balance")
 	}
 }
 
 func TestFinalityDelay(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	base := buildState(params.BeaconConfig().SlotsPerEpoch*10, 1)
 	base.FinalizedCheckpoint = &ethpb.Checkpoint{Epoch: 3}
@@ -195,25 +196,25 @@ func TestFinalityDelay(t *testing.T) {
 		finalizedEpoch = beaconState.FinalizedCheckpointEpoch()
 	}
 	setVal()
-	d := FinalityDelay(prevEpoch, finalizedEpoch)
+	d := helpers.FinalityDelay(prevEpoch, finalizedEpoch)
 	w := time.PrevEpoch(beaconState) - beaconState.FinalizedCheckpointEpoch()
 	assert.Equal(t, w, d, "Did not get wanted finality delay")
 
 	require.NoError(t, beaconState.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 4}))
 	setVal()
-	d = FinalityDelay(prevEpoch, finalizedEpoch)
+	d = helpers.FinalityDelay(prevEpoch, finalizedEpoch)
 	w = time.PrevEpoch(beaconState) - beaconState.FinalizedCheckpointEpoch()
 	assert.Equal(t, w, d, "Did not get wanted finality delay")
 
 	require.NoError(t, beaconState.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 5}))
 	setVal()
-	d = FinalityDelay(prevEpoch, finalizedEpoch)
+	d = helpers.FinalityDelay(prevEpoch, finalizedEpoch)
 	w = time.PrevEpoch(beaconState) - beaconState.FinalizedCheckpointEpoch()
 	assert.Equal(t, w, d, "Did not get wanted finality delay")
 }
 
 func TestIsInInactivityLeak(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	base := buildState(params.BeaconConfig().SlotsPerEpoch*10, 1)
 	base.FinalizedCheckpoint = &ethpb.Checkpoint{Epoch: 3}
@@ -227,13 +228,13 @@ func TestIsInInactivityLeak(t *testing.T) {
 		finalizedEpoch = beaconState.FinalizedCheckpointEpoch()
 	}
 	setVal()
-	assert.Equal(t, true, IsInInactivityLeak(prevEpoch, finalizedEpoch), "Wanted inactivity leak true")
+	assert.Equal(t, true, helpers.IsInInactivityLeak(prevEpoch, finalizedEpoch), "Wanted inactivity leak true")
 	require.NoError(t, beaconState.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 4}))
 	setVal()
-	assert.Equal(t, true, IsInInactivityLeak(prevEpoch, finalizedEpoch), "Wanted inactivity leak true")
+	assert.Equal(t, true, helpers.IsInInactivityLeak(prevEpoch, finalizedEpoch), "Wanted inactivity leak true")
 	require.NoError(t, beaconState.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 5}))
 	setVal()
-	assert.Equal(t, false, IsInInactivityLeak(prevEpoch, finalizedEpoch), "Wanted inactivity leak false")
+	assert.Equal(t, false, helpers.IsInInactivityLeak(prevEpoch, finalizedEpoch), "Wanted inactivity leak false")
 }
 
 func buildState(slot primitives.Slot, validatorCount uint64) *ethpb.BeaconState {
@@ -285,7 +286,7 @@ func TestIncreaseBadBalance_NotOK(t *testing.T) {
 		{i: 2, b: []uint64{math.MaxUint64, math.MaxUint64, math.MaxUint64}, nb: 33 * 1e9},
 	}
 	for _, test := range tests {
-		ClearCache()
+		helpers.ClearCache()
 
 		state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 			Validators: []*ethpb.Validator{
@@ -293,6 +294,6 @@ func TestIncreaseBadBalance_NotOK(t *testing.T) {
 			Balances: test.b,
 		})
 		require.NoError(t, err)
-		require.ErrorContains(t, "addition overflows", IncreaseBalance(state, test.i, test.nb))
+		require.ErrorContains(t, "addition overflows", helpers.IncreaseBalance(state, test.i, test.nb))
 	}
 }

--- a/beacon-chain/core/helpers/sync_committee.go
+++ b/beacon-chain/core/helpers/sync_committee.go
@@ -26,7 +26,7 @@ var (
 // 1. Checks if the public key exists in the sync committee cache
 // 2. If 1 fails, checks if the public key exists in the input current sync committee object
 func IsCurrentPeriodSyncCommittee(st state.BeaconState, valIdx primitives.ValidatorIndex) (bool, error) {
-	root, err := syncPeriodBoundaryRoot(st)
+	root, err := SyncPeriodBoundaryRoot(st)
 	if err != nil {
 		return false, err
 	}
@@ -63,7 +63,7 @@ func IsCurrentPeriodSyncCommittee(st state.BeaconState, valIdx primitives.Valida
 func IsNextPeriodSyncCommittee(
 	st state.BeaconState, valIdx primitives.ValidatorIndex,
 ) (bool, error) {
-	root, err := syncPeriodBoundaryRoot(st)
+	root, err := SyncPeriodBoundaryRoot(st)
 	if err != nil {
 		return false, err
 	}
@@ -90,7 +90,7 @@ func IsNextPeriodSyncCommittee(
 func CurrentPeriodSyncSubcommitteeIndices(
 	st state.BeaconState, valIdx primitives.ValidatorIndex,
 ) ([]primitives.CommitteeIndex, error) {
-	root, err := syncPeriodBoundaryRoot(st)
+	root, err := SyncPeriodBoundaryRoot(st)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func CurrentPeriodSyncSubcommitteeIndices(
 func NextPeriodSyncSubcommitteeIndices(
 	st state.BeaconState, valIdx primitives.ValidatorIndex,
 ) ([]primitives.CommitteeIndex, error) {
-	root, err := syncPeriodBoundaryRoot(st)
+	root, err := SyncPeriodBoundaryRoot(st)
 	if err != nil {
 		return nil, err
 	}
@@ -182,10 +182,10 @@ func findSubCommitteeIndices(pubKey []byte, pubKeys [][]byte) []primitives.Commi
 	return indices
 }
 
-// Retrieve the current sync period boundary root by calculating sync period start epoch
+// SyncPeriodBoundaryRoot computes the current sync period boundary root by calculating sync period start epoch
 // and calling `BlockRoot`.
 // It uses the boundary slot - 1 for block root. (Ex: SlotsPerEpoch * EpochsPerSyncCommitteePeriod - 1)
-func syncPeriodBoundaryRoot(st state.ReadOnlyBeaconState) ([32]byte, error) {
+func SyncPeriodBoundaryRoot(st state.ReadOnlyBeaconState) ([32]byte, error) {
 	// Can't call `BlockRoot` until the first slot.
 	if st.Slot() == params.BeaconConfig().GenesisSlot {
 		return params.BeaconConfig().ZeroHash, nil

--- a/beacon-chain/core/helpers/sync_committee_test.go
+++ b/beacon-chain/core/helpers/sync_committee_test.go
@@ -1,4 +1,4 @@
-package helpers
+package helpers_test
 
 import (
 	"math/rand"
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	state_native "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestIsCurrentEpochSyncCommittee_UsingCache(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -40,15 +41,15 @@ func TestIsCurrentEpochSyncCommittee_UsingCache(t *testing.T) {
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
 	r := [32]byte{'a'}
-	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+	require.NoError(t, err, helpers.SyncCommitteeCache().UpdatePositionsInCommittee(r, state))
 
-	ok, err := IsCurrentPeriodSyncCommittee(state, 0)
+	ok, err := helpers.IsCurrentPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
 
 func TestIsCurrentEpochSyncCommittee_UsingCommittee(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -70,13 +71,13 @@ func TestIsCurrentEpochSyncCommittee_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsCurrentPeriodSyncCommittee(state, 0)
+	ok, err := helpers.IsCurrentPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
 
 func TestIsCurrentEpochSyncCommittee_DoesNotExist(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -98,13 +99,13 @@ func TestIsCurrentEpochSyncCommittee_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsCurrentPeriodSyncCommittee(state, 12390192)
+	ok, err := helpers.IsCurrentPeriodSyncCommittee(state, 12390192)
 	require.ErrorContains(t, "validator index 12390192 does not exist", err)
 	require.Equal(t, false, ok)
 }
 
 func TestIsNextEpochSyncCommittee_UsingCache(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -127,15 +128,15 @@ func TestIsNextEpochSyncCommittee_UsingCache(t *testing.T) {
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
 	r := [32]byte{'a'}
-	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+	require.NoError(t, err, helpers.SyncCommitteeCache().UpdatePositionsInCommittee(r, state))
 
-	ok, err := IsNextPeriodSyncCommittee(state, 0)
+	ok, err := helpers.IsNextPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
 
 func TestIsNextEpochSyncCommittee_UsingCommittee(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -157,13 +158,13 @@ func TestIsNextEpochSyncCommittee_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsNextPeriodSyncCommittee(state, 0)
+	ok, err := helpers.IsNextPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
 
 func TestIsNextEpochSyncCommittee_DoesNotExist(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -185,13 +186,13 @@ func TestIsNextEpochSyncCommittee_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsNextPeriodSyncCommittee(state, 120391029)
+	ok, err := helpers.IsNextPeriodSyncCommittee(state, 120391029)
 	require.ErrorContains(t, "validator index 120391029 does not exist", err)
 	require.Equal(t, false, ok)
 }
 
 func TestCurrentEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -214,15 +215,15 @@ func TestCurrentEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
 	r := [32]byte{'a'}
-	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+	require.NoError(t, err, helpers.SyncCommitteeCache().UpdatePositionsInCommittee(r, state))
 
-	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 0)
+	index, err := helpers.CurrentPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []primitives.CommitteeIndex{0}, index)
 }
 
 func TestCurrentEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -243,27 +244,27 @@ func TestCurrentEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
-	root, err := syncPeriodBoundaryRoot(state)
+	root, err := helpers.SyncPeriodBoundaryRoot(state)
 	require.NoError(t, err)
 
 	// Test that cache was empty.
-	_, err = syncCommitteeCache.CurrentPeriodIndexPosition(root, 0)
+	_, err = helpers.SyncCommitteeCache().CurrentPeriodIndexPosition(root, 0)
 	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
 
 	// Test that helper can retrieve the index given empty cache.
-	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 0)
+	index, err := helpers.CurrentPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []primitives.CommitteeIndex{0}, index)
 
 	// Test that cache was able to fill on miss.
 	time.Sleep(100 * time.Millisecond)
-	index, err = syncCommitteeCache.CurrentPeriodIndexPosition(root, 0)
+	index, err = helpers.SyncCommitteeCache().CurrentPeriodIndexPosition(root, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []primitives.CommitteeIndex{0}, index)
 }
 
 func TestCurrentEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -285,13 +286,13 @@ func TestCurrentEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 129301923)
+	index, err := helpers.CurrentPeriodSyncSubcommitteeIndices(state, 129301923)
 	require.ErrorContains(t, "validator index 129301923 does not exist", err)
 	require.DeepEqual(t, []primitives.CommitteeIndex(nil), index)
 }
 
 func TestNextEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -314,15 +315,15 @@ func TestNextEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
 	r := [32]byte{'a'}
-	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+	require.NoError(t, err, helpers.SyncCommitteeCache().UpdatePositionsInCommittee(r, state))
 
-	index, err := NextPeriodSyncSubcommitteeIndices(state, 0)
+	index, err := helpers.NextPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []primitives.CommitteeIndex{0}, index)
 }
 
 func TestNextEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -344,13 +345,13 @@ func TestNextEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	index, err := NextPeriodSyncSubcommitteeIndices(state, 0)
+	index, err := helpers.NextPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []primitives.CommitteeIndex{0}, index)
 }
 
 func TestNextEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -372,43 +373,43 @@ func TestNextEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	index, err := NextPeriodSyncSubcommitteeIndices(state, 21093019)
+	index, err := helpers.NextPeriodSyncSubcommitteeIndices(state, 21093019)
 	require.ErrorContains(t, "validator index 21093019 does not exist", err)
 	require.DeepEqual(t, []primitives.CommitteeIndex(nil), index)
 }
 
 func TestUpdateSyncCommitteeCache_BadSlot(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 		Slot: 1,
 	})
 	require.NoError(t, err)
-	err = UpdateSyncCommitteeCache(state)
+	err = helpers.UpdateSyncCommitteeCache(state)
 	require.ErrorContains(t, "not at the end of the epoch to update cache", err)
 
 	state, err = state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 		Slot: params.BeaconConfig().SlotsPerEpoch - 1,
 	})
 	require.NoError(t, err)
-	err = UpdateSyncCommitteeCache(state)
+	err = helpers.UpdateSyncCommitteeCache(state)
 	require.ErrorContains(t, "not at sync committee period boundary to update cache", err)
 }
 
 func TestUpdateSyncCommitteeCache_BadRoot(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 		Slot:              primitives.Slot(params.BeaconConfig().EpochsPerSyncCommitteePeriod)*params.BeaconConfig().SlotsPerEpoch - 1,
 		LatestBlockHeader: &ethpb.BeaconBlockHeader{StateRoot: params.BeaconConfig().ZeroHash[:]},
 	})
 	require.NoError(t, err)
-	err = UpdateSyncCommitteeCache(state)
+	err = helpers.UpdateSyncCommitteeCache(state)
 	require.ErrorContains(t, "zero hash state root can't be used to update cache", err)
 }
 
 func TestIsCurrentEpochSyncCommittee_SameBlockRoot(t *testing.T) {
-	ClearCache()
+	helpers.ClearCache()
 
 	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
 	syncCommittee := &ethpb.SyncCommittee{
@@ -435,7 +436,7 @@ func TestIsCurrentEpochSyncCommittee_SameBlockRoot(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	comIdxs, err := CurrentPeriodSyncSubcommitteeIndices(state, 200)
+	comIdxs, err := helpers.CurrentPeriodSyncSubcommitteeIndices(state, 200)
 	require.NoError(t, err)
 
 	wantedSlot := params.BeaconConfig().EpochsPerSyncCommitteePeriod.Mul(uint64(params.BeaconConfig().SlotsPerEpoch))
@@ -446,7 +447,7 @@ func TestIsCurrentEpochSyncCommittee_SameBlockRoot(t *testing.T) {
 		syncCommittee.Pubkeys[i], syncCommittee.Pubkeys[j] = syncCommittee.Pubkeys[j], syncCommittee.Pubkeys[i]
 	})
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
-	newIdxs, err := CurrentPeriodSyncSubcommitteeIndices(state, 200)
+	newIdxs, err := helpers.CurrentPeriodSyncSubcommitteeIndices(state, 200)
 	require.NoError(t, err)
 	require.DeepNotEqual(t, comIdxs, newIdxs)
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

I started doing this as part of #13903, but probably won't need it there. 

In any case, I think it's a good pattern to adopt so I'm propose these changes here. The gist is
that the tests should call the imported package as if it were using the public API. There are some
test setups that require access to the private caches. Therefore, a privace_access_test.go is added
to surface package private methods or members to the tests.

**Which issues(s) does this PR fix?**

**Other notes for review**
