### PR TITLE
Fix Merkle proof generator for Electra

### DIFF
--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -403,6 +403,26 @@ func TestSidecarInclusionProven(t *testing.T) {
 	require.NotNil(t, v.results.result(RequireSidecarInclusionProven))
 }
 
+func TestSidecarInclusionProvenElectra(t *testing.T) {
+	// GenerateTestDenebBlockWithSidecar is supposed to generate valid inclusion proofs
+	_, blobs := util.GenerateTestElectraBlockWithSidecar(t, [32]byte{}, 1, 1)
+	b := blobs[0]
+
+	ini := Initializer{}
+	v := ini.NewBlobVerifier(b, GossipSidecarRequirements)
+	require.NoError(t, v.SidecarInclusionProven())
+	require.Equal(t, true, v.results.executed(RequireSidecarInclusionProven))
+	require.NoError(t, v.results.result(RequireSidecarInclusionProven))
+
+	// Invert bits of the first byte of the body root to mess up the proof
+	byte0 := b.SignedBlockHeader.Header.BodyRoot[0]
+	b.SignedBlockHeader.Header.BodyRoot[0] = byte0 ^ 255
+	v = ini.NewBlobVerifier(b, GossipSidecarRequirements)
+	require.ErrorIs(t, v.SidecarInclusionProven(), ErrSidecarInclusionProofInvalid)
+	require.Equal(t, true, v.results.executed(RequireSidecarInclusionProven))
+	require.NotNil(t, v.results.result(RequireSidecarInclusionProven))
+}
+
 func TestSidecarKzgProofVerified(t *testing.T) {
 	// GenerateTestDenebBlockWithSidecar is supposed to generate valid commitments
 	_, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, 1, 1)

--- a/consensus-types/blocks/kzg.go
+++ b/consensus-types/blocks/kzg.go
@@ -156,7 +156,12 @@ func topLevelRoots(body interfaces.ReadOnlyBeaconBlockBody) ([][]byte, error) {
 
 	// Attester slashings
 	as := body.AttesterSlashings()
-	root, err = ssz.MerkleizeListSSZ(as, params.BeaconConfig().MaxAttesterSlashings)
+	bodyVersion := body.Version()
+	if bodyVersion < version.Electra {
+		root, err = ssz.MerkleizeListSSZ(as, params.BeaconConfig().MaxAttesterSlashings)
+	} else {
+		root, err = ssz.MerkleizeListSSZ(as, params.BeaconConfig().MaxAttesterSlashingsElectra)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +169,11 @@ func topLevelRoots(body interfaces.ReadOnlyBeaconBlockBody) ([][]byte, error) {
 
 	// Attestations
 	att := body.Attestations()
-	root, err = ssz.MerkleizeListSSZ(att, params.BeaconConfig().MaxAttestations)
+	if bodyVersion < version.Electra {
+		root, err = ssz.MerkleizeListSSZ(att, params.BeaconConfig().MaxAttestations)
+	} else {
+		root, err = ssz.MerkleizeListSSZ(att, params.BeaconConfig().MaxAttestationsElectra)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes the blob inclusion  Merkle proof generator for Electra due to the hardcoded limits for Attestations and Attester slashings that changed in the Electra fork. 