### PR TITLE
Convert ZeroWei to a func (avoid shared pointer)

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block_test.go
@@ -18,7 +18,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 
 	// Test when sBlk or sBlk.Block() is nil
 	t.Run("NilBlock", func(t *testing.T) {
-		_, err := vs.constructGenericBeaconBlock(nil, nil, primitives.ZeroWei)
+		_, err := vs.constructGenericBeaconBlock(nil, nil, primitives.ZeroWei())
 		require.ErrorContains(t, "block cannot be nil", err)
 	})
 
@@ -39,7 +39,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 		require.NoError(t, err)
 		r1, err := eb.Block.HashTreeRoot()
 		require.NoError(t, err)
-		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei())
 		require.NoError(t, err)
 		r2, err := result.GetElectra().Block.HashTreeRoot()
 		require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 		contents := &eth.BeaconBlockContentsDeneb{Block: eb.Block, KzgProofs: bundle.Proofs, Blobs: bundle.Blobs}
 		r1, err := contents.HashTreeRoot()
 		require.NoError(t, err)
-		result, err := vs.constructGenericBeaconBlock(b, bundle, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, bundle, primitives.ZeroWei())
 		require.NoError(t, err)
 		r2, err := result.GetDeneb().HashTreeRoot()
 		require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 		r1, err := b.Block().HashTreeRoot()
 		require.NoError(t, err)
 		scs := &enginev1.BlobsBundle{}
-		result, err := vs.constructGenericBeaconBlock(b, scs, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, scs, primitives.ZeroWei())
 		require.NoError(t, err)
 		r2, err := result.GetBlindedDeneb().HashTreeRoot()
 		require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 	t.Run("capella block", func(t *testing.T) {
 		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
 		require.NoError(t, err)
-		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei())
 		require.NoError(t, err)
 		r1, err := result.GetCapella().HashTreeRoot()
 		require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 	t.Run("blind capella block", func(t *testing.T) {
 		b, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockCapella())
 		require.NoError(t, err)
-		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei())
 		require.NoError(t, err)
 		r1, err := result.GetBlindedCapella().HashTreeRoot()
 		require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 	t.Run("bellatrix block", func(t *testing.T) {
 		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
 		require.NoError(t, err)
-		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei())
 		require.NoError(t, err)
 		r1, err := result.GetBellatrix().HashTreeRoot()
 		require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 	t.Run("altair block", func(t *testing.T) {
 		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockAltair())
 		require.NoError(t, err)
-		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei())
 		require.NoError(t, err)
 		r1, err := result.GetAltair().HashTreeRoot()
 		require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestConstructGenericBeaconBlock(t *testing.T) {
 	t.Run("phase0 block", func(t *testing.T) {
 		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 		require.NoError(t, err)
-		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei)
+		result, err := vs.constructGenericBeaconBlock(b, nil, primitives.ZeroWei())
 		require.NoError(t, err)
 		r1, err := result.GetPhase0().HashTreeRoot()
 		require.NoError(t, err)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -225,7 +225,7 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 		vs.setBlsToExecData(sBlk, head)
 	}()
 
-	winningBid := primitives.ZeroWei
+	winningBid := primitives.ZeroWei()
 	var bundle *enginev1.BlobsBundle
 	if sBlk.Version() >= version.Bellatrix {
 		local, err := vs.getLocalPayload(ctx, sBlk.Block(), head)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -59,11 +59,11 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 
 	slot := blk.Block().Slot()
 	if slots.ToEpoch(slot) < params.BeaconConfig().BellatrixForkEpoch {
-		return primitives.ZeroWei, nil, nil
+		return primitives.ZeroWei(), nil, nil
 	}
 
 	if local == nil {
-		return primitives.ZeroWei, nil, errors.New("local payload is nil")
+		return primitives.ZeroWei(), nil, errors.New("local payload is nil")
 	}
 
 	// Use local payload if builder payload is nil.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -503,7 +503,7 @@ func TestServer_setExecutionData(t *testing.T) {
 			GetPayloadResponse: &blocks.GetPayloadResponse{
 				ExecutionData: ed,
 				BlobsBundle:   blobsBundle,
-				Bid:           primitives.ZeroWei,
+				Bid:           primitives.ZeroWei(),
 			},
 		}
 		blk.SetSlot(primitives.Slot(params.BeaconConfig().DenebForkEpoch) * params.BeaconConfig().SlotsPerEpoch)

--- a/consensus-types/blocks/get_payload.go
+++ b/consensus-types/blocks/get_payload.go
@@ -38,7 +38,7 @@ func NewGetPayloadResponse(msg proto.Message) (*GetPayloadResponse, error) {
 		r.BlobsBundle = bundleGetter.GetBlobsBundle()
 	}
 	bidValueGetter, hasBid := msg.(bidValueGetter)
-	wei := primitives.ZeroWei
+	wei := primitives.ZeroWei()
 	if hasBid {
 		// The protobuf types that engine api responses unmarshal into store their values in little endian form.
 		// This is done for consistency with other uint256 values stored in protobufs for SSZ values.

--- a/consensus-types/primitives/wei.go
+++ b/consensus-types/primitives/wei.go
@@ -8,8 +8,10 @@ import (
 	fssz "github.com/prysmaticlabs/fastssz"
 )
 
-// ZeroWei is a non-nil zero value for primitives.Wei
-var ZeroWei Wei = big.NewInt(0)
+// ZW returns a non-nil zero value for primitives.Wei
+func ZeroWei() Wei {
+	return big.NewInt(0)
+}
 
 // Wei is the smallest unit of Ether, represented as a pointer to a bigInt.
 type Wei *big.Int

--- a/consensus-types/primitives/wei_test.go
+++ b/consensus-types/primitives/wei_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWeiStringer(t *testing.T) {
-	require.Equal(t, "0", primitives.WeiToBigInt(primitives.ZeroWei).String())
+	require.Equal(t, "0", primitives.WeiToBigInt(primitives.ZeroWei()).String())
 	require.Equal(t, "1234", primitives.WeiToBigInt(primitives.Uint64ToWei(1234)).String())
 	require.Equal(t, "18446744073709551615", primitives.WeiToBigInt(primitives.Uint64ToWei(math.MaxUint64)).String())
 }
@@ -41,6 +41,6 @@ func TestWeiToGwei_CopyOk(t *testing.T) {
 }
 
 func TestZero(t *testing.T) {
-	z := primitives.ZeroWei
+	z := primitives.ZeroWei()
 	require.Equal(t, 0, big.NewInt(0).Cmp(z))
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

Well this isn't a bug yet but it probably would be someday. I defined a package var for `ZeroWei` to serve in places where we need a default value for a `primitives.Wei` which is an alias for a `*big.Int`, but since this is a reference type it seems dangerous to share a pointer value that something could accidentally mutate. So this simple PR converts that value to a func. 
