### PR TITLE
Modify `get_ptc` function to follow the Python spec

### DIFF
--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -325,11 +325,8 @@ func PTCAssignments(committee []primitives.ValidatorIndex,
 		return assignments
 	}
 
-	// Calculate the starting index for PTC committee.
-	ptcStartIndex := committeeLength - membersPerCommittee
-
 	// Loop through the selected committee members for PTC assignments.
-	for i := ptcStartIndex; i < committeeLength; i++ {
+	for i := uint64(0); i < membersPerCommittee; i++ {
 		vIndex := committee[i]
 
 		assignment, exists := assignments[vIndex]

--- a/beacon-chain/core/helpers/payload_attestation.go
+++ b/beacon-chain/core/helpers/payload_attestation.go
@@ -83,8 +83,7 @@ func GetPayloadTimelinessCommittee(ctx context.Context, state state.ReadOnlyBeac
 		if uint64(len(committee)) < membersPerCommittee {
 			return nil, errCommitteeOverflow
 		}
-		start := uint64(len(committee)) - membersPerCommittee
-		indices = append(indices, committee[start:]...)
+		indices = append(indices, committee[:membersPerCommittee]...)
 	}
 	return
 }

--- a/beacon-chain/core/helpers/payload_attestation_test.go
+++ b/beacon-chain/core/helpers/payload_attestation_test.go
@@ -89,7 +89,7 @@ func TestGetPayloadTimelinessCommittee(t *testing.T) {
 	committee1, err := helpers.BeaconCommitteeFromState(ctx, state, state.Slot(), 0)
 	require.NoError(t, err)
 
-	require.DeepEqual(t, committee1[len(committee1)-64:], ptc[:64])
+	require.DeepEqual(t, committee1[:64], ptc[:64])
 }
 
 func Test_PtcAllocation(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
This PR modifies `get_ptc` function to follow the Python spec. The Python spec extracts PTC members from the beginning of committee array while current Prysm implementation assembles PTC members from the rear.