### PR TITLE
Payload attributes misleading value fix

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -904,10 +904,11 @@ func (s *Service) debugEndpoints(stater lookup.Stater) []endpoint {
 
 func (s *Service) eventsEndpoints() []endpoint {
 	server := &events.Server{
-		StateNotifier:     s.cfg.StateNotifier,
-		OperationNotifier: s.cfg.OperationNotifier,
-		HeadFetcher:       s.cfg.HeadFetcher,
-		ChainInfoFetcher:  s.cfg.ChainInfoFetcher,
+		StateNotifier:          s.cfg.StateNotifier,
+		OperationNotifier:      s.cfg.OperationNotifier,
+		HeadFetcher:            s.cfg.HeadFetcher,
+		ChainInfoFetcher:       s.cfg.ChainInfoFetcher,
+		TrackedValidatorsCache: s.cfg.TrackedValidatorsCache,
 	}
 
 	const namespace = "events"

--- a/beacon-chain/rpc/eth/events/BUILD.bazel
+++ b/beacon-chain/rpc/eth/events/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
+        "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/operation:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
@@ -51,5 +52,6 @@ go_test(
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/eth/events/BUILD.bazel
+++ b/beacon-chain/rpc/eth/events/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//api:go_default_library",
         "//api/server/structs:go_default_library",
         "//beacon-chain/blockchain:go_default_library",
+        "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/operation:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -439,14 +439,18 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 	if err != nil {
 		return write(w, flusher, "Could not get head state proposer index: "+err.Error())
 	}
-
+	feeRecipient := params.BeaconConfig().DefaultFeeRecipient.Bytes()
+	tValidator, exists := s.TrackedValidatorsCache.Validator(proposerIndex)
+	if exists {
+		feeRecipient = tValidator.FeeRecipient[:]
+	}
 	var attributes interface{}
 	switch headState.Version() {
 	case version.Bellatrix:
 		attributes = &structs.PayloadAttributesV1{
 			Timestamp:             fmt.Sprintf("%d", t.Unix()),
 			PrevRandao:            hexutil.Encode(prevRando),
-			SuggestedFeeRecipient: hexutil.Encode(headPayload.FeeRecipient()),
+			SuggestedFeeRecipient: hexutil.Encode(feeRecipient),
 		}
 	case version.Capella:
 		withdrawals, _, err := headState.ExpectedWithdrawals()
@@ -456,10 +460,10 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 		attributes = &structs.PayloadAttributesV2{
 			Timestamp:             fmt.Sprintf("%d", t.Unix()),
 			PrevRandao:            hexutil.Encode(prevRando),
-			SuggestedFeeRecipient: hexutil.Encode(headPayload.FeeRecipient()),
+			SuggestedFeeRecipient: hexutil.Encode(feeRecipient),
 			Withdrawals:           structs.WithdrawalsFromConsensus(withdrawals),
 		}
-	case version.Deneb:
+	case version.Deneb, version.Electra:
 		withdrawals, _, err := headState.ExpectedWithdrawals()
 		if err != nil {
 			return write(w, flusher, "Could not get head state expected withdrawals: "+err.Error())
@@ -471,7 +475,7 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 		attributes = &structs.PayloadAttributesV3{
 			Timestamp:             fmt.Sprintf("%d", t.Unix()),
 			PrevRandao:            hexutil.Encode(prevRando),
-			SuggestedFeeRecipient: hexutil.Encode(headPayload.FeeRecipient()),
+			SuggestedFeeRecipient: hexutil.Encode(feeRecipient),
 			Withdrawals:           structs.WithdrawalsFromConsensus(withdrawals),
 			ParentBeaconBlockRoot: hexutil.Encode(parentRoot[:]),
 		}

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -463,7 +463,7 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 			SuggestedFeeRecipient: hexutil.Encode(feeRecipient),
 			Withdrawals:           structs.WithdrawalsFromConsensus(withdrawals),
 		}
-	case version.Deneb, version.Electra:
+	case version.Deneb:
 		withdrawals, _, err := headState.ExpectedWithdrawals()
 		if err != nil {
 			return write(w, flusher, "Could not get head state expected withdrawals: "+err.Error())

--- a/beacon-chain/rpc/eth/events/server.go
+++ b/beacon-chain/rpc/eth/events/server.go
@@ -5,6 +5,7 @@ package events
 
 import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
 	opfeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/operation"
 	statefeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/state"
 )
@@ -12,8 +13,9 @@ import (
 // Server defines a server implementation of the gRPC events service,
 // providing RPC endpoints to subscribe to events from the beacon node.
 type Server struct {
-	StateNotifier     statefeed.Notifier
-	OperationNotifier opfeed.Notifier
-	HeadFetcher       blockchain.HeadFetcher
-	ChainInfoFetcher  blockchain.ChainInfoFetcher
+	StateNotifier          statefeed.Notifier
+	OperationNotifier      opfeed.Notifier
+	HeadFetcher            blockchain.HeadFetcher
+	ChainInfoFetcher       blockchain.ChainInfoFetcher
+	TrackedValidatorsCache *cache.TrackedValidatorsCache
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Makes the fee recipient more consistent with other clients such as lighthouse. the default value will be used when the proposer is not registered and the value from the proposer cache will be used when a known validator proposes. 
this fee recipient field should not be used by builders and apis as the correct version should be from the validator registration endpoint. 

**Which issues(s) does this PR fix?**

Fixes #14204

**Other notes for review**
