### PR TITLE
paranoid underflow protection without error handling

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -461,7 +461,7 @@ func (r *blobRange) Request() *p2ppb.BlobSidecarsByRangeRequest {
 	}
 	return &p2ppb.BlobSidecarsByRangeRequest{
 		StartSlot: r.low,
-		Count:     uint64(r.high.SubSlot(r.low)) + 1,
+		Count:     uint64(r.high.FlooredSubSlot(r.low)) + 1,
 	}
 }
 

--- a/consensus-types/primitives/slot.go
+++ b/consensus-types/primitives/slot.go
@@ -124,6 +124,14 @@ func (s Slot) SubSlot(x Slot) Slot {
 	return s.Sub(uint64(x))
 }
 
+// FlooredSubSlot safely subtracts x from the slot, returning 0 if the result would underflow.
+func (s Slot) FlooredSubSlot(x Slot) Slot {
+	if s < x {
+		return 0
+	}
+	return s - x
+}
+
 // SafeSubSlot finds difference between two slot values.
 // In case of arithmetic issues (overflow/underflow/div by zero) error is returned.
 func (s Slot) SafeSubSlot(x Slot) (Slot, error) {


### PR DESCRIPTION
Another "not a bug, yet" change. I found this commit in a branch on my laptop. I meant to commit it in the PR where these blob request filtering methods were added but it got left out. Essentially I want to add this additional option for avoiding slot underflows, because it's good to be paranoid and prevent panics when subtracting slots, but it's also silly to have to handle errors when the underflow should be impossible based on other invariants. In this case the list of blocks has to be sorted by slot by p2p validation rules, so we should never fool the request bound calculation into picking a high slot lower than low slot, but this change makes sure that if some bug is introduced that breaks that invariant we at least won't panic.

**What type of PR is this?**
Bug fix