### PR TITLE
Increase attestation seen cache exp time to two epochs

### DIFF
--- a/beacon-chain/operations/attestations/kv/kv.go
+++ b/beacon-chain/operations/attestations/kv/kv.go
@@ -32,7 +32,7 @@ type AttCaches struct {
 // various kind of attestations.
 func NewAttCaches() *AttCaches {
 	secsInEpoch := time.Duration(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-	c := cache.New(secsInEpoch*time.Second, 2*secsInEpoch*time.Second)
+	c := cache.New(2*secsInEpoch*time.Second, 2*secsInEpoch*time.Second)
 	pool := &AttCaches{
 		unAggregatedAtt: make(map[attestation.Id]ethpb.Att),
 		aggregatedAtt:   make(map[attestation.Id][]ethpb.Att),


### PR DESCRIPTION
h/t to @nerolation for discovering this

We updated the expired helper to work with the Deneb boundary, which now considers the current and previous epochs. The expired helper will only return true if the attestation is older than the previous epoch. Additionally, there is a seen cache that tracks attestations the node has observed using a bitfield. This seen cache operates on a time-based expiration system, expiring entries after 32 slots. However, it has not been updated to align with Deneb behavior. As a result, the seen cache and expired helper do not align perfectly. An old attestation can remain in the pool for over 32 slots and will not be pruned until it is older than the previous epoch. This PR updates seen cache to respect expire boundary