### PR TITLE
Do not fail production when consensus block value is unavailable

### DIFF
--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "handlers.go",
         "handlers_block.go",
+        "log.go",
         "server.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc/eth/validator",

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -31,7 +31,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/network/httputil"
 	ethpbalpha "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -592,7 +592,7 @@ func (s *Server) PrepareBeaconProposer(w http.ResponseWriter, r *http.Request) {
 	if len(validatorIndices) == 0 {
 		return
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"validatorIndices": validatorIndices,
 	}).Info("Updated fee recipient addresses")
 }

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -222,7 +222,7 @@ func (s *Server) produceBlockV3(ctx context.Context, w http.ResponseWriter, r *h
 	if httpError != nil {
 		log.WithError(httpError).Debug("Failed to get consensus block value")
 		// Having the consensus block value is not critical to block production
-		consensusBlockValue = "0"
+		consensusBlockValue = ""
 	}
 
 	w.Header().Set(api.ExecutionPayloadBlindedHeader, fmt.Sprintf("%v", v1alpha1resp.IsBlinded))
@@ -299,7 +299,7 @@ func getConsensusBlockValue(ctx context.Context, blockRewardsFetcher rewards.Blo
 	}
 	if bb.Version() == version.Phase0 {
 		// Getting the block value for Phase 0 is very hard, so we ignore it
-		return "0", nil
+		return "", nil
 	}
 	// Get consensus payload value which is the same as the total from the block rewards api.
 	// The value is in Gwei, but Wei should be returned from the endpoint.

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -220,8 +220,8 @@ func (s *Server) produceBlockV3(ctx context.Context, w http.ResponseWriter, r *h
 
 	consensusBlockValue, httpError := getConsensusBlockValue(ctx, s.BlockRewardFetcher, v1alpha1resp.Block)
 	if httpError != nil {
-		httputil.WriteError(w, httpError)
-		return
+		// Having the consensus block value is not critical to block production
+		consensusBlockValue = "0"
 	}
 
 	w.Header().Set(api.ExecutionPayloadBlindedHeader, fmt.Sprintf("%v", v1alpha1resp.IsBlinded))
@@ -297,8 +297,8 @@ func getConsensusBlockValue(ctx context.Context, blockRewardsFetcher rewards.Blo
 		}
 	}
 	if bb.Version() == version.Phase0 {
-		// ignore for phase 0
-		return "", nil
+		// Getting the block value for Phase 0 is very hard, so we ignore it
+		return "0", nil
 	}
 	// Get consensus payload value which is the same as the total from the block rewards api.
 	// The value is in Gwei, but Wei should be returned from the endpoint.

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -220,6 +220,7 @@ func (s *Server) produceBlockV3(ctx context.Context, w http.ResponseWriter, r *h
 
 	consensusBlockValue, httpError := getConsensusBlockValue(ctx, s.BlockRewardFetcher, v1alpha1resp.Block)
 	if httpError != nil {
+		log.WithError(httpError).Debug("Failed to get consensus block value")
 		// Having the consensus block value is not critical to block production
 		consensusBlockValue = "0"
 	}

--- a/beacon-chain/rpc/eth/validator/log.go
+++ b/beacon-chain/rpc/eth/validator/log.go
@@ -1,0 +1,5 @@
+package validator
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("prefix", "beacon-api")


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

We sometimes see sync committee signature verification failures when trying to get sync committee rewards for a given block. The reason for this bug is still unknown, but failing block production because of such a non-critical thing is too radical.

**Which issues(s) does this PR fix?**

Fixes #13910

**Other notes for review**

I modified the comment for Phase 0 to explain why we ignore it.
