### PR TITLE
Keep only the latest value in the health channel

### DIFF
--- a/api/client/beacon/health.go
+++ b/api/client/beacon/health.go
@@ -17,7 +17,7 @@ type NodeHealthTracker struct {
 func NewNodeHealthTracker(node iface.HealthNode) *NodeHealthTracker {
 	return &NodeHealthTracker{
 		node:       node,
-		healthChan: make(chan bool, 1),
+		healthChan: make(chan bool, 5), // large enough to make sure multiple writes without reading don't block causing a deadlock
 	}
 }
 

--- a/api/client/beacon/health.go
+++ b/api/client/beacon/health.go
@@ -17,7 +17,7 @@ type NodeHealthTracker struct {
 func NewNodeHealthTracker(node iface.HealthNode) *NodeHealthTracker {
 	return &NodeHealthTracker{
 		node:       node,
-		healthChan: make(chan bool, 5), // large enough to make sure multiple writes without reading don't block causing a deadlock
+		healthChan: make(chan bool, 1),
 	}
 }
 
@@ -48,8 +48,13 @@ func (n *NodeHealthTracker) CheckHealth(ctx context.Context) bool {
 	if isStatusChanged {
 		// Update the health status
 		n.isHealthy = &newStatus
-		// Send the new status to the health channel
-		n.healthChan <- newStatus
+		// Send the new status to the health channel, potentially overwriting the existing value
+		select {
+		case <-n.healthChan:
+			n.healthChan <- newStatus
+		default:
+			n.healthChan <- newStatus
+		}
 	}
 	return newStatus
 }

--- a/api/client/beacon/health_test.go
+++ b/api/client/beacon/health_test.go
@@ -87,12 +87,6 @@ func TestNodeHealth_Concurrency(t *testing.T) {
 	// Number of goroutines to spawn for both reading and writing
 	numGoroutines := 6
 
-	go func() {
-		for range n.HealthUpdates() {
-			// Consume values to avoid blocking on channel send.
-		}
-	}()
-
 	wg.Add(numGoroutines * 2) // for readers and writers
 
 	// Concurrently update health status

--- a/api/client/beacon/testing/mock.go
+++ b/api/client/beacon/testing/mock.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	"github.com/prysmaticlabs/prysm/v5/api/client/beacon/iface"
 	"go.uber.org/mock/gomock"
@@ -16,6 +17,7 @@ var (
 type MockHealthClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockHealthClientMockRecorder
+	sync.Mutex
 }
 
 // MockHealthClientMockRecorder is the mock recorder for MockHealthClient.
@@ -25,6 +27,8 @@ type MockHealthClientMockRecorder struct {
 
 // IsHealthy mocks base method.
 func (m *MockHealthClient) IsHealthy(arg0 context.Context) bool {
+	m.Lock()
+	defer m.Unlock()
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsHealthy", arg0)
 	ret0, ok := ret[0].(bool)
@@ -41,6 +45,8 @@ func (m *MockHealthClient) EXPECT() *MockHealthClientMockRecorder {
 
 // IsHealthy indicates an expected call of IsHealthy.
 func (mr *MockHealthClientMockRecorder) IsHealthy(arg0 any) *gomock.Call {
+	mr.mock.Lock()
+	defer mr.mock.Unlock()
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsHealthy", reflect.TypeOf((*MockHealthClient)(nil).IsHealthy), arg0)
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

https://github.com/prysmaticlabs/prysm/pull/14033 introduced a subtle race condition. The channel has a buffer size of 1. Previously we unlocked before sending to the channel. This means that if we tried to send a second value, sending to the channel blocked but any other function that required the lock could take it. In the current version this other function will need to wait for the lock. And that's what happened with the REST VC. I don't know how exactly it got to this, but apparently a second value was sent to the channel before reading the first one, which captured the lock. Another function tried to obtain the lock, and reading the first value from the channel depended on this function returning.

To fix this, we introduce a switch statement that always replaces the existing value in the channel with a new one.
