### PR TITLE
always close cache warm chan to prevent blocking

### DIFF
--- a/beacon-chain/db/filesystem/pruner.go
+++ b/beacon-chain/db/filesystem/pruner.go
@@ -93,12 +93,14 @@ func windowMin(latest, offset primitives.Slot) primitives.Slot {
 func (p *blobPruner) warmCache() error {
 	p.Lock()
 	defer p.Unlock()
+	defer func() {
+		if !p.warmed {
+			p.warmed = true
+			close(p.cacheReady)
+		}
+	}()
 	if err := p.prune(0); err != nil {
 		return err
-	}
-	if !p.warmed {
-		p.warmed = true
-		close(p.cacheReady)
 	}
 	return nil
 }

--- a/beacon-chain/db/filesystem/pruner.go
+++ b/beacon-chain/db/filesystem/pruner.go
@@ -92,12 +92,12 @@ func windowMin(latest, offset primitives.Slot) primitives.Slot {
 
 func (p *blobPruner) warmCache() error {
 	p.Lock()
-	defer p.Unlock()
 	defer func() {
 		if !p.warmed {
 			p.warmed = true
 			close(p.cacheReady)
 		}
+		p.Unlock()
 	}()
 	if err := p.prune(0); err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

`5.0.4-rc.1` has a bug where invalid blobs in blob storage can cause the cache warmup code to fail to close the channel which other users of the cache wait on to indicate the cache is ready. This results in initial-sync (which does not use a timeout when requesting the cache) to hang indefinitely if there are truncated blobs in storage.

This PR fixes the issue by ensuring the sentinel channel is always closed, even if the cache warmup call to the pruning func produces an error.