### PR TITLE
Ignore `[]*ethpb.SignedConsolidation` if it's nil

### DIFF
--- a/beacon-chain/core/electra/consolidations.go
+++ b/beacon-chain/core/electra/consolidations.go
@@ -147,9 +147,6 @@ func ProcessConsolidations(ctx context.Context, st state.BeaconState, cs []*ethp
 	if st == nil || st.IsNil() {
 		return nil, errors.New("nil state")
 	}
-	if cs == nil {
-		return nil, ErrNilConsolidations
-	}
 
 	domain, err := signing.ComputeDomain(params.BeaconConfig().DomainConsolidation, st.Fork().CurrentVersion, st.GenesisValidatorsRoot())
 	if err != nil {


### PR DESCRIPTION
In Go, if you range over a nil slice, it behaves like an empty slice. The loop body will not execute because there are no elements to iterate over. This means that the program won't panic or throw an error. 
For a beacon block, if the block does not contain any consolidation, the field is nil by default. This is similar to attestation and other deposit objects. We should not cause the state transition function to fail, as that would result in a consensus failure. Another approach to altering this behavior involves how the block is initialized; if the object is nil in p2p, we initialize an empty list instead of nil, but this warrants a more significant change.