### PR TITLE
process Electra operations in the right order

### DIFF
--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -84,16 +84,14 @@ func ProcessOperations(
 	if !ok {
 		return nil, errors.New("could not cast execution data to electra execution data")
 	}
-	st, err = ProcessWithdrawalRequests(ctx, st, exe.WithdrawalRequests())
-	if err != nil {
-		return nil, errors.Wrap(err, "could not process execution layer withdrawal requests")
-	}
-
 	st, err = ProcessDepositRequests(ctx, st, exe.DepositRequests())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process deposit receipts")
 	}
-
+	st, err = ProcessWithdrawalRequests(ctx, st, exe.WithdrawalRequests())
+	if err != nil {
+		return nil, errors.Wrap(err, "could not process execution layer withdrawal requests")
+	}
 	if err := ProcessConsolidationRequests(ctx, st, exe.ConsolidationRequests()); err != nil {
 		return nil, fmt.Errorf("could not process consolidation requests: %w", err)
 	}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -22,29 +22,31 @@ var (
 //
 // Spec definition:
 //
-//	def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
-//	    # [Modified in Electra:EIP6110]
-//	    # Disable former deposit mechanism once all prior deposits are processed
-//	    eth1_deposit_index_limit = min(state.eth1_data.deposit_count, state.deposit_requests_start_index)
-//	    if state.eth1_deposit_index < eth1_deposit_index_limit:
-//	        assert len(body.deposits) == min(MAX_DEPOSITS, eth1_deposit_index_limit - state.eth1_deposit_index)
-//	    else:
-//	        assert len(body.deposits) == 0
+//  def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
+//      # [Modified in Electra:EIP6110]
+//      # Disable former deposit mechanism once all prior deposits are processed
+//      eth1_deposit_index_limit = min(state.eth1_data.deposit_count, state.deposit_requests_start_index)
+//      if state.eth1_deposit_index < eth1_deposit_index_limit:
+//          assert len(body.deposits) == min(MAX_DEPOSITS, eth1_deposit_index_limit - state.eth1_deposit_index)
+//      else:
+//          assert len(body.deposits) == 0
 //
-//	    def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
-//	        for operation in operations:
-//	            fn(state, operation)
+//      def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
+//          for operation in operations:
+//              fn(state, operation)
 //
-//	    for_ops(body.proposer_slashings, process_proposer_slashing)
-//	    for_ops(body.attester_slashings, process_attester_slashing)
-//	    for_ops(body.attestations, process_attestation)  # [Modified in Electra:EIP7549]
-//	    for_ops(body.deposits, process_deposit)  # [Modified in Electra:EIP7251]
-//	    for_ops(body.voluntary_exits, process_voluntary_exit)  # [Modified in Electra:EIP7251]
-//	    for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
-//	    # [New in Electra:EIP7002:EIP7251]
-//	    for_ops(body.execution_payload.withdrawal_requests, process_execution_layer_withdrawal_request)
-//	    for_ops(body.execution_payload.deposit_requests, process_deposit_requests)  # [New in Electra:EIP6110]
-//	    for_ops(body.consolidations, process_consolidation)  # [New in Electra:EIP7251]
+//      for_ops(body.proposer_slashings, process_proposer_slashing)
+//      for_ops(body.attester_slashings, process_attester_slashing)
+//      for_ops(body.attestations, process_attestation)  # [Modified in Electra:EIP7549]
+//      for_ops(body.deposits, process_deposit)  # [Modified in Electra:EIP7251]
+//      for_ops(body.voluntary_exits, process_voluntary_exit)  # [Modified in Electra:EIP7251]
+//      for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
+//      for_ops(body.execution_payload.deposit_requests, process_deposit_request)  # [New in Electra:EIP6110]
+//      # [New in Electra:EIP7002:EIP7251]
+//      for_ops(body.execution_payload.withdrawal_requests, process_withdrawal_request)
+//      # [New in Electra:EIP7251]
+//      for_ops(body.execution_payload.consolidation_requests, process_consolidation_request)
+
 func ProcessOperations(
 	ctx context.Context,
 	st state.BeaconState,


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#operations

```python
    ...
    for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
    for_ops(body.execution_payload.deposit_requests, process_deposit_request)  # [New in Electra:EIP6110]
    # [New in Electra:EIP7002:EIP7251]
    for_ops(body.execution_payload.withdrawal_requests, process_withdrawal_request)
    # [New in Electra:EIP7251]
    for_ops(body.execution_payload.consolidation_requests, process_consolidation_request)

```