### PR TITLE
Refactor currentlySyncingPayload cache

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -544,8 +544,9 @@ func (s *Service) recoverStateSummary(ctx context.Context, blockRoot [32]byte) (
 	return nil, errBlockDoesNotExist
 }
 
-// PayloadBeingSynced returns whether the payload for the block with the given root is currently being synced
-func (s *Service) PayloadBeingSynced(root [32]byte) bool {
+// PayloadBeingSynced returns whether the payload for the block with the given
+// root is currently being synced and what is the withheld status in the payload
+func (s *Service) PayloadBeingSynced(root [32]byte) (primitives.PTCStatus, bool) {
 	return s.payloadBeingSynced.isSyncing(root)
 }
 

--- a/beacon-chain/blockchain/currently_syncing_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/currently_syncing_execution_payload_envelope.go
@@ -1,16 +1,25 @@
 package blockchain
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+)
 
 type currentlySyncingPayload struct {
 	sync.Mutex
-	roots map[[32]byte]struct{}
+	roots map[[32]byte]primitives.PTCStatus
 }
 
-func (b *currentlySyncingPayload) set(root [32]byte) {
+func (b *currentlySyncingPayload) set(envelope interfaces.ROExecutionPayloadEnvelope) {
 	b.Lock()
 	defer b.Unlock()
-	b.roots[root] = struct{}{}
+	if envelope.PayloadWithheld() {
+		b.roots[envelope.BeaconBlockRoot()] = primitives.PAYLOAD_WITHHELD
+	} else {
+		b.roots[envelope.BeaconBlockRoot()] = primitives.PAYLOAD_PRESENT
+	}
 }
 
 func (b *currentlySyncingPayload) unset(root [32]byte) {
@@ -19,9 +28,9 @@ func (b *currentlySyncingPayload) unset(root [32]byte) {
 	delete(b.roots, root)
 }
 
-func (b *currentlySyncingPayload) isSyncing(root [32]byte) bool {
+func (b *currentlySyncingPayload) isSyncing(root [32]byte) (status primitives.PTCStatus, isSyncing bool) {
 	b.Lock()
 	defer b.Unlock()
-	_, ok := b.roots[root]
-	return ok
+	status, isSyncing = b.roots[root]
+	return
 }

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -26,7 +26,7 @@ import (
 func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, envelope interfaces.ROExecutionPayloadEnvelope, _ das.AvailabilityStore) error {
 	receivedTime := time.Now()
 	root := envelope.BeaconBlockRoot()
-	s.payloadBeingSynced.set(root)
+	s.payloadBeingSynced.set(envelope)
 	defer s.payloadBeingSynced.unset(root)
 
 	preState, err := s.getPayloadEnvelopePrestate(ctx, envelope)

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -182,7 +182,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		blobNotifiers:        bn,
 		cfg:                  &config{},
 		blockBeingSynced:     &currentlySyncingBlock{roots: make(map[[32]byte]struct{})},
-		payloadBeingSynced:   &currentlySyncingPayload{roots: make(map[[32]byte]struct{})},
+		payloadBeingSynced:   &currentlySyncingPayload{roots: make(map[[32]byte]primitives.PTCStatus)},
 	}
 	for _, opt := range opts {
 		if err := opt(srv); err != nil {


### PR DESCRIPTION
Refactors the `currentlySyncingPayload` cache to keep the withholding status for the payload. 

This is one part of two. A PTC voter will request first to this cache. If thi call fails then it will request from forkchoice