### PR TITLE
EIP-7549: Allow multiple committee bits

### DIFF
--- a/proto/prysm/v1alpha1/attestation/BUILD.bazel
+++ b/proto/prysm/v1alpha1/attestation/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//crypto/bls:go_default_library",
+        "//crypto/hash:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//runtime/version:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/proto/prysm/v1alpha1/attestation/id_test.go
+++ b/proto/prysm/v1alpha1/attestation/id_test.go
@@ -41,6 +41,22 @@ func TestNewId(t *testing.T) {
 
 		assert.NotEqual(t, phase0Id, electraId)
 	})
+	t.Run("ID is different for different committee bits", func(t *testing.T) {
+		cb := primitives.NewAttestationCommitteeBits()
+		cb.SetBitAt(0, true)
+		cb.SetBitAt(1, true)
+		att := util.HydrateAttestationElectra(&ethpb.AttestationElectra{CommitteeBits: cb})
+		id1, err := attestation.NewId(att, attestation.Data)
+		assert.NoError(t, err)
+		cb = primitives.NewAttestationCommitteeBits()
+		cb.SetBitAt(0, true)
+		cb.SetBitAt(2, true)
+		att = util.HydrateAttestationElectra(&ethpb.AttestationElectra{CommitteeBits: cb})
+		id2, err := attestation.NewId(att, attestation.Data)
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, id1, id2)
+	})
 	t.Run("invalid source", func(t *testing.T) {
 		att := util.HydrateAttestation(&ethpb.Attestation{})
 		_, err := attestation.NewId(att, 123)
@@ -50,14 +66,6 @@ func TestNewId(t *testing.T) {
 		cb := primitives.NewAttestationCommitteeBits()
 		att := util.HydrateAttestationElectra(&ethpb.AttestationElectra{CommitteeBits: cb})
 		_, err := attestation.NewId(att, attestation.Data)
-		assert.ErrorContains(t, "0 committee bits are set", err)
-	})
-	t.Run("data source Electra - multiple bits set", func(t *testing.T) {
-		cb := primitives.NewAttestationCommitteeBits()
-		cb.SetBitAt(0, true)
-		cb.SetBitAt(1, true)
-		att := util.HydrateAttestationElectra(&ethpb.AttestationElectra{CommitteeBits: cb})
-		_, err := attestation.NewId(att, attestation.Data)
-		assert.ErrorContains(t, "2 committee bits are set", err)
+		assert.ErrorContains(t, "no committee bits are set", err)
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR fixes tests failing with `could not create attestation ID` in https://github.com/prysmaticlabs/prysm/pull/14180.

We need to allow more than 1 committee bit set when creating an attestation ID because when we prune attestations we create IDs based on what we see in a block. And an Electra block will have aggregated attestations with more than 1 committee bit.
