### PR TITLE
eip-7251: queue_entire_balance_and_reset_validator, queue_excess_active_balance, and switch_to_compounding_validator

### DIFF
--- a/beacon-chain/core/electra/BUILD.bazel
+++ b/beacon-chain/core/electra/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "transition.go",
         "upgrade.go",
+        "validator.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/electra",
     visibility = ["//visibility:public"],
@@ -28,11 +29,15 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["upgrade_test.go"],
+    srcs = [
+        "upgrade_test.go",
+        "validator_test.go",
+    ],
     deps = [
         ":go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/time:go_default_library",
+        "//beacon-chain/state/state-native:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",

--- a/beacon-chain/core/electra/validator.go
+++ b/beacon-chain/core/electra/validator.go
@@ -1,0 +1,103 @@
+package electra
+
+import (
+	"context"
+	"errors"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+)
+
+// SwitchToCompoundingValidator
+//
+// Spec definition:
+//
+//	 def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -> None:
+//		validator = state.validators[index]
+//		if has_eth1_withdrawal_credential(validator):
+//		    validator.withdrawal_credentials = COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
+//		    queue_excess_active_balance(state, index)
+func SwitchToCompoundingValidator(ctx context.Context, s state.BeaconState, idx primitives.ValidatorIndex) error {
+	v, err := s.ValidatorAtIndex(idx)
+	if err != nil {
+		return err
+	}
+	if len(v.WithdrawalCredentials) == 0 {
+		return errors.New("validator has no withdrawal credentials")
+	}
+	if helpers.HasETH1WithdrawalCredential(v) {
+		v.WithdrawalCredentials[0] = params.BeaconConfig().CompoundingWithdrawalPrefixByte
+		if err := s.UpdateValidatorAtIndex(idx, v); err != nil {
+			return err
+		}
+		return queueExcessActiveBalance(ctx, s, idx)
+	}
+	return nil
+}
+
+// queueExcessActiveBalance
+//
+// Spec definition:
+//
+//	def queue_excess_active_balance(state: BeaconState, index: ValidatorIndex) -> None:
+//	    balance = state.balances[index]
+//	    if balance > MIN_ACTIVATION_BALANCE:
+//	        excess_balance = balance - MIN_ACTIVATION_BALANCE
+//	        state.balances[index] = MIN_ACTIVATION_BALANCE
+//	        state.pending_balance_deposits.append(
+//	            PendingBalanceDeposit(index=index, amount=excess_balance)
+//	        )
+func queueExcessActiveBalance(ctx context.Context, s state.BeaconState, idx primitives.ValidatorIndex) error {
+	bal, err := s.BalanceAtIndex(idx)
+	if err != nil {
+		return err
+	}
+
+	if bal > params.BeaconConfig().MinActivationBalance {
+		excessBalance := bal - params.BeaconConfig().MinActivationBalance
+		if err := s.UpdateBalancesAtIndex(idx, params.BeaconConfig().MinActivationBalance); err != nil {
+			return err
+		}
+		return s.AppendPendingBalanceDeposit(idx, excessBalance)
+	}
+	return nil
+}
+
+// QueueEntireBalanceAndResetValidator queues the entire balance and resets the validator. This is used in electra fork logic.
+//
+// Spec definition:
+//
+//	def queue_entire_balance_and_reset_validator(state: BeaconState, index: ValidatorIndex) -> None:
+//	    balance = state.balances[index]
+//	    state.balances[index] = 0
+//	    validator = state.validators[index]
+//	    validator.effective_balance = 0
+//	    validator.activation_eligibility_epoch = FAR_FUTURE_EPOCH
+//	    state.pending_balance_deposits.append(
+//	        PendingBalanceDeposit(index=index, amount=balance)
+//	    )
+func QueueEntireBalanceAndResetValidator(ctx context.Context, s state.BeaconState, idx primitives.ValidatorIndex) error {
+	bal, err := s.BalanceAtIndex(idx)
+	if err != nil {
+		return err
+	}
+
+	if err := s.UpdateBalancesAtIndex(idx, 0); err != nil {
+		return err
+	}
+
+	v, err := s.ValidatorAtIndex(idx)
+	if err != nil {
+		return err
+	}
+
+	v.EffectiveBalance = 0
+	v.ActivationEligibilityEpoch = params.BeaconConfig().FarFutureEpoch
+	if err := s.UpdateValidatorAtIndex(idx, v); err != nil {
+		return err
+	}
+
+	return s.AppendPendingBalanceDeposit(idx, bal)
+}

--- a/beacon-chain/core/electra/validator_test.go
+++ b/beacon-chain/core/electra/validator_test.go
@@ -1,0 +1,90 @@
+package electra_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/electra"
+	state_native "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+)
+
+func TestSwitchToCompoundingValidator(t *testing.T) {
+	s, err := state_native.InitializeFromProtoElectra(&eth.BeaconStateElectra{
+		Validators: []*eth.Validator{
+			{
+				WithdrawalCredentials: []byte{}, // No withdrawal credentials
+			},
+			{
+				WithdrawalCredentials: []byte{0x01, 0xFF}, // Has withdrawal credentials
+			},
+			{
+				WithdrawalCredentials: []byte{0x01, 0xFF}, // Has withdrawal credentials
+			},
+		},
+		Balances: []uint64{
+			params.BeaconConfig().MinActivationBalance,
+			params.BeaconConfig().MinActivationBalance,
+			params.BeaconConfig().MinActivationBalance + 100_000, // Has excess balance
+		},
+	})
+	// Test that a validator with no withdrawal credentials cannot be switched to compounding.
+	require.NoError(t, err)
+	require.ErrorContains(t, "validator has no withdrawal credentials", electra.SwitchToCompoundingValidator(context.TODO(), s, 0))
+
+	// Test that a validator with withdrawal credentials can be switched to compounding.
+	require.NoError(t, electra.SwitchToCompoundingValidator(context.TODO(), s, 1))
+	v, err := s.ValidatorAtIndex(1)
+	require.NoError(t, err)
+	require.Equal(t, true, bytes.HasPrefix(v.WithdrawalCredentials, []byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte}), "withdrawal credentials were not updated")
+	// val_1 Balance is not changed
+	b, err := s.BalanceAtIndex(1)
+	require.NoError(t, err)
+	require.Equal(t, params.BeaconConfig().MinActivationBalance, b, "balance was changed")
+	pbd, err := s.PendingBalanceDeposits()
+	require.NoError(t, err)
+	require.Equal(t, 0, len(pbd), "pending balance deposits should be empty")
+
+	// Test that a validator with excess balance can be switched to compounding, excess balance is queued.
+	require.NoError(t, electra.SwitchToCompoundingValidator(context.TODO(), s, 2))
+	b, err = s.BalanceAtIndex(2)
+	require.NoError(t, err)
+	require.Equal(t, params.BeaconConfig().MinActivationBalance, b, "balance was not changed")
+	pbd, err = s.PendingBalanceDeposits()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(pbd), "pending balance deposits should have one element")
+	require.Equal(t, uint64(100_000), pbd[0].Amount, "pending balance deposit amount is incorrect")
+	require.Equal(t, primitives.ValidatorIndex(2), pbd[0].Index, "pending balance deposit index is incorrect")
+}
+
+func TestQueueEntireBalanceAndResetValidator(t *testing.T) {
+	s, err := state_native.InitializeFromProtoElectra(&eth.BeaconStateElectra{
+		Validators: []*eth.Validator{
+			{
+				EffectiveBalance:           params.BeaconConfig().MinActivationBalance + 100_000,
+				ActivationEligibilityEpoch: primitives.Epoch(100),
+			},
+		},
+		Balances: []uint64{
+			params.BeaconConfig().MinActivationBalance + 100_000,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, electra.QueueEntireBalanceAndResetValidator(context.TODO(), s, 0))
+	b, err := s.BalanceAtIndex(0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), b, "balance was not changed")
+	v, err := s.ValidatorAtIndex(0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), v.EffectiveBalance, "effective balance was not reset")
+	require.Equal(t, params.BeaconConfig().FarFutureEpoch, v.ActivationEligibilityEpoch, "activation eligibility epoch was not reset")
+	pbd, err := s.PendingBalanceDeposits()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(pbd), "pending balance deposits should have one element")
+	require.Equal(t, params.BeaconConfig().MinActivationBalance+100_000, pbd[0].Amount, "pending balance deposit amount is incorrect")
+	require.Equal(t, primitives.ValidatorIndex(0), pbd[0].Index, "pending balance deposit index is incorrect")
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Extracted from #13903.

**Which issues(s) does this PR fix?**

Tracking @ #13849

**Other notes for review**

https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/specs/electra/beacon-chain.md#new-queue_entire_balance_and_reset_validator

https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/specs/electra/beacon-chain.md#new-queue_excess_active_balance

https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/specs/electra/beacon-chain.md#new-switch_to_compounding_validator
