### PR TITLE
Revert default LocalBlockValueBoost to 0

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -29,7 +29,7 @@ var (
 		Name: "local-block-value-boost",
 		Usage: "A percentage boost for local block construction as a Uint64. This is used to prioritize local block construction over relay/builder block construction" +
 			"Boost is an additional percentage to multiple local block value. Use builder block if: builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)",
-		Value: 10,
+		Value: 0,
 	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer
 	ExecutionEngineEndpoint = &cli.StringFlag{


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**
Reversion of https://github.com/prysmaticlabs/prysm/pull/13772

Since the geth team made an [opinionated decision](https://github.com/ethereum/go-ethereum/issues/29771#issuecomment-2109725168) to, by default, enforce a 1 gwei minimum tip and intentionally exclude over half of valid transactions in their locally built blocks (approximately [100 transactions](https://dune.com/queries/3718742/6256673) per block) it may no longer be a benefit for censorship resistance and network health to encourage more local block building.

Since this geth behavior is already live on the network, we should consider whether it makes sense to revert `LocalBlockValueBoost` to 0 if geth decides to maintain the status quo.
