### PR TITLE
Correctly return electra attestations for block getter

### DIFF
--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -1116,7 +1116,7 @@ func (b *BeaconBlockBody) Attestations() []interfaces.Attestation {
 			return nil
 		}
 		atts = make([]interfaces.Attestation, len(b.attestationsElectra))
-		for i, a := range b.attestations {
+		for i, a := range b.attestationsElectra {
 			atts[i] = a
 		}
 	}

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -369,6 +369,19 @@ func Test_BeaconBlockBody_Attestations(t *testing.T) {
 	assert.DeepSSZEqual(t, a, bb.Block().Body().Attestations())
 }
 
+func Test_BeaconBlockBody_ElectraAttestations(t *testing.T) {
+	bb := &SignedBeaconBlock{
+		block: &BeaconBlock{body: &BeaconBlockBody{
+			version: version.Electra,
+			attestationsElectra: []*eth.AttestationElectra{{
+				Signature: []byte("electra"),
+			}},
+		}}}
+	a := bb.Block().Body().Attestations()
+	require.Equal(t, 1, len(a))
+	require.DeepEqual(t, a[0].GetSignature(), []byte("electra"))
+}
+
 func Test_BeaconBlockBody_Deposits(t *testing.T) {
 	d := make([]*eth.Deposit, 0)
 	bb := &SignedBeaconBlock{block: &BeaconBlock{body: &BeaconBlockBody{}}}


### PR DESCRIPTION
Block getter `Attestations()` returns non-Electra attestations even if the block version is Electra. This PR ensures the correct version of attestation is returned with a unit test.