### PR TITLE
Process epoch error to use correct state version

### DIFF
--- a/beacon-chain/core/altair/transition.go
+++ b/beacon-chain/core/altair/transition.go
@@ -28,87 +28,87 @@ import (
 //	process_historical_roots_update(state)
 //	process_participation_flag_updates(state)  # [New in Altair]
 //	process_sync_committee_updates(state)  # [New in Altair]
-func ProcessEpoch(ctx context.Context, state state.BeaconState) (state.BeaconState, error) {
+func ProcessEpoch(ctx context.Context, state state.BeaconState) error {
 	ctx, span := trace.StartSpan(ctx, "altair.ProcessEpoch")
 	defer span.End()
 
 	if state == nil || state.IsNil() {
-		return nil, errors.New("nil state")
+		return errors.New("nil state")
 	}
 	vp, bp, err := InitializePrecomputeValidators(ctx, state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// New in Altair.
 	vp, bp, err = ProcessEpochParticipation(ctx, state, bp, vp)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	state, err = precompute.ProcessJustificationAndFinalizationPreCompute(state, bp)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process justification")
+		return errors.Wrap(err, "could not process justification")
 	}
 
 	// New in Altair.
 	state, vp, err = ProcessInactivityScores(ctx, state, vp)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process inactivity updates")
+		return errors.Wrap(err, "could not process inactivity updates")
 	}
 
 	// New in Altair.
 	state, err = ProcessRewardsAndPenaltiesPrecompute(state, bp, vp)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process rewards and penalties")
+		return errors.Wrap(err, "could not process rewards and penalties")
 	}
 
 	state, err = e.ProcessRegistryUpdates(ctx, state)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process registry updates")
+		return errors.Wrap(err, "could not process registry updates")
 	}
 
 	// Modified in Altair and Bellatrix.
 	proportionalSlashingMultiplier, err := state.ProportionalSlashingMultiplier()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = e.ProcessSlashings(state, proportionalSlashingMultiplier)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = e.ProcessEth1DataReset(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = e.ProcessEffectiveBalanceUpdates(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = e.ProcessSlashingsReset(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = e.ProcessRandaoMixesReset(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = e.ProcessHistoricalDataUpdate(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// New in Altair.
 	state, err = ProcessParticipationFlagUpdates(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// New in Altair.
-	state, err = ProcessSyncCommitteeUpdates(ctx, state)
+	_, err = ProcessSyncCommitteeUpdates(ctx, state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return state, nil
+	return nil
 }

--- a/beacon-chain/core/altair/transition_test.go
+++ b/beacon-chain/core/altair/transition_test.go
@@ -13,9 +13,9 @@ import (
 func TestProcessEpoch_CanProcess(t *testing.T) {
 	st, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().MaxValidatorsPerCommittee)
 	require.NoError(t, st.SetSlot(10*params.BeaconConfig().SlotsPerEpoch))
-	newState, err := altair.ProcessEpoch(context.Background(), st)
+	err := altair.ProcessEpoch(context.Background(), st)
 	require.NoError(t, err)
-	require.Equal(t, uint64(0), newState.Slashings()[2], "Unexpected slashed balance")
+	require.Equal(t, uint64(0), st.Slashings()[2], "Unexpected slashed balance")
 
 	b := st.Balances()
 	require.Equal(t, params.BeaconConfig().MaxValidatorsPerCommittee, uint64(len(b)))
@@ -45,9 +45,9 @@ func TestProcessEpoch_CanProcess(t *testing.T) {
 func TestProcessEpoch_CanProcessBellatrix(t *testing.T) {
 	st, _ := util.DeterministicGenesisStateBellatrix(t, params.BeaconConfig().MaxValidatorsPerCommittee)
 	require.NoError(t, st.SetSlot(10*params.BeaconConfig().SlotsPerEpoch))
-	newState, err := altair.ProcessEpoch(context.Background(), st)
+	err := altair.ProcessEpoch(context.Background(), st)
 	require.NoError(t, err)
-	require.Equal(t, uint64(0), newState.Slashings()[2], "Unexpected slashed balance")
+	require.Equal(t, uint64(0), st.Slashings()[2], "Unexpected slashed balance")
 
 	b := st.Balances()
 	require.Equal(t, params.BeaconConfig().MaxValidatorsPerCommittee, uint64(len(b)))

--- a/beacon-chain/core/electra/transition.go
+++ b/beacon-chain/core/electra/transition.go
@@ -46,84 +46,84 @@ var (
 //	    process_effective_balance_updates(state)
 //	    process_slashings_reset(state)
 //	    process_randao_mixes_reset(state)
-func ProcessEpoch(ctx context.Context, state state.BeaconState) (state.BeaconState, error) {
+func ProcessEpoch(ctx context.Context, state state.BeaconState) error {
 	_, span := trace.StartSpan(ctx, "electra.ProcessEpoch")
 	defer span.End()
 
 	if state == nil || state.IsNil() {
-		return nil, errors.New("nil state")
+		return errors.New("nil state")
 	}
 	vp, bp, err := InitializePrecomputeValidators(ctx, state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	vp, bp, err = ProcessEpochParticipation(ctx, state, bp, vp)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = precompute.ProcessJustificationAndFinalizationPreCompute(state, bp)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process justification")
+		return errors.Wrap(err, "could not process justification")
 	}
 	state, vp, err = ProcessInactivityScores(ctx, state, vp)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process inactivity updates")
+		return errors.Wrap(err, "could not process inactivity updates")
 	}
 	state, err = ProcessRewardsAndPenaltiesPrecompute(state, bp, vp)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process rewards and penalties")
+		return errors.Wrap(err, "could not process rewards and penalties")
 	}
 
 	state, err = ProcessRegistryUpdates(ctx, state)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not process registry updates")
+		return errors.Wrap(err, "could not process registry updates")
 	}
 
 	proportionalSlashingMultiplier, err := state.ProportionalSlashingMultiplier()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = ProcessSlashings(state, proportionalSlashingMultiplier)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = ProcessEth1DataReset(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if err = ProcessPendingBalanceDeposits(ctx, state, primitives.Gwei(bp.ActiveCurrentEpoch)); err != nil {
-		return nil, err
+		return err
 	}
-	if err := ProcessPendingConsolidations(ctx, state); err != nil {
-		return nil, err
+	if err = ProcessPendingConsolidations(ctx, state); err != nil {
+		return err
 	}
-	if err := ProcessEffectiveBalanceUpdates(state); err != nil {
-		return nil, err
+	if err = ProcessEffectiveBalanceUpdates(state); err != nil {
+		return err
 	}
 
 	state, err = ProcessSlashingsReset(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = ProcessRandaoMixesReset(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	state, err = ProcessHistoricalDataUpdate(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	state, err = ProcessParticipationFlagUpdates(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	state, err = ProcessSyncCommitteeUpdates(ctx, state)
+	_, err = ProcessSyncCommitteeUpdates(ctx, state)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return state, nil
+	return nil
 }

--- a/beacon-chain/core/transition/altair_transition_no_verify_sig_test.go
+++ b/beacon-chain/core/transition/altair_transition_no_verify_sig_test.go
@@ -226,7 +226,7 @@ func TestProcessEpoch_BadBalanceAltair(t *testing.T) {
 	epochParticipation[0] = participation
 	assert.NoError(t, s.SetCurrentParticipationBits(epochParticipation))
 	assert.NoError(t, s.SetPreviousParticipationBits(epochParticipation))
-	_, err = altair.ProcessEpoch(context.Background(), s)
+	err = altair.ProcessEpoch(context.Background(), s)
 	assert.ErrorContains(t, "addition overflows", err)
 }
 

--- a/beacon-chain/core/transition/bellatrix_transition_no_verify_sig_test.go
+++ b/beacon-chain/core/transition/bellatrix_transition_no_verify_sig_test.go
@@ -216,7 +216,7 @@ func TestProcessEpoch_BadBalanceBellatrix(t *testing.T) {
 	epochParticipation[0] = participation
 	assert.NoError(t, s.SetCurrentParticipationBits(epochParticipation))
 	assert.NoError(t, s.SetPreviousParticipationBits(epochParticipation))
-	_, err = altair.ProcessEpoch(context.Background(), s)
+	err = altair.ProcessEpoch(context.Background(), s)
 	assert.ErrorContains(t, "addition overflows", err)
 }
 

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -257,16 +257,18 @@ func ProcessSlots(ctx context.Context, state state.BeaconState, slot primitives.
 					return nil, errors.Wrap(err, "could not process epoch with optimizations")
 				}
 			} else if state.Version() <= version.Deneb {
+				stateVersion := version.String(state.Version())
 				state, err = altair.ProcessEpoch(ctx, state)
 				if err != nil {
 					tracing.AnnotateError(span, err)
-					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", version.String(state.Version())))
+					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", stateVersion))
 				}
 			} else {
+				stateVersion := version.String(state.Version())
 				state, err = electra.ProcessEpoch(ctx, state)
 				if err != nil {
 					tracing.AnnotateError(span, err)
-					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", version.String(state.Version())))
+					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", stateVersion))
 				}
 			}
 		}

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -257,18 +257,14 @@ func ProcessSlots(ctx context.Context, state state.BeaconState, slot primitives.
 					return nil, errors.Wrap(err, "could not process epoch with optimizations")
 				}
 			} else if state.Version() <= version.Deneb {
-				stateVersion := version.String(state.Version())
-				state, err = altair.ProcessEpoch(ctx, state)
-				if err != nil {
+				if err = altair.ProcessEpoch(ctx, state); err != nil {
 					tracing.AnnotateError(span, err)
-					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", stateVersion))
+					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", version.String(state.Version())))
 				}
 			} else {
-				stateVersion := version.String(state.Version())
-				state, err = electra.ProcessEpoch(ctx, state)
-				if err != nil {
+				if err = electra.ProcessEpoch(ctx, state); err != nil {
 					tracing.AnnotateError(span, err)
-					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", stateVersion))
+					return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", version.String(state.Version())))
 				}
 			}
 		}

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -209,7 +209,7 @@ func ReplayProcessSlots(ctx context.Context, state state.BeaconState, slot primi
 					return nil, errors.Wrap(err, "could not process epoch with optimizations")
 				}
 			} else {
-				state, err = altair.ProcessEpoch(ctx, state)
+				err = altair.ProcessEpoch(ctx, state)
 				if err != nil {
 					tracing.AnnotateError(span, err)
 					return nil, errors.Wrap(err, "could not process epoch")


### PR DESCRIPTION
h/t Seamonkey for pointing out a regression from #14001.

If the `ProcessEpoch` function returns an error, the state is `nil` by default. We can't use that to get the state version, or it will panic as seen below:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x468 pc=0x37a1d60]

goroutine 607921584 [running]:
github.com/prysmaticlabs/prysm/v5/beacon-chain/core/transition.ProcessSlots({0x1b5eb88?, 0xc10910b1f0?}, {0x1b8abe8, 0xc10de18700}, 0x1b16a0)
        beacon-chain/core/transition/transition.go:263 +0xba0
github.com/prysmaticlabs/prysm/v5/beacon-chain/core/transition.UpdateNextSlotCache({0x1b5eb88, 0xc10910b1f0}, {0xc07f7ffea0, 0x20, 0x1ed738942d8c?}, {0x1b8abe8?, 0xc05b936a80?})
```
This PR fixes the caller return pattern since state is mutated, we don't need to return it