### PR TITLE
More tracing in the validator client

### DIFF
--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -138,6 +138,9 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot primitives
 
 // Signs input slot with domain selection proof. This is used to create the signature for aggregator selection.
 func (v *validator) signSlotWithSelectionProof(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, slot primitives.Slot) (signature []byte, err error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signSlotWithSelectionProof")
+	defer span.End()
+
 	domain, err := v.domainData(ctx, slots.ToEpoch(slot), params.BeaconConfig().DomainSelectionProof[:])
 	if err != nil {
 		return nil, err
@@ -194,6 +197,9 @@ func (v *validator) waitToSlotTwoThirds(ctx context.Context, slot primitives.Slo
 // This returns the signature of validator signing over aggregate and
 // proof object.
 func (v *validator) aggregateAndProofSig(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, agg *ethpb.AggregateAttestationAndProof, slot primitives.Slot) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.aggregateAndProofSig")
+	defer span.End()
+
 	d, err := v.domainData(ctx, slots.ToEpoch(agg.Aggregate.Data.Slot), params.BeaconConfig().DomainAggregateAndProof[:])
 	if err != nil {
 		return nil, err

--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -199,6 +199,9 @@ func (v *validator) duty(pubKey [fieldparams.BLSPubkeyLength]byte) (*ethpb.Dutie
 
 // Given validator's public key, this function returns the signature of an attestation data and its signing root.
 func (v *validator) signAtt(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, data *ethpb.AttestationData, slot primitives.Slot) ([]byte, [32]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signAtt")
+	defer span.End()
+
 	domain, root, err := v.domainAndSigningRoot(ctx, data)
 	if err != nil {
 		return nil, [32]byte{}, err

--- a/validator/client/beacon-api/BUILD.bazel
+++ b/validator/client/beacon-api/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",

--- a/validator/client/beacon-api/activation_test.go
+++ b/validator/client/beacon-api/activation_test.go
@@ -116,7 +116,7 @@ func TestActivation_Nominal(t *testing.T) {
 
 	// Get does not return any result for non existing key
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		bytes.NewBuffer(reqBytes),
@@ -240,7 +240,7 @@ func TestActivation_InvalidData(t *testing.T) {
 
 				jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 				jsonRestHandler.EXPECT().Post(
-					ctx,
+					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
@@ -281,7 +281,7 @@ func TestActivation_JsonResponseError(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
@@ -291,7 +291,7 @@ func TestActivation_JsonResponseError(t *testing.T) {
 	).Times(1)
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 	).Return(

--- a/validator/client/beacon-api/attestation_data_test.go
+++ b/validator/client/beacon-api/attestation_data_test.go
@@ -33,7 +33,7 @@ func TestGetAttestationData_ValidAttestation(t *testing.T) {
 	produceAttestationDataResponseJson := structs.GetAttestationDataResponse{}
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", expectedCommitteeIndex, expectedSlot),
 		&produceAttestationDataResponseJson,
 	).Return(
@@ -183,7 +183,7 @@ func TestGetAttestationData_InvalidData(t *testing.T) {
 			produceAttestationDataResponseJson := structs.GetAttestationDataResponse{}
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/validator/attestation_data?committee_index=2&slot=1",
 				&produceAttestationDataResponseJson,
 			).Return(
@@ -212,7 +212,7 @@ func TestGetAttestationData_JsonResponseError(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	produceAttestationDataResponseJson := structs.GetAttestationDataResponse{}
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", committeeIndex, slot),
 		&produceAttestationDataResponseJson,
 	).Return(

--- a/validator/client/beacon-api/beacon_api_beacon_chain_client_test.go
+++ b/validator/client/beacon-api/beacon_api_beacon_chain_client_test.go
@@ -58,7 +58,7 @@ func TestListValidators(t *testing.T) {
 		ctx := context.Background()
 
 		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
-		stateValidatorsProvider.EXPECT().StateValidatorsForSlot(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			nil,
 			errors.New("foo error"),
 		)
@@ -78,7 +78,7 @@ func TestListValidators(t *testing.T) {
 		ctx := context.Background()
 
 		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
-		stateValidatorsProvider.EXPECT().StateValidatorsForSlot(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			nil,
 			errors.New("bar error"),
 		)
@@ -96,7 +96,7 @@ func TestListValidators(t *testing.T) {
 		ctx := context.Background()
 
 		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
-		stateValidatorsProvider.EXPECT().StateValidatorsForHead(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		stateValidatorsProvider.EXPECT().StateValidatorsForHead(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			nil,
 			errors.New("foo error"),
 		)
@@ -114,13 +114,13 @@ func TestListValidators(t *testing.T) {
 		ctx := context.Background()
 
 		stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
-		stateValidatorsProvider.EXPECT().StateValidatorsForHead(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		stateValidatorsProvider.EXPECT().StateValidatorsForHead(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 			nil,
 			nil,
 		)
 
 		jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
-		jsonRestHandler.EXPECT().Get(ctx, blockHeaderEndpoint, gomock.Any()).Return(errors.New("bar error"))
+		jsonRestHandler.EXPECT().Get(gomock.Any(), blockHeaderEndpoint, gomock.Any()).Return(errors.New("bar error"))
 
 		beaconChainClient := beaconApiChainClient{
 			stateValidatorsProvider: stateValidatorsProvider,
@@ -187,13 +187,13 @@ func TestListValidators(t *testing.T) {
 				ctx := context.Background()
 
 				stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
-				stateValidatorsProvider.EXPECT().StateValidatorsForHead(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				stateValidatorsProvider.EXPECT().StateValidatorsForHead(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					nil,
 					nil,
 				)
 
 				jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
-				jsonRestHandler.EXPECT().Get(ctx, blockHeaderEndpoint, gomock.Any()).Return(
+				jsonRestHandler.EXPECT().Get(gomock.Any(), blockHeaderEndpoint, gomock.Any()).Return(
 					nil,
 				).SetArg(
 					2,
@@ -328,7 +328,7 @@ func TestListValidators(t *testing.T) {
 				ctx := context.Background()
 
 				stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
-				stateValidatorsProvider.EXPECT().StateValidatorsForSlot(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					testCase.generateStateValidatorsResponse(),
 					nil,
 				)
@@ -556,7 +556,7 @@ func TestListValidators(t *testing.T) {
 				ctx := context.Background()
 
 				stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
-				stateValidatorsProvider.EXPECT().StateValidatorsForSlot(ctx, primitives.Slot(0), make([]string, 0), []primitives.ValidatorIndex{}, nil).Return(
+				stateValidatorsProvider.EXPECT().StateValidatorsForSlot(gomock.Any(), primitives.Slot(0), make([]string, 0), []primitives.ValidatorIndex{}, nil).Return(
 					testCase.generateJsonStateValidatorsResponse(),
 					nil,
 				)
@@ -745,7 +745,7 @@ func TestGetChainHead(t *testing.T) {
 
 				finalityCheckpointsResponse := structs.GetFinalityCheckpointsResponse{}
 				jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
-				jsonRestHandler.EXPECT().Get(ctx, finalityCheckpointsEndpoint, &finalityCheckpointsResponse).Return(
+				jsonRestHandler.EXPECT().Get(gomock.Any(), finalityCheckpointsEndpoint, &finalityCheckpointsResponse).Return(
 					testCase.finalityCheckpointsError,
 				).SetArg(
 					2,
@@ -844,7 +844,7 @@ func TestGetChainHead(t *testing.T) {
 				jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
 				finalityCheckpointsResponse := structs.GetFinalityCheckpointsResponse{}
-				jsonRestHandler.EXPECT().Get(ctx, finalityCheckpointsEndpoint, &finalityCheckpointsResponse).Return(
+				jsonRestHandler.EXPECT().Get(gomock.Any(), finalityCheckpointsEndpoint, &finalityCheckpointsResponse).Return(
 					nil,
 				).SetArg(
 					2,
@@ -852,7 +852,7 @@ func TestGetChainHead(t *testing.T) {
 				)
 
 				headBlockHeadersResponse := structs.GetBlockHeaderResponse{}
-				jsonRestHandler.EXPECT().Get(ctx, headBlockHeadersEndpoint, &headBlockHeadersResponse).Return(
+				jsonRestHandler.EXPECT().Get(gomock.Any(), headBlockHeadersEndpoint, &headBlockHeadersResponse).Return(
 					testCase.headBlockHeadersError,
 				).SetArg(
 					2,
@@ -874,7 +874,7 @@ func TestGetChainHead(t *testing.T) {
 		jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
 		finalityCheckpointsResponse := structs.GetFinalityCheckpointsResponse{}
-		jsonRestHandler.EXPECT().Get(ctx, finalityCheckpointsEndpoint, &finalityCheckpointsResponse).Return(
+		jsonRestHandler.EXPECT().Get(gomock.Any(), finalityCheckpointsEndpoint, &finalityCheckpointsResponse).Return(
 			nil,
 		).SetArg(
 			2,
@@ -882,7 +882,7 @@ func TestGetChainHead(t *testing.T) {
 		)
 
 		headBlockHeadersResponse := structs.GetBlockHeaderResponse{}
-		jsonRestHandler.EXPECT().Get(ctx, headBlockHeadersEndpoint, &headBlockHeadersResponse).Return(
+		jsonRestHandler.EXPECT().Get(gomock.Any(), headBlockHeadersEndpoint, &headBlockHeadersResponse).Return(
 			nil,
 		).SetArg(
 			2,
@@ -940,7 +940,7 @@ func Test_beaconApiBeaconChainClient_GetValidatorPerformance(t *testing.T) {
 	want := &ethpb.ValidatorPerformanceResponse{}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		getValidatorPerformanceEndpoint,
 		nil,
 		bytes.NewBuffer(request),

--- a/validator/client/beacon-api/beacon_api_helpers_test.go
+++ b/validator/client/beacon-api/beacon_api_helpers_test.go
@@ -109,7 +109,7 @@ func TestGetFork_Nominal(t *testing.T) {
 	ctx := context.Background()
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		forkEndpoint,
 		&stateForkResponseJson,
 	).Return(
@@ -137,7 +137,7 @@ func TestGetFork_Invalid(t *testing.T) {
 	ctx := context.Background()
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		forkEndpoint,
 		gomock.Any(),
 	).Return(
@@ -176,7 +176,7 @@ func TestGetHeaders_Nominal(t *testing.T) {
 	ctx := context.Background()
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		headersEndpoint,
 		&blockHeadersResponseJson,
 	).Return(
@@ -204,7 +204,7 @@ func TestGetHeaders_Invalid(t *testing.T) {
 	ctx := context.Background()
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		headersEndpoint,
 		gomock.Any(),
 	).Return(
@@ -248,7 +248,7 @@ func TestGetLiveness_Nominal(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		livenessEndpoint,
 		nil,
 		bytes.NewBuffer(marshalledIndexes),
@@ -275,7 +275,7 @@ func TestGetLiveness_Invalid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		livenessEndpoint,
 		nil,
 		gomock.Any(),
@@ -324,7 +324,7 @@ func TestGetIsSyncing_Nominal(t *testing.T) {
 			ctx := context.Background()
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				syncingEndpoint,
 				&syncingResponseJson,
 			).Return(
@@ -355,7 +355,7 @@ func TestGetIsSyncing_Invalid(t *testing.T) {
 	ctx := context.Background()
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		syncingEndpoint,
 		&syncingResponseJson,
 	).Return(

--- a/validator/client/beacon-api/beacon_api_node_client_test.go
+++ b/validator/client/beacon-api/beacon_api_node_client_test.go
@@ -113,7 +113,7 @@ func TestGetGenesis(t *testing.T) {
 
 			genesisProvider := mock.NewMockGenesisProvider(ctrl)
 			genesisProvider.EXPECT().Genesis(
-				ctx,
+				gomock.Any(),
 			).Return(
 				testCase.genesisResponse,
 				testCase.genesisError,
@@ -124,7 +124,7 @@ func TestGetGenesis(t *testing.T) {
 
 			if testCase.queriesDepositContract {
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					"/eth/v1/config/deposit_contract",
 					&depositContractJson,
 				).Return(
@@ -203,7 +203,7 @@ func TestGetSyncStatus(t *testing.T) {
 			syncingResponse := structs.SyncStatusResponse{}
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				syncingEndpoint,
 				&syncingResponse,
 			).Return(
@@ -267,7 +267,7 @@ func TestGetVersion(t *testing.T) {
 			var versionResponse structs.GetVersionResponse
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				versionEndpoint,
 				&versionResponse,
 			).Return(

--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/validator/client/iface"
+	"go.opencensus.io/trace"
 )
 
 type ValidatorClientOpt func(*beaconApiValidatorClient)
@@ -47,12 +48,16 @@ func NewBeaconApiValidatorClient(jsonRestHandler JsonRestHandler, opts ...Valida
 }
 
 func (c *beaconApiValidatorClient) Duties(ctx context.Context, in *ethpb.DutiesRequest) (*ethpb.DutiesResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.Duties")
+	defer span.End()
 	return wrapInMetrics[*ethpb.DutiesResponse]("Duties", func() (*ethpb.DutiesResponse, error) {
 		return c.duties(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) CheckDoppelGanger(ctx context.Context, in *ethpb.DoppelGangerRequest) (*ethpb.DoppelGangerResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.CheckDoppelGanger")
+	defer span.End()
 	return wrapInMetrics[*ethpb.DoppelGangerResponse]("CheckDoppelGanger", func() (*ethpb.DoppelGangerResponse, error) {
 		return c.checkDoppelGanger(ctx, in)
 	})
@@ -62,6 +67,10 @@ func (c *beaconApiValidatorClient) DomainData(ctx context.Context, in *ethpb.Dom
 	if len(in.Domain) != 4 {
 		return nil, errors.Errorf("invalid domain type: %s", hexutil.Encode(in.Domain))
 	}
+
+	ctx, span := trace.StartSpan(ctx, "beacon-api.DomainData")
+	defer span.End()
+
 	domainType := bytesutil.ToBytes4(in.Domain)
 
 	return wrapInMetrics[*ethpb.DomainResponse]("DomainData", func() (*ethpb.DomainResponse, error) {
@@ -70,12 +79,18 @@ func (c *beaconApiValidatorClient) DomainData(ctx context.Context, in *ethpb.Dom
 }
 
 func (c *beaconApiValidatorClient) AttestationData(ctx context.Context, in *ethpb.AttestationDataRequest) (*ethpb.AttestationData, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.AttestationData")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.AttestationData]("AttestationData", func() (*ethpb.AttestationData, error) {
 		return c.attestationData(ctx, in.Slot, in.CommitteeIndex)
 	})
 }
 
 func (c *beaconApiValidatorClient) BeaconBlock(ctx context.Context, in *ethpb.BlockRequest) (*ethpb.GenericBeaconBlock, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.BeaconBlock")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.GenericBeaconBlock]("BeaconBlock", func() (*ethpb.GenericBeaconBlock, error) {
 		return c.beaconBlock(ctx, in.Slot, in.RandaoReveal, in.Graffiti)
 	})
@@ -86,48 +101,72 @@ func (c *beaconApiValidatorClient) FeeRecipientByPubKey(_ context.Context, _ *et
 }
 
 func (c *beaconApiValidatorClient) SyncCommitteeContribution(ctx context.Context, in *ethpb.SyncCommitteeContributionRequest) (*ethpb.SyncCommitteeContribution, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SyncCommitteeContribution")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.SyncCommitteeContribution]("SyncCommitteeContribution", func() (*ethpb.SyncCommitteeContribution, error) {
 		return c.syncCommitteeContribution(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) SyncMessageBlockRoot(ctx context.Context, _ *empty.Empty) (*ethpb.SyncMessageBlockRootResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SyncMessageBlockRoot")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.SyncMessageBlockRootResponse]("SyncMessageBlockRoot", func() (*ethpb.SyncMessageBlockRootResponse, error) {
 		return c.syncMessageBlockRoot(ctx)
 	})
 }
 
 func (c *beaconApiValidatorClient) SyncSubcommitteeIndex(ctx context.Context, in *ethpb.SyncSubcommitteeIndexRequest) (*ethpb.SyncSubcommitteeIndexResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SyncSubcommitteeIndex")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.SyncSubcommitteeIndexResponse]("SyncSubcommitteeIndex", func() (*ethpb.SyncSubcommitteeIndexResponse, error) {
 		return c.syncSubcommitteeIndex(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) MultipleValidatorStatus(ctx context.Context, in *ethpb.MultipleValidatorStatusRequest) (*ethpb.MultipleValidatorStatusResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.MultipleValidatorStatus")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.MultipleValidatorStatusResponse]("MultipleValidatorStatus", func() (*ethpb.MultipleValidatorStatusResponse, error) {
 		return c.multipleValidatorStatus(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) PrepareBeaconProposer(ctx context.Context, in *ethpb.PrepareBeaconProposerRequest) (*empty.Empty, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.PrepareBeaconProposer")
+	defer span.End()
+
 	return wrapInMetrics[*empty.Empty]("PrepareBeaconProposer", func() (*empty.Empty, error) {
 		return new(empty.Empty), c.prepareBeaconProposer(ctx, in.Recipients)
 	})
 }
 
 func (c *beaconApiValidatorClient) ProposeAttestation(ctx context.Context, in *ethpb.Attestation) (*ethpb.AttestResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.ProposeAttestation")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.AttestResponse]("ProposeAttestation", func() (*ethpb.AttestResponse, error) {
 		return c.proposeAttestation(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) ProposeBeaconBlock(ctx context.Context, in *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.ProposeBeaconBlock")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.ProposeResponse]("ProposeBeaconBlock", func() (*ethpb.ProposeResponse, error) {
 		return c.proposeBeaconBlock(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) ProposeExit(ctx context.Context, in *ethpb.SignedVoluntaryExit) (*ethpb.ProposeExitResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.ProposeExit")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.ProposeExitResponse]("ProposeExit", func() (*ethpb.ProposeExitResponse, error) {
 		return c.proposeExit(ctx, in)
 	})
@@ -138,52 +177,79 @@ func (c *beaconApiValidatorClient) StreamBlocksAltair(ctx context.Context, in *e
 }
 
 func (c *beaconApiValidatorClient) SubmitAggregateSelectionProof(ctx context.Context, in *ethpb.AggregateSelectionRequest, index primitives.ValidatorIndex, committeeLength uint64) (*ethpb.AggregateSelectionResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SubmitAggregateSelectionProof")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.AggregateSelectionResponse]("SubmitAggregateSelectionProof", func() (*ethpb.AggregateSelectionResponse, error) {
 		return c.submitAggregateSelectionProof(ctx, in, index, committeeLength)
 	})
 }
 
 func (c *beaconApiValidatorClient) SubmitSignedAggregateSelectionProof(ctx context.Context, in *ethpb.SignedAggregateSubmitRequest) (*ethpb.SignedAggregateSubmitResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SubmitSignedAggregateSelectionProof")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.SignedAggregateSubmitResponse]("SubmitSignedAggregateSelectionProof", func() (*ethpb.SignedAggregateSubmitResponse, error) {
 		return c.submitSignedAggregateSelectionProof(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) SubmitSignedContributionAndProof(ctx context.Context, in *ethpb.SignedContributionAndProof) (*empty.Empty, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SubmitSignedContributionAndProof")
+	defer span.End()
+
 	return wrapInMetrics[*empty.Empty]("SubmitSignedContributionAndProof", func() (*empty.Empty, error) {
 		return new(empty.Empty), c.submitSignedContributionAndProof(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) SubmitSyncMessage(ctx context.Context, in *ethpb.SyncCommitteeMessage) (*empty.Empty, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SubmitSyncMessage")
+	defer span.End()
+
 	return wrapInMetrics[*empty.Empty]("SubmitSyncMessage", func() (*empty.Empty, error) {
 		return new(empty.Empty), c.submitSyncMessage(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) SubmitValidatorRegistrations(ctx context.Context, in *ethpb.SignedValidatorRegistrationsV1) (*empty.Empty, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SubmitValidatorRegistrations")
+	defer span.End()
+
 	return wrapInMetrics[*empty.Empty]("SubmitValidatorRegistrations", func() (*empty.Empty, error) {
 		return new(empty.Empty), c.submitValidatorRegistrations(ctx, in.Messages)
 	})
 }
 
 func (c *beaconApiValidatorClient) SubscribeCommitteeSubnets(ctx context.Context, in *ethpb.CommitteeSubnetsSubscribeRequest, duties []*ethpb.DutiesResponse_Duty) (*empty.Empty, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.SubscribeCommitteeSubnets")
+	defer span.End()
+
 	return wrapInMetrics[*empty.Empty]("SubscribeCommitteeSubnets", func() (*empty.Empty, error) {
 		return new(empty.Empty), c.subscribeCommitteeSubnets(ctx, in, duties)
 	})
 }
 
 func (c *beaconApiValidatorClient) ValidatorIndex(ctx context.Context, in *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.ValidatorIndex")
+	defer span.End()
+
 	return wrapInMetrics[*ethpb.ValidatorIndexResponse]("ValidatorIndex", func() (*ethpb.ValidatorIndexResponse, error) {
 		return c.validatorIndex(ctx, in)
 	})
 }
 
 func (c *beaconApiValidatorClient) ValidatorStatus(ctx context.Context, in *ethpb.ValidatorStatusRequest) (*ethpb.ValidatorStatusResponse, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.ValidatorStatus")
+	defer span.End()
+
 	return c.validatorStatus(ctx, in)
 }
 
 func (c *beaconApiValidatorClient) WaitForActivation(ctx context.Context, in *ethpb.ValidatorActivationRequest) (ethpb.BeaconNodeValidator_WaitForActivationClient, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-api.WaitForActivation")
+	defer span.End()
+
 	return c.waitForActivation(ctx, in)
 }
 
@@ -212,11 +278,21 @@ func (c *beaconApiValidatorClient) EventStreamIsRunning() bool {
 }
 
 func (c *beaconApiValidatorClient) AggregatedSelections(ctx context.Context, selections []iface.BeaconCommitteeSelection) ([]iface.BeaconCommitteeSelection, error) {
-	return c.aggregatedSelection(ctx, selections)
+	ctx, span := trace.StartSpan(ctx, "beacon-api.AggregatedSelections")
+	defer span.End()
+
+	return wrapInMetrics[[]iface.BeaconCommitteeSelection]("AggregatedSelections", func() ([]iface.BeaconCommitteeSelection, error) {
+		return c.aggregatedSelection(ctx, selections)
+	})
 }
 
 func (c *beaconApiValidatorClient) AggregatedSyncSelections(ctx context.Context, selections []iface.SyncCommitteeSelection) ([]iface.SyncCommitteeSelection, error) {
-	return c.aggregatedSyncSelections(ctx, selections)
+	ctx, span := trace.StartSpan(ctx, "beacon-api.AggregatedSyncSelections")
+	defer span.End()
+
+	return wrapInMetrics[[]iface.SyncCommitteeSelection]("AggregatedSyncSelections", func() ([]iface.SyncCommitteeSelection, error) {
+		return c.aggregatedSyncSelections(ctx, selections)
+	})
 }
 
 func wrapInMetrics[Resp any](action string, f func() (Resp, error)) (Resp, error) {

--- a/validator/client/beacon-api/beacon_api_validator_client_test.go
+++ b/validator/client/beacon-api/beacon_api_validator_client_test.go
@@ -32,7 +32,7 @@ func TestBeaconApiValidatorClient_GetAttestationDataValid(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	produceAttestationDataResponseJson := structs.GetAttestationDataResponse{}
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", committeeIndex, slot),
 		&produceAttestationDataResponseJson,
 	).Return(
@@ -66,7 +66,7 @@ func TestBeaconApiValidatorClient_GetAttestationDataError(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	produceAttestationDataResponseJson := structs.GetAttestationDataResponse{}
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", committeeIndex, slot),
 		&produceAttestationDataResponseJson,
 	).Return(
@@ -109,7 +109,7 @@ func TestBeaconApiValidatorClient_DomainDataValid(t *testing.T) {
 	ctx := context.Background()
 
 	genesisProvider := mock.NewMockGenesisProvider(ctrl)
-	genesisProvider.EXPECT().Genesis(ctx).Return(
+	genesisProvider.EXPECT().Genesis(gomock.Any()).Return(
 		&structs.Genesis{GenesisValidatorsRoot: genesisValidatorRoot},
 		nil,
 	).Times(2)
@@ -139,7 +139,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/blocks",
 		map[string]string{"Eth-Consensus-Version": "phase0"},
 		gomock.Any(),
@@ -175,7 +175,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockError(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/blocks",
 		map[string]string{"Eth-Consensus-Version": "phase0"},
 		gomock.Any(),

--- a/validator/client/beacon-api/beacon_committee_selections_test.go
+++ b/validator/client/beacon-api/beacon_committee_selections_test.go
@@ -98,7 +98,7 @@ func TestGetAggregatedSelections(t *testing.T) {
 
 			ctx := context.Background()
 			jsonRestHandler.EXPECT().Post(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/validator/beacon_committee_selections",
 				nil,
 				bytes.NewBuffer(reqBody),

--- a/validator/client/beacon-api/domain_data_test.go
+++ b/validator/client/beacon-api/domain_data_test.go
@@ -37,7 +37,7 @@ func TestGetDomainData_ValidDomainData(t *testing.T) {
 
 	// Make sure that Genesis() is called exactly once
 	genesisProvider := mock.NewMockGenesisProvider(ctrl)
-	genesisProvider.EXPECT().Genesis(ctx).Return(
+	genesisProvider.EXPECT().Genesis(gomock.Any()).Return(
 		&structs.Genesis{GenesisValidatorsRoot: genesisValidatorRoot},
 		nil,
 	).Times(1)
@@ -66,7 +66,7 @@ func TestGetDomainData_GenesisError(t *testing.T) {
 
 	// Make sure that Genesis() is called exactly once
 	genesisProvider := mock.NewMockGenesisProvider(ctrl)
-	genesisProvider.EXPECT().Genesis(ctx).Return(nil, errors.New("foo error")).Times(1)
+	genesisProvider.EXPECT().Genesis(gomock.Any()).Return(nil, errors.New("foo error")).Times(1)
 
 	validatorClient := &beaconApiValidatorClient{genesisProvider: genesisProvider}
 	_, err := validatorClient.domainData(ctx, epoch, domainType)
@@ -85,7 +85,7 @@ func TestGetDomainData_InvalidGenesisRoot(t *testing.T) {
 
 	// Make sure that Genesis() is called exactly once
 	genesisProvider := mock.NewMockGenesisProvider(ctrl)
-	genesisProvider.EXPECT().Genesis(ctx).Return(
+	genesisProvider.EXPECT().Genesis(gomock.Any()).Return(
 		&structs.Genesis{GenesisValidatorsRoot: "foo"},
 		nil,
 	).Times(1)

--- a/validator/client/beacon-api/doppelganger_test.go
+++ b/validator/client/beacon-api/doppelganger_test.go
@@ -291,13 +291,11 @@ func TestCheckDoppelGanger_Nominal(t *testing.T) {
 
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
-			ctx := context.Background()
-
 			if testCase.getSyncingOutput != nil {
 				syncingResponseJson := structs.SyncStatusResponse{}
 
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					syncingEndpoint,
 					&syncingResponseJson,
 				).Return(
@@ -312,7 +310,7 @@ func TestCheckDoppelGanger_Nominal(t *testing.T) {
 				stateForkResponseJson := structs.GetStateForkResponse{}
 
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					forkEndpoint,
 					&stateForkResponseJson,
 				).Return(
@@ -327,7 +325,7 @@ func TestCheckDoppelGanger_Nominal(t *testing.T) {
 				blockHeadersResponseJson := structs.GetBlockHeadersResponse{}
 
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					headersEndpoint,
 					&blockHeadersResponseJson,
 				).Return(
@@ -346,7 +344,7 @@ func TestCheckDoppelGanger_Nominal(t *testing.T) {
 					require.NoError(t, err)
 
 					jsonRestHandler.EXPECT().Post(
-						ctx,
+						gomock.Any(),
 						iface.inputUrl,
 						nil,
 						bytes.NewBuffer(marshalledIndexes),
@@ -364,7 +362,7 @@ func TestCheckDoppelGanger_Nominal(t *testing.T) {
 
 			if testCase.getStateValidatorsInterface != nil {
 				stateValidatorsProvider.EXPECT().StateValidators(
-					ctx,
+					gomock.Any(),
 					testCase.getStateValidatorsInterface.input,
 					nil,
 					nil,
@@ -727,13 +725,11 @@ func TestCheckDoppelGanger_Errors(t *testing.T) {
 
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
-			ctx := context.Background()
-
 			if testCase.getSyncingOutput != nil {
 				syncingResponseJson := structs.SyncStatusResponse{}
 
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					syncingEndpoint,
 					&syncingResponseJson,
 				).Return(
@@ -748,7 +744,7 @@ func TestCheckDoppelGanger_Errors(t *testing.T) {
 				stateForkResponseJson := structs.GetStateForkResponse{}
 
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					forkEndpoint,
 					&stateForkResponseJson,
 				).Return(
@@ -763,7 +759,7 @@ func TestCheckDoppelGanger_Errors(t *testing.T) {
 				blockHeadersResponseJson := structs.GetBlockHeadersResponse{}
 
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					headersEndpoint,
 					&blockHeadersResponseJson,
 				).Return(
@@ -778,7 +774,7 @@ func TestCheckDoppelGanger_Errors(t *testing.T) {
 
 			if testCase.getStateValidatorsInterface != nil {
 				stateValidatorsProvider.EXPECT().StateValidators(
-					ctx,
+					gomock.Any(),
 					testCase.getStateValidatorsInterface.input,
 					nil,
 					nil,
@@ -796,7 +792,7 @@ func TestCheckDoppelGanger_Errors(t *testing.T) {
 					require.NoError(t, err)
 
 					jsonRestHandler.EXPECT().Post(
-						ctx,
+						gomock.Any(),
 						iface.inputUrl,
 						nil,
 						bytes.NewBuffer(marshalledIndexes),

--- a/validator/client/beacon-api/duties_test.go
+++ b/validator/client/beacon-api/duties_test.go
@@ -63,7 +63,7 @@ func TestGetAttesterDuties_Valid(t *testing.T) {
 	validatorIndices := []primitives.ValidatorIndex{2, 9}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getAttesterDutiesTestEndpoint, epoch),
 		nil,
 		bytes.NewBuffer(validatorIndicesBytes),
@@ -91,7 +91,7 @@ func TestGetAttesterDuties_HttpError(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getAttesterDutiesTestEndpoint, epoch),
 		gomock.Any(),
 		gomock.Any(),
@@ -115,7 +115,7 @@ func TestGetAttesterDuties_NilAttesterDuty(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getAttesterDutiesTestEndpoint, epoch),
 		gomock.Any(),
 		gomock.Any(),
@@ -159,7 +159,7 @@ func TestGetProposerDuties_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getProposerDutiesTestEndpoint, epoch),
 		&structs.GetProposerDutiesResponse{},
 	).Return(
@@ -185,7 +185,7 @@ func TestGetProposerDuties_HttpError(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getProposerDutiesTestEndpoint, epoch),
 		gomock.Any(),
 	).Return(
@@ -207,7 +207,7 @@ func TestGetProposerDuties_NilData(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getProposerDutiesTestEndpoint, epoch),
 		gomock.Any(),
 	).Return(
@@ -234,7 +234,7 @@ func TestGetProposerDuties_NilProposerDuty(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getProposerDutiesTestEndpoint, epoch),
 		gomock.Any(),
 	).Return(
@@ -287,7 +287,7 @@ func TestGetSyncDuties_Valid(t *testing.T) {
 	validatorIndices := []primitives.ValidatorIndex{2, 6}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getSyncDutiesTestEndpoint, epoch),
 		nil,
 		bytes.NewBuffer(validatorIndicesBytes),
@@ -315,7 +315,7 @@ func TestGetSyncDuties_HttpError(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getSyncDutiesTestEndpoint, epoch),
 		gomock.Any(),
 		gomock.Any(),
@@ -339,7 +339,7 @@ func TestGetSyncDuties_NilData(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getSyncDutiesTestEndpoint, epoch),
 		gomock.Any(),
 		gomock.Any(),
@@ -368,7 +368,7 @@ func TestGetSyncDuties_NilSyncDuty(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s/%d", getSyncDutiesTestEndpoint, epoch),
 		gomock.Any(),
 		gomock.Any(),
@@ -418,7 +418,7 @@ func TestGetCommittees_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s?epoch=%d", getCommitteesTestEndpoint, epoch),
 		&structs.GetCommitteesResponse{},
 	).Return(
@@ -444,7 +444,7 @@ func TestGetCommittees_HttpError(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s?epoch=%d", getCommitteesTestEndpoint, epoch),
 		gomock.Any(),
 	).Return(
@@ -466,7 +466,7 @@ func TestGetCommittees_NilData(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s?epoch=%d", getCommitteesTestEndpoint, epoch),
 		gomock.Any(),
 	).Return(
@@ -493,7 +493,7 @@ func TestGetCommittees_NilCommittee(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("%s?epoch=%d", getCommitteesTestEndpoint, epoch),
 		gomock.Any(),
 	).Return(
@@ -1079,7 +1079,7 @@ func TestGetDuties_Valid(t *testing.T) {
 
 			stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 			stateValidatorsProvider.EXPECT().StateValidators(
-				ctx,
+				gomock.Any(),
 				gomock.Any(),
 				gomock.Any(),
 				gomock.Any(),
@@ -1233,7 +1233,7 @@ func TestGetDuties_GetStateValidatorsFailed(t *testing.T) {
 
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
@@ -1263,7 +1263,7 @@ func TestGetDuties_GetDutiesForEpochFailed(t *testing.T) {
 
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),

--- a/validator/client/beacon-api/genesis_test.go
+++ b/validator/client/beacon-api/genesis_test.go
@@ -21,7 +21,7 @@ func TestGetGenesis_ValidGenesis(t *testing.T) {
 	genesisResponseJson := structs.GetGenesisResponse{}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -53,7 +53,7 @@ func TestGetGenesis_NilData(t *testing.T) {
 	genesisResponseJson := structs.GetGenesisResponse{}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -77,7 +77,7 @@ func TestGetGenesis_EndpointCalledOnlyOnce(t *testing.T) {
 	genesisResponseJson := structs.GetGenesisResponse{}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -111,14 +111,14 @@ func TestGetGenesis_EndpointCanBeCalledAgainAfterError(t *testing.T) {
 	genesisResponseJson := structs.GetGenesisResponse{}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
 		errors.New("foo"),
 	).Times(1)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(

--- a/validator/client/beacon-api/get_beacon_block_test.go
+++ b/validator/client/beacon-api/get_beacon_block_test.go
@@ -28,7 +28,7 @@ func TestGetBeaconBlock_RequestFailed(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
 	).Return(
@@ -125,7 +125,7 @@ func TestGetBeaconBlock_Error(t *testing.T) {
 
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				gomock.Any(),
 				&structs.ProduceBlockV3Response{},
 			).SetArg(
@@ -161,7 +161,7 @@ func TestGetBeaconBlock_Phase0Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -204,7 +204,7 @@ func TestGetBeaconBlock_AltairValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -247,7 +247,7 @@ func TestGetBeaconBlock_BellatrixValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -292,7 +292,7 @@ func TestGetBeaconBlock_BlindedBellatrixValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -337,7 +337,7 @@ func TestGetBeaconBlock_CapellaValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -382,7 +382,7 @@ func TestGetBeaconBlock_BlindedCapellaValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -427,7 +427,7 @@ func TestGetBeaconBlock_DenebValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -472,7 +472,7 @@ func TestGetBeaconBlock_BlindedDenebValid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).SetArg(
@@ -517,14 +517,14 @@ func TestGetBeaconBlock_FallbackToBlindedBlock(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).Return(
 		&httputil.DefaultJsonError{Code: http.StatusNotFound},
 	).Times(1)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v1/validator/blinded_blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&abstractProduceBlockResponseJson{},
 	).SetArg(
@@ -568,14 +568,14 @@ func TestGetBeaconBlock_FallbackToFullBlock(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&structs.ProduceBlockV3Response{},
 	).Return(
 		&httputil.DefaultJsonError{Code: http.StatusNotFound},
 	).Times(1)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		fmt.Sprintf("/eth/v1/validator/blinded_blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&abstractProduceBlockResponseJson{},
 	).Return(

--- a/validator/client/beacon-api/index_test.go
+++ b/validator/client/beacon-api/index_test.go
@@ -44,7 +44,7 @@ func TestIndex_Nominal(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		reqBuffer,
@@ -94,7 +94,7 @@ func TestIndex_UnexistingValidator(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		reqBuffer,
@@ -136,7 +136,7 @@ func TestIndex_BadIndexError(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		reqBuffer,
@@ -185,7 +185,7 @@ func TestIndex_JsonResponseError(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		reqBuffer,
@@ -208,7 +208,7 @@ func TestIndex_JsonResponseError(t *testing.T) {
 	}
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		buildURL("/eth/v1/beacon/states/head/validators", queryParams),
 		&stateValidatorsResponseJson,
 	).Return(

--- a/validator/client/beacon-api/prepare_beacon_proposer_test.go
+++ b/validator/client/beacon-api/prepare_beacon_proposer_test.go
@@ -48,7 +48,7 @@ func TestPrepareBeaconProposer_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		prepareBeaconProposerTestEndpoint,
 		nil,
 		bytes.NewBuffer(marshalledJsonRecipients),
@@ -92,7 +92,7 @@ func TestPrepareBeaconProposer_BadRequest(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		prepareBeaconProposerTestEndpoint,
 		nil,
 		gomock.Any(),

--- a/validator/client/beacon-api/propose_attestation_test.go
+++ b/validator/client/beacon-api/propose_attestation_test.go
@@ -126,7 +126,7 @@ func TestProposeAttestation(t *testing.T) {
 			ctx := context.Background()
 
 			jsonRestHandler.EXPECT().Post(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/beacon/pool/attestations",
 				nil,
 				bytes.NewBuffer(marshalledAttestations),

--- a/validator/client/beacon-api/propose_beacon_block_altair_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_altair_test.go
@@ -58,7 +58,7 @@ func TestProposeBeaconBlock_Altair(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "altair"}
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),

--- a/validator/client/beacon-api/propose_beacon_block_bellatrix_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_bellatrix_test.go
@@ -75,7 +75,7 @@ func TestProposeBeaconBlock_Bellatrix(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "bellatrix"}
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),

--- a/validator/client/beacon-api/propose_beacon_block_blinded_bellatrix_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_blinded_bellatrix_test.go
@@ -76,7 +76,7 @@ func TestProposeBeaconBlock_BlindedBellatrix(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "bellatrix"}
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/blinded_blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),

--- a/validator/client/beacon-api/propose_beacon_block_blinded_capella_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_blinded_capella_test.go
@@ -78,7 +78,7 @@ func TestProposeBeaconBlock_BlindedCapella(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "capella"}
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/blinded_blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),

--- a/validator/client/beacon-api/propose_beacon_block_blinded_deneb_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_blinded_deneb_test.go
@@ -31,7 +31,7 @@ func TestProposeBeaconBlock_BlindedDeneb(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "deneb"}
 	jsonRestHandler.EXPECT().Post(
-		context.Background(),
+		gomock.Any(),
 		"/eth/v1/beacon/blinded_blocks",
 		headers,
 		bytes.NewBuffer(denebBytes),

--- a/validator/client/beacon-api/propose_beacon_block_capella_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_capella_test.go
@@ -75,7 +75,7 @@ func TestProposeBeaconBlock_Capella(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "capella"}
 	jsonRestHandler.EXPECT().Post(
-		context.Background(),
+		gomock.Any(),
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),

--- a/validator/client/beacon-api/propose_beacon_block_deneb_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_deneb_test.go
@@ -32,7 +32,7 @@ func TestProposeBeaconBlock_Deneb(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "deneb"}
 	jsonRestHandler.EXPECT().Post(
-		context.Background(),
+		gomock.Any(),
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(denebBytes),

--- a/validator/client/beacon-api/propose_beacon_block_phase0_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_phase0_test.go
@@ -54,7 +54,7 @@ func TestProposeBeaconBlock_Phase0(t *testing.T) {
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "phase0"}
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),

--- a/validator/client/beacon-api/propose_beacon_block_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_test.go
@@ -101,7 +101,7 @@ func TestProposeBeaconBlock_Error(t *testing.T) {
 
 				headers := map[string]string{"Eth-Consensus-Version": testCase.consensusVersion}
 				jsonRestHandler.EXPECT().Post(
-					ctx,
+					gomock.Any(),
 					testCase.endpoint,
 					headers,
 					gomock.Any(),

--- a/validator/client/beacon-api/propose_exit_test.go
+++ b/validator/client/beacon-api/propose_exit_test.go
@@ -39,7 +39,7 @@ func TestProposeExit_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		proposeExitTestEndpoint,
 		nil,
 		bytes.NewBuffer(marshalledVoluntaryExit),
@@ -88,7 +88,7 @@ func TestProposeExit_BadRequest(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		proposeExitTestEndpoint,
 		nil,
 		gomock.Any(),

--- a/validator/client/beacon-api/registration_test.go
+++ b/validator/client/beacon-api/registration_test.go
@@ -68,7 +68,7 @@ func TestRegistration_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		context.Background(),
+		gomock.Any(),
 		"/eth/v1/validator/register_validator",
 		nil,
 		bytes.NewBuffer(marshalledJsonRegistrations),
@@ -143,7 +143,7 @@ func TestRegistration_BadRequest(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		context.Background(),
+		gomock.Any(),
 		"/eth/v1/validator/register_validator",
 		nil,
 		gomock.Any(),

--- a/validator/client/beacon-api/state_validators_test.go
+++ b/validator/client/beacon-api/state_validators_test.go
@@ -70,7 +70,7 @@ func TestGetStateValidators_Nominal_POST(t *testing.T) {
 	ctx := context.Background()
 
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		bytes.NewBuffer(reqBytes),
@@ -157,7 +157,7 @@ func TestGetStateValidators_Nominal_GET(t *testing.T) {
 
 	// First return an error from POST call.
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		bytes.NewBuffer(reqBytes),
@@ -178,7 +178,7 @@ func TestGetStateValidators_Nominal_GET(t *testing.T) {
 	query := buildURL("/eth/v1/beacon/states/head/validators", queryParams)
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		query,
 		&stateValidatorsResponseJson,
 	).Return(
@@ -226,7 +226,7 @@ func TestGetStateValidators_GetRestJsonResponseOnError(t *testing.T) {
 
 	// First call POST.
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		bytes.NewBuffer(reqBytes),
@@ -247,7 +247,7 @@ func TestGetStateValidators_GetRestJsonResponseOnError(t *testing.T) {
 	query := buildURL("/eth/v1/beacon/states/head/validators", queryParams)
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		query,
 		&stateValidatorsResponseJson,
 	).Return(
@@ -280,7 +280,7 @@ func TestGetStateValidators_DataIsNil_POST(t *testing.T) {
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil, bytes.NewBuffer(reqBytes),
 		&stateValidatorsResponseJson,
@@ -320,7 +320,7 @@ func TestGetStateValidators_DataIsNil_GET(t *testing.T) {
 
 	// First call POST which will return an error.
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validators",
 		nil,
 		bytes.NewBuffer(reqBytes),
@@ -341,7 +341,7 @@ func TestGetStateValidators_DataIsNil_GET(t *testing.T) {
 	query := buildURL("/eth/v1/beacon/states/head/validators", queryParams)
 
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		query,
 		&stateValidatorsResponseJson,
 	).Return(

--- a/validator/client/beacon-api/status_test.go
+++ b/validator/client/beacon-api/status_test.go
@@ -32,7 +32,7 @@ func TestValidatorStatus_Nominal(t *testing.T) {
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		[]string{stringValidatorPubKey},
 		nil,
 		nil,
@@ -65,7 +65,7 @@ func TestValidatorStatus_Nominal(t *testing.T) {
 	// Expect node version endpoint call.
 	var nodeVersionResponse structs.GetVersionResponse
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/node/version",
 		&nodeVersionResponse,
 	).Return(
@@ -97,7 +97,7 @@ func TestValidatorStatus_Error(t *testing.T) {
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		nil,
 		nil,
@@ -139,7 +139,7 @@ func TestMultipleValidatorStatus_Nominal(t *testing.T) {
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		stringValidatorsPubKey,
 		[]primitives.ValidatorIndex{},
 		nil,
@@ -172,7 +172,7 @@ func TestMultipleValidatorStatus_Nominal(t *testing.T) {
 	// Expect node version endpoint call.
 	var nodeVersionResponse structs.GetVersionResponse
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/node/version",
 		&nodeVersionResponse,
 	).Return(
@@ -224,7 +224,7 @@ func TestMultipleValidatorStatus_Error(t *testing.T) {
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		[]primitives.ValidatorIndex{},
 		nil,
@@ -276,7 +276,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		stringValidatorsPubKey,
 		validatorsIndex,
 		nil,
@@ -333,7 +333,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 	// Expect node version endpoint call.
 	var nodeVersionResponse structs.GetVersionResponse
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/node/version",
 		&nodeVersionResponse,
 	).Return(
@@ -345,7 +345,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 
 	var validatorCountResponse structs.GetValidatorCountResponse
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/states/head/validator_count?",
 		&validatorCountResponse,
 	).Return(
@@ -456,7 +456,7 @@ func TestGetValidatorsStatusResponse_Nominal_NoActiveValidators(t *testing.T) {
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().StateValidators(
-		ctx,
+		gomock.Any(),
 		[]string{stringValidatorPubKey},
 		nil,
 		nil,
@@ -481,7 +481,7 @@ func TestGetValidatorsStatusResponse_Nominal_NoActiveValidators(t *testing.T) {
 	// Expect node version endpoint call.
 	var nodeVersionResponse structs.GetVersionResponse
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/node/version",
 		&nodeVersionResponse,
 	).Return(
@@ -706,7 +706,7 @@ func TestValidatorStatusResponse_InvalidData(t *testing.T) {
 				ctx := context.Background()
 				stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 				stateValidatorsProvider.EXPECT().StateValidators(
-					ctx,
+					gomock.Any(),
 					testCase.inputGetStateValidatorsInterface.inputStringPubKeys,
 					testCase.inputGetStateValidatorsInterface.inputIndexes,
 					testCase.inputGetStateValidatorsInterface.inputStatuses,
@@ -720,7 +720,7 @@ func TestValidatorStatusResponse_InvalidData(t *testing.T) {
 				// Expect node version endpoint call.
 				var nodeVersionResponse structs.GetVersionResponse
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					"/eth/v1/node/version",
 					&nodeVersionResponse,
 				).Return(

--- a/validator/client/beacon-api/stream_blocks_test.go
+++ b/validator/client/beacon-api/stream_blocks_test.go
@@ -27,7 +27,7 @@ func TestStreamBlocks_UnsupportedConsensusVersion(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		gomock.Any(),
 		&abstractSignedBlockResponseJson{},
 	).SetArg(
@@ -149,7 +149,7 @@ func TestStreamBlocks_Error(t *testing.T) {
 
 					jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 					jsonRestHandler.EXPECT().Get(
-						ctx,
+						gomock.Any(),
 						gomock.Any(),
 						&abstractSignedBlockResponseJson{},
 					).SetArg(
@@ -214,7 +214,7 @@ func TestStreamBlocks_Phase0Valid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -251,7 +251,7 @@ func TestStreamBlocks_Phase0Valid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -278,7 +278,7 @@ func TestStreamBlocks_Phase0Valid(t *testing.T) {
 			// The fourth call is only necessary when verifiedOnly == true since the previous block was optimistic
 			if testCase.verifiedOnly {
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					"/eth/v2/beacon/blocks/head",
 					&signedBlockResponseJson,
 				).Return(
@@ -375,7 +375,7 @@ func TestStreamBlocks_AltairValid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -412,7 +412,7 @@ func TestStreamBlocks_AltairValid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -439,7 +439,7 @@ func TestStreamBlocks_AltairValid(t *testing.T) {
 			// The fourth call is only necessary when verifiedOnly == true since the previous block was optimistic
 			if testCase.verifiedOnly {
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					"/eth/v2/beacon/blocks/head",
 					&signedBlockResponseJson,
 				).Return(
@@ -536,7 +536,7 @@ func TestStreamBlocks_BellatrixValid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -573,7 +573,7 @@ func TestStreamBlocks_BellatrixValid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -600,7 +600,7 @@ func TestStreamBlocks_BellatrixValid(t *testing.T) {
 			// The fourth call is only necessary when verifiedOnly == true since the previous block was optimistic
 			if testCase.verifiedOnly {
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					"/eth/v2/beacon/blocks/head",
 					&signedBlockResponseJson,
 				).Return(
@@ -697,7 +697,7 @@ func TestStreamBlocks_CapellaValid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -734,7 +734,7 @@ func TestStreamBlocks_CapellaValid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -761,7 +761,7 @@ func TestStreamBlocks_CapellaValid(t *testing.T) {
 			// The fourth call is only necessary when verifiedOnly == true since the previous block was optimistic
 			if testCase.verifiedOnly {
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					"/eth/v2/beacon/blocks/head",
 					&signedBlockResponseJson,
 				).Return(
@@ -858,7 +858,7 @@ func TestStreamBlocks_DenebValid(t *testing.T) {
 			marshalledSignedBeaconBlockContainer1, err := json.Marshal(denebBlock)
 			require.NoError(t, err)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -887,7 +887,7 @@ func TestStreamBlocks_DenebValid(t *testing.T) {
 			require.NoError(t, err)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v2/beacon/blocks/head",
 				&signedBlockResponseJson,
 			).Return(
@@ -904,7 +904,7 @@ func TestStreamBlocks_DenebValid(t *testing.T) {
 			// The fourth call is only necessary when verifiedOnly == true since the previous block was optimistic
 			if testCase.verifiedOnly {
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					"/eth/v2/beacon/blocks/head",
 					&signedBlockResponseJson,
 				).Return(

--- a/validator/client/beacon-api/submit_aggregate_selection_proof_test.go
+++ b/validator/client/beacon-api/submit_aggregate_selection_proof_test.go
@@ -98,7 +98,7 @@ func TestSubmitAggregateSelectionProof(t *testing.T) {
 
 			// Call node syncing endpoint to check if head is optimistic.
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				syncingEndpoint,
 				&structs.SyncStatusResponse{},
 			).SetArg(
@@ -114,7 +114,7 @@ func TestSubmitAggregateSelectionProof(t *testing.T) {
 
 			// Call attestation data to get attestation data root to query aggregate attestation.
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				fmt.Sprintf("%s?committee_index=%d&slot=%d", attestationDataEndpoint, committeeIndex, slot),
 				&structs.GetAttestationDataResponse{},
 			).SetArg(
@@ -126,7 +126,7 @@ func TestSubmitAggregateSelectionProof(t *testing.T) {
 
 			// Call attestation data to get attestation data root to query aggregate attestation.
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				fmt.Sprintf("%s?attestation_data_root=%s&slot=%d", aggregateAttestationEndpoint, hexutil.Encode(attestationDataRootBytes[:]), slot),
 				&structs.AggregateAttestationResponse{},
 			).SetArg(

--- a/validator/client/beacon-api/submit_signed_aggregate_proof_test.go
+++ b/validator/client/beacon-api/submit_signed_aggregate_proof_test.go
@@ -28,7 +28,7 @@ func TestSubmitSignedAggregateSelectionProof_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/validator/aggregate_and_proofs",
 		nil,
 		bytes.NewBuffer(marshalledSignedAggregateSignedAndProof),
@@ -59,7 +59,7 @@ func TestSubmitSignedAggregateSelectionProof_BadRequest(t *testing.T) {
 	ctx := context.Background()
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/validator/aggregate_and_proofs",
 		nil,
 		bytes.NewBuffer(marshalledSignedAggregateSignedAndProof),

--- a/validator/client/beacon-api/submit_signed_contribution_and_proof_test.go
+++ b/validator/client/beacon-api/submit_signed_contribution_and_proof_test.go
@@ -46,7 +46,7 @@ func TestSubmitSignedContributionAndProof_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		submitSignedContributionAndProofTestEndpoint,
 		nil,
 		bytes.NewBuffer(marshalledContributionAndProofs),
@@ -121,7 +121,7 @@ func TestSubmitSignedContributionAndProof_Error(t *testing.T) {
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			if testCase.httpRequestExpected {
 				jsonRestHandler.EXPECT().Post(
-					ctx,
+					gomock.Any(),
 					submitSignedContributionAndProofTestEndpoint,
 					gomock.Any(),
 					gomock.Any(),

--- a/validator/client/beacon-api/subscribe_committee_subnets_test.go
+++ b/validator/client/beacon-api/subscribe_committee_subnets_test.go
@@ -47,7 +47,7 @@ func TestSubscribeCommitteeSubnets_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		ctx,
+		gomock.Any(),
 		subscribeCommitteeSubnetsTestEndpoint,
 		nil,
 		bytes.NewBuffer(committeeSubscriptionsBytes),
@@ -209,7 +209,7 @@ func TestSubscribeCommitteeSubnets_Error(t *testing.T) {
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			if testCase.expectSubscribeRestCall {
 				jsonRestHandler.EXPECT().Post(
-					ctx,
+					gomock.Any(),
 					subscribeCommitteeSubnetsTestEndpoint,
 					gomock.Any(),
 					gomock.Any(),

--- a/validator/client/beacon-api/sync_committee_selections_test.go
+++ b/validator/client/beacon-api/sync_committee_selections_test.go
@@ -104,7 +104,7 @@ func TestGetAggregatedSyncSelections(t *testing.T) {
 
 			ctx := context.Background()
 			jsonRestHandler.EXPECT().Post(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/validator/sync_committee_selections",
 				nil,
 				bytes.NewBuffer(reqBody),

--- a/validator/client/beacon-api/sync_committee_test.go
+++ b/validator/client/beacon-api/sync_committee_test.go
@@ -46,7 +46,7 @@ func TestSubmitSyncMessage_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		context.Background(),
+		gomock.Any(),
 		"/eth/v1/beacon/pool/sync_committees",
 		nil,
 		bytes.NewBuffer(marshalledJsonRegistrations),
@@ -75,7 +75,7 @@ func TestSubmitSyncMessage_BadRequest(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Post(
-		context.Background(),
+		gomock.Any(),
 		"/eth/v1/beacon/pool/sync_committees",
 		nil,
 		gomock.Any(),
@@ -139,7 +139,7 @@ func TestGetSyncMessageBlockRoot(t *testing.T) {
 			ctx := context.Background()
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/beacon/blocks/head/root",
 				&structs.BlockRootResponse{},
 			).SetArg(
@@ -209,7 +209,7 @@ func TestGetSyncCommitteeContribution(t *testing.T) {
 			ctx := context.Background()
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/beacon/blocks/head/root",
 				&structs.BlockRootResponse{},
 			).SetArg(
@@ -224,7 +224,7 @@ func TestGetSyncCommitteeContribution(t *testing.T) {
 			).Times(1)
 
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				fmt.Sprintf("/eth/v1/validator/sync_committee_contribution?beacon_block_root=%s&slot=%d&subcommittee_index=%d",
 					blockRoot, uint64(request.Slot), request.SubnetId),
 				&structs.ProduceSyncCommitteeContributionResponse{},
@@ -316,7 +316,7 @@ func TestGetSyncSubCommitteeIndex(t *testing.T) {
 			require.NoError(t, err)
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Post(
-				ctx,
+				gomock.Any(),
 				validatorsEndpoint,
 				nil,
 				bytes.NewBuffer(valsReqBytes),
@@ -351,7 +351,7 @@ func TestGetSyncSubCommitteeIndex(t *testing.T) {
 				query := buildURL("/eth/v1/beacon/states/head/validators", queryParams)
 
 				jsonRestHandler.EXPECT().Get(
-					ctx,
+					gomock.Any(),
 					query,
 					&structs.GetValidatorsResponse{},
 				).Return(
@@ -368,7 +368,7 @@ func TestGetSyncSubCommitteeIndex(t *testing.T) {
 			}
 
 			jsonRestHandler.EXPECT().Post(
-				ctx,
+				gomock.Any(),
 				fmt.Sprintf("%s/%d", syncDutiesEndpoint, slots.ToEpoch(slot)),
 				nil,
 				bytes.NewBuffer(validatorIndicesBytes),

--- a/validator/client/beacon-api/validator_count_test.go
+++ b/validator/client/beacon-api/validator_count_test.go
@@ -118,7 +118,7 @@ func TestGetValidatorCount(t *testing.T) {
 			// Expect node version endpoint call.
 			var nodeVersionResponse structs.GetVersionResponse
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/node/version",
 				&nodeVersionResponse,
 			).Return(
@@ -130,7 +130,7 @@ func TestGetValidatorCount(t *testing.T) {
 
 			var validatorCountResponse structs.GetValidatorCountResponse
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/beacon/states/head/validator_count?status=active",
 				&validatorCountResponse,
 			).Return(

--- a/validator/client/beacon-api/wait_for_chain_start_test.go
+++ b/validator/client/beacon-api/wait_for_chain_start_test.go
@@ -24,7 +24,7 @@ func TestWaitForChainStart_ValidGenesis(t *testing.T) {
 	genesisResponseJson := structs.GetGenesisResponse{}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -91,7 +91,7 @@ func TestWaitForChainStart_BadGenesis(t *testing.T) {
 			genesisResponseJson := structs.GetGenesisResponse{}
 			jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				"/eth/v1/beacon/genesis",
 				&genesisResponseJson,
 			).Return(
@@ -119,7 +119,7 @@ func TestWaitForChainStart_JsonResponseError(t *testing.T) {
 	genesisResponseJson := structs.GetGenesisResponse{}
 	jsonRestHandler := mock.NewMockJsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -144,7 +144,7 @@ func TestWaitForChainStart_JsonResponseError404(t *testing.T) {
 
 	// First, mock a request that receives a 404 error (which means that the genesis data is not available yet)
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -156,7 +156,7 @@ func TestWaitForChainStart_JsonResponseError404(t *testing.T) {
 
 	// After receiving a 404 error, mock a request that actually has genesis data available
 	jsonRestHandler.EXPECT().Get(
-		ctx,
+		gomock.Any(),
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -329,6 +329,9 @@ func CreateSignedVoluntaryExit(
 
 // Sign randao reveal with randao domain and private key.
 func (v *validator) signRandaoReveal(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch, slot primitives.Slot) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signRandaoReveal")
+	defer span.End()
+
 	domain, err := v.domainData(ctx, epoch, params.BeaconConfig().DomainRandao[:])
 	if err != nil {
 		return nil, errors.Wrap(err, domainDataErr)
@@ -359,6 +362,9 @@ func (v *validator) signRandaoReveal(ctx context.Context, pubKey [fieldparams.BL
 // Sign block with proposer domain and private key.
 // Returns the signature, block signing root, and any error.
 func (v *validator) signBlock(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch, slot primitives.Slot, b interfaces.ReadOnlyBeaconBlock) ([]byte, [32]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signBlock")
+	defer span.End()
+
 	domain, err := v.domainData(ctx, epoch, params.BeaconConfig().DomainBeaconProposer[:])
 	if err != nil {
 		return nil, [32]byte{}, errors.Wrap(err, domainDataErr)
@@ -397,6 +403,9 @@ func signVoluntaryExit(
 	exit *ethpb.VoluntaryExit,
 	slot primitives.Slot,
 ) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signVoluntaryExit")
+	defer span.End()
+
 	req := &ethpb.DomainRequest{
 		Epoch:  exit.Epoch,
 		Domain: params.BeaconConfig().DomainVoluntaryExit[:],
@@ -430,6 +439,9 @@ func signVoluntaryExit(
 
 // Graffiti gets the graffiti from cli or file for the validator public key.
 func (v *validator) Graffiti(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.Graffiti")
+	defer span.End()
+
 	if v.proposerSettings != nil {
 		// Check proposer settings for specific key first
 		if v.proposerSettings.ProposeConfig != nil {
@@ -493,6 +505,9 @@ func (v *validator) Graffiti(ctx context.Context, pubKey [fieldparams.BLSPubkeyL
 }
 
 func (v *validator) SetGraffiti(ctx context.Context, pubkey [fieldparams.BLSPubkeyLength]byte, graffiti []byte) error {
+	ctx, span := trace.StartSpan(ctx, "validator.SetGraffiti")
+	defer span.End()
+
 	if graffiti == nil {
 		return nil
 	}
@@ -518,6 +533,9 @@ func (v *validator) SetGraffiti(ctx context.Context, pubkey [fieldparams.BLSPubk
 }
 
 func (v *validator) DeleteGraffiti(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte) error {
+	ctx, span := trace.StartSpan(ctx, "validator.DeleteGraffiti")
+	defer span.End()
+
 	if v.proposerSettings == nil || v.proposerSettings.ProposeConfig == nil {
 		return errors.New("attempted to delete graffiti without proposer settings, graffiti will default to flag options")
 	}

--- a/validator/client/registration.go
+++ b/validator/client/registration.go
@@ -62,6 +62,9 @@ func SubmitValidatorRegistrations(
 
 // Sings validator registration obj with the proposer domain and private key.
 func signValidatorRegistration(ctx context.Context, signer iface.SigningFunc, reg *ethpb.ValidatorRegistrationV1) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signValidatorRegistration")
+	defer span.End()
+
 	// Per spec, we want the fork version and genesis validator to be nil.
 	// Which is genesis value and zero by default.
 	d, err := signing.ComputeDomain(
@@ -91,6 +94,9 @@ func signValidatorRegistration(ctx context.Context, signer iface.SigningFunc, re
 
 // SignValidatorRegistrationRequest compares and returns either the cached validator registration request or signs a new one.
 func (v *validator) SignValidatorRegistrationRequest(ctx context.Context, signer iface.SigningFunc, newValidatorRegistration *ethpb.ValidatorRegistrationV1) (*ethpb.SignedValidatorRegistrationV1, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.SignValidatorRegistrationRequest")
+	defer span.End()
+
 	signedReg, ok := v.signedValidatorRegistrations[bytesutil.ToBytes48(newValidatorRegistration.Pubkey)]
 	if ok && isValidatorRegistrationSame(signedReg.Message, newValidatorRegistration) {
 		return signedReg, nil

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -160,6 +160,9 @@ func onAccountsChanged(ctx context.Context, v iface.Validator, current [][48]byt
 }
 
 func initializeValidatorAndGetHeadSlot(ctx context.Context, v iface.Validator) (primitives.Slot, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.initializeValidatorAndGetHeadSlot")
+	defer span.End()
+
 	ticker := time.NewTicker(backOffPeriod)
 	defer ticker.Stop()
 

--- a/validator/client/sync_committee.go
+++ b/validator/client/sync_committee.go
@@ -192,6 +192,9 @@ func (v *validator) SubmitSignedContributionAndProof(ctx context.Context, slot p
 
 // Signs and returns selection proofs per validator for slot and pub key.
 func (v *validator) selectionProofs(ctx context.Context, slot primitives.Slot, pubKey [fieldparams.BLSPubkeyLength]byte, indexRes *ethpb.SyncSubcommitteeIndexResponse, validatorIndex primitives.ValidatorIndex) ([][]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.selectionProofs")
+	defer span.End()
+
 	selectionProofs := make([][]byte, len(indexRes.Indices))
 	cfg := params.BeaconConfig()
 	size := cfg.SyncCommitteeSize
@@ -231,6 +234,9 @@ func (v *validator) selectionProofs(ctx context.Context, slot primitives.Slot, p
 
 // Signs input slot with domain sync committee selection proof. This is used to create the signature for sync committee selection.
 func (v *validator) signSyncSelectionData(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, index uint64, slot primitives.Slot) (signature []byte, err error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signSyncSelectionData")
+	defer span.End()
+
 	domain, err := v.domainData(ctx, slots.ToEpoch(slot), params.BeaconConfig().DomainSyncCommitteeSelectionProof[:])
 	if err != nil {
 		return nil, err
@@ -258,6 +264,9 @@ func (v *validator) signSyncSelectionData(ctx context.Context, pubKey [fieldpara
 
 // This returns the signature of validator signing over sync committee contribution and proof object.
 func (v *validator) signContributionAndProof(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, c *ethpb.ContributionAndProof, slot primitives.Slot) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "validator.signContributionAndProof")
+	defer span.End()
+
 	d, err := v.domainData(ctx, slots.ToEpoch(c.Contribution.Slot), params.BeaconConfig().DomainContributionAndProof[:])
 	if err != nil {
 		return nil, err

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -2075,7 +2075,7 @@ func TestValidator_buildPrepProposerReqs_WithoutDefaultConfig(t *testing.T) {
 	ctx := context.Background()
 	client := validatormock.NewMockValidatorClient(ctrl)
 	client.EXPECT().ValidatorIndex(
-		ctx,
+		gomock.Any(),
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubkey2[:],
 		},
@@ -2084,7 +2084,7 @@ func TestValidator_buildPrepProposerReqs_WithoutDefaultConfig(t *testing.T) {
 	}, nil)
 
 	client.EXPECT().ValidatorIndex(
-		ctx,
+		gomock.Any(),
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubkey3[:],
 		},
@@ -2210,7 +2210,7 @@ func TestValidator_buildPrepProposerReqs_WithDefaultConfig(t *testing.T) {
 	client := validatormock.NewMockValidatorClient(ctrl)
 
 	client.EXPECT().ValidatorIndex(
-		ctx,
+		gomock.Any(),
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubkey2[:],
 		},
@@ -2219,7 +2219,7 @@ func TestValidator_buildPrepProposerReqs_WithDefaultConfig(t *testing.T) {
 	}, nil)
 
 	client.EXPECT().ValidatorIndex(
-		ctx,
+		gomock.Any(),
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubkey3[:],
 		},


### PR DESCRIPTION
Tracing in the validator client is currently rare therefore not very useful. Especially there is no tracing in the `beacon-api` package.