### PR TITLE
PeerDAS: Withhold data on purpose.

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -473,8 +473,9 @@ func (vs *Server) broadcastAndReceiveDataColumns(ctx context.Context, sidecars [
 
 			if colIdx < dataColumnsWithholdCount {
 				log.WithFields(logrus.Fields{
-					"dataColumnIndex": colIdx,
 					"root":            fmt.Sprintf("%#x", root),
+					"subnet":          subnet,
+					"dataColumnIndex": colIdx,
 				}).Warning("Withholding data column")
 			} else {
 				if err := vs.P2P.BroadcastDataColumn(ctx, subnet, sidecar); err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -459,14 +459,27 @@ func (vs *Server) broadcastAndReceiveBlobs(ctx context.Context, sidecars []*ethp
 // broadcastAndReceiveDataColumns handles the broadcasting and reception of data columns sidecars.
 func (vs *Server) broadcastAndReceiveDataColumns(ctx context.Context, sidecars []*ethpb.DataColumnSidecar, root [fieldparams.RootLength]byte) error {
 	eg, _ := errgroup.WithContext(ctx)
+
+	dataColumnsWithholdCount := features.Get().DataColumnsWithholdCount
+
 	for i, sd := range sidecars {
 		// Copy the iteration instance to a local variable to give each go-routine its own copy to play with.
 		// See https://golang.org/doc/faq#closures_and_goroutines for more details.
-		colIdx := i
-		sidecar := sd
+		colIdx, sidecar := i, sd
+
 		eg.Go(func() error {
-			if err := vs.P2P.BroadcastDataColumn(ctx, uint64(colIdx)%params.BeaconConfig().DataColumnSidecarSubnetCount, sidecar); err != nil {
-				return errors.Wrap(err, "broadcast data column")
+			// Compute the subnet index based on the column index.
+			subnet := uint64(colIdx) % params.BeaconConfig().DataColumnSidecarSubnetCount
+
+			if colIdx < dataColumnsWithholdCount {
+				log.WithFields(logrus.Fields{
+					"dataColumnIndex": colIdx,
+					"root":            fmt.Sprintf("%#x", root),
+				}).Warning("Withholding data column")
+			} else {
+				if err := vs.P2P.BroadcastDataColumn(ctx, subnet, sidecar); err != nil {
+					return errors.Wrap(err, "broadcast data column")
+				}
 			}
 
 			roDataColumn, err := blocks.NewRODataColumnWithRoot(sidecar, root)

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -75,6 +75,9 @@ type Flags struct {
 	// EnablePeerDAS enables running the node with the experimental data availability sampling scheme.
 	EnablePeerDAS bool
 
+	// DataColumnsWithholdCount specifies the likelihood of withholding a data column sidecar when proposing a block (percentage)
+	DataColumnsWithholdCount int
+
 	SaveInvalidBlock           bool // SaveInvalidBlock saves invalid block to temp.
 	SaveInvalidBlob            bool // SaveInvalidBlob saves invalid blob to temp.
 	EIP6110ValidatorIndexCache bool // EIP6110ValidatorIndexCache specifies whether to use the new validator index cache.
@@ -260,6 +263,11 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.IsSet(EnablePeerDAS.Name) {
 		logEnabled(EnablePeerDAS)
 		cfg.EnablePeerDAS = true
+	}
+
+	if ctx.IsSet(DataColumnsWithholdCount.Name) {
+		logEnabled(DataColumnsWithholdCount)
+		cfg.DataColumnsWithholdCount = ctx.Int(DataColumnsWithholdCount.Name)
 	}
 
 	if ctx.IsSet(eip6110ValidatorCache.Name) {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -171,9 +171,17 @@ var (
 		Name:  "eip6110-validator-cache",
 		Usage: "Enables the EIP-6110 validator cache.",
 	}
+	// EnablePeerDAS is a flag for enabling the peer data availability sampling.
 	EnablePeerDAS = &cli.BoolFlag{
 		Name:  "peer-das",
 		Usage: "Enables Prysm to run with the experimental peer data availability sampling scheme.",
+	}
+	// DataColumnsWithholdCount is a flag for withholding data columns when proposing a block.
+	DataColumnsWithholdCount = &cli.IntFlag{
+		Name:   "data-columns-withhold-count",
+		Usage:  "Number of columns to withhold when proposing a block. DO NOT USE IN PRODUCTION.",
+		Value:  0,
+		Hidden: true,
 	}
 )
 
@@ -234,6 +242,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	EnableQUIC,
 	eip6110ValidatorCache,
 	EnablePeerDAS,
+	DataColumnsWithholdCount,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
This PR introduces the **hidden** `--data-columns-withhold-count` flag.

When set to a non null `i` value, the block proposer will withhold all the data columns with index `< i`.
The main purpose of this flag is to test the correctness of the reconstruction either in E2E tests or in interop with Kurtosis.