### PR TITLE
Refactor get local payload

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -71,7 +71,6 @@ func (vs *Server) getLocalPayloadFromEngine(
 	parentRoot [32]byte,
 	slot primitives.Slot,
 	proposerId primitives.ValidatorIndex) (*consensusblocks.GetPayloadResponse, error) {
-
 	logFields := logrus.Fields{
 		"validatorIndex": proposerId,
 		"slot":           slot,


### PR DESCRIPTION
Refactored `getLocalPayload` by moving part of its functionality into a new helper function, `getLocalPayloadFromEngine`. This helper function is utilized by epbs' `GetExecutionPayloadHeader` API implementation. `getLocalPayloadFromEngine` retrieves the local execution payload based on the slot, proposer ID, and parent root, assuming the payload is cached. If the payload ID is not cached, the function prepares a new payload using the local EL engine and returns it based on the head state.