### PR TITLE
Electra: process_registry_updates handle exiting validators

### DIFF
--- a/beacon-chain/core/electra/registry_updates.go
+++ b/beacon-chain/core/electra/registry_updates.go
@@ -2,6 +2,7 @@ package electra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
@@ -84,7 +85,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) error {
 		var err error
 		// exitQueueEpoch and churn arguments are not used in electra.
 		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, 0 /*exitQueueEpoch*/, 0 /*churn*/)
-		if err != nil {
+		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return fmt.Errorf("failed to initiate validator exit at index %d: %w", idx, err)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

ProcessRegistryUpdates should not fail when exiting a validator that is already exiting. This is
expected and can safely be ignored.

**Which issues(s) does this PR fix?**

**Other notes for review**

Required for #14220 
