### PR TITLE
p2p: Increase pubsub message seen TTL from 120s to two epochs

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -138,12 +138,12 @@ func (s *Service) internalBroadcastAttestation(ctx context.Context, subnet uint6
 	}
 	// In the event our attestation is outdated and beyond the
 	// acceptable threshold, we exit early and do not broadcast it.
-	currSlot := slots.CurrentSlot(uint64(s.genesisTime.Unix()))
 	if err := helpers.ValidateAttestationTime(att.GetData().Slot, s.genesisTime, params.BeaconConfig().MaximumGossipClockDisparityDuration()); err != nil {
+		currSlot := slots.CurrentSlot(uint64(s.genesisTime.Unix()))
 		log.WithFields(logrus.Fields{
 			"attestationSlot": att.GetData().Slot,
 			"currentSlot":     currSlot,
-		}).WithError(err).Warning("Attestation is too old to broadcast, discarding it")
+		}).WithError(err).Debug("Attestation is too old to broadcast, discarding it")
 		return
 	}
 

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	pbrpc "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 )
@@ -147,6 +148,7 @@ func (s *Service) pubsubOptions() []pubsub.Option {
 		pubsub.WithPeerScoreInspect(s.peerInspector, time.Minute),
 		pubsub.WithGossipSubParams(pubsubGossipParam()),
 		pubsub.WithRawTracer(gossipTracer{host: s.host}),
+		pubsub.WithSeenMessagesTTL(time.Duration(params.BeaconConfig().SlotsPerEpoch*primitives.Slot(params.BeaconConfig().SecondsPerSlot)) * 2),
 	}
 
 	if len(s.cfg.StaticPeers) > 0 {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Since attestations are valid for two epochs, it is more appropriate to maintain a history of these
seen messages for two epochs so that Prysm is not redundantly sending valid attestations through the
network.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

This matches [Lighthouse's configuration](https://github.com/sigp/lighthouse/blob/3058b96f2560f1da04ada4f9d8ba8e5651794ff6/beacon_node/lighthouse_network/src/config.rs#L487)

This PR also changes the log level of expired attestations to debug since it was occuring so often
during my testing and some [users have reported it](https://github.com/prysmaticlabs/prysm/issues/13810#issuecomment-2119782720).
