### PR TITLE
Remove unused validator map copy method

### DIFF
--- a/beacon-chain/state/state-native/state_test.go
+++ b/beacon-chain/state/state-native/state_test.go
@@ -20,34 +20,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 )
 
-func TestValidatorMap_DistinctCopy(t *testing.T) {
-	count := uint64(100)
-	vals := make([]*ethpb.Validator, 0, count)
-	for i := uint64(1); i < count; i++ {
-		var someRoot [32]byte
-		var someKey [fieldparams.BLSPubkeyLength]byte
-		copy(someRoot[:], strconv.Itoa(int(i)))
-		copy(someKey[:], strconv.Itoa(int(i)))
-		vals = append(vals, &ethpb.Validator{
-			PublicKey:                  someKey[:],
-			WithdrawalCredentials:      someRoot[:],
-			EffectiveBalance:           params.BeaconConfig().MaxEffectiveBalance,
-			Slashed:                    false,
-			ActivationEligibilityEpoch: 1,
-			ActivationEpoch:            1,
-			ExitEpoch:                  1,
-			WithdrawableEpoch:          1,
-		})
-	}
-	handler := stateutil.NewValMapHandler(vals)
-	newHandler := handler.Copy()
-	wantedPubkey := strconv.Itoa(22)
-	handler.Set(bytesutil.ToBytes48([]byte(wantedPubkey)), 27)
-	val1, _ := handler.Get(bytesutil.ToBytes48([]byte(wantedPubkey)))
-	val2, _ := newHandler.Get(bytesutil.ToBytes48([]byte(wantedPubkey)))
-	assert.NotEqual(t, val1, val2, "Values are supposed to be unequal due to copy")
-}
-
 func TestBeaconState_NoDeadlock_Phase0(t *testing.T) {
 	count := uint64(100)
 	vals := make([]*ethpb.Validator, 0, count)

--- a/beacon-chain/state/stateutil/validator_map_handler.go
+++ b/beacon-chain/state/stateutil/validator_map_handler.go
@@ -36,24 +36,6 @@ func (v *ValidatorMapHandler) IsNil() bool {
 	return v.mapRef == nil || v.valIdxMap == nil
 }
 
-// Copy the whole map and returns a map handler with the copied map.
-func (v *ValidatorMapHandler) Copy() *ValidatorMapHandler {
-	if v == nil || v.valIdxMap == nil {
-		return &ValidatorMapHandler{valIdxMap: map[[fieldparams.BLSPubkeyLength]byte]primitives.ValidatorIndex{}, mapRef: new(Reference), RWMutex: new(sync.RWMutex)}
-	}
-	v.RLock()
-	defer v.RUnlock()
-	m := make(map[[fieldparams.BLSPubkeyLength]byte]primitives.ValidatorIndex, len(v.valIdxMap))
-	for k, v := range v.valIdxMap {
-		m[k] = v
-	}
-	return &ValidatorMapHandler{
-		valIdxMap: m,
-		mapRef:    &Reference{refs: 1},
-		RWMutex:   new(sync.RWMutex),
-	}
-}
-
 // Get the validator index using the corresponding public key.
 func (v *ValidatorMapHandler) Get(key [fieldparams.BLSPubkeyLength]byte) (primitives.ValidatorIndex, bool) {
 	v.RLock()


### PR DESCRIPTION
`Copy` for `ValidatorMapHandler` is not used. When a state is copied, it points to the same reference. It's better to remove an unused method to prevent future misuse.