### PR TITLE
Revert Backoff When Searching For Viable Peers

### DIFF
--- a/beacon-chain/p2p/iterator.go
+++ b/beacon-chain/p2p/iterator.go
@@ -2,13 +2,9 @@ package p2p
 
 import (
 	"context"
-	"runtime"
-	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
-
-const backOffCounter = 50
 
 // filterNodes wraps an iterator such that Next only returns nodes for which
 // the 'check' function returns true. This custom implementation also
@@ -28,21 +24,13 @@ type filterIter struct {
 // Next looks up for the next valid node according to our
 // filter criteria.
 func (f *filterIter) Next() bool {
-	lookupCounter := 0
 	for f.Iterator.Next() {
-		// Do not excessively perform lookups if we constantly receive non-viable peers.
-		if lookupCounter > backOffCounter {
-			lookupCounter = 0
-			runtime.Gosched()
-			time.Sleep(pollingPeriod)
-		}
 		if f.Context.Err() != nil {
 			return false
 		}
 		if f.check(f.Node()) {
 			return true
 		}
-		lookupCounter++
 	}
 	return false
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #14137, we introduced a few things to allow for nodes running in more restrictive operating systems to be able to maintain their peer count. Unfortunately these changes have lead to poorer attestation and sync committee performance, this PR reverts one of those changes which would slow down peer search if we encountered too many non-viable peers. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
