### PR TITLE
Ensure epbs state getters & setters check versions

### DIFF
--- a/beacon-chain/state/interfaces_epbs.go
+++ b/beacon-chain/state/interfaces_epbs.go
@@ -7,14 +7,14 @@ import (
 
 type ReadOnlyEpbsFields interface {
 	IsParentBlockFull() (bool, error)
-	ExecutionPayloadHeader() (*enginev1.ExecutionPayloadHeaderEPBS, error)
+	LatestExecutionPayloadHeaderEPBS() (*enginev1.ExecutionPayloadHeaderEPBS, error)
 	LatestBlockHash() ([]byte, error)
 	LatestFullSlot() (primitives.Slot, error)
 	LastWithdrawalsRoot() ([]byte, error)
 }
 
 type WriteOnlyEpbsFields interface {
-	SetExecutionPayloadHeader(val *enginev1.ExecutionPayloadHeaderEPBS) error
+	SetLatestExecutionPayloadHeaderEPBS(val *enginev1.ExecutionPayloadHeaderEPBS) error
 	SetLatestBlockHash(val []byte) error
 	SetLatestFullSlot(val primitives.Slot) error
 	SetLastWithdrawalsRoot(val []byte) error

--- a/beacon-chain/state/interfaces_epbs.go
+++ b/beacon-chain/state/interfaces_epbs.go
@@ -6,16 +6,16 @@ import (
 )
 
 type ReadOnlyEpbsFields interface {
-	IsParentBlockFull() bool
-	ExecutionPayloadHeader() *enginev1.ExecutionPayloadHeaderEPBS
-	LatestBlockHash() []byte
-	LatestFullSlot() primitives.Slot
-	LastWithdrawalsRoot() []byte
+	IsParentBlockFull() (bool, error)
+	ExecutionPayloadHeader() (*enginev1.ExecutionPayloadHeaderEPBS, error)
+	LatestBlockHash() ([]byte, error)
+	LatestFullSlot() (primitives.Slot, error)
+	LastWithdrawalsRoot() ([]byte, error)
 }
 
 type WriteOnlyEpbsFields interface {
-	SetExecutionPayloadHeader(val *enginev1.ExecutionPayloadHeaderEPBS)
-	SetLatestBlockHash(val []byte)
-	SetLatestFullSlot(val primitives.Slot)
-	SetLastWithdrawalsRoot(val []byte)
+	SetExecutionPayloadHeader(val *enginev1.ExecutionPayloadHeaderEPBS) error
+	SetLatestBlockHash(val []byte) error
+	SetLatestFullSlot(val primitives.Slot) error
+	SetLastWithdrawalsRoot(val []byte) error
 }

--- a/beacon-chain/state/state-native/beacon_state_mainnet.go
+++ b/beacon-chain/state/state-native/beacon_state_mainnet.go
@@ -61,10 +61,10 @@ type BeaconState struct {
 	nextWithdrawalIndex                 uint64
 	nextWithdrawalValidatorIndex        primitives.ValidatorIndex
 	// ePBS fields
-	latestBlockHash        [32]byte
-	latestFullSlot         primitives.Slot
-	executionPayloadHeader *enginev1.ExecutionPayloadHeaderEPBS
-	lastWithdrawalsRoot    [32]byte
+	latestBlockHash                  [32]byte
+	latestFullSlot                   primitives.Slot
+	latestExecutionPayloadHeaderEPBS *enginev1.ExecutionPayloadHeaderEPBS
+	lastWithdrawalsRoot              [32]byte
 
 	// Electra fields
 	depositRequestsStartIndex     uint64

--- a/beacon-chain/state/state-native/beacon_state_minimal.go
+++ b/beacon-chain/state/state-native/beacon_state_minimal.go
@@ -61,10 +61,10 @@ type BeaconState struct {
 	nextWithdrawalIndex                 uint64
 	nextWithdrawalValidatorIndex        primitives.ValidatorIndex
 	// ePBS fields
-	latestBlockHash        [32]byte
-	latestFullSlot         primitives.Slot
-	executionPayloadHeader *enginev1.ExecutionPayloadHeaderEPBS
-	lastWithdrawalsRoot    [32]byte
+	latestBlockHash                  [32]byte
+	latestFullSlot                   primitives.Slot
+	latestExecutionPayloadHeaderEPBS *enginev1.ExecutionPayloadHeaderEPBS
+	lastWithdrawalsRoot              [32]byte
 
 	// Electra fields
 	depositRequestsStartIndex     uint64

--- a/beacon-chain/state/state-native/getters_epbs.go
+++ b/beacon-chain/state/state-native/getters_epbs.go
@@ -4,48 +4,72 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 )
 
 // ExecutionPayloadHeader retrieves a copy of the execution payload header.
 // It returns an error if the operation is not supported for the beacon state's version.
-func (b *BeaconState) ExecutionPayloadHeader() *enginev1.ExecutionPayloadHeaderEPBS {
+func (b *BeaconState) ExecutionPayloadHeader() (*enginev1.ExecutionPayloadHeaderEPBS, error) {
+	if b.version < version.EPBS {
+		return nil, errNotSupported("ExecutionPayloadHeader", b.version)
+	}
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.executionPayloadHeaderVal()
+	return b.executionPayloadHeaderVal(), nil
 }
 
 // IsParentBlockFull checks if the last committed payload header was fulfilled.
 // Returns true if both the beacon block and payload were present.
 // Call this function on a beacon state before processing the execution payload header.
-func (b *BeaconState) IsParentBlockFull() bool {
+// It returns an error if the operation is not supported for the beacon state's version.
+func (b *BeaconState) IsParentBlockFull() (bool, error) {
+	if b.version < version.EPBS {
+		return false, errNotSupported("IsParentBlockFull", b.version)
+	}
+
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
 	headerBlockHash := bytesutil.ToBytes32(b.executionPayloadHeader.BlockHash)
-	return headerBlockHash == b.latestBlockHash
+	return headerBlockHash == b.latestBlockHash, nil
 }
 
 // LatestBlockHash returns the latest block hash.
-func (b *BeaconState) LatestBlockHash() []byte {
+// It returns an error if the operation is not supported for the beacon state's version.
+func (b *BeaconState) LatestBlockHash() ([]byte, error) {
+	if b.version < version.EPBS {
+		return nil, errNotSupported("LatestBlockHash", b.version)
+	}
+
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.latestBlockHash[:]
+	return b.latestBlockHash[:], nil
 }
 
 // LatestFullSlot returns the slot of the latest full block.
-func (b *BeaconState) LatestFullSlot() primitives.Slot {
+// It returns an error if the operation is not supported for the beacon state's version.
+func (b *BeaconState) LatestFullSlot() (primitives.Slot, error) {
+	if b.version < version.EPBS {
+		return 0, errNotSupported("LatestFullSlot", b.version)
+	}
+
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.latestFullSlot
+	return b.latestFullSlot, nil
 }
 
 // LastWithdrawalsRoot returns the latest withdrawal root.
-func (b *BeaconState) LastWithdrawalsRoot() []byte {
+// It returns an error if the operation is not supported for the beacon state's version.
+func (b *BeaconState) LastWithdrawalsRoot() ([]byte, error) {
+	if b.version < version.EPBS {
+		return nil, errNotSupported("LastWithdrawalsRoot", b.version)
+	}
+
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.lastWithdrawalsRoot[:]
+	return b.lastWithdrawalsRoot[:], nil
 }

--- a/beacon-chain/state/state-native/getters_epbs.go
+++ b/beacon-chain/state/state-native/getters_epbs.go
@@ -7,11 +7,11 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 )
 
-// ExecutionPayloadHeader retrieves a copy of the execution payload header.
+// LatestExecutionPayloadHeaderEPBS retrieves a copy of the execution payload header from epbs state.
 // It returns an error if the operation is not supported for the beacon state's version.
-func (b *BeaconState) ExecutionPayloadHeader() (*enginev1.ExecutionPayloadHeaderEPBS, error) {
+func (b *BeaconState) LatestExecutionPayloadHeaderEPBS() (*enginev1.ExecutionPayloadHeaderEPBS, error) {
 	if b.version < version.EPBS {
-		return nil, errNotSupported("ExecutionPayloadHeader", b.version)
+		return nil, errNotSupported("LatestExecutionPayloadHeaderEPBS", b.version)
 	}
 	b.lock.RLock()
 	defer b.lock.RUnlock()
@@ -31,7 +31,7 @@ func (b *BeaconState) IsParentBlockFull() (bool, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	headerBlockHash := bytesutil.ToBytes32(b.executionPayloadHeader.BlockHash)
+	headerBlockHash := bytesutil.ToBytes32(b.latestExecutionPayloadHeaderEPBS.BlockHash)
 	return headerBlockHash == b.latestBlockHash, nil
 }
 

--- a/beacon-chain/state/state-native/getters_payload_header_epbs.go
+++ b/beacon-chain/state/state-native/getters_payload_header_epbs.go
@@ -6,5 +6,5 @@ import (
 )
 
 func (b *BeaconState) executionPayloadHeaderVal() *enginev1.ExecutionPayloadHeaderEPBS {
-	return eth.CopyExecutionPayloadHeaderEPBS(b.executionPayloadHeader)
+	return eth.CopyExecutionPayloadHeaderEPBS(b.latestExecutionPayloadHeaderEPBS)
 }

--- a/beacon-chain/state/state-native/getters_setters_epbs_test.go
+++ b/beacon-chain/state/state-native/getters_setters_epbs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/testing/util/random"
 )
 
-func Test_LatestExecutionPayloadHeader(t *testing.T) {
+func Test_LatestExecutionPayloadHeaderEPBS(t *testing.T) {
 	s := &BeaconState{version: version.EPBS}
 	_, err := s.LatestExecutionPayloadHeader()
 	require.ErrorContains(t, "unsupported version (epbs) for latest execution payload header", err)
@@ -23,13 +23,13 @@ func Test_SetLatestExecutionPayloadHeader(t *testing.T) {
 	require.ErrorContains(t, "SetLatestExecutionPayloadHeader is not supported for epbs", s.SetLatestExecutionPayloadHeader(nil))
 }
 
-func Test_SetExecutionPayloadHeader(t *testing.T) {
+func Test_SetLatestExecutionPayloadHeaderEPBS(t *testing.T) {
 	s := &BeaconState{version: version.EPBS, dirtyFields: make(map[types.FieldIndex]bool)}
 	header := random.ExecutionPayloadHeader(t)
-	require.NoError(t, s.SetExecutionPayloadHeader(header))
+	require.NoError(t, s.SetLatestExecutionPayloadHeaderEPBS(header))
 	require.Equal(t, true, s.dirtyFields[types.ExecutionPayloadHeader])
 
-	got, err := s.ExecutionPayloadHeader()
+	got, err := s.LatestExecutionPayloadHeaderEPBS()
 	require.NoError(t, err)
 	require.DeepEqual(t, got, header)
 }
@@ -80,9 +80,11 @@ func Test_UnsupportedStateVersionEpbs(t *testing.T) {
 	require.ErrorContains(t, "LatestFullSlot is not supported for electra", err)
 	_, err = s.LastWithdrawalsRoot()
 	require.ErrorContains(t, "LastWithdrawalsRoot is not supported for electra", err)
+	_, err = s.LatestExecutionPayloadHeaderEPBS()
+	require.ErrorContains(t, "LatestExecutionPayloadHeaderEPBS is not supported for electra", err)
 
 	require.ErrorContains(t, "LastWithdrawalsRoot is not supported for electra", s.SetLastWithdrawalsRoot(nil))
 	require.ErrorContains(t, "SetLatestBlockHash is not supported for electra", s.SetLatestBlockHash(nil))
 	require.ErrorContains(t, "SetLatestFullSlot is not supported for electra", s.SetLatestFullSlot(0))
-	require.ErrorContains(t, "SetExecutionPayloadHeader is not supported for electra", s.SetExecutionPayloadHeader(nil))
+	require.ErrorContains(t, "SetLatestExecutionPayloadHeaderEPBS is not supported for electra", s.SetLatestExecutionPayloadHeaderEPBS(nil))
 }

--- a/beacon-chain/state/state-native/getters_state.go
+++ b/beacon-chain/state/state-native/getters_state.go
@@ -252,7 +252,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 			PendingConsolidations:         b.pendingConsolidations,
 			LatestBlockHash:               b.latestBlockHash[:],
 			LatestFullSlot:                b.latestFullSlot,
-			LatestExecutionPayloadHeader:  b.executionPayloadHeader,
+			LatestExecutionPayloadHeader:  b.latestExecutionPayloadHeaderEPBS,
 			LastWithdrawalsRoot:           b.lastWithdrawalsRoot[:],
 		}
 	default:

--- a/beacon-chain/state/state-native/hasher.go
+++ b/beacon-chain/state/state-native/hasher.go
@@ -264,7 +264,7 @@ func ComputeFieldRootsWithHasher(ctx context.Context, state *BeaconState) ([][]b
 	}
 	if state.version == version.EPBS {
 		// Execution payload header root.
-		executionPayloadRoot, err := state.executionPayloadHeader.HashTreeRoot()
+		executionPayloadRoot, err := state.latestExecutionPayloadHeaderEPBS.HashTreeRoot()
 		if err != nil {
 			return nil, err
 		}

--- a/beacon-chain/state/state-native/setters_epbs.go
+++ b/beacon-chain/state/state-native/setters_epbs.go
@@ -8,16 +8,16 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 )
 
-// SetExecutionPayloadHeader sets the execution payload header for the beacon state.
-func (b *BeaconState) SetExecutionPayloadHeader(h *enginev1.ExecutionPayloadHeaderEPBS) error {
+// SetLatestExecutionPayloadHeaderEPBS sets the latest execution payload header for the epbs beacon state.
+func (b *BeaconState) SetLatestExecutionPayloadHeaderEPBS(h *enginev1.ExecutionPayloadHeaderEPBS) error {
 	if b.version < version.EPBS {
-		return errNotSupported("SetExecutionPayloadHeader", b.version)
+		return errNotSupported("SetLatestExecutionPayloadHeaderEPBS", b.version)
 	}
 
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.executionPayloadHeader = h
+	b.latestExecutionPayloadHeaderEPBS = h
 	b.markFieldAsDirty(types.ExecutionPayloadHeader)
 
 	return nil

--- a/beacon-chain/state/state-native/setters_epbs.go
+++ b/beacon-chain/state/state-native/setters_epbs.go
@@ -5,40 +5,65 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 )
 
 // SetExecutionPayloadHeader sets the execution payload header for the beacon state.
-func (b *BeaconState) SetExecutionPayloadHeader(h *enginev1.ExecutionPayloadHeaderEPBS) {
+func (b *BeaconState) SetExecutionPayloadHeader(h *enginev1.ExecutionPayloadHeaderEPBS) error {
+	if b.version < version.EPBS {
+		return errNotSupported("SetExecutionPayloadHeader", b.version)
+	}
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
 	b.executionPayloadHeader = h
 	b.markFieldAsDirty(types.ExecutionPayloadHeader)
+
+	return nil
 }
 
 // SetLatestBlockHash sets the latest block hash for the beacon state.
-func (b *BeaconState) SetLatestBlockHash(h []byte) {
+func (b *BeaconState) SetLatestBlockHash(h []byte) error {
+	if b.version < version.EPBS {
+		return errNotSupported("SetLatestBlockHash", b.version)
+	}
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
 	b.latestBlockHash = bytesutil.ToBytes32(h)
 	b.markFieldAsDirty(types.LatestBlockHash)
+
+	return nil
 }
 
 // SetLatestFullSlot sets the latest full slot for the beacon state.
-func (b *BeaconState) SetLatestFullSlot(s primitives.Slot) {
+func (b *BeaconState) SetLatestFullSlot(s primitives.Slot) error {
+	if b.version < version.EPBS {
+		return errNotSupported("SetLatestFullSlot", b.version)
+	}
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
 	b.latestFullSlot = s
 	b.markFieldAsDirty(types.LatestFullSlot)
+
+	return nil
 }
 
 // SetLastWithdrawalsRoot sets the latest withdrawals root for the beacon state.
-func (b *BeaconState) SetLastWithdrawalsRoot(r []byte) {
+func (b *BeaconState) SetLastWithdrawalsRoot(r []byte) error {
+	if b.version < version.EPBS {
+		return errNotSupported("SetLastWithdrawalsRoot", b.version)
+	}
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
 	b.lastWithdrawalsRoot = bytesutil.ToBytes32(r)
 	b.markFieldAsDirty(types.LastWithdrawalsRoot)
+
+	return nil
 }

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -950,7 +950,7 @@ func (b *BeaconState) Copy() state.BeaconState {
 		latestExecutionPayloadHeaderCapella: b.latestExecutionPayloadHeaderCapella.Copy(),
 		latestExecutionPayloadHeaderDeneb:   b.latestExecutionPayloadHeaderDeneb.Copy(),
 		latestExecutionPayloadHeaderElectra: b.latestExecutionPayloadHeaderElectra.Copy(),
-		executionPayloadHeader:              b.executionPayloadHeaderVal(),
+		latestExecutionPayloadHeaderEPBS:    b.executionPayloadHeaderVal(),
 
 		id: types.Enumerator.Inc(),
 
@@ -1355,7 +1355,7 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 	case types.LatestFullSlot:
 		return ssz.Uint64Root(uint64(b.latestFullSlot)), nil
 	case types.ExecutionPayloadHeader:
-		return b.executionPayloadHeader.HashTreeRoot()
+		return b.latestExecutionPayloadHeaderEPBS.HashTreeRoot()
 	case types.LastWithdrawalsRoot:
 		return b.lastWithdrawalsRoot, nil
 	}

--- a/beacon-chain/state/state-native/state_trie_epbs.go
+++ b/beacon-chain/state/state-native/state_trie_epbs.go
@@ -64,10 +64,10 @@ func InitializeFromProtoUnsafeEpbs(st *ethpb.BeaconStateEPBS) (*BeaconState, err
 		pendingConsolidations:         st.PendingConsolidations,
 
 		// ePBS fields
-		latestBlockHash:        bytesutil.ToBytes32(st.LatestBlockHash),
-		latestFullSlot:         st.LatestFullSlot,
-		executionPayloadHeader: st.LatestExecutionPayloadHeader,
-		lastWithdrawalsRoot:    bytesutil.ToBytes32(st.LastWithdrawalsRoot),
+		latestBlockHash:                  bytesutil.ToBytes32(st.LatestBlockHash),
+		latestFullSlot:                   st.LatestFullSlot,
+		latestExecutionPayloadHeaderEPBS: st.LatestExecutionPayloadHeader,
+		lastWithdrawalsRoot:              bytesutil.ToBytes32(st.LastWithdrawalsRoot),
 
 		dirtyFields:      make(map[types.FieldIndex]bool, fieldCount),
 		dirtyIndices:     make(map[types.FieldIndex][]uint64, fieldCount),

--- a/beacon-chain/state/state-native/state_trie_epbs_test.go
+++ b/beacon-chain/state/state-native/state_trie_epbs_test.go
@@ -27,7 +27,7 @@ func Test_InitializeFromProtoEpbs(t *testing.T) {
 	gotLatestFullSlot, err := s.LatestFullSlot()
 	require.NoError(t, err)
 	require.Equal(t, latestFullSlot, gotLatestFullSlot)
-	gotHeader, err := s.ExecutionPayloadHeader()
+	gotHeader, err := s.LatestExecutionPayloadHeaderEPBS()
 	require.NoError(t, err)
 	require.DeepEqual(t, header, gotHeader)
 	gotLastWithdrawalsRoot, err := s.LastWithdrawalsRoot()
@@ -42,22 +42,22 @@ func Test_CopyEpbs(t *testing.T) {
 
 	// Test shallow copy.
 	sNoCopy := s
-	require.DeepEqual(t, s.executionPayloadHeader, sNoCopy.executionPayloadHeader)
+	require.DeepEqual(t, s.latestExecutionPayloadHeaderEPBS, sNoCopy.latestExecutionPayloadHeaderEPBS)
 
 	// Modify a field to check if it reflects in the shallow copy.
-	s.executionPayloadHeader.Slot = 100
-	require.Equal(t, s.executionPayloadHeader, sNoCopy.executionPayloadHeader)
+	s.latestExecutionPayloadHeaderEPBS.Slot = 100
+	require.Equal(t, s.latestExecutionPayloadHeaderEPBS, sNoCopy.latestExecutionPayloadHeaderEPBS)
 
 	// Copy the state
 	sCopy := s.Copy()
 	require.NoError(t, err)
-	header, err := sCopy.ExecutionPayloadHeader()
+	header, err := sCopy.LatestExecutionPayloadHeaderEPBS()
 	require.NoError(t, err)
-	require.DeepEqual(t, s.executionPayloadHeader, header)
+	require.DeepEqual(t, s.latestExecutionPayloadHeaderEPBS, header)
 
 	// Modify the original to check if the copied state is independent.
-	s.executionPayloadHeader.Slot = 200
-	require.DeepNotEqual(t, s.executionPayloadHeader, header)
+	s.latestExecutionPayloadHeaderEPBS.Slot = 200
+	require.DeepNotEqual(t, s.latestExecutionPayloadHeaderEPBS, header)
 }
 
 func Test_HashTreeRootEpbs(t *testing.T) {

--- a/beacon-chain/state/state-native/state_trie_epbs_test.go
+++ b/beacon-chain/state/state-native/state_trie_epbs_test.go
@@ -21,13 +21,17 @@ func Test_InitializeFromProtoEpbs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert that initial values match those in the new state.
-	gotLatestBlockHash := s.LatestBlockHash()
+	gotLatestBlockHash, err := s.LatestBlockHash()
+	require.NoError(t, err)
 	require.DeepEqual(t, latestBlockHash, gotLatestBlockHash)
-	gotLatestFullSlot := s.LatestFullSlot()
+	gotLatestFullSlot, err := s.LatestFullSlot()
+	require.NoError(t, err)
 	require.Equal(t, latestFullSlot, gotLatestFullSlot)
-	gotHeader := s.ExecutionPayloadHeader()
+	gotHeader, err := s.ExecutionPayloadHeader()
+	require.NoError(t, err)
 	require.DeepEqual(t, header, gotHeader)
-	gotLastWithdrawalsRoot := s.LastWithdrawalsRoot()
+	gotLastWithdrawalsRoot, err := s.LastWithdrawalsRoot()
+	require.NoError(t, err)
 	require.DeepEqual(t, lastWithdrawalsRoot, gotLastWithdrawalsRoot)
 }
 
@@ -47,7 +51,8 @@ func Test_CopyEpbs(t *testing.T) {
 	// Copy the state
 	sCopy := s.Copy()
 	require.NoError(t, err)
-	header := sCopy.ExecutionPayloadHeader()
+	header, err := sCopy.ExecutionPayloadHeader()
+	require.NoError(t, err)
 	require.DeepEqual(t, s.executionPayloadHeader, header)
 
 	// Modify the original to check if the copied state is independent.


### PR DESCRIPTION
Ensure that epbs state getters and setters check the version. This prevents potential panics when calling epbs getters with an outdated state. A similar pattern is followed in Electra and Deneb functions.






