### PR TITLE
Check locally for min-bid and min-bid-difference

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -73,6 +73,21 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
+	if cliCtx.IsSet(flags.MinBuilderBid.Name) {
+		c := params.BeaconConfig().Copy()
+		c.MinBuilderBid = cliCtx.Uint64(flags.MinBuilderBid.Name)
+		if err := params.SetActive(c); err != nil {
+			return err
+		}
+	}
+	if cliCtx.IsSet(flags.MinBuilderDiff.Name) {
+		c := params.BeaconConfig().Copy()
+		c.MinBuilderDiff = cliCtx.Uint64(flags.MinBuilderBid.Name)
+		if err := params.SetActive(c); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -96,6 +96,24 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 		// Compare payload values between local and builder. Default to the local value if it is higher.
 		localValueGwei := primitives.WeiToGwei(local.Bid)
 		builderValueGwei := primitives.WeiToGwei(bid.Value())
+		// Use local block if min bid is not attained
+		if builderValueGwei < primitives.Gwei(params.BeaconConfig().MinBuilderBid) {
+			log.WithFields(logrus.Fields{
+				"localGweiValue":   localValueGwei,
+				"builderGweiValue": builderValueGwei,
+			}).Warn("Proposer: using local execution payload because min bid not attained")
+			return local.Bid, local.BlobsBundle, setLocalExecution(blk, local)
+		}
+
+		// Use local block if min difference is not attained
+		if builderValueGwei < localValueGwei+primitives.Gwei(params.BeaconConfig().MinBuilderDiff) {
+			log.WithFields(logrus.Fields{
+				"localGweiValue":   localValueGwei,
+				"builderGweiValue": builderValueGwei,
+			}).Warn("Proposer: using local execution payload because min difference with local value was not attained")
+			return local.Bid, local.BlobsBundle, setLocalExecution(blk, local)
+		}
+
 		// Use builder payload if the following in true:
 		// builder_bid_value * builderBoostFactor(default 100) > local_block_value * (local-block-value-boost + 100)
 		boost := primitives.Gwei(params.BeaconConfig().LocalBlockValueBoost)

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -31,6 +31,23 @@ var (
 			"Boost is an additional percentage to multiple local block value. Use builder block if: builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)",
 		Value: 10,
 	}
+	// MinBuilderBid sets an absolute value for the builder bid that this
+	// node will accept without reverting to local building
+	MinBuilderBid = &cli.Uint64Flag{
+		Name: "min-builder-bid",
+		Usage: "An absolute value in Gwei that the builder bid has to have in order for this beacon node to use the builder's block. Anything less than this value" +
+			" and the beacon will revert to local building.",
+		Value: 0,
+	}
+	// MinBuilderDiff sets an absolute value for the difference between the
+	// builder's  bid  and the local block value that this node will accept
+	// without reverting to local building
+	MinBuilderDiff = &cli.Uint64Flag{
+		Name: "min-builder-to-local-difference",
+		Usage: "An absolute value in Gwei that the builder bid has to have in order for this beacon node to use the builder's block. Anything less than this value" +
+			" and the beacon will revert to local building.",
+		Value: 0,
+	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer
 	ExecutionEngineEndpoint = &cli.StringFlag{
 		Name:  "execution-endpoint",

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -82,6 +82,8 @@ var appFlags = []cli.Flag{
 	flags.MaxBuilderConsecutiveMissedSlots,
 	flags.EngineEndpointTimeoutSeconds,
 	flags.LocalBlockValueBoost,
+	flags.MinBuilderBid,
+	flags.MinBuilderDiff,
 	cmd.BackupWebhookOutputDir,
 	cmd.MinimalConfigFlag,
 	cmd.E2EConfigFlag,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -131,6 +131,8 @@ var appHelpFlagGroups = []flagGroup{
 			flags.EngineEndpointTimeoutSeconds,
 			flags.SlasherDirFlag,
 			flags.LocalBlockValueBoost,
+			flags.MinBuilderBid,
+			flags.MinBuilderDiff,
 			flags.JwtId,
 			checkpoint.BlockPath,
 			checkpoint.StatePath,

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -222,7 +222,8 @@ type BeaconChainConfig struct {
 	MaxBuilderConsecutiveMissedSlots primitives.Slot // MaxBuilderConsecutiveMissedSlots defines the number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction.
 	MaxBuilderEpochMissedSlots       primitives.Slot // MaxBuilderEpochMissedSlots is defining the number of total skip slot (per epoch rolling windows) to fallback from using relay/builder to local execution engine for block construction.
 	LocalBlockValueBoost             uint64          // LocalBlockValueBoost is the value boost for local block construction. This is used to prioritize local block construction over relay/builder block construction.
-
+	MinBuilderBid                    uint64          // MinBuilderBid is the minimum value that the builder's block can have to be considered by this node.
+	MinBuilderDiff                   uint64          // MinBuilderDiff is the minimum value above the local block value that the builder has to bid to be considered by this node
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue uint64 // ExecutionEngineTimeoutValue defines the seconds to wait before timing out engine endpoints with execution payload execution semantics (newPayload, forkchoiceUpdated).
 


### PR DESCRIPTION
h/t @dataalways for these flags. Following up on suggestions from 

https://hackmd.io/@dataalways/censorship-resistance-today

This PR gives the users the ability of specifying locally a min bid that they would accept from the builder's block and a min difference with the local payload that they would accept before reverting to local execution. 