### PR TITLE
removing explicit deadlines on push proposer settings

### DIFF
--- a/validator/accounts/testing/mock.go
+++ b/validator/accounts/testing/mock.go
@@ -204,7 +204,7 @@ func (*Validator) HasProposerSettings() bool {
 }
 
 // PushProposerSettings for mocking
-func (_ *Validator) PushProposerSettings(_ context.Context, _ keymanager.IKeymanager, _ primitives.Slot, _ time.Time) error {
+func (_ *Validator) PushProposerSettings(_ context.Context, _ keymanager.IKeymanager, _ primitives.Slot) error {
 	panic("implement me")
 }
 

--- a/validator/client/iface/validator.go
+++ b/validator/client/iface/validator.go
@@ -57,7 +57,7 @@ type Validator interface {
 	Keymanager() (keymanager.IKeymanager, error)
 	HandleKeyReload(ctx context.Context, currentKeys [][fieldparams.BLSPubkeyLength]byte) (bool, error)
 	CheckDoppelGanger(ctx context.Context) error
-	PushProposerSettings(ctx context.Context, km keymanager.IKeymanager, slot primitives.Slot, deadline time.Time) error
+	PushProposerSettings(ctx context.Context, km keymanager.IKeymanager, slot primitives.Slot) error
 	SignValidatorRegistrationRequest(ctx context.Context, signer SigningFunc, newValidatorRegistration *ethpb.ValidatorRegistrationV1) (*ethpb.SignedValidatorRegistrationV1, error)
 	StartEventStream(ctx context.Context, topics []string, eventsChan chan<- *event.Event)
 	EventStreamIsRunning() bool

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -61,9 +61,8 @@ func run(ctx context.Context, v iface.Validator) {
 		log.Warn("Validator client started without proposer settings such as fee recipient" +
 			" and will continue to use settings provided in the beacon node.")
 	}
-	deadline := time.Now().Add(5 * time.Minute)
-	if err := v.PushProposerSettings(ctx, km, headSlot, deadline); err != nil {
-		log.WithError(err).Fatal("Failed to update proposer settings") // allow fatal. skipcq
+	if err := v.PushProposerSettings(ctx, km, headSlot); err != nil {
+		log.WithError(err).Fatal("Failed to update proposer settings")
 	}
 	for {
 		ctx, span := trace.StartSpan(ctx, "validator.processSlot")
@@ -97,7 +96,7 @@ func run(ctx context.Context, v iface.Validator) {
 			// call push proposer settings often to account for the following edge cases:
 			// proposer is activated at the start of epoch and tries to propose immediately
 			// account has changed in the middle of an epoch
-			if err := v.PushProposerSettings(ctx, km, slot, deadline); err != nil {
+			if err := v.PushProposerSettings(ctx, km, slot); err != nil {
 				log.WithError(err).Warn("Failed to update proposer settings")
 			}
 
@@ -316,8 +315,7 @@ func runHealthCheckRoutine(ctx context.Context, v iface.Validator, eventsChan ch
 					log.WithError(err).Error("Could not get canonical head slot")
 					return
 				}
-				deadline := time.Now().Add(5 * time.Minute) // Should consider changing to a constant
-				if err := v.PushProposerSettings(ctx, km, slot, deadline); err != nil {
+				if err := v.PushProposerSettings(ctx, km, slot); err != nil {
 					log.WithError(err).Warn("Failed to update proposer settings")
 				}
 			}

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -254,10 +254,7 @@ func (*FakeValidator) HasProposerSettings() bool {
 }
 
 // PushProposerSettings for mocking
-func (fv *FakeValidator) PushProposerSettings(ctx context.Context, _ keymanager.IKeymanager, _ primitives.Slot, deadline time.Time) error {
-	nctx, cancel := context.WithDeadline(ctx, deadline)
-	ctx = nctx
-	defer cancel()
+func (fv *FakeValidator) PushProposerSettings(ctx context.Context, _ keymanager.IKeymanager, _ primitives.Slot) error {
 	time.Sleep(fv.ProposerSettingWait)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		log.Error("deadline exceeded")

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1102,16 +1102,13 @@ func (v *validator) SetProposerSettings(ctx context.Context, settings *proposer.
 }
 
 // PushProposerSettings calls the prepareBeaconProposer RPC to set the fee recipient and also the register validator API if using a custom builder.
-func (v *validator) PushProposerSettings(ctx context.Context, km keymanager.IKeymanager, slot primitives.Slot, deadline time.Time) error {
+func (v *validator) PushProposerSettings(ctx context.Context, km keymanager.IKeymanager, slot primitives.Slot) error {
 	ctx, span := trace.StartSpan(ctx, "validator.PushProposerSettings")
 	defer span.End()
 
 	if km == nil {
 		return errors.New("keymanager is nil when calling PrepareBeaconProposer")
 	}
-	nctx, cancel := context.WithDeadline(ctx, deadline)
-	ctx = nctx
-	defer cancel()
 
 	pubkeys, err := km.FetchValidatingPublicKeys(ctx)
 	if err != nil {

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -2027,8 +2027,7 @@ func TestValidator_PushSettings(t *testing.T) {
 					require.Equal(t, len(tt.mockExpectedRequests), len(signedRegisterValidatorRequests))
 					require.Equal(t, len(signedRegisterValidatorRequests), len(v.signedValidatorRegistrations))
 				}
-				deadline := time.Now().Add(time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)
-				if err := v.PushProposerSettings(ctx, km, 0, deadline); tt.err != "" {
+				if err := v.PushProposerSettings(ctx, km, 0); tt.err != "" {
 					assert.ErrorContains(t, tt.err, err)
 				}
 				if len(tt.logMessages) > 0 {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

PR https://github.com/prysmaticlabs/prysm/pull/14155 broke builder e2e but upon debugging it appears that deadline probably won't be needed in this design with submissions every slot so I removed explicit deadlines on the calls, all deadlines should be inherited or explicit on the HTTP client.

the current issue results in context cancellation while the registrations are being submitted

```
time="2024-07-31 00:27:31" level=warning msg="failed to register validator on builder" error="could not submit signed registrations to beacon node: failed to perform request for endpoint http://localhost:4375/eth/v1/validator/register_validator: Post "http://localhost:4375/eth/v1/validator/register_validator": context canceled: Builder API validator registration unsuccessful" prefix=client
```

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
