### PR TITLE
Add electra DB

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -813,6 +813,16 @@ func unmarshalBlock(_ context.Context, enc []byte) (interfaces.ReadOnlySignedBea
 		if err := rawBlock.UnmarshalSSZ(enc[len(denebBlindKey):]); err != nil {
 			return nil, errors.Wrap(err, "could not unmarshal blinded Deneb block")
 		}
+	case hasElectraKey(enc):
+		rawBlock = &ethpb.SignedBeaconBlockElectra{}
+		if err := rawBlock.UnmarshalSSZ(enc[len(electraKey):]); err != nil {
+			return nil, errors.Wrap(err, "could not unmarshal Electra block")
+		}
+	case hasElectraBlindKey(enc):
+		rawBlock = &ethpb.SignedBlindedBeaconBlockElectra{}
+		if err := rawBlock.UnmarshalSSZ(enc[len(electraBlindKey):]); err != nil {
+			return nil, errors.Wrap(err, "could not unmarshal blinded Electra block")
+		}
 	default:
 		// Marshal block bytes to phase 0 beacon block.
 		rawBlock = &ethpb.SignedBeaconBlock{}
@@ -842,6 +852,11 @@ func encodeBlock(blk interfaces.ReadOnlySignedBeaconBlock) ([]byte, error) {
 
 func keyForBlock(blk interfaces.ReadOnlySignedBeaconBlock) ([]byte, error) {
 	switch blk.Version() {
+	case version.Electra:
+		if blk.IsBlinded() {
+			return electraBlindKey, nil
+		}
+		return electraKey, nil
 	case version.Deneb:
 		if blk.IsBlinded() {
 			return denebBlindKey, nil

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -125,6 +125,47 @@ var blockTests = []struct {
 			return blocks.NewSignedBeaconBlock(b)
 		},
 	},
+	{
+		name: "electra",
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
+			b := util.NewBeaconBlockElectra()
+			b.Block.Slot = slot
+			if root != nil {
+				b.Block.ParentRoot = root
+				b.Block.Body.Consolidations = []*ethpb.SignedConsolidation{
+					{
+						Message: &ethpb.Consolidation{
+							SourceIndex: 1,
+							TargetIndex: 2,
+							Epoch:       3,
+						},
+						Signature: make([]byte, 96),
+					},
+				}
+			}
+			return blocks.NewSignedBeaconBlock(b)
+		},
+	},
+	{
+		name: "electra blind",
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
+			b := util.NewBlindedBeaconBlockElectra()
+			b.Message.Slot = slot
+			if root != nil {
+				b.Message.ParentRoot = root
+				b.Message.Body.Consolidations = []*ethpb.SignedConsolidation{
+					{
+						Message: &ethpb.Consolidation{
+							SourceIndex: 1,
+							TargetIndex: 2,
+							Epoch:       3,
+						},
+						Signature: make([]byte, 96),
+					},
+				}
+			}
+			return blocks.NewSignedBeaconBlock(b)
+		}},
 }
 
 func TestStore_SaveBlock_NoDuplicates(t *testing.T) {

--- a/beacon-chain/db/kv/key.go
+++ b/beacon-chain/db/kv/key.go
@@ -51,3 +51,17 @@ func hasDenebBlindKey(enc []byte) bool {
 	}
 	return bytes.Equal(enc[:len(denebBlindKey)], denebBlindKey)
 }
+
+func hasElectraKey(enc []byte) bool {
+	if len(electraKey) >= len(enc) {
+		return false
+	}
+	return bytes.Equal(enc[:len(electraKey)], electraKey)
+}
+
+func hasElectraBlindKey(enc []byte) bool {
+	if len(electraBlindKey) >= len(enc) {
+		return false
+	}
+	return bytes.Equal(enc[:len(electraBlindKey)], electraBlindKey)
+}

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -48,6 +48,8 @@ var (
 	saveBlindedBeaconBlocksKey = []byte("save-blinded-beacon-blocks")
 	denebKey                   = []byte("deneb")
 	denebBlindKey              = []byte("blind-deneb")
+	electraKey                 = []byte("electra")
+	electraBlindKey            = []byte("blind-electra")
 
 	// block root included in the beacon state used by weak subjectivity initial sync
 	originCheckpointBlockRootKey = []byte("origin-checkpoint-block-root")

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -229,160 +229,142 @@ func (s *Store) saveStatesEfficientInternal(ctx context.Context, tx *bolt.Tx, bl
 		// look at issue https://github.com/prysmaticlabs/prysm/issues/9262.
 		switch rawType := states[i].ToProtoUnsafe().(type) {
 		case *ethpb.BeaconState:
-			pbState, err := getPhase0PbState(rawType)
-			if err != nil {
-				return err
-			}
-			valEntries := pbState.Validators
-			pbState.Validators = make([]*ethpb.Validator, 0)
-			encodedState, err := encode(ctx, pbState)
-			if err != nil {
-				return err
-			}
-			pbState.Validators = valEntries
-			if err := bucket.Put(rt[:], encodedState); err != nil {
-				return err
-			}
-			if err := valIdxBkt.Put(rt[:], validatorKeys[i]); err != nil {
+			if err := s.processPhase0(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
 				return err
 			}
 		case *ethpb.BeaconStateAltair:
-			pbState, err := getAltairPbState(rawType)
-			if err != nil {
-				return err
-			}
-			valEntries := pbState.Validators
-			pbState.Validators = make([]*ethpb.Validator, 0)
-			rawObj, err := pbState.MarshalSSZ()
-			if err != nil {
-				return err
-			}
-			encodedState := snappy.Encode(nil, append(altairKey, rawObj...))
-			if err := bucket.Put(rt[:], encodedState); err != nil {
-				return err
-			}
-			pbState.Validators = valEntries
-			if err := valIdxBkt.Put(rt[:], validatorKeys[i]); err != nil {
+			if err := s.processAltair(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
 				return err
 			}
 		case *ethpb.BeaconStateBellatrix:
-			pbState, err := getBellatrixPbState(rawType)
-			if err != nil {
-				return err
-			}
-			valEntries := pbState.Validators
-			pbState.Validators = make([]*ethpb.Validator, 0)
-			rawObj, err := pbState.MarshalSSZ()
-			if err != nil {
-				return err
-			}
-			encodedState := snappy.Encode(nil, append(bellatrixKey, rawObj...))
-			if err := bucket.Put(rt[:], encodedState); err != nil {
-				return err
-			}
-			pbState.Validators = valEntries
-			if err := valIdxBkt.Put(rt[:], validatorKeys[i]); err != nil {
+			if err := s.processBellatrix(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
 				return err
 			}
 		case *ethpb.BeaconStateCapella:
-			pbState, err := getCapellaPbState(rawType)
-			if err != nil {
-				return err
-			}
-			valEntries := pbState.Validators
-			pbState.Validators = make([]*ethpb.Validator, 0)
-			rawObj, err := pbState.MarshalSSZ()
-			if err != nil {
-				return err
-			}
-			encodedState := snappy.Encode(nil, append(capellaKey, rawObj...))
-			if err := bucket.Put(rt[:], encodedState); err != nil {
-				return err
-			}
-			pbState.Validators = valEntries
-			if err := valIdxBkt.Put(rt[:], validatorKeys[i]); err != nil {
+			if err := s.processCapella(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
 				return err
 			}
 		case *ethpb.BeaconStateDeneb:
-			pbState, err := getDenebPbState(rawType)
-			if err != nil {
+			if err := s.processDeneb(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
 				return err
 			}
-			valEntries := pbState.Validators
-			pbState.Validators = make([]*ethpb.Validator, 0)
-			rawObj, err := pbState.MarshalSSZ()
-			if err != nil {
-				return err
-			}
-			encodedState := snappy.Encode(nil, append(denebKey, rawObj...))
-			if err := bucket.Put(rt[:], encodedState); err != nil {
-				return err
-			}
-			pbState.Validators = valEntries
-			if err := valIdxBkt.Put(rt[:], validatorKeys[i]); err != nil {
+		case *ethpb.BeaconStateElectra:
+			if err := s.processEPBS(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
 				return err
 			}
 		default:
 			return errors.New("invalid state type")
 		}
 	}
-	// store the validator entries separately to save space.
+
 	return s.storeValidatorEntriesSeparately(ctx, tx, validatorsEntries)
 }
 
-func getPhase0PbState(rawState interface{}) (*ethpb.BeaconState, error) {
-	pbState, err := statenative.ProtobufBeaconStatePhase0(rawState)
+func (s *Store) processPhase0(ctx context.Context, pbState *ethpb.BeaconState, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
+	valEntries := pbState.Validators
+	pbState.Validators = make([]*ethpb.Validator, 0)
+	encodedState, err := encode(ctx, pbState)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if pbState == nil {
-		return nil, errors.New("nil state")
+	pbState.Validators = valEntries
+	if err := bucket.Put(rootHash, encodedState); err != nil {
+		return err
 	}
-	return pbState, nil
+	if err := valIdxBkt.Put(rootHash, validatorKey); err != nil {
+		return err
+	}
+	return nil
 }
 
-func getAltairPbState(rawState interface{}) (*ethpb.BeaconStateAltair, error) {
-	pbState, err := statenative.ProtobufBeaconStateAltair(rawState)
+func (s *Store) processAltair(ctx context.Context, pbState *ethpb.BeaconStateAltair, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
+	valEntries := pbState.Validators
+	pbState.Validators = make([]*ethpb.Validator, 0)
+	rawObj, err := pbState.MarshalSSZ()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if pbState == nil {
-		return nil, errors.New("nil state")
+	encodedState := snappy.Encode(nil, append(altairKey, rawObj...))
+	if err := bucket.Put(rootHash, encodedState); err != nil {
+		return err
 	}
-	return pbState, nil
+	pbState.Validators = valEntries
+	if err := valIdxBkt.Put(rootHash, validatorKey); err != nil {
+		return err
+	}
+	return nil
 }
 
-func getBellatrixPbState(rawState interface{}) (*ethpb.BeaconStateBellatrix, error) {
-	pbState, err := statenative.ProtobufBeaconStateBellatrix(rawState)
+func (s *Store) processBellatrix(ctx context.Context, pbState *ethpb.BeaconStateBellatrix, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
+	valEntries := pbState.Validators
+	pbState.Validators = make([]*ethpb.Validator, 0)
+	rawObj, err := pbState.MarshalSSZ()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if pbState == nil {
-		return nil, errors.New("nil state")
+	encodedState := snappy.Encode(nil, append(bellatrixKey, rawObj...))
+	if err := bucket.Put(rootHash, encodedState); err != nil {
+		return err
 	}
-	return pbState, nil
+	pbState.Validators = valEntries
+	if err := valIdxBkt.Put(rootHash, validatorKey); err != nil {
+		return err
+	}
+	return nil
 }
 
-func getCapellaPbState(rawState interface{}) (*ethpb.BeaconStateCapella, error) {
-	pbState, err := statenative.ProtobufBeaconStateCapella(rawState)
+func (s *Store) processCapella(ctx context.Context, pbState *ethpb.BeaconStateCapella, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
+	valEntries := pbState.Validators
+	pbState.Validators = make([]*ethpb.Validator, 0)
+	rawObj, err := pbState.MarshalSSZ()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if pbState == nil {
-		return nil, errors.New("nil state")
+	encodedState := snappy.Encode(nil, append(capellaKey, rawObj...))
+	if err := bucket.Put(rootHash, encodedState); err != nil {
+		return err
 	}
-	return pbState, nil
+	pbState.Validators = valEntries
+	if err := valIdxBkt.Put(rootHash, validatorKey); err != nil {
+		return err
+	}
+	return nil
 }
 
-func getDenebPbState(rawState interface{}) (*ethpb.BeaconStateDeneb, error) {
-	pbState, err := statenative.ProtobufBeaconStateDeneb(rawState)
+func (s *Store) processDeneb(ctx context.Context, pbState *ethpb.BeaconStateDeneb, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
+	valEntries := pbState.Validators
+	pbState.Validators = make([]*ethpb.Validator, 0)
+	rawObj, err := pbState.MarshalSSZ()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if pbState == nil {
-		return nil, errors.New("nil state")
+	encodedState := snappy.Encode(nil, append(denebKey, rawObj...))
+	if err := bucket.Put(rootHash, encodedState); err != nil {
+		return err
 	}
-	return pbState, nil
+	pbState.Validators = valEntries
+	if err := valIdxBkt.Put(rootHash, validatorKey); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) processEPBS(ctx context.Context, pbState *ethpb.BeaconStateElectra, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
+	valEntries := pbState.Validators
+	pbState.Validators = make([]*ethpb.Validator, 0)
+	rawObj, err := pbState.MarshalSSZ()
+	if err != nil {
+		return err
+	}
+	encodedState := snappy.Encode(nil, append(electraKey, rawObj...))
+	if err := bucket.Put(rootHash, encodedState); err != nil {
+		return err
+	}
+	pbState.Validators = valEntries
+	if err := valIdxBkt.Put(rootHash, validatorKey); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *Store) storeValidatorEntriesSeparately(ctx context.Context, tx *bolt.Tx, validatorsEntries map[string]*ethpb.Validator) error {
@@ -534,6 +516,19 @@ func (s *Store) unmarshalState(_ context.Context, enc []byte, validatorEntries [
 	}
 
 	switch {
+	case hasElectraKey(enc):
+		protoState := &ethpb.BeaconStateElectra{}
+		if err := protoState.UnmarshalSSZ(enc[len(electraKey):]); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal encoding for Electra")
+		}
+		ok, err := s.isStateValidatorMigrationOver()
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			protoState.Validators = validatorEntries
+		}
+		return statenative.InitializeFromProtoUnsafeElectra(protoState)
 	case hasDenebKey(enc):
 		protoState := &ethpb.BeaconStateDeneb{}
 		if err := protoState.UnmarshalSSZ(enc[len(denebKey):]); err != nil {
@@ -667,6 +662,19 @@ func marshalState(ctx context.Context, st state.ReadOnlyBeaconState) ([]byte, er
 			return nil, err
 		}
 		return snappy.Encode(nil, append(denebKey, rawObj...)), nil
+	case *ethpb.BeaconStateElectra:
+		rState, ok := st.ToProtoUnsafe().(*ethpb.BeaconStateElectra)
+		if !ok {
+			return nil, errors.New("non valid inner state")
+		}
+		if rState == nil {
+			return nil, errors.New("nil state")
+		}
+		rawObj, err := rState.MarshalSSZ()
+		if err != nil {
+			return nil, err
+		}
+		return snappy.Encode(nil, append(electraKey, rawObj...)), nil
 	default:
 		return nil, errors.New("invalid inner state")
 	}

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -249,7 +249,7 @@ func (s *Store) saveStatesEfficientInternal(ctx context.Context, tx *bolt.Tx, bl
 				return err
 			}
 		case *ethpb.BeaconStateElectra:
-			if err := s.processEPBS(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
+			if err := s.processElectra(ctx, rawType, rt[:], bucket, valIdxBkt, validatorKeys[i]); err != nil {
 				return err
 			}
 		default:
@@ -349,7 +349,7 @@ func (s *Store) processDeneb(ctx context.Context, pbState *ethpb.BeaconStateDene
 	return nil
 }
 
-func (s *Store) processEPBS(ctx context.Context, pbState *ethpb.BeaconStateElectra, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
+func (s *Store) processElectra(ctx context.Context, pbState *ethpb.BeaconStateElectra, rootHash []byte, bucket, valIdxBkt *bolt.Bucket, validatorKey []byte) error {
 	valEntries := pbState.Validators
 	pbState.Validators = make([]*ethpb.Validator, 0)
 	rawObj, err := pbState.MarshalSSZ()

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -132,6 +132,33 @@ func TestState_CanSaveRetrieve(t *testing.T) {
 			},
 			rootSeed: 'D',
 		},
+		{
+			name: "electra",
+			s: func() state.BeaconState {
+				st, err := util.NewBeaconStateElectra()
+				require.NoError(t, err)
+				require.NoError(t, st.SetSlot(100))
+				p, err := blocks.WrappedExecutionPayloadHeaderElectra(&enginev1.ExecutionPayloadHeaderElectra{
+					ParentHash:             make([]byte, 32),
+					FeeRecipient:           make([]byte, 20),
+					StateRoot:              make([]byte, 32),
+					ReceiptsRoot:           make([]byte, 32),
+					LogsBloom:              make([]byte, 256),
+					PrevRandao:             make([]byte, 32),
+					ExtraData:              []byte("foo"),
+					BaseFeePerGas:          make([]byte, 32),
+					BlockHash:              make([]byte, 32),
+					TransactionsRoot:       make([]byte, 32),
+					WithdrawalsRoot:        make([]byte, 32),
+					DepositReceiptsRoot:    make([]byte, 32),
+					WithdrawalRequestsRoot: make([]byte, 32),
+				}, big.NewInt(0))
+				require.NoError(t, err)
+				require.NoError(t, st.SetLatestExecutionPayloadHeader(p))
+				return st
+			},
+			rootSeed: 'E',
+		},
 	}
 
 	db := setupDB(t)
@@ -155,7 +182,7 @@ func TestState_CanSaveRetrieve(t *testing.T) {
 				savedSt, err := db.State(context.Background(), root)
 				require.NoError(t, err)
 
-				assert.DeepSSZEqual(t, st.ToProtoUnsafe(), savedSt.ToProtoUnsafe())
+				require.DeepEqual(t, st.ToProtoUnsafe(), savedSt.ToProtoUnsafe())
 			})
 		}
 
@@ -1101,6 +1128,100 @@ func TestStateDeneb_CanSaveRetrieveValidatorEntries(t *testing.T) {
 
 	stateValidators := validators(10)
 	st, _ := util.DeterministicGenesisStateDeneb(t, 20)
+	require.NoError(t, st.SetSlot(100))
+	require.NoError(t, st.SetValidators(stateValidators))
+
+	ctx := context.Background()
+	require.NoError(t, db.SaveState(ctx, st, r))
+	assert.Equal(t, true, db.HasState(context.Background(), r))
+
+	savedS, err := db.State(context.Background(), r)
+	require.NoError(t, err)
+
+	require.DeepSSZEqual(t, st.Validators(), savedS.Validators(), "saved state with validators and retrieved state are not matching")
+
+	// check if the index of the second state is still present.
+	err = db.db.Update(func(tx *bolt.Tx) error {
+		idxBkt := tx.Bucket(blockRootValidatorHashesBucket)
+		data := idxBkt.Get(r[:])
+		require.NotEqual(t, 0, len(data))
+		return nil
+	})
+	require.NoError(t, err)
+
+	// check if all the validator entries are still intact in the validator entry bucket.
+	err = db.db.Update(func(tx *bolt.Tx) error {
+		valBkt := tx.Bucket(stateValidatorsBucket)
+		// if any of the original validator entry is not present, then fail the test.
+		for _, val := range stateValidators {
+			hash, hashErr := val.HashTreeRoot()
+			assert.NoError(t, hashErr)
+			data := valBkt.Get(hash[:])
+			require.NotNil(t, data)
+			require.NotEqual(t, 0, len(data))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestElectraState_CanSaveRetrieve(t *testing.T) {
+	db := setupDB(t)
+
+	r := [32]byte{'A'}
+
+	require.Equal(t, false, db.HasState(context.Background(), r))
+
+	st, _ := util.DeterministicGenesisStateElectra(t, 1)
+	require.NoError(t, st.SetSlot(100))
+
+	require.NoError(t, db.SaveState(context.Background(), st, r))
+	require.Equal(t, true, db.HasState(context.Background(), r))
+
+	savedS, err := db.State(context.Background(), r)
+	require.NoError(t, err)
+
+	assert.DeepSSZEqual(t, st.ToProtoUnsafe(), savedS.ToProtoUnsafe())
+
+	savedS, err = db.State(context.Background(), [32]byte{'B'})
+	require.NoError(t, err)
+	require.Equal(t, state.ReadOnlyBeaconState(nil), savedS, "Unsaved state should've been nil")
+}
+
+func TestElectraState_CanDelete(t *testing.T) {
+	db := setupDB(t)
+
+	r := [32]byte{'A'}
+
+	require.Equal(t, false, db.HasState(context.Background(), r))
+
+	st, _ := util.DeterministicGenesisStateElectra(t, 1)
+	require.NoError(t, st.SetSlot(100))
+
+	require.NoError(t, db.SaveState(context.Background(), st, r))
+	require.Equal(t, true, db.HasState(context.Background(), r))
+
+	require.NoError(t, db.DeleteState(context.Background(), r))
+	savedS, err := db.State(context.Background(), r)
+	require.NoError(t, err)
+	require.Equal(t, state.ReadOnlyBeaconState(nil), savedS, "Unsaved state should've been nil")
+}
+
+func TestStateElectra_CanSaveRetrieveValidatorEntries(t *testing.T) {
+	db := setupDB(t)
+
+	// enable historical state representation flag to test this
+	resetCfg := features.InitWithReset(&features.Flags{
+		EnableHistoricalSpaceRepresentation: true,
+	})
+	defer resetCfg()
+
+	r := [32]byte{'A'}
+
+	require.Equal(t, false, db.HasState(context.Background(), r))
+
+	stateValidators := validators(10)
+	st, _ := util.DeterministicGenesisStateElectra(t, 20)
 	require.NoError(t, st.SetSlot(100))
 	require.NoError(t, st.SetValidators(stateValidators))
 

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -182,7 +182,7 @@ func TestState_CanSaveRetrieve(t *testing.T) {
 				savedSt, err := db.State(context.Background(), root)
 				require.NoError(t, err)
 
-				require.DeepEqual(t, st.ToProtoUnsafe(), savedSt.ToProtoUnsafe())
+				assert.DeepSSZEqual(t, st.ToProtoUnsafe(), savedSt.ToProtoUnsafe())
 			})
 		}
 

--- a/encoding/ssz/equality/BUILD.bazel
+++ b/encoding/ssz/equality/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//consensus-types/primitives:go_default_library",
+        "//math:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )

--- a/encoding/ssz/equality/deep_equal.go
+++ b/encoding/ssz/equality/deep_equal.go
@@ -5,6 +5,7 @@ import (
 	"unsafe"
 
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/math"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -230,6 +231,8 @@ func deepValueBaseTypeEqual(v1, v2 reflect.Value) bool {
 			return v1.Interface().(primitives.ValidatorIndex) == v2.Interface().(primitives.ValidatorIndex)
 		case "CommitteeIndex":
 			return v1.Interface().(primitives.CommitteeIndex) == v2.Interface().(primitives.CommitteeIndex)
+		case "Gwei":
+			return v1.Interface().(math.Gwei) == v2.Interface().(math.Gwei)
 		}
 		return v1.Interface().(uint64) == v2.Interface().(uint64)
 	case reflect.Uint32:

--- a/testing/util/electra_state.go
+++ b/testing/util/electra_state.go
@@ -83,6 +83,10 @@ func emptyGenesisStateElectra() (state.BeaconState, error) {
 		Eth1DepositIndex: 0,
 
 		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderElectra{},
+
+		DepositBalanceToConsume:       math.Gwei(0),
+		ExitBalanceToConsume:          math.Gwei(0),
+		ConsolidationBalanceToConsume: math.Gwei(0),
 	}
 	return state_native.InitializeFromProtoElectra(st)
 }


### PR DESCRIPTION
This PR adds electra changes to db. Mainly two things and a note
1.) Add electra block support
2.) Add electra state support
3.) Refactor `saveStatesEfficientInternal` into multiple helpers. The functionality remains the same. It needs to be done to reduce cognitive complexity or CI will be red
