### PR TITLE
Avoid Cloning When Creating a New Gossip Message

### DIFF
--- a/beacon-chain/p2p/gossip_topic_mappings.go
+++ b/beacon-chain/p2p/gossip_topic_mappings.go
@@ -11,17 +11,17 @@ import (
 
 // gossipTopicMappings represent the protocol ID to protobuf message type map for easy
 // lookup.
-var gossipTopicMappings = map[string]proto.Message{
-	BlockSubnetTopicFormat:                    &ethpb.SignedBeaconBlock{},
-	AttestationSubnetTopicFormat:              &ethpb.Attestation{},
-	ExitSubnetTopicFormat:                     &ethpb.SignedVoluntaryExit{},
-	ProposerSlashingSubnetTopicFormat:         &ethpb.ProposerSlashing{},
-	AttesterSlashingSubnetTopicFormat:         &ethpb.AttesterSlashing{},
-	AggregateAndProofSubnetTopicFormat:        &ethpb.SignedAggregateAttestationAndProof{},
-	SyncContributionAndProofSubnetTopicFormat: &ethpb.SignedContributionAndProof{},
-	SyncCommitteeSubnetTopicFormat:            &ethpb.SyncCommitteeMessage{},
-	BlsToExecutionChangeSubnetTopicFormat:     &ethpb.SignedBLSToExecutionChange{},
-	BlobSubnetTopicFormat:                     &ethpb.BlobSidecar{},
+var gossipTopicMappings = map[string]func() proto.Message{
+	BlockSubnetTopicFormat:                    func() proto.Message { return &ethpb.SignedBeaconBlock{} },
+	AttestationSubnetTopicFormat:              func() proto.Message { return &ethpb.Attestation{} },
+	ExitSubnetTopicFormat:                     func() proto.Message { return &ethpb.SignedVoluntaryExit{} },
+	ProposerSlashingSubnetTopicFormat:         func() proto.Message { return &ethpb.ProposerSlashing{} },
+	AttesterSlashingSubnetTopicFormat:         func() proto.Message { return &ethpb.AttesterSlashing{} },
+	AggregateAndProofSubnetTopicFormat:        func() proto.Message { return &ethpb.SignedAggregateAttestationAndProof{} },
+	SyncContributionAndProofSubnetTopicFormat: func() proto.Message { return &ethpb.SignedContributionAndProof{} },
+	SyncCommitteeSubnetTopicFormat:            func() proto.Message { return &ethpb.SyncCommitteeMessage{} },
+	BlsToExecutionChangeSubnetTopicFormat:     func() proto.Message { return &ethpb.SignedBLSToExecutionChange{} },
+	BlobSubnetTopicFormat:                     func() proto.Message { return &ethpb.BlobSidecar{} },
 }
 
 // GossipTopicMappings is a function to return the assigned data type
@@ -44,24 +44,24 @@ func GossipTopicMappings(topic string, epoch primitives.Epoch) proto.Message {
 		if epoch >= params.BeaconConfig().AltairForkEpoch {
 			return &ethpb.SignedBeaconBlockAltair{}
 		}
-		return gossipTopicMappings[topic]
+		return gossipTopicMappings[topic]()
 	case AttestationSubnetTopicFormat:
 		if epoch >= params.BeaconConfig().ElectraForkEpoch {
 			return &ethpb.AttestationElectra{}
 		}
-		return gossipTopicMappings[topic]
+		return gossipTopicMappings[topic]()
 	case AttesterSlashingSubnetTopicFormat:
 		if epoch >= params.BeaconConfig().ElectraForkEpoch {
 			return &ethpb.AttesterSlashingElectra{}
 		}
-		return gossipTopicMappings[topic]
+		return gossipTopicMappings[topic]()
 	case AggregateAndProofSubnetTopicFormat:
 		if epoch >= params.BeaconConfig().ElectraForkEpoch {
 			return &ethpb.SignedAggregateAttestationAndProofElectra{}
 		}
-		return gossipTopicMappings[topic]
+		return gossipTopicMappings[topic]()
 	default:
-		return gossipTopicMappings[topic]
+		return gossipTopicMappings[topic]()
 	}
 }
 
@@ -81,7 +81,7 @@ var GossipTypeMapping = make(map[reflect.Type]string, len(gossipTopicMappings))
 
 func init() {
 	for k, v := range gossipTopicMappings {
-		GossipTypeMapping[reflect.TypeOf(v)] = k
+		GossipTypeMapping[reflect.TypeOf(v())] = k
 	}
 	// Specially handle Altair objects.
 	GossipTypeMapping[reflect.TypeOf(&ethpb.SignedBeaconBlockAltair{})] = BlockSubnetTopicFormat

--- a/beacon-chain/p2p/gossip_topic_mappings.go
+++ b/beacon-chain/p2p/gossip_topic_mappings.go
@@ -44,25 +44,33 @@ func GossipTopicMappings(topic string, epoch primitives.Epoch) proto.Message {
 		if epoch >= params.BeaconConfig().AltairForkEpoch {
 			return &ethpb.SignedBeaconBlockAltair{}
 		}
-		return gossipTopicMappings[topic]()
+		return gossipMessage(topic)
 	case AttestationSubnetTopicFormat:
 		if epoch >= params.BeaconConfig().ElectraForkEpoch {
 			return &ethpb.AttestationElectra{}
 		}
-		return gossipTopicMappings[topic]()
+		return gossipMessage(topic)
 	case AttesterSlashingSubnetTopicFormat:
 		if epoch >= params.BeaconConfig().ElectraForkEpoch {
 			return &ethpb.AttesterSlashingElectra{}
 		}
-		return gossipTopicMappings[topic]()
+		return gossipMessage(topic)
 	case AggregateAndProofSubnetTopicFormat:
 		if epoch >= params.BeaconConfig().ElectraForkEpoch {
 			return &ethpb.SignedAggregateAttestationAndProofElectra{}
 		}
-		return gossipTopicMappings[topic]()
+		return gossipMessage(topic)
 	default:
-		return gossipTopicMappings[topic]()
+		return gossipMessage(topic)
 	}
+}
+
+func gossipMessage(topic string) proto.Message {
+	msgGen, ok := gossipTopicMappings[topic]
+	if !ok {
+		return nil
+	}
+	return msgGen()
 }
 
 // AllTopics returns all topics stored in our

--- a/beacon-chain/p2p/gossip_topic_mappings_test.go
+++ b/beacon-chain/p2p/gossip_topic_mappings_test.go
@@ -15,7 +15,7 @@ func TestMappingHasNoDuplicates(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	m := make(map[reflect.Type]bool)
 	for _, v := range gossipTopicMappings {
-		if _, ok := m[reflect.TypeOf(v)]; ok {
+		if _, ok := m[reflect.TypeOf(v())]; ok {
 			t.Errorf("%T is duplicated in the topic mapping", v)
 		}
 		m[reflect.TypeOf(v)] = true

--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
-	"google.golang.org/protobuf/proto"
 )
 
 var errNilPubsubMessage = errors.New("nil pubsub message")
@@ -52,10 +51,7 @@ func (s *Service) decodePubsubMessage(msg *pubsub.Message) (ssz.Unmarshaler, err
 	if base == nil {
 		return nil, p2p.ErrMessageNotMapped
 	}
-	m, ok := proto.Clone(base).(ssz.Unmarshaler)
-	if !ok {
-		return nil, errors.Errorf("message of %T does not support marshaller interface", base)
-	}
+	m := base.(ssz.Unmarshaler)
 	// Handle different message types across forks.
 	dt, err := extractValidDataTypeFromTopic(topic, fDigest[:], s.cfg.clock)
 	if err != nil {

--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -51,7 +51,10 @@ func (s *Service) decodePubsubMessage(msg *pubsub.Message) (ssz.Unmarshaler, err
 	if base == nil {
 		return nil, p2p.ErrMessageNotMapped
 	}
-	m := base.(ssz.Unmarshaler)
+	m, ok := base.(ssz.Unmarshaler)
+	if !ok {
+		return nil, errors.Errorf("message of %T does not support marshaller interface", base)
+	}
 	// Handle different message types across forks.
 	dt, err := extractValidDataTypeFromTopic(topic, fDigest[:], s.cfg.clock)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Instead of performing a protobuf clone operation from our base message map, we simply replace it with a method which generates a new message each time. Doing this is significantly cheaper rather than an expensive clone operation on an empty message each time.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
