### PR TITLE
engine_getPayloadBodiesByRangeV1 - fix, adding hexutil encoding on request parameters

### DIFF
--- a/beacon-chain/execution/mock_test.go
+++ b/beacon-chain/execution/mock_test.go
@@ -150,7 +150,7 @@ func TestParseRequest(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.method, func(t *testing.T) {
 			cli, srv := newMockEngine(t)
-			srv.register(c.method, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
+			srv.register(c.method, func(msg *jsonrpcMessage, w http.ResponseWriter, _ *http.Request) {
 				require.Equal(t, c.method, msg.Method)
 				nr := uint64(len(c.byteArgs))
 				if len(c.byteArgs) > 0 {
@@ -209,7 +209,7 @@ func TestCallCount(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.method, func(t *testing.T) {
 			cli, srv := newMockEngine(t)
-			srv.register(c.method, func(msg *jsonrpcMessage, w http.ResponseWriter, r *http.Request) {
+			srv.register(c.method, func(msg *jsonrpcMessage, w http.ResponseWriter, _ *http.Request) {
 				mockWriteResult(t, w, msg, nil)
 			})
 			for i := 0; i < c.count; i++ {

--- a/beacon-chain/execution/mock_test.go
+++ b/beacon-chain/execution/mock_test.go
@@ -84,11 +84,15 @@ func (s *mockEngine) callCount(method string) int {
 }
 
 func mockParseUintList(t *testing.T, data json.RawMessage) []uint64 {
-	var list []uint64
+	var list []string
 	if err := json.Unmarshal(data, &list); err != nil {
 		t.Fatalf("failed to parse uint list: %v", err)
 	}
-	return list
+	uints := make([]uint64, len(list))
+	for i, u := range list {
+		uints[i] = hexutil.MustDecodeUint64(u)
+	}
+	return uints
 }
 
 func mockParseHexByteList(t *testing.T, data json.RawMessage) []hexutil.Bytes {

--- a/beacon-chain/execution/payload_body.go
+++ b/beacon-chain/execution/payload_body.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
@@ -160,7 +161,7 @@ func computeRanges(hbns []hashBlockNumber) []byRangeReq {
 
 func (r *blindedBlockReconstructor) requestBodiesByRange(ctx context.Context, client RPCClient, method string, req byRangeReq) error {
 	result := make([]*pb.ExecutionPayloadBody, 0)
-	if err := client.CallContext(ctx, &result, method, req.start, req.count); err != nil {
+	if err := client.CallContext(ctx, &result, method, hexutil.EncodeUint64(req.start), hexutil.EncodeUint64(req.count)); err != nil {
 		return err
 	}
 	if uint64(len(result)) != req.count {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

engine_getPayloadBodiesByRangeV1  parameters should be hex-encoded before call

**Which issues(s) does this PR fix?**

Fixes #14313

**Other notes for review**
