### PR TITLE
Proposer: filter attestations for invalid signature

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -49,7 +49,6 @@ type ForkchoiceFetcher interface {
 	NewSlot(context.Context, primitives.Slot) error
 	ProposerBoost() [32]byte
 	RecentBlockSlot(root [32]byte) (primitives.Slot, error)
-	CommonAncestor(ctx context.Context, root1 [32]byte, root2 [32]byte) ([32]byte, primitives.Slot, error)
 	IsCanonical(ctx context.Context, blockRoot [32]byte) (bool, error)
 }
 
@@ -541,13 +540,6 @@ func (s *Service) RecentBlockSlot(root [32]byte) (primitives.Slot, error) {
 	s.cfg.ForkChoiceStore.RLock()
 	defer s.cfg.ForkChoiceStore.RUnlock()
 	return s.cfg.ForkChoiceStore.Slot(root)
-}
-
-// CommonAncestor returns the common ancestor of two blocks
-func (s *Service) CommonAncestor(ctx context.Context, root1 [32]byte, root2 [32]byte) ([32]byte, primitives.Slot, error) {
-	s.cfg.ForkChoiceStore.RLock()
-	defer s.cfg.ForkChoiceStore.RUnlock()
-	return s.cfg.ForkChoiceStore.CommonAncestor(ctx, root1, root2)
 }
 
 // inRegularSync queries the initial sync service to

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -50,6 +50,7 @@ type ForkchoiceFetcher interface {
 	ProposerBoost() [32]byte
 	RecentBlockSlot(root [32]byte) (primitives.Slot, error)
 	CommonAncestor(ctx context.Context, root1 [32]byte, root2 [32]byte) ([32]byte, primitives.Slot, error)
+	IsCanonical(ctx context.Context, blockRoot [32]byte) (bool, error)
 }
 
 // TimeFetcher retrieves the Ethereum consensus data that's related to time.

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -48,6 +48,8 @@ type ForkchoiceFetcher interface {
 	ForkChoiceDump(context.Context) (*forkchoice.Dump, error)
 	NewSlot(context.Context, primitives.Slot) error
 	ProposerBoost() [32]byte
+	RecentBlockSlot(root [32]byte) (primitives.Slot, error)
+	CommonAncestor(ctx context.Context, root1 [32]byte, root2 [32]byte) ([32]byte, primitives.Slot, error)
 }
 
 // TimeFetcher retrieves the Ethereum consensus data that's related to time.
@@ -538,6 +540,13 @@ func (s *Service) RecentBlockSlot(root [32]byte) (primitives.Slot, error) {
 	s.cfg.ForkChoiceStore.RLock()
 	defer s.cfg.ForkChoiceStore.RUnlock()
 	return s.cfg.ForkChoiceStore.Slot(root)
+}
+
+// CommonAncestor returns the common ancestor of two blocks
+func (s *Service) CommonAncestor(ctx context.Context, root1 [32]byte, root2 [32]byte) ([32]byte, primitives.Slot, error) {
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
+	return s.cfg.ForkChoiceStore.CommonAncestor(ctx, root1, root2)
 }
 
 // inRegularSync queries the initial sync service to

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -75,6 +75,7 @@ type ChainService struct {
 	SyncingRoot                 [32]byte
 	Blobs                       []blocks.VerifiedROBlob
 	TargetRoot                  [32]byte
+	CommonAncestorSlot          primitives.Slot
 }
 
 func (s *ChainService) Ancestor(ctx context.Context, root []byte, slot primitives.Slot) ([]byte, error) {
@@ -631,4 +632,9 @@ func (c *ChainService) ReceiveBlob(_ context.Context, b blocks.VerifiedROBlob) e
 // TargetRootForEpoch mocks the same method in the chain service
 func (c *ChainService) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
 	return c.TargetRoot, nil
+}
+
+// CommonAncestor mocks the same method.
+func (c *ChainService) CommonAncestor(_ context.Context, _ [32]byte, _ [32]byte) ([32]byte, primitives.Slot, error) {
+	return [32]byte{}, c.CommonAncestorSlot, nil
 }

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -75,7 +75,6 @@ type ChainService struct {
 	SyncingRoot                 [32]byte
 	Blobs                       []blocks.VerifiedROBlob
 	TargetRoot                  [32]byte
-	CommonAncestorSlot          primitives.Slot
 }
 
 func (s *ChainService) Ancestor(ctx context.Context, root []byte, slot primitives.Slot) ([]byte, error) {
@@ -632,9 +631,4 @@ func (c *ChainService) ReceiveBlob(_ context.Context, b blocks.VerifiedROBlob) e
 // TargetRootForEpoch mocks the same method in the chain service
 func (c *ChainService) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
 	return c.TargetRoot, nil
-}
-
-// CommonAncestor mocks the same method.
-func (c *ChainService) CommonAncestor(_ context.Context, _ [32]byte, _ [32]byte) ([32]byte, primitives.Slot, error) {
-	return [32]byte{}, c.CommonAncestorSlot, nil
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -336,7 +336,7 @@ func (vs *Server) filterAttestationBySignature(ctx context.Context, atts propose
 		return nil, err
 	}
 	prevTargetEpoch := primitives.Epoch(0)
-	if targetEpoch > 2 {
+	if targetEpoch > 1 {
 		prevTargetEpoch = targetEpoch.Sub(1)
 	}
 	prevTargetRoot, err := vs.HeadFetcher.TargetRootForEpoch([32]byte(headRoot), prevTargetEpoch)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -340,7 +340,7 @@ func (vs *Server) isAttestationFromPreviousEpoch(att ethpb.Att) bool {
 }
 
 // filterCurrentEpochAttestationByForkchoice filters attestations from the current epoch based on fork choice conditions.
-// Returns true if any of the following conditions are met:
+// Returns true if all of the following conditions are met:
 // 1. The attestation beacon block root is for a slot in the previous epoch (according to fork choice).
 // 2. The attestation target root is the same as the attestation beacon block root.
 // 3. The common ancestor of the head block and the attestation beacon block root is from the previous epoch.
@@ -351,8 +351,8 @@ func (vs *Server) filterCurrentEpochAttestationByForkchoice(ctx context.Context,
 
 	attTargetRoot := [32]byte(att.GetData().Target.Root)
 	attBlockRoot := [32]byte(att.GetData().BeaconBlockRoot)
-	if attBlockRoot == attTargetRoot {
-		return true, nil
+	if attBlockRoot != attTargetRoot {
+		return false, nil
 	}
 
 	slot, err := vs.ForkchoiceFetcher.RecentBlockSlot(attBlockRoot)
@@ -364,8 +364,8 @@ func (vs *Server) filterCurrentEpochAttestationByForkchoice(ctx context.Context,
 	if prevEpoch >= 1 {
 		prevEpoch = prevEpoch.Sub(1)
 	}
-	if epoch == prevEpoch {
-		return true, nil
+	if epoch != prevEpoch {
+		return false, nil
 	}
 
 	_, slot, err = vs.ForkchoiceFetcher.CommonAncestor(ctx, headRoot, attBlockRoot)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -333,7 +333,7 @@ func (vs *Server) isAttestationFromPreviousEpoch(att ethpb.Att, currentEpoch pri
 // Returns true if all of the following conditions are met:
 // 1. The attestation beacon block root is for a slot in the previous epoch (according to fork choice).
 // 2. The attestation target root is the same as the attestation beacon block root.
-// 3. The common ancestor of the head block and the attestation beacon block root is from the previous epoch.
+// 3. The attestation beacon block root is canonical according to fork choice.
 func (vs *Server) filterCurrentEpochAttestationByForkchoice(ctx context.Context, att ethpb.Att, currentEpoch primitives.Epoch) (bool, error) {
 	if !vs.isAttestationFromCurrentEpoch(att, currentEpoch) {
 		return false, nil

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -656,7 +656,7 @@ func Test_filterCurrentEpochAttestationByForkchoice(t *testing.T) {
 	targetRoot := [32]byte{'a'}
 	a := &ethpb.Attestation{
 		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: targetRoot[:],
+			BeaconBlockRoot: make([]byte, 32),
 			Slot:            params.BeaconConfig().SlotsPerEpoch,
 			Target: &ethpb.Checkpoint{
 				Epoch: 1,
@@ -668,10 +668,9 @@ func Test_filterCurrentEpochAttestationByForkchoice(t *testing.T) {
 	ctx := context.Background()
 	got, err := s.filterCurrentEpochAttestationByForkchoice(ctx, a, [32]byte{})
 	require.NoError(t, err)
-	require.Equal(t, true, got)
+	require.Equal(t, false, got)
 
-	r := [32]byte{'b'}
-	a.Data.BeaconBlockRoot = r[:]
+	a.Data.BeaconBlockRoot = targetRoot[:]
 	s.ForkchoiceFetcher = &chainMock.ChainService{BlockSlot: 1}
 	got, err = s.filterCurrentEpochAttestationByForkchoice(ctx, a, [32]byte{})
 	require.NoError(t, err)
@@ -680,7 +679,7 @@ func Test_filterCurrentEpochAttestationByForkchoice(t *testing.T) {
 	s.ForkchoiceFetcher = &chainMock.ChainService{BlockSlot: 100, CommonAncestorSlot: 1}
 	got, err = s.filterCurrentEpochAttestationByForkchoice(ctx, a, [32]byte{})
 	require.NoError(t, err)
-	require.Equal(t, true, got)
+	require.Equal(t, false, got)
 
 	slot = params.BeaconConfig().SlotsPerEpoch * 2
 	s = &Server{TimeFetcher: &chainMock.ChainService{Slot: &slot}}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -692,7 +692,7 @@ func Test_filterCurrentEpochAttestationByForkchoice(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, got)
 
-	s.ForkchoiceFetcher = &chainMock.ChainService{BlockSlot: 100, CommonAncestorSlot: 1}
+	s.ForkchoiceFetcher = &chainMock.ChainService{BlockSlot: 100}
 	got, err = s.filterCurrentEpochAttestationByForkchoice(ctx, a, epoch)
 	require.NoError(t, err)
 	require.Equal(t, false, got)


### PR DESCRIPTION
Many thanks to @potuz and @nisdas for helping and iterating on this idea.

This PR introduces a filter for proposer-pack attestations to exclude invalid signature attestations. The primary design goal is to minimize the work in the common case by implementing the following filtering scheme. We assume the following variables:

**Local Variables:**
$\text{CurrentEpoch} = \text{ToEpoch(CurrentSlot)}$
$\text{TargetEpoch} = \text{ToEpoch(HeadSlot)}$
$\text{PrevTargetEpoch} = \text{ToEpoch(HeadSlot) - 1}$
$\text{TargetRoot} = \text{TargetRootForEpoch(HeadRoot, TargetEpoch)}$
$\text{PreviousTargetRoot} = \text{TargetRootForEpoch(HeadRoot, PrevTargetEpoch)}$

**Attestation Variables:**
$\text{AttEpoch} = \text{ToEpoch(Att.Data.Slot)}$
$\text{AttTargetEpoch} = \text{Att.Data.Target.Epoch}$
$\text{AttTargetRoot} = \text{Att.Data.Target.Root}$
$\text{AttBlockRoot} = \text{Att.Data.BeaconBlockroot}$


**Filtering Scheme:**
For each attestation in the list, we can skip the signature check if all of the following conditions is true:

1.) $\text{CurrentEpoch} = \text{AttEpoch} \land \text{TargetEpoch} = \text{AttTargetEpoch} \land \text{TargetRoot} = \text{AttTargetRoot}$

2.) $\text{CurrentEpoch-1} = \text{AttEpoch} \land \text{PreviousTargetRoot} = \text{AttTargetRoot} \land \text{PreviousTargetEpoch} = \text{AttTargetEpoch}$

3.) Only if $\text{CurrentEpoch} = \text{AttEpoch}$
   - $\text{AttBlockRoot} = \text{AttTargetRoot}$
   - $\text{AttBlockRoot}$ exists in forkchoice and epoch lands in $CurrentEpoch-1$
   - Common ancestor epoch of $\text{HeadRoot}$ and $\text{AttBlockRoot}$ lands in $CurrentEpoch-1$

For attestations that don't meet these conditions, we will batch verify all signatures at once. If any batch verification fails, we will verify each signature individually.