### PR TITLE
Add flag to set time tolerance for external builder block proposals

### DIFF
--- a/beacon-chain/builder/testing/mock.go
+++ b/beacon-chain/builder/testing/mock.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/api/client/builder"
@@ -30,6 +31,7 @@ type MockBuilderService struct {
 	PayloadDeneb          *v1.ExecutionPayloadDeneb
 	BlobBundle            *v1.BlobsBundle
 	ErrSubmitBlindedBlock error
+	GetHeaderSleep        time.Duration
 	Bid                   *ethpb.SignedBuilderBid
 	BidCapella            *ethpb.SignedBuilderBidCapella
 	BidDeneb              *ethpb.SignedBuilderBidDeneb
@@ -72,6 +74,9 @@ func (s *MockBuilderService) SubmitBlindedBlock(_ context.Context, b interfaces.
 
 // GetHeader for mocking.
 func (s *MockBuilderService) GetHeader(_ context.Context, slot primitives.Slot, _ [32]byte, _ [48]byte) (builder.SignedBid, error) {
+	if s.GetHeaderSleep > 0 {
+		time.Sleep(s.GetHeaderSleep)
+	}
 	if slots.ToEpoch(slot) >= params.BeaconConfig().DenebForkEpoch || s.BidDeneb != nil {
 		return builder.WrappedSignedBuilderBidDeneb(s.BidDeneb)
 	}

--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -67,6 +67,13 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
+	if cliCtx.IsSet(flags.BuilderProposalDelayTolerance.Name) {
+		c := params.BeaconConfig().Copy()
+		c.BuilderProposalDelayTolerance = cliCtx.Uint64(flags.BuilderProposalDelayTolerance.Name)
+		if err := params.SetActive(c); err != nil {
+			return err
+		}
+	}
 	if cliCtx.IsSet(flags.LocalBlockValueBoost.Name) {
 		c := params.BeaconConfig().Copy()
 		c.LocalBlockValueBoost = cliCtx.Uint64(flags.LocalBlockValueBoost.Name)

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -24,6 +24,13 @@ var (
 		Name:  "max-builder-epoch-missed-slots",
 		Usage: "Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window",
 	}
+	BuilderProposalDelayTolerance = &cli.Uint64Flag{
+		Name: "builder-proposal-delay-tolerance",
+		Usage: "The maximum amount of time (in ms) allowed for a block builder to respond to a block request. " +
+                        "This value is known as BUILDER_PROPOSAL_DELAY_TOLERANCE in builder spec.",
+		Value: 1000,
+	}
+
 	// LocalBlockValueBoost sets a percentage boost for local block construction while using a custom builder.
 	LocalBlockValueBoost = &cli.Uint64Flag{
 		Name: "local-block-value-boost",

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -80,6 +80,7 @@ var appFlags = []cli.Flag{
 	flags.MevRelayEndpoint,
 	flags.MaxBuilderEpochMissedSlots,
 	flags.MaxBuilderConsecutiveMissedSlots,
+	flags.BuilderProposalDelayTolerance,
 	flags.EngineEndpointTimeoutSeconds,
 	flags.LocalBlockValueBoost,
 	cmd.BackupWebhookOutputDir,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -128,6 +128,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.MevRelayEndpoint,
 			flags.MaxBuilderEpochMissedSlots,
 			flags.MaxBuilderConsecutiveMissedSlots,
+			flags.BuilderProposalDelayTolerance,
 			flags.EngineEndpointTimeoutSeconds,
 			flags.SlasherDirFlag,
 			flags.LocalBlockValueBoost,

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -221,6 +221,7 @@ type BeaconChainConfig struct {
 	// Mev-boost circuit breaker
 	MaxBuilderConsecutiveMissedSlots primitives.Slot // MaxBuilderConsecutiveMissedSlots defines the number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction.
 	MaxBuilderEpochMissedSlots       primitives.Slot // MaxBuilderEpochMissedSlots is defining the number of total skip slot (per epoch rolling windows) to fallback from using relay/builder to local execution engine for block construction.
+	BuilderProposalDelayTolerance    uint64          // Maximum time allowed for a builder to respond to a block request.
 	LocalBlockValueBoost             uint64          // LocalBlockValueBoost is the value boost for local block construction. This is used to prioritize local block construction over relay/builder block construction.
 
 	// Execution engine timeout value
@@ -333,6 +334,18 @@ func (b *BeaconChainConfig) PreviousEpochAttestationsLength() uint64 {
 // BeaconChainConfig.
 func (b *BeaconChainConfig) CurrentEpochAttestationsLength() uint64 {
 	return uint64(b.SlotsPerEpoch.Mul(b.MaxAttestations))
+}
+
+// BuilderProposalDelayTolerance returns the maximum time duration
+// allowed for a builder to respond to a block request.
+func (b *BeaconChainConfig) BuilderProposalDelayToleranceDuration() time.Duration {
+	// Tolerance lower than 200 ms will certainly miss proposal
+	// opportunities, so let's set a reasonable minimum.
+	tolerance := b.BuilderProposalDelayTolerance
+	if tolerance < 200 {
+		tolerance = 200
+	}
+	return time.Duration(tolerance) * time.Millisecond
 }
 
 // TtfbTimeoutDuration returns the time duration of the timeout.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -263,6 +263,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
+	BuilderProposalDelayTolerance:    1000, // measured in ms
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core
 


### PR DESCRIPTION
Adds `--builder-proposal-delay-tolerance`
It defaults to 1000 ms, maintaining the existing behavior.


**What type of PR is this?**

Feature


**What does this PR do? Why is it needed?**

PR adds a new flag: `--builder-proposal-delay-tolerance`.  It allows
users to explicitly set a time duration.  If it's exceeded while
requesting `getHeader()` from an external block builder, the request
fails with an appropriate error.


**Which issues(s) does this PR fix?**

No issue (yet).


**Other notes for review**

Requesting docs to be updated.