### PR TITLE
Fix the problem of configuring multiple gRPC endpoints where the first endpoint times out and cannot switch to the second endpoint

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,6 +159,16 @@ git_repository(
     # gazelle args: -go_prefix github.com/gogo/protobuf -proto legacy
 )
 
+git_repository(
+    name = "org_golang_google_grpc",
+    commit = "1055b481ed2204a29d233286b9b50c42b63f8825",
+    patch_args = ["-p1"],
+    patches = [
+        "//third_party:org_golang_google_grpc_clientconn.patch",
+    ],
+    remote = "https://github.com/grpc/grpc-go",
+)
+
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 # A multi-arch base image

--- a/third_party/org_golang_google_grpc_clientconn.patch
+++ b/third_party/org_golang_google_grpc_clientconn.patch
@@ -1,0 +1,41 @@
+diff --git a/clientconn.go b/clientconn.go
+index 95a7459b..a7acdabc 100644
+--- a/clientconn.go
++++ b/clientconn.go
+@@ -1323,18 +1323,11 @@ func (ac *addrConn) resetTransport() {
+ 		// Give dial more time as we keep failing to connect.
+ 		dialDuration = backoffFor
+ 	}
+-	// We can potentially spend all the time trying the first address, and
+-	// if the server accepts the connection and then hangs, the following
+-	// addresses will never be tried.
+-	//
+-	// The spec doesn't mention what should be done for multiple addresses.
+-	// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md#proposed-backoff-algorithm
+-	connectDeadline := time.Now().Add(dialDuration)
+ 
+ 	ac.updateConnectivityState(connectivity.Connecting, nil)
+ 	ac.mu.Unlock()
+ 
+-	if err := ac.tryAllAddrs(acCtx, addrs, connectDeadline); err != nil {
++	if err := ac.tryAllAddrs(acCtx, addrs, dialDuration); err != nil {
+ 		ac.cc.resolveNow(resolver.ResolveNowOptions{})
+ 		// After exhausting all addresses, the addrConn enters
+ 		// TRANSIENT_FAILURE.
+@@ -1377,7 +1370,7 @@ func (ac *addrConn) resetTransport() {
+ // tryAllAddrs tries to creates a connection to the addresses, and stop when at
+ // the first successful one. It returns an error if no address was successfully
+ // connected, or updates ac appropriately with the new transport.
+-func (ac *addrConn) tryAllAddrs(ctx context.Context, addrs []resolver.Address, connectDeadline time.Time) error {
++func (ac *addrConn) tryAllAddrs(ctx context.Context, addrs []resolver.Address, dialDuration time.Duration) error {
+ 	var firstConnErr error
+ 	for _, addr := range addrs {
+ 		if ctx.Err() != nil {
+@@ -1397,6 +1390,7 @@ func (ac *addrConn) tryAllAddrs(ctx context.Context, addrs []resolver.Address, c
+ 
+ 		channelz.Infof(logger, ac.channelzID, "Subchannel picks a new address %q to connect", addr.Addr)
+ 
++		connectDeadline := time.Now().Add(dialDuration)
+ 		err := ac.createTransport(ctx, addr, copts, connectDeadline)
+ 		if err == nil {
+ 			return nil


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

>
> Bug fix

**What does this PR do? Why is it needed?**

In the grpc-go's code, if multiple gRPC endpoints are configured and the first endpoint times out, the subsequent endpoints will also time out, causing the connection to be unable to be re-established. This PR modifies the timeout duration for the subsequent endpoints, so that when the first endpoint times out, the subsequent endpoints can connect normally.

**Which issues(s) does this PR fix?**

Fixes #14133