### PR TITLE
Fix dependent root retrieval for first epoch

### DIFF
--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -709,7 +709,7 @@ func (s *Server) GetAttesterDuties(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var dependentRoot []byte
-	if requestedEpoch == 0 {
+	if requestedEpoch <= 1 {
 		r, err := s.BeaconDB.GenesisBlockRoot(ctx)
 		if err != nil {
 			httputil.HandleError(w, "Could not get genesis block root: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
The issue we encountered during the long-running e2e post-summit is as follows:

- The caller requests duties for epoch 1 at the end of epoch 0
- In this case, we still use the genesis state even if the requested epoch is 1
- We should use the genesis root for the dependent root if the requested epoch is 1