### PR TITLE
Prysmctl ui bug

### DIFF
--- a/validator/accounts/accounts_helper.go
+++ b/validator/accounts/accounts_helper.go
@@ -49,7 +49,6 @@ func selectAccounts(selectionPrompt string, pubKeys [][fieldparams.BLSPubkeyLeng
 		p := promptui.Select{
 			Label:        selectionPrompt,
 			HideSelected: true,
-			Size:         len(pubKeyStrings),
 			Items:        append([]string{exit, allAccountsText}, pubKeyStrings...),
 			Templates:    templates,
 		}

--- a/validator/accounts/accounts_helper.go
+++ b/validator/accounts/accounts_helper.go
@@ -43,12 +43,14 @@ func selectAccounts(selectionPrompt string, pubKeys [][fieldparams.BLSPubkeyLeng
 	results := make([]int, 0)
 	au := aurora.NewAurora(true)
 	if len(pubKeyStrings) > 5 {
-		log.Warnf("there are more than %d potential public keys to exit, please consider using the --%s or --%s flags", 5, flags.VoluntaryExitPublicKeysFlag.Name, flags.ExitAllFlag.Name)
+		log.Warnf("There are more than %d potential public keys to exit, please consider using the --%s or --%s flags", 5, flags.VoluntaryExitPublicKeysFlag.Name, flags.ExitAllFlag.Name)
 	}
+	log.Infof("Found a total of %d keys", len(pubKeyStrings))
 	for result != exit {
 		p := promptui.Select{
 			Label:        selectionPrompt,
 			HideSelected: true,
+			Size:         10, // Display 10 items at a time.
 			Items:        append([]string{exit, allAccountsText}, pubKeyStrings...),
 			Templates:    templates,
 		}


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

This PR solves a bug to the prysmctl ui where given a list of 20 or more validators the user would be unable to scroll through and select the validators to exit.

This was due to setting a dynamic size of `len(pubKeyStrings)` in the `promptui.Select` statement which set the window size for the interactive selection. This meant that when someone had over 20 keys, the window would be so large that the scrolling would break.
Fixing the window size to 10 items solves the problem on all affected versions of prysm (v5+).

**Which issues(s) does this PR fix?**

Fixes #14092

**Other notes for review**
