### PR TITLE
Fork-specific consensus-types interfaces

### DIFF
--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -35,6 +35,8 @@ func NewWrappedExecutionData(v proto.Message, weiValue math.Wei) (interfaces.Exe
 		return WrappedExecutionPayloadCapella(pbStruct, weiValue)
 	case *enginev1.ExecutionPayloadDeneb:
 		return WrappedExecutionPayloadDeneb(pbStruct, weiValue)
+	case *enginev1.ExecutionPayloadElectra:
+		return WrappedExecutionPayloadElectra(pbStruct, weiValue)
 	default:
 		return nil, ErrUnsupportedVersion
 	}

--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -1455,26 +1455,6 @@ func (e executionPayloadHeaderElectra) ExcessBlobGas() (uint64, error) {
 	return e.p.ExcessBlobGas, nil
 }
 
-// PbElectra --
-func (e executionPayloadHeaderElectra) PbElectra() (*enginev1.ExecutionPayloadElectra, error) {
-	return nil, consensus_types.ErrUnsupportedField
-}
-
-// PbDeneb --
-func (executionPayloadHeaderElectra) PbDeneb() (*enginev1.ExecutionPayloadDeneb, error) {
-	return nil, consensus_types.ErrUnsupportedField
-}
-
-// PbBellatrix --
-func (executionPayloadHeaderElectra) PbBellatrix() (*enginev1.ExecutionPayload, error) {
-	return nil, consensus_types.ErrUnsupportedField
-}
-
-// PbCapella --
-func (executionPayloadHeaderElectra) PbCapella() (*enginev1.ExecutionPayloadCapella, error) {
-	return nil, consensus_types.ErrUnsupportedField
-}
-
 // ValueInWei --
 func (e executionPayloadHeaderElectra) ValueInWei() (math.Wei, error) {
 	return e.weiValue, nil
@@ -1652,26 +1632,6 @@ func (e executionPayloadElectra) BlobGasUsed() (uint64, error) {
 
 func (e executionPayloadElectra) ExcessBlobGas() (uint64, error) {
 	return e.p.ExcessBlobGas, nil
-}
-
-// PbBellatrix --
-func (e executionPayloadElectra) PbBellatrix() (*enginev1.ExecutionPayload, error) {
-	return nil, consensus_types.ErrUnsupportedField
-}
-
-// PbCapella --
-func (e executionPayloadElectra) PbCapella() (*enginev1.ExecutionPayloadCapella, error) {
-	return nil, consensus_types.ErrUnsupportedField
-}
-
-// PbDeneb --
-func (e executionPayloadElectra) PbDeneb() (*enginev1.ExecutionPayloadDeneb, error) {
-	return nil, consensus_types.ErrUnsupportedField
-}
-
-// PbElectra --
-func (e executionPayloadElectra) PbElectra() (*enginev1.ExecutionPayloadElectra, error) {
-	return e.p, nil
 }
 
 // ValueInWei --

--- a/consensus-types/blocks/factory.go
+++ b/consensus-types/blocks/factory.go
@@ -460,10 +460,11 @@ func BuildSignedBeaconBlockFromExecutionPayload(blk interfaces.ReadOnlySignedBea
 		if err != nil {
 			return nil, err
 		}
-		consolidations, err := b.Body().Consolidations()
-		if err != nil {
-			return nil, err
+		electraBody, ok := b.Body().(interfaces.ROBlockBodyElectra)
+		if !ok {
+			return nil, errors.Wrapf(interfaces.ErrInvalidCast, "%T does not support electra getters", b.Body())
 		}
+		consolidations := electraBody.Consolidations()
 		var atts []*eth.AttestationElectra
 		if b.Body().Attestations() != nil {
 			atts = make([]*eth.AttestationElectra, len(b.Body().Attestations()))

--- a/consensus-types/blocks/factory_test.go
+++ b/consensus-types/blocks/factory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
@@ -535,5 +536,28 @@ func TestBuildSignedBeaconBlockFromExecutionPayload(t *testing.T) {
 		require.DeepEqual(t, payload, got.Proto())
 		require.DeepEqual(t, uint64(123), payload.ExcessBlobGas)
 		require.DeepEqual(t, uint64(321), payload.BlobGasUsed)
+	})
+}
+
+func TestElectraBlockBodyCast(t *testing.T) {
+	t.Run("deneb cast fails", func(t *testing.T) {
+		pb := &eth.BeaconBlockBodyDeneb{}
+		i, err := NewBeaconBlockBody(pb)
+		require.NoError(t, err)
+		b, ok := i.(*BeaconBlockBody)
+		require.Equal(t, true, ok)
+		assert.Equal(t, version.Deneb, b.version)
+		_, err = interfaces.AsROBlockBodyElectra(b)
+		require.ErrorIs(t, err, interfaces.ErrInvalidCast)
+	})
+	t.Run("electra cast succeeds", func(t *testing.T) {
+		pb := &eth.BeaconBlockBodyElectra{}
+		i, err := NewBeaconBlockBody(pb)
+		require.NoError(t, err)
+		b, ok := i.(*BeaconBlockBody)
+		require.Equal(t, true, ok)
+		assert.Equal(t, version.Electra, b.version)
+		_, err = interfaces.AsROBlockBodyElectra(b)
+		require.NoError(t, err)
 	})
 }

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -252,7 +252,11 @@ func (b *SignedBeaconBlock) ToBlinded() (interfaces.ReadOnlySignedBeaconBlock, e
 				Signature: b.signature[:],
 			})
 	case *enginev1.ExecutionPayloadElectra:
-		header, err := PayloadToHeaderElectra(payload)
+		pe, ok := payload.(interfaces.ExecutionDataElectra)
+		if !ok {
+			return nil, interfaces.ErrIncompatibleFork
+		}
+		header, err := PayloadToHeaderElectra(pe)
 		if err != nil {
 			return nil, err
 		}
@@ -281,7 +285,6 @@ func (b *SignedBeaconBlock) ToBlinded() (interfaces.ReadOnlySignedBeaconBlock, e
 				},
 				Signature: b.signature[:],
 			})
-
 	default:
 		return nil, fmt.Errorf("%T is not an execution payload header", p)
 	}
@@ -1170,11 +1173,8 @@ func (b *BeaconBlockBody) BlobKzgCommitments() ([][]byte, error) {
 	}
 }
 
-func (b *BeaconBlockBody) Consolidations() ([]*eth.SignedConsolidation, error) {
-	if b.version < version.Electra {
-		return nil, consensus_types.ErrNotSupported("Consolidations", b.version)
-	}
-	return b.signedConsolidations, nil
+func (b *BeaconBlockBody) Consolidations() []*eth.SignedConsolidation {
+	return b.signedConsolidations
 }
 
 // Version returns the version of the beacon block body

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -490,3 +490,9 @@ func hydrateBeaconBlockBody() *eth.BeaconBlockBody {
 		},
 	}
 }
+
+func TestPreElectraFailsInterfaceAssertion(t *testing.T) {
+	var epd interfaces.ExecutionData = &executionPayloadDeneb{}
+	_, ok := epd.(interfaces.ExecutionDataElectra)
+	require.Equal(t, false, ok)
+}

--- a/consensus-types/blocks/types.go
+++ b/consensus-types/blocks/types.go
@@ -57,6 +57,9 @@ type BeaconBlockBody struct {
 	signedConsolidations     []*eth.SignedConsolidation
 }
 
+var _ interfaces.ReadOnlyBeaconBlockBody = &BeaconBlockBody{}
+var _ interfaces.ROBlockBodyElectra = &BeaconBlockBody{}
+
 // BeaconBlock is the main beacon block structure. It can represent any block type.
 type BeaconBlock struct {
 	version       int

--- a/consensus-types/interfaces/BUILD.bazel
+++ b/consensus-types/interfaces/BUILD.bazel
@@ -4,6 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "beacon_block.go",
+        "cast.go",
+        "error.go",
         "utils.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces",
@@ -15,6 +17,7 @@ go_library(
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/prysm/v1alpha1/validator-client:go_default_library",
+        "//runtime/version:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_fastssz//:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
@@ -24,14 +27,19 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["utils_test.go"],
+    srcs = [
+        "error_test.go",
+        "utils_test.go",
+    ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//config/fieldparams:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//runtime/version:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
     ],
 )

--- a/consensus-types/interfaces/beacon_block.go
+++ b/consensus-types/interfaces/beacon_block.go
@@ -1,6 +1,7 @@
 package interfaces
 
 import (
+	"github.com/pkg/errors"
 	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/go-bitfield"
 	field_params "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
@@ -11,6 +12,8 @@ import (
 	validatorpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1/validator-client"
 	"google.golang.org/protobuf/proto"
 )
+
+var ErrIncompatibleFork = errors.New("Can't convert to fork-specific interface")
 
 // ReadOnlySignedBeaconBlock is an interface describing the method set of
 // a signed beacon block.
@@ -70,7 +73,11 @@ type ReadOnlyBeaconBlockBody interface {
 	Execution() (ExecutionData, error)
 	BLSToExecutionChanges() ([]*ethpb.SignedBLSToExecutionChange, error)
 	BlobKzgCommitments() ([][]byte, error)
-	Consolidations() ([]*ethpb.SignedConsolidation, error)
+}
+
+type ROBlockBodyElectra interface {
+	ReadOnlyBeaconBlockBody
+	Consolidations() []*ethpb.SignedConsolidation
 }
 
 type SignedBeaconBlock interface {
@@ -125,8 +132,12 @@ type ExecutionData interface {
 	WithdrawalsRoot() ([]byte, error)
 	ValueInWei() (math.Wei, error)
 	ValueInGwei() (uint64, error)
-	DepositReceipts() ([]*enginev1.DepositReceipt, error)
-	WithdrawalRequests() ([]*enginev1.ExecutionLayerWithdrawalRequest, error)
+}
+
+type ExecutionDataElectra interface {
+	ExecutionData
+	DepositReceipts() []*enginev1.DepositReceipt
+	WithdrawalRequests() []*enginev1.ExecutionLayerWithdrawalRequest
 }
 
 type Attestation interface {

--- a/consensus-types/interfaces/cast.go
+++ b/consensus-types/interfaces/cast.go
@@ -1,0 +1,15 @@
+package interfaces
+
+import "github.com/prysmaticlabs/prysm/v5/runtime/version"
+
+// AsROBlockBodyElectra safely asserts the ReadOnlyBeaconBlockBody to a ROBlockBodyElectra.
+// This allows the caller to access methods on the block body which are only available on values after
+// the Electra hard fork. If the value is for an earlier fork (based on comparing its Version() to the electra version)
+// an error will be returned. Callers that want to conditionally process electra data can check for this condition
+// and safely ignore it like `if err != nil && errors.Is(interfaces.ErrInvalidCast) {`
+func AsROBlockBodyElectra(in ReadOnlyBeaconBlockBody) (ROBlockBodyElectra, error) {
+	if in.Version() >= version.Electra {
+		return in.(ROBlockBodyElectra), nil
+	}
+	return nil, NewInvalidCastError(in.Version(), version.Electra)
+}

--- a/consensus-types/interfaces/error.go
+++ b/consensus-types/interfaces/error.go
@@ -1,0 +1,27 @@
+package interfaces
+
+import (
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
+)
+
+var ErrInvalidCast = errors.New("unable to cast between types")
+
+type InvalidCastError struct {
+	from int
+	to   int
+}
+
+func (e *InvalidCastError) Error() string {
+	return errors.Wrapf(ErrInvalidCast,
+		"from=%s(%d), to=%s(%d)", version.String(e.from), e.from, version.String(e.to), e.to).
+		Error()
+}
+
+func (e *InvalidCastError) Is(err error) bool {
+	return errors.Is(err, ErrInvalidCast)
+}
+
+func NewInvalidCastError(from, to int) *InvalidCastError {
+	return &InvalidCastError{from: from, to: to}
+}

--- a/consensus-types/interfaces/error.go
+++ b/consensus-types/interfaces/error.go
@@ -18,7 +18,7 @@ func (e *InvalidCastError) Error() string {
 		Error()
 }
 
-func (e *InvalidCastError) Is(err error) bool {
+func (*InvalidCastError) Is(err error) bool {
 	return errors.Is(err, ErrInvalidCast)
 }
 

--- a/consensus-types/interfaces/error_test.go
+++ b/consensus-types/interfaces/error_test.go
@@ -1,0 +1,14 @@
+package interfaces
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+)
+
+func TestNewInvalidCastError(t *testing.T) {
+	err := NewInvalidCastError(version.Phase0, version.Electra)
+	require.Equal(t, true, errors.Is(err, ErrInvalidCast))
+}

--- a/consensus-types/mock/block.go
+++ b/consensus-types/mock/block.go
@@ -284,8 +284,7 @@ func (b *BeaconBlockBody) BlobKzgCommitments() ([][]byte, error) {
 func (b *BeaconBlockBody) Attestations() []interfaces.Attestation {
 	panic("implement me")
 }
-
-func (b *BeaconBlockBody) Consolidations() ([]*eth.SignedConsolidation, error) {
+func (b *BeaconBlockBody) Consolidations() []*eth.SignedConsolidation {
 	panic("implement me")
 }
 
@@ -296,3 +295,4 @@ func (b *BeaconBlockBody) Version() int {
 var _ interfaces.ReadOnlySignedBeaconBlock = &SignedBeaconBlock{}
 var _ interfaces.ReadOnlyBeaconBlock = &BeaconBlock{}
 var _ interfaces.ReadOnlyBeaconBlockBody = &BeaconBlockBody{}
+var _ interfaces.ROBlockBodyElectra = &BeaconBlockBody{}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This brings back the changes from https://github.com/prysmaticlabs/prysm/pull/13928 that got lost in the shuffle of various electra branches.

The goal of this PR is to deprecate the following patterns:
- monolithic block body interface across all forks. This model requires all non-phase0 attributes getters to return an error that must be checked.
- monolithic ExecutionData interface. In addition to the unsupported getter error checking issue, these types also require new getters to be backported to every previous fork.

In place of these patterns, we can use interface composition to add a new interface at each fork. The ExecutionData version for a particular fork can be accessed with a vanilla go type assertion. The BeaconBlockBody equivalent requires a little more wiring, because there is only one underlying concrete type which satisfies the interfaces of all forks. So we can add safe cast helpers to `consensus-types/interfaces/cast.go`.
