### PR TITLE
Fix TestNodeHealth_Concurrently race condition

### DIFF
--- a/api/client/beacon/health_test.go
+++ b/api/client/beacon/health_test.go
@@ -99,9 +99,9 @@ func TestNodeHealth_Concurrency(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			defer wg.Done()
-			client.EXPECT().IsHealthy(gomock.Any()).Return(false)
+			client.EXPECT().IsHealthy(gomock.Any()).Return(false).Times(1)
 			n.CheckHealth(context.Background())
-			client.EXPECT().IsHealthy(gomock.Any()).Return(true)
+			client.EXPECT().IsHealthy(gomock.Any()).Return(true).Times(1)
 			n.CheckHealth(context.Background())
 		}()
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
`bazel test //... --@io_bazel_rules_go//go/config:race` detected multiple race conditions present in our code base. 

This PR fixes the race condition detected in `TestNodeHealth_Concurrently`.

**Other notes for review**
