### PR TITLE
Refactor assignment container to include proposer slots

### DIFF
--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -191,7 +191,7 @@ func Assignments(
 	if err != nil {
 		return nil, err
 	}
-	assignmentMap := make(map[primitives.ValidatorIndex]*AssignmentContainer, len(activeValidatorIndices))
+	assignmentMap := make(map[primitives.ValidatorIndex]*AssignmentContainer)
 
 	for slot := startSlot; slot < startSlot+params.BeaconConfig().SlotsPerEpoch; slot++ {
 		// Skip proposer assignment for genesis slot.

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/assignments.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/assignments.go
@@ -105,7 +105,7 @@ func (bs *Server) ListValidatorAssignments(
 	}
 
 	// Initialize all committee related data.
-	committeeAssignments, proposerIndexToSlots, err := helpers.CommitteeAssignments(ctx, requestedState, requestedEpoch)
+	assignments, err := helpers.Assignments(ctx, requestedState, requestedEpoch)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not compute committee assignments: %v", err)
 	}
@@ -115,13 +115,13 @@ func (bs *Server) ListValidatorAssignments(
 			return nil, status.Errorf(codes.OutOfRange, "Validator index %d >= validator count %d",
 				index, requestedState.NumValidators())
 		}
-		comAssignment := committeeAssignments[index]
+		a := assignments[index]
 		pubkey := requestedState.PubkeyAtIndex(index)
 		assign := &ethpb.ValidatorAssignments_CommitteeAssignment{
-			BeaconCommittees: comAssignment.Committee,
-			CommitteeIndex:   comAssignment.CommitteeIndex,
-			AttesterSlot:     comAssignment.AttesterSlot,
-			ProposerSlots:    proposerIndexToSlots[index],
+			BeaconCommittees: a.Committee,
+			CommitteeIndex:   a.CommitteeIndex,
+			AttesterSlot:     a.AttesterSlot,
+			ProposerSlots:    a.ProposerSlots,
 			PublicKey:        pubkey[:],
 			ValidatorIndex:   index,
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/assignments_test.go
@@ -174,16 +174,16 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.
 
 	activeIndices, err := helpers.ActiveValidatorIndices(ctx, s, 0)
 	require.NoError(t, err)
-	committeeAssignments, proposerIndexToSlots, err := helpers.CommitteeAssignments(context.Background(), s, 0)
+	assignments, err := helpers.Assignments(context.Background(), s, 0)
 	require.NoError(t, err)
 	for _, index := range activeIndices[0:params.BeaconConfig().DefaultPageSize] {
 		val, err := s.ValidatorAtIndex(index)
 		require.NoError(t, err)
 		wanted = append(wanted, &ethpb.ValidatorAssignments_CommitteeAssignment{
-			BeaconCommittees: committeeAssignments[index].Committee,
-			CommitteeIndex:   committeeAssignments[index].CommitteeIndex,
-			AttesterSlot:     committeeAssignments[index].AttesterSlot,
-			ProposerSlots:    proposerIndexToSlots[index],
+			BeaconCommittees: assignments[index].Committee,
+			CommitteeIndex:   assignments[index].CommitteeIndex,
+			AttesterSlot:     assignments[index].AttesterSlot,
+			ProposerSlots:    assignments[index].ProposerSlots,
 			PublicKey:        val.PublicKey,
 			ValidatorIndex:   index,
 		})
@@ -244,16 +244,16 @@ func TestServer_ListAssignments_FilterPubkeysIndices_NoPagination(t *testing.T) 
 
 	activeIndices, err := helpers.ActiveValidatorIndices(ctx, s, 0)
 	require.NoError(t, err)
-	committeeAssignments, proposerIndexToSlots, err := helpers.CommitteeAssignments(context.Background(), s, 0)
+	assignments, err := helpers.Assignments(context.Background(), s, 0)
 	require.NoError(t, err)
 	for _, index := range activeIndices[1:4] {
 		val, err := s.ValidatorAtIndex(index)
 		require.NoError(t, err)
 		wanted = append(wanted, &ethpb.ValidatorAssignments_CommitteeAssignment{
-			BeaconCommittees: committeeAssignments[index].Committee,
-			CommitteeIndex:   committeeAssignments[index].CommitteeIndex,
-			AttesterSlot:     committeeAssignments[index].AttesterSlot,
-			ProposerSlots:    proposerIndexToSlots[index],
+			BeaconCommittees: assignments[index].Committee,
+			CommitteeIndex:   assignments[index].CommitteeIndex,
+			AttesterSlot:     assignments[index].AttesterSlot,
+			ProposerSlots:    assignments[index].ProposerSlots,
 			PublicKey:        val.PublicKey,
 			ValidatorIndex:   index,
 		})
@@ -312,16 +312,16 @@ func TestServer_ListAssignments_CanFilterPubkeysIndices_WithPagination(t *testin
 
 	activeIndices, err := helpers.ActiveValidatorIndices(ctx, s, 0)
 	require.NoError(t, err)
-	committeeAssignments, proposerIndexToSlots, err := helpers.CommitteeAssignments(context.Background(), s, 0)
+	as, err := helpers.Assignments(context.Background(), s, 0)
 	require.NoError(t, err)
 	for _, index := range activeIndices[3:5] {
 		val, err := s.ValidatorAtIndex(index)
 		require.NoError(t, err)
 		assignments = append(assignments, &ethpb.ValidatorAssignments_CommitteeAssignment{
-			BeaconCommittees: committeeAssignments[index].Committee,
-			CommitteeIndex:   committeeAssignments[index].CommitteeIndex,
-			AttesterSlot:     committeeAssignments[index].AttesterSlot,
-			ProposerSlots:    proposerIndexToSlots[index],
+			BeaconCommittees: as[index].Committee,
+			CommitteeIndex:   as[index].CommitteeIndex,
+			AttesterSlot:     as[index].AttesterSlot,
+			ProposerSlots:    as[index].ProposerSlots,
 			PublicKey:        val.PublicKey,
 			ValidatorIndex:   index,
 		})
@@ -340,16 +340,16 @@ func TestServer_ListAssignments_CanFilterPubkeysIndices_WithPagination(t *testin
 	req = &ethpb.ListValidatorAssignmentsRequest{Indices: []primitives.ValidatorIndex{1, 2, 3, 4, 5, 6}, PageSize: 5, PageToken: "1"}
 	res, err = bs.ListValidatorAssignments(context.Background(), req)
 	require.NoError(t, err)
-	cAssignments, proposerIndexToSlots, err := helpers.CommitteeAssignments(context.Background(), s, 0)
+	as, err = helpers.Assignments(context.Background(), s, 0)
 	require.NoError(t, err)
 	for _, index := range activeIndices[6:7] {
 		val, err := s.ValidatorAtIndex(index)
 		require.NoError(t, err)
 		assignments = append(assignments, &ethpb.ValidatorAssignments_CommitteeAssignment{
-			BeaconCommittees: cAssignments[index].Committee,
-			CommitteeIndex:   cAssignments[index].CommitteeIndex,
-			AttesterSlot:     cAssignments[index].AttesterSlot,
-			ProposerSlots:    proposerIndexToSlots[index],
+			BeaconCommittees: as[index].Committee,
+			CommitteeIndex:   as[index].CommitteeIndex,
+			AttesterSlot:     as[index].AttesterSlot,
+			ProposerSlots:    as[index].ProposerSlots,
 			PublicKey:        val.PublicKey,
 			ValidatorIndex:   index,
 		})


### PR DESCRIPTION
No functional changes. This PR refactors 
- Adds `ProposerSlots` fields to `CommitteeAssignmentContainer`
- `CommitteeAssignments` return one less argument since proposer slots is already part of the container
- A few renaming for clarity 