### PR TITLE
Use BeaconCommittees helper to get the ptc

### DIFF
--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//beacon-chain/cache:go_default_library",
+        "//beacon-chain/core/signing:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",
@@ -72,6 +73,7 @@ go_test(
     tags = ["CI_race_detection"],
     deps = [
         "//beacon-chain/cache:go_default_library",
+        "//beacon-chain/core/signing:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",
@@ -81,7 +83,9 @@ go_test(
         "//consensus-types/epbs:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//container/slice:go_default_library",
+        "//crypto/bls:go_default_library",
         "//crypto/hash:go_default_library",
+        "//crypto/rand:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//math:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/beacon-chain/core/helpers/payload_attestation_test.go
+++ b/beacon-chain/core/helpers/payload_attestation_test.go
@@ -101,24 +101,24 @@ func TestGetPayloadTimelinessCommittee(t *testing.T) {
 
 func Test_PtcAllocation(t *testing.T) {
 	tests := []struct {
-		totalActive        uint64
+		committeeCount     int
 		memberPerCommittee uint64
 		committeesPerSlot  uint64
 	}{
-		{64, 512, 1},
-		{params.BeaconConfig().MinGenesisActiveValidatorCount, 128, 4},
-		{25600, 128, 4},
-		{256000, 16, 32},
-		{1024000, 8, 64},
+		{1, 512, 1},
+		{4, 128, 4},
+		{128, 4, 128},
+		{512, 1, 512},
+		{1024, 1, 512},
 	}
 
 	for _, test := range tests {
-		committeesPerSlot, memberPerCommittee := helpers.PtcAllocation(test.totalActive)
+		committeesPerSlot, memberPerCommittee := helpers.PtcAllocation(test.committeeCount)
 		if memberPerCommittee != test.memberPerCommittee {
-			t.Errorf("memberPerCommittee(%d) = %d; expected %d", test.totalActive, memberPerCommittee, test.memberPerCommittee)
+			t.Errorf("memberPerCommittee(%d) = %d; expected %d", test.committeeCount, memberPerCommittee, test.memberPerCommittee)
 		}
 		if committeesPerSlot != test.committeesPerSlot {
-			t.Errorf("committeesPerSlot(%d) = %d; expected %d", test.totalActive, committeesPerSlot, test.committeesPerSlot)
+			t.Errorf("committeesPerSlot(%d) = %d; expected %d", test.committeeCount, committeesPerSlot, test.committeesPerSlot)
 		}
 	}
 }


### PR DESCRIPTION
This removes the unnecessary helper `PTCAssignments` and computes the assignments in the loop by getting all committees at once. 