### PR TITLE
Only log error when aggregator check fails

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -706,7 +706,7 @@ func (v *validator) RolesAt(ctx context.Context, slot primitives.Slot) (map[[fie
 			aggregator, err := v.isAggregator(ctx, duty.Committee, slot, bytesutil.ToBytes48(duty.PublicKey), duty.ValidatorIndex)
 			if err != nil {
 				aggregator = false
-				log.WithError(err).Error("Could not check if a validator is an aggregator")
+				log.WithError(err).Errorf("Could not check if validator %#x is an aggregator", bytesutil.Trunc(duty.PublicKey))
 			}
 			if aggregator {
 				roles = append(roles, iface.RoleAggregator)
@@ -732,7 +732,7 @@ func (v *validator) RolesAt(ctx context.Context, slot primitives.Slot) (map[[fie
 			aggregator, err := v.isSyncCommitteeAggregator(ctx, slot, bytesutil.ToBytes48(duty.PublicKey), duty.ValidatorIndex)
 			if err != nil {
 				aggregator = false
-				log.WithError(err).Error("Could not check if a validator is a sync committee aggregator")
+				log.WithError(err).Errorf("Could not check if validator %#x is an aggregator", bytesutil.Trunc(duty.PublicKey))
 			}
 			if aggregator {
 				roles = append(roles, iface.RoleSyncCommitteeAggregator)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -705,7 +705,8 @@ func (v *validator) RolesAt(ctx context.Context, slot primitives.Slot) (map[[fie
 
 			aggregator, err := v.isAggregator(ctx, duty.Committee, slot, bytesutil.ToBytes48(duty.PublicKey), duty.ValidatorIndex)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not check if a validator is an aggregator")
+				aggregator = false
+				log.WithError(err).Error("Could not check if a validator is an aggregator")
 			}
 			if aggregator {
 				roles = append(roles, iface.RoleAggregator)
@@ -730,7 +731,8 @@ func (v *validator) RolesAt(ctx context.Context, slot primitives.Slot) (map[[fie
 		if inSyncCommittee {
 			aggregator, err := v.isSyncCommitteeAggregator(ctx, slot, bytesutil.ToBytes48(duty.PublicKey), duty.ValidatorIndex)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not check if a validator is a sync committee aggregator")
+				aggregator = false
+				log.WithError(err).Error("Could not check if a validator is a sync committee aggregator")
 			}
 			if aggregator {
 				roles = append(roles, iface.RoleSyncCommitteeAggregator)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

If for whatever reason we are unable to check if the validator is an aggregator, instead of failing and not assigning any roles we should assume the validator is not an aggregator, log the error and continue. That way the validator will be able to get other rewards for the slot.