### PR TITLE
[DRAFT] Horusec: fix docker misconfiguration

### DIFF
--- a/.github/actions/gomodtidy/Dockerfile
+++ b/.github/actions/gomodtidy/Dockerfile
@@ -2,4 +2,6 @@ FROM golang:1.21-alpine
 
 COPY entrypoint.sh /entrypoint.sh
 
+USER nonroot
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/tools/cross-toolchain/Dockerfile
+++ b/tools/cross-toolchain/Dockerfile
@@ -17,14 +17,14 @@ RUN apt-get update && \
 
 # install llvm/clang cross-build toolchains
 ENV INSTALL_LLVM_VERSION=12.0.0
-ADD install_clang_cross.sh /tmp/install_clang_cross.sh
+COPY install_clang_cross.sh /tmp/install_clang_cross.sh
 RUN /tmp/install_clang_cross.sh
 
 # install osxcross
-ADD install_osxcross.sh /tmp/install_osxcross.sh
-ADD common_osxcross.sh /tmp/common_osxcross.sh
+COPY install_osxcross.sh /tmp/install_osxcross.sh
+COPY common_osxcross.sh /tmp/common_osxcross.sh
 RUN /tmp/install_osxcross.sh
-ADD link_osxcross.sh /tmp/link_osxcross.sh
+COPY link_osxcross.sh /tmp/link_osxcross.sh
 RUN /tmp/link_osxcross.sh
 
 # containerized development environment


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
as described into issue this pr aimed to fix some docker misconfiguration in docker files
<details>
  <summary>Running containers with 'root' user</summary>
  
  ```
Language: Generic
Severity: HIGH
Line: 0
Column: 0
SecurityTool: Trivy
Confidence: MEDIUM
File: /Users/.../prysm/.github/actions/gomodtidy/Dockerfile
Code: root user
Type: Vulnerability
ReferenceHash: 49099b0d2b0686ce3e0cb8e08691995be9ecca43fe18467fdf5ee1e28c8cdfaa
Details: (1/1) * Possible vulnerability detected: MissConfiguration
      Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.
      Message: Specify at least 1 USER command in Dockerfile with non-root user as argument
      Resolution: Add 'USER <non root user name>' line to the Dockerfile
      References: [https://docs.docker.com/develop/develop-images/dockerfile_best-practices/ https://avd.aquasec.com/appshield/ds002]
  ```
  
</details>

<details>
  <summary>You should use COPY instead of ADD</summary>
    
  ```
Language: Generic
Severity: LOW
Line: 0
Column: 0
SecurityTool: Trivy
Confidence: MEDIUM
File: /Users/.../prysm/tools/cross-toolchain/Dockerfile
Code: ADD instead of COPY
Type: Vulnerability
ReferenceHash: b6531b86d3c2ac67764225661d153d41192a48493ec90b1ca788cdca7828ca3f
Details: (1/4) * Possible vulnerability detected: MissConfiguration
      You should use COPY instead of ADD unless you want to extract a tar file. Note that an ADD command will extract a tar file, which adds the risk of Zip-based vulnerabilities. Accordingly, it is advised to use a COPY command, which does not extract tar files.
      Message: Consider using 'COPY common_osxcross.sh /tmp/common_osxcross.sh' command instead of 'ADD common_osxcross.sh /tmp/common_osxcross.sh'
      Resolution: Use COPY instead of ADD
      References: [https://docs.docker.com/engine/reference/builder/#add https://avd.aquasec.com/appshield/ds005]
         
(2/4) * Possible vulnerability detected: MissConfiguration
      You should use COPY instead of ADD unless you want to extract a tar file. Note that an ADD command will extract a tar file, which adds the risk of Zip-based vulnerabilities. Accordingly, it is advised to use a COPY command, which does not extract tar files.
      Message: Consider using 'COPY install_clang_cross.sh /tmp/install_clang_cross.sh' command instead of 'ADD install_clang_cross.sh /tmp/install_clang_cross.sh'
      Resolution: Use COPY instead of ADD
      References: [https://docs.docker.com/engine/reference/builder/#add https://avd.aquasec.com/appshield/ds005]
         
(3/4) * Possible vulnerability detected: MissConfiguration
      You should use COPY instead of ADD unless you want to extract a tar file. Note that an ADD command will extract a tar file, which adds the risk of Zip-based vulnerabilities. Accordingly, it is advised to use a COPY command, which does not extract tar files.
      Message: Consider using 'COPY install_osxcross.sh /tmp/install_osxcross.sh' command instead of 'ADD install_osxcross.sh /tmp/install_osxcross.sh'
      Resolution: Use COPY instead of ADD
      References: [https://docs.docker.com/engine/reference/builder/#add https://avd.aquasec.com/appshield/ds005]
         
(4/4) * Possible vulnerability detected: MissConfiguration
      You should use COPY instead of ADD unless you want to extract a tar file. Note that an ADD command will extract a tar file, which adds the risk of Zip-based vulnerabilities. Accordingly, it is advised to use a COPY command, which does not extract tar files.
      Message: Consider using 'COPY link_osxcross.sh /tmp/link_osxcross.sh' command instead of 'ADD link_osxcross.sh /tmp/link_osxcross.sh'
      Resolution: Use COPY instead of ADD
      References: [https://docs.docker.com/engine/reference/builder/#add https://avd.aquasec.com/appshield/ds005]

  ```
  
</details>


**Which issues(s) does this PR fix?**
fixes https://github.com/prysmaticlabs/prysm/issues/13791

**Other notes for review**
this is additional step for fixing all horusec vulnerabilities, and way to adding horusec into ci
