### PR TITLE
`recoverBlobs`: Cover the `0 < blobsCount < fieldparams.MaxBlobsPerBlock` case.

### DIFF
--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -23,25 +23,23 @@ func recoverBlobs(
 	columnsCount int,
 	blockRoot [fieldparams.RootLength]byte,
 ) ([]cKzg4844.Blob, error) {
-	// Check if all columns have the same length.
-	var blobCount *int
+	if len(dataColumnSideCars) == 0 {
+		return nil, errors.New("no data column sidecars")
+	}
 
+	// Check if all columns have the same length.
+	blobCount := len(dataColumnSideCars[0].DataColumn)
 	for _, sidecar := range dataColumnSideCars {
 		length := len(sidecar.DataColumn)
 
-		if blobCount == nil {
-			blobCount = &length
-			continue
-		}
-
-		if *blobCount != length {
+		if length != blobCount {
 			return nil, errors.New("columns do not have the same length")
 		}
 	}
 
-	recoveredBlobs := make([]cKzg4844.Blob, 0, *blobCount)
+	recoveredBlobs := make([]cKzg4844.Blob, 0, blobCount)
 
-	for blobIndex := 0; blobIndex < *blobCount; blobIndex++ {
+	for blobIndex := 0; blobIndex < blobCount; blobIndex++ {
 		start := time.Now()
 
 		cellsId := make([]uint64, 0, columnsCount)

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -23,9 +23,25 @@ func recoverBlobs(
 	columnsCount int,
 	blockRoot [fieldparams.RootLength]byte,
 ) ([]cKzg4844.Blob, error) {
-	recoveredBlobs := make([]cKzg4844.Blob, 0, fieldparams.MaxBlobsPerBlock)
+	// Check if all columns have the same length.
+	var blobCount *int
 
-	for blobIndex := 0; blobIndex < fieldparams.MaxBlobsPerBlock; blobIndex++ {
+	for _, sidecar := range dataColumnSideCars {
+		length := len(sidecar.DataColumn)
+
+		if blobCount == nil {
+			blobCount = &length
+			continue
+		}
+
+		if *blobCount != length {
+			return nil, errors.New("columns do not have the same length")
+		}
+	}
+
+	recoveredBlobs := make([]cKzg4844.Blob, 0, *blobCount)
+
+	for blobIndex := 0; blobIndex < *blobCount; blobIndex++ {
 		start := time.Now()
 
 		cellsId := make([]uint64, 0, columnsCount)


### PR DESCRIPTION
Fix:
```
["2024-05-30 15:15:19"]  ERROR sync: "Panic occurred" error="runtime error: index out of range [4] with length 4" recoveredAt=subscribeWithBase stack="goroutineruntime/debug.Stack()
```