### PR TITLE
Support version Electra for ForkchoiceUpdated

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -222,7 +222,7 @@ func (s *Service) ForkchoiceUpdated(
 		if err != nil {
 			return nil, nil, handleRPCError(err)
 		}
-	case version.Deneb:
+	case version.Deneb, version.Electra:
 		a, err := attrs.PbV3()
 		if err != nil {
 			return nil, nil, err

--- a/consensus-types/payload-attribute/getters.go
+++ b/consensus-types/payload-attribute/getters.go
@@ -80,7 +80,7 @@ func (a *data) PbV3() (*enginev1.PayloadAttributesV3, error) {
 	if a == nil {
 		return nil, errNilPayloadAttribute
 	}
-	if a.version != version.Deneb {
+	if a.version < version.Deneb {
 		return nil, consensus_types.ErrNotSupported("PbV3", a.version)
 	}
 	if a.timeStamp == 0 && len(a.prevRandao) == 0 && len(a.parentBeaconBlockRoot) == 0 {


### PR DESCRIPTION
This ensures we can call FCU with the correct attribute post Electra