### PR TITLE
Remove no deposit requests found debug log

### DIFF
--- a/beacon-chain/core/electra/deposits.go
+++ b/beacon-chain/core/electra/deposits.go
@@ -308,7 +308,6 @@ func ProcessDepositRequests(ctx context.Context, beaconState state.BeaconState, 
 	defer span.End()
 
 	if len(requests) == 0 {
-		log.Debug("ProcessDepositRequests: no deposit requests found")
 		return beaconState, nil
 	}
 


### PR DESCRIPTION
Should we be logging empty deposit requests, which are presumably the normal case? It seems to me it makes more sense to log deposit requests if they are >0 and, under existing state transition log

![Screenshot 2024-07-23 at 9 42 56 AM](https://github.com/user-attachments/assets/4334fa71-729b-4710-987a-1b502bca5a26)
