### PR TITLE
PeerDAS: Gossip the reconstructed columns

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -593,8 +593,13 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 			if len(missing) == 0 {
 				return
 			}
-			log.WithFields(daCheckLogFields(root, signed.Block().Slot(), expected, len(missing))).
-				Error("Still waiting for DA check at slot end.")
+
+			log.WithFields(logrus.Fields{
+				"slot":          signed.Block().Slot(),
+				"root":          fmt.Sprintf("%#x", root),
+				"blobsExpected": expected,
+				"blobsWaiting":  len(missing),
+			}).Error("Still waiting for blobs DA check at slot end.")
 		})
 		defer nst.Stop()
 	}
@@ -650,24 +655,28 @@ func (s *Service) isDataAvailableDataColumns(ctx context.Context, root [32]byte,
 	if err != nil {
 		return err
 	}
-	// expected is the number of custodied data columnns a node is expected to have.
+	// Expected is the number of custodied data columnns a node is expected to have.
 	expected := len(colMap)
 	if expected == 0 {
 		return nil
 	}
-	// get a map of data column indices that are not currently available.
+
+	// Subscribe to newsly data columns stored in the database.
+	rootIndexChan := make(chan filesystem.RootIndexPair)
+	subscription := s.blobStorage.DataColumnFeed.Subscribe(rootIndexChan)
+	defer subscription.Unsubscribe()
+
+	// Get a map of data column indices that are not currently available.
 	missing, err := missingDataColumns(s.blobStorage, root, colMap)
 	if err != nil {
 		return err
 	}
+
 	// If there are no missing indices, all data column sidecars are available.
+	// This is the happy path.
 	if len(missing) == 0 {
 		return nil
 	}
-
-	// The gossip handler for data columns writes the index of each verified data column referencing the given
-	// root to the channel returned by blobNotifiers.forRoot.
-	nc := s.blobNotifiers.forRoot(root)
 
 	// Log for DA checks that cross over into the next slot; helpful for debugging.
 	nextSlot := slots.BeginsAt(signed.Block().Slot()+1, s.genesisTime)
@@ -677,40 +686,39 @@ func (s *Service) isDataAvailableDataColumns(ctx context.Context, root [32]byte,
 			if len(missing) == 0 {
 				return
 			}
-			log.WithFields(daCheckLogFields(root, signed.Block().Slot(), expected, len(missing))).
-				Error("Still waiting for DA check at slot end.")
+
+			log.WithFields(logrus.Fields{
+				"slot":            signed.Block().Slot(),
+				"root":            fmt.Sprintf("%#x", root),
+				"columnsExpected": expected,
+				"columnsWaiting":  len(missing),
+			}).Error("Still waiting for data columns DA check at slot end.")
 		})
 		defer nst.Stop()
 	}
 	for {
 		select {
-		case idx := <-nc:
-			// Delete each index seen in the notification channel.
-			delete(missing, idx)
-			// Read from the channel until there are no more missing sidecars.
-			if len(missing) > 0 {
+		case rootIndex := <-rootIndexChan:
+			if rootIndex.Root != root {
+				// This is not the root we are looking for.
 				continue
 			}
-			// Once all sidecars have been observed, clean up the notification channel.
-			s.blobNotifiers.delete(root)
-			return nil
+
+			// Remove the index from the missing map.
+			delete(missing, rootIndex.Index)
+
+			// Exit if there is no more missing data columns.
+			if len(missing) == 0 {
+				return nil
+			}
 		case <-ctx.Done():
 			missingIndexes := make([]uint64, 0, len(missing))
 			for val := range missing {
 				copiedVal := val
 				missingIndexes = append(missingIndexes, copiedVal)
 			}
-			return errors.Wrapf(ctx.Err(), "context deadline waiting for blob sidecars slot: %d, BlockRoot: %#x, missing %v", block.Slot(), root, missingIndexes)
+			return errors.Wrapf(ctx.Err(), "context deadline waiting for data column sidecars slot: %d, BlockRoot: %#x, missing %v", block.Slot(), root, missingIndexes)
 		}
-	}
-}
-
-func daCheckLogFields(root [32]byte, slot primitives.Slot, expected, missing int) logrus.Fields {
-	return logrus.Fields{
-		"slot":          slot,
-		"root":          fmt.Sprintf("%#x", root),
-		"blobsExpected": expected,
-		"blobsWaiting":  missing,
 	}
 }
 

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -122,15 +122,6 @@ func (s *Service) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySig
 	if err := eg.Wait(); err != nil {
 		return err
 	}
-
-	if features.Get().EnablePeerDAS {
-		// We need to save the block before checking data availability since reconstruction needs it.
-		// It is safe to save the block multiple times, since it won't be re-stored if it is already in the cache.
-		if err := s.cfg.BeaconDB.SaveBlock(ctx, blockCopy); err != nil {
-			return errors.Wrapf(err, "save block at slot %d", blockCopy.Block().Slot())
-		}
-	}
-
 	daStartTime := time.Now()
 	if avs != nil {
 		if err := avs.IsDataAvailable(ctx, s.CurrentSlot(), rob); err != nil {

--- a/beacon-chain/blockchain/receive_data_column.go
+++ b/beacon-chain/blockchain/receive_data_column.go
@@ -3,16 +3,14 @@ package blockchain
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 )
 
 func (s *Service) ReceiveDataColumn(ctx context.Context, ds blocks.VerifiedRODataColumn) error {
 	if err := s.blobStorage.SaveDataColumn(ds); err != nil {
-		return err
+		return errors.Wrap(err, "save data column")
 	}
 
-	// TODO use a custom event or new method of for data columns. For speed
-	// we are simply reusing blob paths here.
-	s.sendNewBlobEvent(ds.BlockRoot(), ds.ColumnIndex)
 	return nil
 }

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	cKzg4844 "github.com/ethereum/c-kzg-4844/bindings/go"
@@ -10,12 +11,17 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/peerdas"
+	"github.com/prysmaticlabs/prysm/v5/cmd/beacon-chain/flags"
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/time/slots"
 	"github.com/sirupsen/logrus"
 )
+
+const broadCastMissingDataColumnsTimeIntoSlot = 3 * time.Second
 
 // recoverBlobs recovers the blobs from the data column sidecars.
 func recoverBlobs(
@@ -139,12 +145,12 @@ func (s *Service) reconstructDataColumns(ctx context.Context, verifiedRODataColu
 	blockRoot := verifiedRODataColumn.BlockRoot()
 
 	// Get the columns we store.
-	storedColumnsIndices, err := s.cfg.blobStorage.ColumnIndices(blockRoot)
+	storedDataColumns, err := s.cfg.blobStorage.ColumnIndices(blockRoot)
 	if err != nil {
 		return errors.Wrap(err, "columns indices")
 	}
 
-	storedColumnsCount := len(storedColumnsIndices)
+	storedColumnsCount := len(storedDataColumns)
 	numberOfColumns := fieldparams.NumberOfColumns
 
 	// If less than half of the columns are stored, reconstruction is not possible.
@@ -155,7 +161,7 @@ func (s *Service) reconstructDataColumns(ctx context.Context, verifiedRODataColu
 
 	// Load the data columns sidecars.
 	dataColumnSideCars := make([]*ethpb.DataColumnSidecar, 0, storedColumnsCount)
-	for index := range storedColumnsIndices {
+	for index := range storedDataColumns {
 		dataColumnSidecar, err := s.cfg.blobStorage.GetColumn(blockRoot, index)
 		if err != nil {
 			return errors.Wrap(err, "get column")
@@ -197,5 +203,167 @@ func (s *Service) reconstructDataColumns(ctx context.Context, verifiedRODataColu
 
 	log.WithField("root", fmt.Sprintf("%x", blockRoot)).Debug("Data columns reconstructed successfully")
 
+	// Schedule the broadcast.
+	if err := s.scheduleReconstructedDataColumnsBroadcast(ctx, blockRoot, verifiedRODataColumn); err != nil {
+		return errors.Wrap(err, "schedule reconstructed data columns broadcast")
+	}
+
 	return nil
+}
+
+func (s *Service) scheduleReconstructedDataColumnsBroadcast(
+	ctx context.Context,
+	blockRoot [fieldparams.RootLength]byte,
+	dataColumn blocks.VerifiedRODataColumn,
+) error {
+	// Retrieve the slot of the block.
+	slot := dataColumn.Slot()
+
+	// Get the time corresponding to the start of the slot.
+	slotStart, err := slots.ToTime(uint64(s.cfg.chain.GenesisTime().Unix()), slot)
+	if err != nil {
+		return errors.Wrap(err, "to time")
+	}
+
+	// Compute when to broadcast the missing data columns.
+	broadcastTime := slotStart.Add(broadCastMissingDataColumnsTimeIntoSlot)
+
+	// Compute the waiting time. This could be negative. In such a case, broadcast immediately.
+	waitingTime := time.Until(broadcastTime)
+
+	time.AfterFunc(waitingTime, func() {
+		s.dataColumsnReconstructionLock.Lock()
+		defer s.deleteReceivedDataColumns(blockRoot)
+		defer s.dataColumsnReconstructionLock.Unlock()
+
+		// Get the received by gossip data columns.
+		receivedDataColumns := s.receivedDataColumns(blockRoot)
+		if receivedDataColumns == nil {
+			log.WithField("root", fmt.Sprintf("%x", blockRoot)).Error("No received data columns")
+		}
+
+		// Get the data columns we should store.
+		custodiedSubnetCount := params.BeaconConfig().CustodyRequirement
+		if flags.Get().SubscribeToAllSubnets {
+			custodiedSubnetCount = params.BeaconConfig().DataColumnSidecarSubnetCount
+		}
+
+		custodiedDataColumns, err := peerdas.CustodyColumns(s.cfg.p2p.NodeID(), custodiedSubnetCount)
+		if err != nil {
+			log.WithError(err).Error("Custody columns")
+		}
+
+		// Get the data columns we actually store.
+		storedDataColumns, err := s.cfg.blobStorage.ColumnIndices(blockRoot)
+		if err != nil {
+			log.WithField("root", fmt.Sprintf("%x", blockRoot)).WithError(err).Error("Columns indices")
+			return
+		}
+
+		// Compute the missing data columns (data columns we should custody but we do not have received via gossip.)
+		missingColumns := make(map[uint64]bool, len(custodiedDataColumns))
+		for column := range custodiedDataColumns {
+			if ok := receivedDataColumns[column]; !ok {
+				missingColumns[column] = true
+			}
+		}
+
+		// Exit early if there are no missing data columns.
+		// This is the happy path.
+		if len(missingColumns) == 0 {
+			return
+		}
+
+		for column := range missingColumns {
+			if ok := storedDataColumns[column]; !ok {
+				// This column was not received nor reconstructed. This should not happen.
+				log.WithFields(logrus.Fields{
+					"root":   fmt.Sprintf("%x", blockRoot),
+					"slot":   slot,
+					"column": column,
+				}).Error("Data column not received nor reconstructed.")
+				continue
+			}
+
+			// Get the non received but reconstructed data column.
+			dataColumnSidecar, err := s.cfg.blobStorage.GetColumn(blockRoot, column)
+			if err != nil {
+				log.WithError(err).Error("Get column")
+				continue
+			}
+
+			// Compute the subnet for this column.
+			subnet := column % params.BeaconConfig().DataColumnSidecarSubnetCount
+
+			// Broadcast the missing data column.
+			if err := s.cfg.p2p.BroadcastDataColumn(ctx, subnet, dataColumnSidecar); err != nil {
+				log.WithError(err).Error("Broadcast data column")
+			}
+		}
+
+		// Get the missing data columns under sorted form.
+		missingColumnsList := make([]uint64, 0, len(missingColumns))
+		for column := range missingColumns {
+			missingColumnsList = append(missingColumnsList, column)
+		}
+
+		// Sort the missing data columns.
+		sort.Slice(missingColumnsList, func(i, j int) bool {
+			return missingColumnsList[i] < missingColumnsList[j]
+		})
+
+		log.WithFields(logrus.Fields{
+			"root":         fmt.Sprintf("%x", blockRoot),
+			"slot":         slot,
+			"timeIntoSlot": broadCastMissingDataColumnsTimeIntoSlot,
+			"columns":      missingColumnsList,
+		}).Debug("Broadcasting not seen via gossip but reconstructed data columns.")
+	})
+
+	return nil
+}
+
+// setReceivedDataColumn marks the data column for a given root as received.
+func (s *Service) setReceivedDataColumn(root [fieldparams.RootLength]byte, columnIndex uint64) {
+	s.receivedDataColumnsFromRootLock.Lock()
+	defer s.receivedDataColumnsFromRootLock.Unlock()
+
+	// Get all the received data columns for this root.
+	receivedDataColumns, ok := s.receivedDataColumnsFromRoot[root]
+	if !ok {
+		// Create the map for this block root if needed.
+		receivedDataColumns = make(map[uint64]bool, params.BeaconConfig().NumberOfColumns)
+		s.receivedDataColumnsFromRoot[root] = receivedDataColumns
+	}
+
+	// Mark the data column as received.
+	receivedDataColumns[columnIndex] = true
+}
+
+// receivedDataColumns returns the received data columns for a given root.
+func (s *Service) receivedDataColumns(root [fieldparams.RootLength]byte) map[uint64]bool {
+	s.receivedDataColumnsFromRootLock.RLock()
+	defer s.receivedDataColumnsFromRootLock.RUnlock()
+
+	// Get all the received data columns for this root.
+	receivedDataColumns, ok := s.receivedDataColumnsFromRoot[root]
+	if !ok {
+		return nil
+	}
+
+	// Copy the received data columns.
+	copied := make(map[uint64]bool, len(receivedDataColumns))
+	for column, received := range receivedDataColumns {
+		copied[column] = received
+	}
+
+	return copied
+}
+
+// deleteReceivedDataColumns deletes the received data columns for a given root.
+func (s *Service) deleteReceivedDataColumns(root [fieldparams.RootLength]byte) {
+	s.receivedDataColumnsFromRootLock.Lock()
+	defer s.receivedDataColumnsFromRootLock.Unlock()
+
+	delete(s.receivedDataColumnsFromRoot, root)
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/verification"
 	lruwrpr "github.com/prysmaticlabs/prysm/v5/cache/lru"
 	"github.com/prysmaticlabs/prysm/v5/config/features"
+	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
@@ -165,6 +166,8 @@ type Service struct {
 	newBlobVerifier                  verification.NewBlobVerifier
 	availableBlocker                 coverage.AvailableBlocker
 	dataColumsnReconstructionLock    sync.Mutex
+	receivedDataColumnsFromRoot      map[[fieldparams.RootLength]byte]map[uint64]bool
+	receivedDataColumnsFromRootLock  sync.RWMutex
 	ctxMap                           ContextByteVersions
 }
 
@@ -173,14 +176,15 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 	c := gcache.New(pendingBlockExpTime /* exp time */, 0 /* disable janitor */)
 	ctx, cancel := context.WithCancel(ctx)
 	r := &Service{
-		ctx:                  ctx,
-		cancel:               cancel,
-		chainStarted:         abool.New(),
-		cfg:                  &config{clock: startup.NewClock(time.Unix(0, 0), [32]byte{})},
-		slotToPendingBlocks:  c,
-		seenPendingBlocks:    make(map[[32]byte]bool),
-		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
-		signatureChan:        make(chan *signatureVerifier, verifierLimit),
+		ctx:                         ctx,
+		cancel:                      cancel,
+		chainStarted:                abool.New(),
+		cfg:                         &config{clock: startup.NewClock(time.Unix(0, 0), [32]byte{})},
+		slotToPendingBlocks:         c,
+		seenPendingBlocks:           make(map[[32]byte]bool),
+		blkRootToPendingAtts:        make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
+		signatureChan:               make(chan *signatureVerifier, verifierLimit),
+		receivedDataColumnsFromRoot: make(map[[32]byte]map[uint64]bool),
 	}
 	for _, opt := range opts {
 		if err := opt(r); err != nil {

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -18,9 +18,10 @@ func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) e
 	}
 
 	s.setSeenDataColumnIndex(dc.SignedBlockHeader.Header.Slot, dc.SignedBlockHeader.Header.ProposerIndex, dc.ColumnIndex)
+	s.setReceivedDataColumn(dc.BlockRoot(), dc.ColumnIndex)
 
 	if err := s.cfg.chain.ReceiveDataColumn(ctx, dc); err != nil {
-		return err
+		return errors.Wrap(err, "receive data column")
 	}
 
 	s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -278,6 +278,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 		"--" + flags.EnableDebugRPCEndpoints.Name,
 		"--" + features.EnableQUIC.Name,
 		"--" + flags.SubscribeToAllSubnets.Name,
+		fmt.Sprintf("--%s=%d", features.DataColumnsWithholdCount.Name, 3),
 	}
 	if config.UsePprof {
 		args = append(args, "--pprof", fmt.Sprintf("--pprofport=%d", e2e.TestParams.Ports.PrysmBeaconNodePprofPort+index))


### PR DESCRIPTION
**Definition of a missing column:**
A missing column is a column we should custody but which actually was not received via gossip.

- Columns are reconstructed as soon as 50% of the total columns are available.
- Missing columns are gossiped after 3 seconds into the slot. (We can gossip them since we reconstructed them.)
- If reconstruction is done later than 3 seconds into the slot, then missing columns are gossiped immediately.

When a block proposer withhold on purpose a data column, this log is displayed:
```
["2024-06-04 20:08:45"]  WARNING "rpc/validator": "Withholding data column" dataColumnIndex=26 root=0xc4914ff33f7651f18f8e437b5c42689e39c8a06e7585bc1ea42ae2e752c801af subnet=26
```

Then, on a non-proposer node, this log is NOT displayed (since the corresponding data column is not broadcasted by the block proposer.)
```
["2024-06-04 20:08:45"]  DEBUG sync: "Received data column sidecar" columnIndex=26 sinceSlotStartTime=1.172045s validationTime=7.081417ms
```

However, on a node custodying at least 50% of the data columns, reconstruction is triggered, and custodied columns non received via gossip after the 3 seconds into the slot deadline are broadcasted by the node which performed the reconstruction. The following log is displayed:
```
["2024-06-04 20:08:47"]  DEBUG sync: "Broadcasting not seen via gossip but reconstructed data columns." columns=[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63] root=c4914ff33f7651f18f8e437b5c42689e39c8a06e7585bc1ea42ae2e752c801af slot=11 timeIntoSlot=3s
```