### PR TITLE
fix(tests): Fix v1alpha1/node/server_test.go

### DIFF
--- a/beacon-chain/p2p/testing/mock_peersprovider.go
+++ b/beacon-chain/p2p/testing/mock_peersprovider.go
@@ -16,6 +16,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	MockRawPeerId0 = "16Uiu2HAkyWZ4Ni1TpvDS8dPxsozmHY85KaiFjodQuV6Tz5tkHVeR"
+	MockRawPeerId1 = "16Uiu2HAm4HgJ9N1o222xK61o7LSgToYWoAy1wNTJRkh9gLZapVAy"
+)
+
 // MockPeersProvider implements PeersProvider for testing.
 type MockPeersProvider struct {
 	lock  sync.Mutex
@@ -50,7 +55,7 @@ func (m *MockPeersProvider) Peers() *peers.Status {
 			},
 		})
 		// Pretend we are connected to two peers
-		id0, err := peer.Decode("16Uiu2HAkyWZ4Ni1TpvDS8dPxsozmHY85KaiFjodQuV6Tz5tkHVeR")
+		id0, err := peer.Decode(MockRawPeerId0)
 		if err != nil {
 			log.WithError(err).Debug("Cannot decode")
 		}
@@ -61,7 +66,7 @@ func (m *MockPeersProvider) Peers() *peers.Status {
 		m.peers.Add(createENR(), id0, ma0, network.DirInbound)
 		m.peers.SetConnectionState(id0, peers.PeerConnected)
 		m.peers.SetChainState(id0, &pb.Status{FinalizedEpoch: 10})
-		id1, err := peer.Decode("16Uiu2HAm4HgJ9N1o222xK61o7LSgToYWoAy1wNTJRkh9gLZapVAy")
+		id1, err := peer.Decode(MockRawPeerId1)
 		if err != nil {
 			log.WithError(err).Debug("Cannot decode")
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/node/server_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/node/server_test.go
@@ -128,13 +128,12 @@ func TestNodeServer_GetPeer(t *testing.T) {
 	}
 	ethpb.RegisterNodeServer(server, ns)
 	reflection.Register(server)
-	firstPeer := peersProvider.Peers().All()[0]
 
-	res, err := ns.GetPeer(context.Background(), &ethpb.PeerRequest{PeerId: firstPeer.String()})
+	res, err := ns.GetPeer(context.Background(), &ethpb.PeerRequest{PeerId: mockP2p.MockRawPeerId0})
 	require.NoError(t, err)
-	assert.Equal(t, firstPeer.String(), res.PeerId, "Unexpected peer ID")
+	assert.Equal(t, "16Uiu2HAkyWZ4Ni1TpvDS8dPxsozmHY85KaiFjodQuV6Tz5tkHVeR" /* first peer's raw id */, res.PeerId, "Unexpected peer ID")
 	assert.Equal(t, int(ethpb.PeerDirection_INBOUND), int(res.Direction), "Expected 1st peer to be an inbound connection")
-	assert.Equal(t, ethpb.ConnectionState_CONNECTED, res.ConnectionState, "Expected peer to be connected")
+	assert.Equal(t, int(ethpb.ConnectionState_CONNECTED), int(res.ConnectionState), "Expected peer to be connected")
 }
 
 func TestNodeServer_ListPeers(t *testing.T) {
@@ -149,8 +148,25 @@ func TestNodeServer_ListPeers(t *testing.T) {
 	res, err := ns.ListPeers(context.Background(), &emptypb.Empty{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(res.Peers))
-	assert.Equal(t, int(ethpb.PeerDirection_INBOUND), int(res.Peers[0].Direction))
-	assert.Equal(t, ethpb.PeerDirection_OUTBOUND, res.Peers[1].Direction)
+
+	var (
+		firstPeer  *ethpb.Peer
+		secondPeer *ethpb.Peer
+	)
+
+	for _, p := range res.Peers {
+		if p.PeerId == mockP2p.MockRawPeerId0 {
+			firstPeer = p
+		}
+		if p.PeerId == mockP2p.MockRawPeerId1 {
+			secondPeer = p
+		}
+	}
+
+	assert.NotNil(t, firstPeer)
+	assert.NotNil(t, secondPeer)
+	assert.Equal(t, int(ethpb.PeerDirection_INBOUND), int(firstPeer.Direction))
+	assert.Equal(t, int(ethpb.PeerDirection_OUTBOUND), int(secondPeer.Direction))
 }
 
 func TestNodeServer_GetETH1ConnectionStatus(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`TestNodeServer_GetPeer` often failed, because the first element of peer list is not guaranteed to be same with what `MockPeersProvider` actually added to its peer list. `All()` method returns peer list by iterating a map structure, and that iteration can be random: second added peer can be placed at first as a result. Consult this [link](https://stackoverflow.com/questions/9619479/go-what-determines-the-iteration-order-for-map-keys).
So the test should be changed to explicitly find the first peer by its id.

Same issues at `TestNodeServer_ListPeers`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
