### PR TITLE
Proposer checks gas limit before accepting builder's bid

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -242,6 +242,14 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot primitiv
 		return nil, fmt.Errorf("incorrect parent hash %#x != %#x", header.ParentHash(), h.BlockHash())
 	}
 
+	reg, err := vs.BeaconDB.RegistrationByValidatorID(ctx, idx)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get validator registration")
+	}
+	if reg.GasLimit != header.GasLimit() {
+		return nil, fmt.Errorf("incorrect header gas limit %d != %d", reg.GasLimit, header.GasLimit())
+	}
+
 	t, err := slots.ToTime(uint64(vs.TimeFetcher.GenesisTime().Unix()), slot)
 	if err != nil {
 		return nil, err

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -242,12 +242,13 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot primitiv
 		return nil, fmt.Errorf("incorrect parent hash %#x != %#x", header.ParentHash(), h.BlockHash())
 	}
 
-	reg, err := vs.BeaconDB.RegistrationByValidatorID(ctx, idx)
+	reg, err := vs.BlockBuilder.RegistrationByValidatorID(ctx, idx)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get validator registration")
-	}
-	if reg.GasLimit != header.GasLimit() {
-		return nil, fmt.Errorf("incorrect header gas limit %d != %d", reg.GasLimit, header.GasLimit())
+		log.WithError(err).Warn("Proposer: failed to get registration by validator ID, could not check gas limit")
+	} else {
+		if reg.GasLimit != header.GasLimit() {
+			return nil, fmt.Errorf("incorrect header gas limit %d != %d", reg.GasLimit, header.GasLimit())
+		}
 	}
 
 	t, err := slots.ToTime(uint64(vs.TimeFetcher.GenesisTime().Unix()), slot)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -891,16 +891,15 @@ func TestServer_getPayloadHeader(t *testing.T) {
 			vs := &Server{BeaconDB: dbTest.SetupDB(t), BlockBuilder: tc.mock, HeadFetcher: tc.fetcher, TimeFetcher: &blockchainTest.ChainService{
 				Genesis: genesis,
 			}}
-			require.NoError(
-				t, vs.BeaconDB.SaveRegistrationsByValidatorIDs(context.Background(), []primitives.ValidatorIndex{0}, []*ethpb.ValidatorRegistrationV1{
-					{
-						GasLimit:     0,
-						FeeRecipient: make([]byte, 20),
-						Pubkey:       make([]byte, 48),
-					},
-				}),
-			)
-			tc.mock.Cfg = &builderTest.Config{BeaconDB: vs.BeaconDB}
+			regCache := cache.NewRegistrationCache()
+			regCache.UpdateIndexToRegisteredMap(context.Background(), map[primitives.ValidatorIndex]*ethpb.ValidatorRegistrationV1{
+				0: {
+					GasLimit:     0,
+					FeeRecipient: make([]byte, 20),
+					Pubkey:       make([]byte, 48),
+				},
+			})
+			tc.mock.RegistrationCache = regCache
 			hb, err := vs.HeadFetcher.HeadBlock(context.Background())
 			require.NoError(t, err)
 			bid, err := vs.getPayloadHeaderFromBuilder(context.Background(), hb.Block().Slot(), 0)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -900,6 +900,7 @@ func TestServer_getPayloadHeader(t *testing.T) {
 					},
 				}),
 			)
+			tc.mock.Cfg = &builderTest.Config{BeaconDB: vs.BeaconDB}
 			hb, err := vs.HeadFetcher.HeadBlock(context.Background())
 			require.NoError(t, err)
 			bid, err := vs.getPayloadHeaderFromBuilder(context.Background(), hb.Block().Slot(), 0)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -720,6 +720,29 @@ func TestServer_getPayloadHeader(t *testing.T) {
 		Signature: sk.Sign(srCapella[:]).Marshal(),
 	}
 
+	incorrectGasLimitBid := &ethpb.BuilderBid{
+		Header: &v1.ExecutionPayloadHeader{
+			FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:        make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:     make([]byte, fieldparams.RootLength),
+			LogsBloom:        make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:       make([]byte, fieldparams.RootLength),
+			BaseFeePerGas:    make([]byte, fieldparams.RootLength),
+			BlockHash:        make([]byte, fieldparams.RootLength),
+			TransactionsRoot: bytesutil.PadTo([]byte{1}, fieldparams.RootLength),
+			ParentHash:       params.BeaconConfig().ZeroHash[:],
+			Timestamp:        uint64(tiCapella.Unix()),
+			GasLimit:         100,
+		},
+		Pubkey: sk.PublicKey().Marshal(),
+		Value:  bytesutil.PadTo([]byte{1, 2, 3}, 32),
+	}
+	signedIncorrectGasLimitBid :=
+		&ethpb.SignedBuilderBid{
+			Message:   incorrectGasLimitBid,
+			Signature: sk.Sign(srCapella[:]).Marshal(),
+		}
+
 	require.NoError(t, err)
 	tests := []struct {
 		name                  string
@@ -833,6 +856,21 @@ func TestServer_getPayloadHeader(t *testing.T) {
 			err: "is different from head block version",
 		},
 		{
+			name: "incorrect gas limit",
+			mock: &builderTest.MockBuilderService{
+				Bid: signedIncorrectGasLimitBid,
+			},
+			fetcher: &blockchainTest.ChainService{
+				Block: func() interfaces.ReadOnlySignedBeaconBlock {
+					wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
+					require.NoError(t, err)
+					wb.SetSlot(primitives.Slot(params.BeaconConfig().BellatrixForkEpoch) * params.BeaconConfig().SlotsPerEpoch)
+					return wb
+				}(),
+			},
+			err: "incorrect header gas limit 0 != 100",
+		},
+		{
 			name: "different bid version during hard fork",
 			mock: &builderTest.MockBuilderService{
 				BidCapella: sBidCapella,
@@ -850,9 +888,18 @@ func TestServer_getPayloadHeader(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			vs := &Server{BlockBuilder: tc.mock, HeadFetcher: tc.fetcher, TimeFetcher: &blockchainTest.ChainService{
+			vs := &Server{BeaconDB: dbTest.SetupDB(t), BlockBuilder: tc.mock, HeadFetcher: tc.fetcher, TimeFetcher: &blockchainTest.ChainService{
 				Genesis: genesis,
 			}}
+			require.NoError(
+				t, vs.BeaconDB.SaveRegistrationsByValidatorIDs(context.Background(), []primitives.ValidatorIndex{0}, []*ethpb.ValidatorRegistrationV1{
+					{
+						GasLimit:     0,
+						FeeRecipient: make([]byte, 20),
+						Pubkey:       make([]byte, 48),
+					},
+				}),
+			)
 			hb, err := vs.HeadFetcher.HeadBlock(context.Background())
 			require.NoError(t, err)
 			bid, err := vs.getPayloadHeaderFromBuilder(context.Background(), hb.Block().Slot(), 0)


### PR DESCRIPTION
This PR is part of #14309.

Currently, to accept a bid, we do not check the gas limit, but we should. If the builder's bid header gas limit is incorrect, it will simply defer back to local building.

Implications:
1. If the validator's registration is not part of the DB, we will not be able to get the registration for the gas limit. It currently fails here (proposer defaults to local block), but should we be more lenient?
2. Getting registration from RegistrationByValidatorID adds a few milliseconds to the overall hot path, but there's no other way around this, it seems. Block preparation is concurrent here anyway.