### PR TITLE
Use Proposer Cache to Verify Data Columns

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -163,6 +163,7 @@ type Service struct {
 	initialSyncComplete              chan struct{}
 	verifierWaiter                   *verification.InitializerWaiter
 	newBlobVerifier                  verification.NewBlobVerifier
+	newColumnProposerVerifier        verification.NewColumnVerifier
 	availableBlocker                 coverage.AvailableBlocker
 	dataColumsnReconstructionLock    sync.Mutex
 	receivedDataColumnsFromRoot      map[[fieldparams.RootLength]byte]map[uint64]bool
@@ -233,6 +234,7 @@ func (s *Service) Start() {
 		return
 	}
 	s.newBlobVerifier = newBlobVerifierFromInitializer(v)
+	s.newColumnProposerVerifier = v.VerifyProposer
 
 	go s.verifierRoutine()
 	go s.registerHandlers()

--- a/beacon-chain/verification/initializer.go
+++ b/beacon-chain/verification/initializer.go
@@ -12,6 +12,8 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/network/forks"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/time/slots"
+	log "github.com/sirupsen/logrus"
 )
 
 // Forkchoicer represents the forkchoice methods that the verifiers need.
@@ -55,6 +57,37 @@ func (ini *Initializer) NewBlobVerifier(b blocks.ROBlob, reqs []Requirement) *RO
 		results:              newResults(reqs...),
 		verifyBlobCommitment: kzg.Verify,
 	}
+}
+
+func (ini *Initializer) VerifyProposer(ctx context.Context, dc blocks.RODataColumn) error {
+	e := slots.ToEpoch(dc.Slot())
+	if e > 0 {
+		e = e - 1
+	}
+	r, err := ini.shared.fc.TargetRootForEpoch(dc.ParentRoot(), e)
+	if err != nil {
+		return ErrSidecarUnexpectedProposer
+	}
+	c := &forkchoicetypes.Checkpoint{Root: r, Epoch: e}
+	idx, cached := ini.shared.pc.Proposer(c, dc.Slot())
+	if !cached {
+		pst, err := ini.shared.sr.StateByRoot(ctx, dc.ParentRoot())
+		if err != nil {
+			log.WithError(err).Debug("state replay to parent_root failed")
+			return ErrSidecarUnexpectedProposer
+		}
+		idx, err = ini.shared.pc.ComputeProposer(ctx, dc.ParentRoot(), dc.Slot(), pst)
+		if err != nil {
+			log.WithError(err).Debug("error computing proposer index from parent state")
+			return ErrSidecarUnexpectedProposer
+		}
+	}
+	if idx != dc.ProposerIndex() {
+		log.WithError(ErrSidecarUnexpectedProposer).WithField("expectedProposer", idx).
+			Debug("unexpected blob proposer")
+		return ErrSidecarUnexpectedProposer
+	}
+	return nil
 }
 
 // InitializerWaiter provides an Initializer once all dependent resources are ready

--- a/beacon-chain/verification/interface.go
+++ b/beacon-chain/verification/interface.go
@@ -29,3 +29,7 @@ type BlobVerifier interface {
 // NewBlobVerifier is a function signature that can be used by code that needs to be
 // able to mock Initializer.NewBlobVerifier without complex setup.
 type NewBlobVerifier func(b blocks.ROBlob, reqs []Requirement) BlobVerifier
+
+// NewColumnVerifier is a function signature that can be used to mock a setup where a
+// column verifier can be easily initialized.
+type NewColumnVerifier func(ctx context.Context, dc blocks.RODataColumn) error


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Rather than advancing slots for each data column, we instead use the proposer cache to verify them. This prevents Prysm from unnecessarily advancing states and incurring large memory allocations from them.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
