### PR TITLE
Restrict Dials From Discovery

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -106,7 +106,7 @@ func (s *Service) RefreshENR() {
 
 // listen for new nodes watches for new nodes in the network and adds them to the peerstore.
 func (s *Service) listenForNewNodes() {
-	iterator := enode.Filter(s.dv5Listener.RandomNodes(), s.filterPeer)
+	iterator := filterNodes(s.ctx, s.dv5Listener.RandomNodes(), s.filterPeer)
 	defer iterator.Close()
 
 	for {

--- a/beacon-chain/p2p/iterator.go
+++ b/beacon-chain/p2p/iterator.go
@@ -29,16 +29,7 @@ type filterIter struct {
 // filter criteria.
 func (f *filterIter) Next() bool {
 	lookupCounter := 0
-	start := time.Now()
 	for f.Iterator.Next() {
-		if time.Since(start) > 3*time.Second {
-			log.Infof("query takes %s", time.Since(start).String())
-		}
-		if time.Since(start) > 5*time.Second {
-			log.Infof("very long query %s", time.Since(start).String())
-			runtime.Gosched()
-			time.Sleep(30 * time.Second)
-		}
 		// Do not excessively perform lookups if we constantly receive non-viable peers.
 		if lookupCounter > backOffCounter {
 			lookupCounter = 0
@@ -52,7 +43,6 @@ func (f *filterIter) Next() bool {
 			return true
 		}
 		lookupCounter++
-		start = time.Now()
 	}
 	return false
 }

--- a/beacon-chain/p2p/iterator.go
+++ b/beacon-chain/p2p/iterator.go
@@ -2,9 +2,13 @@ package p2p
 
 import (
 	"context"
+	"runtime"
+	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
+
+const backOffCounter = 50
 
 // filterNodes wraps an iterator such that Next only returns nodes for which
 // the 'check' function returns true. This custom implementation also
@@ -24,13 +28,31 @@ type filterIter struct {
 // Next looks up for the next valid node according to our
 // filter criteria.
 func (f *filterIter) Next() bool {
+	lookupCounter := 0
+	start := time.Now()
 	for f.Iterator.Next() {
+		if time.Since(start) > 3*time.Second {
+			log.Infof("query takes %s", time.Since(start).String())
+		}
+		if time.Since(start) > 5*time.Second {
+			log.Infof("very long query %s", time.Since(start).String())
+			runtime.Gosched()
+			time.Sleep(30 * time.Second)
+		}
+		// Do not excessively perform lookups if we constantly receive non-viable peers.
+		if lookupCounter > backOffCounter {
+			lookupCounter = 0
+			runtime.Gosched()
+			time.Sleep(30 * time.Second)
+		}
 		if f.Context.Err() != nil {
 			return false
 		}
 		if f.check(f.Node()) {
 			return true
 		}
+		lookupCounter++
+		start = time.Now()
 	}
 	return false
 }

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -78,7 +78,6 @@ func (s *Service) FindPeersWithSubnet(ctx context.Context, topic string,
 	}
 
 	wg := new(sync.WaitGroup)
-	backOffCounter := 0
 	for {
 		currNum := len(s.pubsub.ListPeers(topic))
 		if currNum >= threshold {
@@ -88,13 +87,7 @@ func (s *Service) FindPeersWithSubnet(ctx context.Context, topic string,
 			return false, errors.Errorf("unable to find requisite number of peers for topic %s - "+
 				"only %d out of %d peers were able to be found", topic, currNum, threshold)
 		}
-		// Sleep to prevent excessive dials.
-		if backOffCounter > 50 {
-			time.Sleep(12 * time.Second)
-			backOffCounter = 0
-		}
 		nodes := enode.ReadNodes(iterator, int(params.BeaconNetworkConfig().MinimumPeersInSubnetSearch))
-		backOffCounter += len(nodes)
 		for _, node := range nodes {
 			info, _, err := convertToAddrInfo(node)
 			if err != nil {

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -78,6 +78,7 @@ func (s *Service) FindPeersWithSubnet(ctx context.Context, topic string,
 	}
 
 	wg := new(sync.WaitGroup)
+	backOffCounter := 0
 	for {
 		currNum := len(s.pubsub.ListPeers(topic))
 		if currNum >= threshold {
@@ -87,7 +88,13 @@ func (s *Service) FindPeersWithSubnet(ctx context.Context, topic string,
 			return false, errors.Errorf("unable to find requisite number of peers for topic %s - "+
 				"only %d out of %d peers were able to be found", topic, currNum, threshold)
 		}
+		// Sleep to prevent excessive dials.
+		if backOffCounter > 50 {
+			time.Sleep(12 * time.Second)
+			backOffCounter = 0
+		}
 		nodes := enode.ReadNodes(iterator, int(params.BeaconNetworkConfig().MinimumPeersInSubnetSearch))
+		backOffCounter += len(nodes)
 		for _, node := range nodes {
 			info, _, err := convertToAddrInfo(node)
 			if err != nil {

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -227,6 +227,11 @@ var (
 		Usage: "Sets the minimum number of peers that a node will attempt to peer with that are subscribed to a subnet.",
 		Value: 6,
 	}
+	// MaxConcurrentDials defines a flag to set the maximum number of peers that a node will attempt to dial with from discovery.
+	MaxConcurrentDials = &cli.Uint64Flag{
+		Name:  "max-concurrent-dials",
+		Usage: "Sets the maximum number of peers that a node will attempt to dial with from discovery.",
+	}
 	// SuggestedFeeRecipient specifies the fee recipient for the transaction fees.
 	SuggestedFeeRecipient = &cli.StringFlag{
 		Name:  "suggested-fee-recipient",

--- a/cmd/beacon-chain/flags/config.go
+++ b/cmd/beacon-chain/flags/config.go
@@ -11,6 +11,7 @@ type GlobalFlags struct {
 	SubscribeToAllSubnets      bool
 	MinimumSyncPeers           int
 	MinimumPeersPerSubnet      int
+	MaxConcurrentDials         int
 	BlockBatchLimit            int
 	BlockBatchLimitBurstFactor int
 	BlobBatchLimit             int
@@ -45,9 +46,15 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg.BlobBatchLimit = ctx.Int(BlobBatchLimit.Name)
 	cfg.BlobBatchLimitBurstFactor = ctx.Int(BlobBatchLimitBurstFactor.Name)
 	cfg.MinimumPeersPerSubnet = ctx.Int(MinPeersPerSubnet.Name)
+	cfg.MaxConcurrentDials = ctx.Int(MaxConcurrentDials.Name)
 	configureMinimumPeers(ctx, cfg)
 
 	Init(cfg)
+}
+
+// MaxDialIsActive checks if the user has enabled the max dial flag.
+func MaxDialIsActive() bool {
+	return Get().MaxConcurrentDials > 0
 }
 
 func configureMinimumPeers(ctx *cli.Context, cfg *GlobalFlags) {

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -72,6 +72,7 @@ var appFlags = []cli.Flag{
 	flags.WeakSubjectivityCheckpoint,
 	flags.Eth1HeaderReqLimit,
 	flags.MinPeersPerSubnet,
+	flags.MaxConcurrentDials,
 	flags.SuggestedFeeRecipient,
 	flags.TerminalTotalDifficultyOverride,
 	flags.TerminalBlockHashOverride,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -124,6 +124,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.WeakSubjectivityCheckpoint,
 			flags.Eth1HeaderReqLimit,
 			flags.MinPeersPerSubnet,
+			flags.MaxConcurrentDials,
 			flags.MevRelayEndpoint,
 			flags.MaxBuilderEpochMissedSlots,
 			flags.MaxBuilderConsecutiveMissedSlots,


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

There have been longstanding reports of windows users randomly losing peers over the years, this had been chalked down to an improperly configured firewall, timeserver or antivirus. Unfortunately over the years as the network has grown along with more intensive requirements in peer search for nodes, this has continued to happen more. It appears that a recent windows update has exacerbated this problem by quite a bit. This PR tries to fix this once and for all:

- [x] For discovery, we have an aggressive peer search algorithm. This was very useful in finding peers quickly for a recently booted node. However windows as an OS doesn't like the aggressive discovery search too much and randomly decides to block outgoing discovery packets from prysm. This PR makes it less aggressive, so it will take longer for nodes to find their desired number of peers

- [x] Add a flag to restrict the maximum amount of concurrent dials(`-max-concurrent-dials`). In the event users continue running into this, they can run with this flag at a smaller value(5,10, etc). This should stop triggering the OS at the cost of discovery being a lot slower along with possible reduced validator performance.  



**Which issues(s) does this PR fix?**

Fixes #14025 #13936 #13431 #8144

**Other notes for review**
