### PR TITLE
Fix missing error check for expired context in getPayloadHeaderFromBuilder

### DIFF
--- a/beacon-chain/builder/testing/mock.go
+++ b/beacon-chain/builder/testing/mock.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/api/client/builder"
@@ -30,6 +31,7 @@ type MockBuilderService struct {
 	PayloadDeneb          *v1.ExecutionPayloadDeneb
 	BlobBundle            *v1.BlobsBundle
 	ErrSubmitBlindedBlock error
+	GetHeaderSleep        time.Duration
 	Bid                   *ethpb.SignedBuilderBid
 	BidCapella            *ethpb.SignedBuilderBidCapella
 	BidDeneb              *ethpb.SignedBuilderBidDeneb
@@ -72,6 +74,9 @@ func (s *MockBuilderService) SubmitBlindedBlock(_ context.Context, b interfaces.
 
 // GetHeader for mocking.
 func (s *MockBuilderService) GetHeader(_ context.Context, slot primitives.Slot, _ [32]byte, _ [48]byte) (builder.SignedBid, error) {
+	if s.GetHeaderSleep > 0 {
+		time.Sleep(s.GetHeaderSleep)
+	}
 	if slots.ToEpoch(slot) >= params.BeaconConfig().DenebForkEpoch || s.BidDeneb != nil {
 		return builder.WrappedSignedBuilderBidDeneb(s.BidDeneb)
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -174,6 +174,9 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot primitiv
 	defer cancel()
 
 	signedBid, err := vs.BlockBuilder.GetHeader(ctx, slot, bytesutil.ToBytes32(h.BlockHash()), pk)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -725,6 +725,21 @@ func TestServer_getPayloadHeader(t *testing.T) {
 			err: "can't get header",
 		},
 		{
+			name: "fails if tolerance is exceeded",
+			mock: &builderTest.MockBuilderService{
+				GetHeaderSleep: 1100 * time.Millisecond,
+			},
+			fetcher: &blockchainTest.ChainService{
+				Block: func() interfaces.ReadOnlySignedBeaconBlock {
+					wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
+					require.NoError(t, err)
+					wb.SetSlot(primitives.Slot(params.BeaconConfig().BellatrixForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
+					return wb
+				}(),
+			},
+			err: "context deadline exceeded",
+		},
+		{
 			name: "0 bid",
 			mock: &builderTest.MockBuilderService{
 				Bid: &ethpb.SignedBuilderBid{


### PR DESCRIPTION
While working on #14095 , I noticed a small bug: if the context expires in `Server.getPayloadHeaderFromBuilder()`, no error is checked or returned.  This PR fixes that and adds an appropriate test.


**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

--


**Which issues(s) does this PR fix?**

--


**Other notes for review**

--