### PR TITLE
Electra: unskip passing spectests at v1.5.0-alpha.3

### DIFF
--- a/testing/spectest/mainnet/electra/finality/finality_test.go
+++ b/testing/spectest/mainnet/electra/finality/finality_test.go
@@ -7,6 +7,5 @@ import (
 )
 
 func TestMainnet_Electra_Finality(t *testing.T) {
-	t.Skip("TODO: Electra")
 	finality.RunFinalityTest(t, "mainnet")
 }

--- a/testing/spectest/mainnet/electra/sanity/blocks_test.go
+++ b/testing/spectest/mainnet/electra/sanity/blocks_test.go
@@ -7,6 +7,5 @@ import (
 )
 
 func TestMainnet_Electra_Sanity_Blocks(t *testing.T) {
-	t.Skip("TODO: Electra")
 	sanity.RunBlockProcessingTest(t, "mainnet", "sanity/blocks/pyspec_tests")
 }

--- a/testing/spectest/shared/electra/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/electra/rewards/rewards_penalties.go
@@ -39,7 +39,6 @@ func (d *Delta) unmarshalSSZ(buf []byte) error {
 
 // RunPrecomputeRewardsAndPenaltiesTests executes "rewards/{basic, leak, random}" tests.
 func RunPrecomputeRewardsAndPenaltiesTests(t *testing.T, config string) {
-	t.Skip("Failing until spectests are updated to v1.5.0-alpha.3")
 	require.NoError(t, utils.SetConfig(t, config))
 
 	_, testsFolderPath := utils.TestFolders(t, config, "electra", "rewards")

--- a/testing/spectest/shared/electra/sanity/block_processing.go
+++ b/testing/spectest/shared/electra/sanity/block_processing.go
@@ -30,7 +30,6 @@ func init() {
 
 // RunBlockProcessingTest executes "sanity/blocks" tests.
 func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
-	t.Skip("Failing until spectests are updated to v1.5.0-alpha.3")
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "electra", folderPath)

--- a/testing/spectest/shared/electra/sanity/slot_processing.go
+++ b/testing/spectest/shared/electra/sanity/slot_processing.go
@@ -21,7 +21,6 @@ func init() {
 
 // RunSlotProcessingTests executes "sanity/slots" tests.
 func RunSlotProcessingTests(t *testing.T, config string) {
-	t.Skip("Failing until spectests are updated to v1.5.0-alpha.3")
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "electra", "sanity/slots/pyspec_tests")


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Unskips all spectests that are passing without modifications after #14112.

**Which issues(s) does this PR fix?**

**Other notes for review**
