### PR TITLE
Fix Gas Limit in Genesis

### DIFF
--- a/runtime/interop/genesis.go
+++ b/runtime/interop/genesis.go
@@ -172,7 +172,7 @@ func GethTestnetGenesis(genesisTime uint64, cfg *clparams.BeaconChainConfig) *co
 		Nonce:      0, // overridden for authorized signer votes in clique, so we should leave it empty?
 		Timestamp:  genesisTime,
 		ExtraData:  extra,
-		GasLimit:   math.MaxUint64 >> 1, // shift 1 back from the max, just in case
+		GasLimit:   cfg.DefaultBuilderGasLimit, // shift 1 back from the max, just in case
 		Difficulty: common.HexToHash(defaultDifficulty).Big(),
 		Mixhash:    common.HexToHash(defaultMixhash),
 		Coinbase:   common.HexToAddress(defaultCoinbase),

--- a/runtime/interop/genesis.go
+++ b/runtime/interop/genesis.go
@@ -172,7 +172,7 @@ func GethTestnetGenesis(genesisTime uint64, cfg *clparams.BeaconChainConfig) *co
 		Nonce:      0, // overridden for authorized signer votes in clique, so we should leave it empty?
 		Timestamp:  genesisTime,
 		ExtraData:  extra,
-		GasLimit:   cfg.DefaultBuilderGasLimit, // shift 1 back from the max, just in case
+		GasLimit:   cfg.DefaultBuilderGasLimit,
 		Difficulty: common.HexToHash(defaultDifficulty).Big(),
 		Mixhash:    common.HexToHash(defaultMixhash),
 		Coinbase:   common.HexToAddress(defaultCoinbase),


### PR DESCRIPTION
**What type of PR is this?**

E2E Fix

**What does this PR do? Why is it needed?**

In E2E , we were setting the max Uint63 value for our gas limit in genesis. This ended up conflicting with the limit provided to the builder which is the default value(30000000). This PR fixes it to the builder default so that the el is always in sync with the provided gas limit.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
