### PR TITLE
PeerDAS: Implement / use data column feed from database.

### DIFF
--- a/beacon-chain/db/filesystem/BUILD.bazel
+++ b/beacon-chain/db/filesystem/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/db/filesystem",
     visibility = ["//visibility:public"],
     deps = [
+        "//async/event:go_default_library",
         "//beacon-chain/verification:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -151,6 +151,7 @@ func (dcn *dataColumnNotifier) ForRoot(root [fieldparams.RootLength]byte) chan u
 	return channel
 }
 
+// Delete removes the channel for the given root.
 func (dcn *dataColumnNotifier) Delete(root [fieldparams.RootLength]byte) {
 	dcn.mut.Lock()
 	defer dcn.mut.Unlock()

--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -65,7 +65,7 @@ func (s *Service) decodePubsubMessage(msg *pubsub.Message) (ssz.Unmarshaler, err
 }
 
 // Replaces our fork digest with the formatter.
-func (_ *Service) replaceForkDigest(topic string) (string, error) {
+func (*Service) replaceForkDigest(topic string) (string, error) {
 	subStrings := strings.Split(topic, "/")
 	if len(subStrings) != 4 {
 		return "", errInvalidTopic

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing"
-	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -71,12 +70,13 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		return errors.Wrapf(err, "unexpected error computing min valid blob request slot, current_slot=%d", cs)
 	}
 
-	// Compute all custodied columns.
+	// Compute all custodied subnets.
 	custodiedSubnets := params.BeaconConfig().CustodyRequirement
 	if flags.Get().SubscribeToAllSubnets {
 		custodiedSubnets = params.BeaconConfig().DataColumnSidecarSubnetCount
 	}
 
+	// Compute all custodied columns.
 	custodiedColumns, err := peerdas.CustodyColumns(s.cfg.p2p.NodeID(), custodiedSubnets)
 	if err != nil {
 		log.WithError(err).Errorf("unexpected error retrieving the node id")
@@ -121,9 +121,10 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		}
 
 		s.rateLimiter.add(stream, 1)
-		root, idx := bytesutil.ToBytes32(requestedColumnIdents[i].BlockRoot), requestedColumnIdents[i].Index
+		requestedRoot, requestedIndex := bytesutil.ToBytes32(requestedColumnIdents[i].BlockRoot), requestedColumnIdents[i].Index
 
-		isCustodied := custodiedColumns[idx]
+		// Decrease the peer's score if it requests a column that is not custodied.
+		isCustodied := custodiedColumns[requestedIndex]
 		if !isCustodied {
 			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 			s.writeErrorResponseToStream(responseCodeInvalidRequest, types.ErrInvalidColumnIndex.Error(), stream)
@@ -133,42 +134,58 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		// TODO: Differentiate between blobs and columns for our storage engine
 		// If the data column is nil, it means it is not yet available in the db.
 		// We wait for it to be available.
-		// TODO: Use a real feed like `nc := s.blobNotifiers.forRoot(root)` instead of this for/sleep loop looking in the DB.
-		var sc *eth.DataColumnSidecar
 
-		for {
-			sc, err = s.cfg.blobStorage.GetColumn(root, idx)
-			if err != nil {
-				if ctxErr := ctx.Err(); ctxErr != nil {
-					closeStream(stream, log)
-					return ctxErr
-				}
+		// Subscribe to the data column channel for this root.
+		rootChannel := s.cfg.blobStorage.DataColumnNotifier.ForRoot(requestedRoot)
+		defer s.cfg.blobStorage.DataColumnNotifier.Delete(requestedRoot)
 
-				if db.IsNotFound(err) {
-					fields := logrus.Fields{
-						"root":  fmt.Sprintf("%#x", root),
-						"index": idx,
-					}
+		// Retrieve the data column from the database.
+		dataColumnSidecar, err := s.cfg.blobStorage.GetColumn(requestedRoot, requestedIndex)
 
-					log.WithFields(fields).Debugf("Peer requested data column sidecar by root not found in db, waiting for it to be available")
-					time.Sleep(100 * time.Millisecond) // My heart is crying
-					continue
-				}
+		if err != nil && !db.IsNotFound(err) {
+			s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
+			return errors.Wrap(err, "get column")
+		}
 
-				log.WithError(err).Errorf("unexpected db error retrieving data column, root=%x, index=%d", root, idx)
-				s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
-
-				return errors.Wrap(err, "get column")
+		if err != nil && db.IsNotFound(err) {
+			fields := logrus.Fields{
+				"root":  fmt.Sprintf("%#x", requestedRoot),
+				"index": requestedIndex,
 			}
 
-			break
+			log.WithFields(fields).Debug("Peer requested data column sidecar by root not found in db, waiting for it to be available")
+
+		loop:
+			for {
+				select {
+				case receivedIndex := <-rootChannel:
+					if receivedIndex == requestedIndex {
+						// This is the data column we are looking for.
+						log.WithFields(fields).Debug("Data column sidecar by root is now available in the db")
+
+						break loop
+					}
+
+				case <-ctx.Done():
+					closeStream(stream, log)
+					return errors.Errorf("context closed while waiting for data column with root %#x and index %d", requestedRoot, requestedIndex)
+				}
+			}
+
+			// Retrieve the data column from the db.
+			dataColumnSidecar, err = s.cfg.blobStorage.GetColumn(requestedRoot, requestedIndex)
+			if err != nil {
+				// This time, no error (even not found error) should be returned.
+				s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
+				return errors.Wrap(err, "get column")
+			}
 		}
 
 		// If any root in the request content references a block earlier than minimum_request_epoch,
 		// peers MAY respond with error code 3: ResourceUnavailable or not include the data column in the response.
 		// note: we are deviating from the spec to allow requests for data column that are before minimum_request_epoch,
 		// up to the beginning of the retention period.
-		if sc.SignedBlockHeader.Header.Slot < minReqSlot {
+		if dataColumnSidecar.SignedBlockHeader.Header.Slot < minReqSlot {
 			s.writeErrorResponseToStream(responseCodeResourceUnavailable, types.ErrDataColumnLTMinRequest.Error(), stream)
 			log.WithError(types.ErrDataColumnLTMinRequest).
 				Debugf("requested data column for block %#x before minimum_request_epoch", requestedColumnIdents[i].BlockRoot)
@@ -176,7 +193,7 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		}
 
 		SetStreamWriteDeadline(stream, defaultWriteDuration)
-		if chunkErr := WriteDataColumnSidecarChunk(stream, s.cfg.chain, s.cfg.p2p.Encoding(), sc); chunkErr != nil {
+		if chunkErr := WriteDataColumnSidecarChunk(stream, s.cfg.chain, s.cfg.p2p.Encoding(), dataColumnSidecar); chunkErr != nil {
 			log.WithError(chunkErr).Debug("Could not send a chunked response")
 			s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 			tracing.AnnotateError(span, chunkErr)

--- a/beacon-chain/sync/subscriber_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation.go
@@ -36,11 +36,11 @@ func (s *Service) committeeIndexBeaconAttestationSubscriber(_ context.Context, m
 	return s.cfg.attPool.SaveUnaggregatedAttestation(a)
 }
 
-func (_ *Service) persistentSubnetIndices() []uint64 {
+func (*Service) persistentSubnetIndices() []uint64 {
 	return cache.SubnetIDs.GetAllSubnets()
 }
 
-func (_ *Service) aggregatorSubnetIndices(currentSlot primitives.Slot) []uint64 {
+func (*Service) aggregatorSubnetIndices(currentSlot primitives.Slot) []uint64 {
 	endEpoch := slots.ToEpoch(currentSlot) + 1
 	endSlot := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(endEpoch))
 	var commIds []uint64
@@ -50,7 +50,7 @@ func (_ *Service) aggregatorSubnetIndices(currentSlot primitives.Slot) []uint64 
 	return slice.SetUint64(commIds)
 }
 
-func (_ *Service) attesterSubnetIndices(currentSlot primitives.Slot) []uint64 {
+func (*Service) attesterSubnetIndices(currentSlot primitives.Slot) []uint64 {
 	endEpoch := slots.ToEpoch(currentSlot) + 1
 	endSlot := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(endEpoch))
 	var commIds []uint64


### PR DESCRIPTION
Please read commit by commit.

When receiving a `dataColumnByRoot` requests, this pull request replaces the 100 ms polling by a event system, produced by the database.

In the following scenario:
1. We custody all the columns
2. When a peer sends us a `dataColumnByRoot`, it wants to retrieve the following columns: `[20 58 83 91 96 102 116 123]`
3. However, column `123` is not (yet) available
4. Once the column is available, we move on

```
...
["2024-05-30 15:22:13"]  DEBUG sync: "Received data column sidecar by root request" custodied=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127] custodiedCount=128 handler="data_column_sidecars_by_root" requested=[20 58 83 91 96 102 116 123] requestedCount=8
...
["2024-05-30 15:22:13"]  DEBUG sync: "Peer requested data column sidecar by root not found in db, waiting for it to be available" handler="data_column_sidecars_by_root" index=123 root=0x86234822f22f0c658c26ed771cb52050eadf8d5ce0a0030877c8aa80b77e8bf8
...
["2024-05-30 15:22:13"]  DEBUG sync: "Data column sidecar by root is now available in the db" handler="data_column_sidecars_by_root" index=123 root=0x86234822f22f0c658c26ed771cb52050eadf8d5ce0a0030877c8aa80b77e8bf8
```
