### PR TITLE
eip-7251: Updated slash_validator

### DIFF
--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -7,14 +7,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
-	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/container/slice"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1/attestation"
 	"github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1/slashings"
-	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
 
@@ -78,19 +76,7 @@ func ProcessAttesterSlashing(
 			return nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			cfg := params.BeaconConfig()
-			var slashingQuotient uint64
-			switch {
-			case beaconState.Version() == version.Phase0:
-				slashingQuotient = cfg.MinSlashingPenaltyQuotient
-			case beaconState.Version() == version.Altair:
-				slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
-			case beaconState.Version() >= version.Bellatrix:
-				slashingQuotient = cfg.MinSlashingPenaltyQuotientBellatrix
-			default:
-				return nil, errors.New("unknown state version")
-			}
-			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), slashingQuotient, cfg.ProposerRewardQuotient)
+			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex))
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not slash validator index %d",
 					validatorIndex)

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -12,12 +12,14 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
-	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 	"google.golang.org/protobuf/proto"
 )
 
-type slashValidatorFunc func(ctx context.Context, st state.BeaconState, vid primitives.ValidatorIndex, penaltyQuotient, proposerRewardQuotient uint64) (state.BeaconState, error)
+type slashValidatorFunc func(
+	ctx context.Context,
+	st state.BeaconState,
+	vid primitives.ValidatorIndex) (state.BeaconState, error)
 
 // ProcessProposerSlashings is one of the operations performed
 // on each processed beacon block to slash proposers based on
@@ -75,19 +77,7 @@ func ProcessProposerSlashing(
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	cfg := params.BeaconConfig()
-	var slashingQuotient uint64
-	switch {
-	case beaconState.Version() == version.Phase0:
-		slashingQuotient = cfg.MinSlashingPenaltyQuotient
-	case beaconState.Version() == version.Altair:
-		slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
-	case beaconState.Version() >= version.Bellatrix:
-		slashingQuotient = cfg.MinSlashingPenaltyQuotientBellatrix
-	default:
-		return nil, errors.New("unknown state version")
-	}
-	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, slashingQuotient, cfg.ProposerRewardQuotient)
+	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -2,7 +2,10 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["validator.go"],
+    srcs = [
+        "slashing.go",
+        "validator.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/validators",
     visibility = [
         "//beacon-chain:__subpackages__",
@@ -26,9 +29,12 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["validator_test.go"],
-    embed = [":go_default_library"],
+    srcs = [
+        "slashing_test.go",
+        "validator_test.go",
+    ],
     deps = [
+        ":go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/state/state-native:go_default_library",

--- a/beacon-chain/core/validators/slashing.go
+++ b/beacon-chain/core/validators/slashing.go
@@ -1,0 +1,33 @@
+package validators
+
+import (
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
+)
+
+// SlashingParamsPerVersion returns the slashing parameters for the given state version.
+func SlashingParamsPerVersion(v int) (slashingQuotient, proposerRewardQuotient, whistleblowerRewardQuotient uint64, err error) {
+	cfg := params.BeaconConfig()
+	switch v {
+	case version.Phase0:
+		slashingQuotient = cfg.MinSlashingPenaltyQuotient
+		proposerRewardQuotient = cfg.ProposerRewardQuotient
+		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
+	case version.Altair:
+		slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
+		proposerRewardQuotient = cfg.ProposerRewardQuotient
+		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
+	case version.Bellatrix, version.Capella, version.Deneb:
+		slashingQuotient = cfg.MinSlashingPenaltyQuotientBellatrix
+		proposerRewardQuotient = cfg.ProposerRewardQuotient
+		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
+	case version.Electra:
+		slashingQuotient = cfg.MinSlashingPenaltyQuotientElectra
+		proposerRewardQuotient = cfg.ProposerRewardQuotient
+		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotientElectra
+	default:
+		err = errors.New("unknown state version")
+	}
+	return
+}

--- a/beacon-chain/core/validators/slashing_test.go
+++ b/beacon-chain/core/validators/slashing_test.go
@@ -1,0 +1,18 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/validators"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
+)
+
+func TestSlashingParamsPerVersion_NoErrors(t *testing.T) {
+	for _, v := range version.All() {
+		_, _, _, err := validators.SlashingParamsPerVersion(v)
+		if err != nil {
+			// If this test is failing, you need to add a case for the version in slashingParamsPerVersion.
+			t.Errorf("Error occurred for version %d: %v", v, err)
+		}
+	}
+}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -120,7 +120,8 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primiti
 }
 
 // SlashValidator slashes the malicious validator's balance and awards
-// the whistleblower's balance.
+// the whistleblower's balance. Note: This implementation does not handle an
+// optional whistleblower index. The whistleblower index is always the proposer index.
 //
 // Spec pseudocode definition:
 //
@@ -136,22 +137,22 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primiti
 //	  validator.slashed = True
 //	  validator.withdrawable_epoch = max(validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR))
 //	  state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
-//	  decrease_balance(state, slashed_index, validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT)
+//	  slashing_penalty = validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT_EIP7251  # [Modified in EIP7251]
+//	  decrease_balance(state, slashed_index, slashing_penalty)
 //
 //	  # Apply proposer and whistleblower rewards
 //	  proposer_index = get_beacon_proposer_index(state)
 //	  if whistleblower_index is None:
 //	      whistleblower_index = proposer_index
-//	  whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-//	  proposer_reward = Gwei(whistleblower_reward // PROPOSER_REWARD_QUOTIENT)
+//	  whistleblower_reward = Gwei(
+//	       validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA)  # [Modified in EIP7251]
+//	  proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
 //	  increase_balance(state, proposer_index, proposer_reward)
 //	  increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
 func SlashValidator(
 	ctx context.Context,
 	s state.BeaconState,
-	slashedIdx primitives.ValidatorIndex,
-	penaltyQuotient uint64,
-	proposerRewardQuotient uint64) (state.BeaconState, error) {
+	slashedIdx primitives.ValidatorIndex) (state.BeaconState, error) {
 	maxExitEpoch, churn := MaxExitEpochAndChurn(s)
 	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, maxExitEpoch, churn)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
@@ -179,7 +180,17 @@ func SlashValidator(
 	); err != nil {
 		return nil, err
 	}
-	if err := helpers.DecreaseBalance(s, slashedIdx, validator.EffectiveBalance/penaltyQuotient); err != nil {
+
+	slashingQuotient, proposerRewardQuotient, whistleblowerRewardQuotient, err := SlashingParamsPerVersion(s.Version())
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get slashing parameters per version")
+	}
+
+	slashingPenalty, err := math.Div64(validator.EffectiveBalance, slashingQuotient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compute slashing slashingPenalty")
+	}
+	if err := helpers.DecreaseBalance(s, slashedIdx, slashingPenalty); err != nil {
 		return nil, err
 	}
 
@@ -188,14 +199,18 @@ func SlashValidator(
 		return nil, errors.Wrap(err, "could not get proposer idx")
 	}
 	whistleBlowerIdx := proposerIdx
-	whistleblowerReward := validator.EffectiveBalance / params.BeaconConfig().WhistleBlowerRewardQuotient
-	proposerReward := whistleblowerReward / proposerRewardQuotient
-	err = helpers.IncreaseBalance(s, proposerIdx, proposerReward)
+	whistleblowerReward, err := math.Div64(validator.EffectiveBalance, whistleblowerRewardQuotient)
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to compute whistleblowerReward")
+	}
+	proposerReward, err := math.Div64(whistleblowerReward, proposerRewardQuotient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compute proposer reward")
+	}
+	if err := helpers.IncreaseBalance(s, proposerIdx, proposerReward); err != nil {
 		return nil, err
 	}
-	err = helpers.IncreaseBalance(s, whistleBlowerIdx, whistleblowerReward-proposerReward)
-	if err != nil {
+	if err := helpers.IncreaseBalance(s, whistleBlowerIdx, whistleblowerReward-proposerReward); err != nil {
 		return nil, err
 	}
 	return s, nil


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR comes with some minor refactoring. 

- tests in beacon-chain/core/validators are blackbox tests
- instead of requiring switch statements from the caller, the correct parameters are derived from within slash_validator using the state version.

Part of #13903

**Which issues(s) does this PR fix?**

Tracking @ #13849

**Other notes for review**

https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/specs/electra/beacon-chain.md#updated-slash_validator
