### PR TITLE
PeerDAS: Stop generating new P2P private key at start.

### DIFF
--- a/beacon-chain/core/peerdas/BUILD.bazel
+++ b/beacon-chain/core/peerdas/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/peerdas",
     visibility = ["//visibility:public"],
     deps = [
-        "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",

--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/v5/config/features"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/wrapper"
 	ecdsaprysm "github.com/prysmaticlabs/prysm/v5/crypto/ecdsa"
 	"github.com/prysmaticlabs/prysm/v5/io/file"
@@ -76,8 +77,8 @@ func privKey(cfg *Config) (*ecdsa.PrivateKey, error) {
 		return nil, err
 	}
 
-	// If the StaticPeerID flag is not set, return the private key.
-	if !cfg.StaticPeerID {
+	// If the StaticPeerID flag is not set and if peerDAS is not enabled, return the private key.
+	if !(cfg.StaticPeerID || features.Get().EnablePeerDAS) {
 		return ecdsaprysm.ConvertFromInterfacePrivKey(priv)
 	}
 

--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -66,6 +66,7 @@ func privKey(cfg *Config) (*ecdsa.PrivateKey, error) {
 	}
 
 	if defaultKeysExist {
+		log.WithField("filePath", defaultKeyPath).Info("Reading static P2P private key from a file. To generate a new random private key at every start, please remove this file.")
 		return privKeyFromFile(defaultKeyPath)
 	}
 
@@ -93,7 +94,7 @@ func privKey(cfg *Config) (*ecdsa.PrivateKey, error) {
 		return nil, err
 	}
 
-	log.Info("Wrote network key to file")
+	log.WithField("file", defaultKeyPath).Info("Wrote network key to")
 	// Read the key from the defaultKeyPath file just written
 	// for the strongest guarantee that the next start will be the same as this one.
 	return privKeyFromFile(defaultKeyPath)


### PR DESCRIPTION
Please read commit by commit.

- With `s = 128` and 4 custody subnets, there is `10,668,000` possible subnets combinations. `128! / (4! * (128 - 4)!)`
- Regarding the current number of nodes on mainnet (6641, including un-synced ones), each node has a very high probablity to have a unique subnets combination. ==> Subnets combination is enough to identify a given node.

As a result, if a node changes its Node ID (for anonymity) but keeps the same subnets combination, it is very easy to notice that it is actually the same node.

==> Regardless of the computational difficulty to generate a pseudo-deterministic node ID, when peerDAS is activated, we stop rotating the P2P private key at every reboot.

Replace https://github.com/prysmaticlabs/prysm/pull/14098