### PR TITLE
Use optimized builds by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,7 @@ coverage --define=coverage_enabled=1
 build --workspace_status_command=./hack/workspace_status.sh
 
 build --define blst_disabled=false
+build --compilation_mode=opt
 run --define blst_disabled=false
 
 build:blst_disabled --define blst_disabled=true


### PR DESCRIPTION
**What type of PR is this?**

Build Fix

**What does this PR do? Why is it needed?**

Fixes builds for peerDAS branch by running optimized builds by default. Our default paths were not able to link our ckzg lib correctly. This is a workaround till our default paths have no issues compiling ckzg

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
