### PR TITLE
fix(third_party): removed internal expired jump targets

### DIFF
--- a/third_party/README.md
+++ b/third_party/README.md
@@ -16,8 +16,6 @@ unless really needed**
 
 - [Prerequisites](#prerequisites)
 - [Creating a Patch](#creating-a-patch)
-- [Ethereum APIs Patch](#ethereum-apis-patch)
-- [Updating Patches](#updating-patches)
 
 ## Prerequisites
 


### PR DESCRIPTION
In[ PR#7910](https://github.com/prysmaticlabs/prysm/pull/7910/files#diff-b6cd85961a9400da4aaf7b171890389189819ed30fcfac0860f61450af7da26aL62) , deleted the sections [Updating Patches] and [Ethereum APIs Patch], but the related references were not removed.