### PR TITLE
Filter attestations by signature before sorting

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -112,18 +112,17 @@ func (vs *Server) packAttestations(ctx context.Context, latestState state.Beacon
 	if err != nil {
 		return nil, err
 	}
-	sorted, err := deduped.sortByProfitability()
+	filtered, err := vs.filterAttestationBySignature(ctx, deduped, latestState)
 	if err != nil {
 		return nil, err
 	}
-	atts = sorted.limitToMaxAttestations()
-
-	atts, err = vs.filterAttestationBySignature(ctx, atts, latestState)
+	sorted, err := filtered.sortByProfitability()
 	if err != nil {
 		return nil, err
 	}
+	limited := sorted.limitToMaxAttestations()
 
-	return atts, nil
+	return limited, nil
 }
 
 // filter separates attestation list into two groups: valid and invalid attestations.


### PR DESCRIPTION
https://github.com/prysmaticlabs/prysm/pull/14225 introduced filtering out attestations that have an incorrect signature. Filtering was added at the end of packing, which means it's after sorting and limiting to max attestations. This is not optimal because:
- We sort attestations that are going to be discarded anyway, which takes more time than sorting only valid ones.
- If attestations with an invalid signature look profitable, they will be included in the limited set, potentially pushing valid attestations out of this set. When we filter them out later, valid attestations will not take their place even though there is still space in the block.