### PR TITLE
spectests: fail hard on missing test folders

### DIFF
--- a/testing/spectest/utils/utils.go
+++ b/testing/spectest/utils/utils.go
@@ -35,9 +35,7 @@ func UnmarshalYaml(y []byte, dest interface{}) error {
 func TestFolders(t testing.TB, config, forkOrPhase, folderPath string) ([]os.DirEntry, string) {
 	testsFolderPath := path.Join("tests", config, forkOrPhase, folderPath)
 	filepath, err := bazel.Runfile(testsFolderPath)
-	if err != nil {
-		return nil, ""
-	}
+	require.NoError(t, err)
 	testFolders, err := os.ReadDir(filepath)
 	require.NoError(t, err)
 


### PR DESCRIPTION

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

I noticed that an invalid spectest directory will pass successfully. This PR prevents that.

**Which issues(s) does this PR fix?**

**Other notes for review**
