### PR TITLE
Electra: updated `get_next_sync_committee_indices`

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "//math:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/prysm/v1alpha1/attestation:go_default_library",
+        "//runtime/version:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

https://github.com/ethereum/consensus-specs/pull/3783

**Which issues(s) does this PR fix?**

Updates get_next_sync_committe_indices to use electra max eb.

**Other notes for review**

Reviewers may notice that this is more code branching in prior fork logic, which I have been against. I plan to revisit this after devnet-1 is feature complete. 