### PR TITLE
CI: Enable experimental_remote_downloader

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -12,8 +12,7 @@
 build:remote-cache --remote_download_minimal
 build:remote-cache --remote_build_event_upload=minimal
 build:remote-cache --remote_cache=grpc://bazel-remote-cache:9092
-# Does not work with rules_oci. See https://github.com/bazel-contrib/rules_oci/issues/292
-#build:remote-cache --experimental_remote_downloader=grpc://bazel-remote-cache:9092
+build:remote-cache --experimental_remote_downloader=grpc://bazel-remote-cache:9092
 build:remote-cache --remote_local_fallback
 build:remote-cache --experimental_remote_cache_async
 build:remote-cache --experimental_remote_merkle_tree_cache


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**


The remote downloader enables CI to cache remote downloads and save on bandwidth consumption.

**Which issues(s) does this PR fix?**

Related: https://github.com/bazel-contrib/rules_oci/issues/292
We should update that issue if this PR merges successfully and is not reverted after a few days.

**Other notes for review**
