### PR TITLE
Use Data Column Validation Across Prysm

### DIFF
--- a/beacon-chain/sync/data_columns_sampling_test.go
+++ b/beacon-chain/sync/data_columns_sampling_test.go
@@ -196,7 +196,7 @@ func setupDataColumnSamplerTest(t *testing.T, blobCount uint64) (*dataSamplerTes
 		kzgProofs:          kzgProofs,
 		dataColumnSidecars: dataColumnSidecars,
 	}
-	sampler := newDataColumnSampler1D(p2pSvc, clock, test.ctxMap, nil)
+	sampler := newDataColumnSampler1D(p2pSvc, clock, test.ctxMap, nil, nil)
 
 	return test, sampler
 }

--- a/beacon-chain/sync/data_columns_sampling_test.go
+++ b/beacon-chain/sync/data_columns_sampling_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	swarmt "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/startup"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/verification"
 	"github.com/sirupsen/logrus"
 
 	kzg "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/kzg"
@@ -196,7 +198,12 @@ func setupDataColumnSamplerTest(t *testing.T, blobCount uint64) (*dataSamplerTes
 		kzgProofs:          kzgProofs,
 		dataColumnSidecars: dataColumnSidecars,
 	}
-	sampler := newDataColumnSampler1D(p2pSvc, clock, test.ctxMap, nil, nil)
+	clockSync := startup.NewClockSynchronizer()
+	require.NoError(t, clockSync.SetClock(clock))
+	iniWaiter := verification.NewInitializerWaiter(clockSync, nil, nil)
+	ini, err := iniWaiter.WaitForInitializer(context.Background())
+	require.NoError(t, err)
+	sampler := newDataColumnSampler1D(p2pSvc, clock, test.ctxMap, nil, newColumnVerifierFromInitializer(ini))
 
 	return test, sampler
 }

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/startup"
 	beaconsync "github.com/prysmaticlabs/prysm/v5/beacon-chain/sync"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/verification"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
@@ -71,6 +72,8 @@ type blocksQueueConfig struct {
 	db                  db.ReadOnlyDatabase
 	mode                syncMode
 	bs                  filesystem.BlobStorageSummarizer
+	bv                  verification.NewBlobVerifier
+	cv                  verification.NewColumnVerifier
 }
 
 // blocksQueue is a priority queue that serves as a intermediary between block fetchers (producers)
@@ -113,6 +116,8 @@ func newBlocksQueue(ctx context.Context, cfg *blocksQueueConfig) *blocksQueue {
 			db:     cfg.db,
 			clock:  cfg.clock,
 			bs:     cfg.bs,
+			bv:     cfg.bv,
+			cv:     cfg.cv,
 		})
 	}
 	highestExpectedSlot := cfg.highestExpectedSlot

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -88,6 +88,8 @@ func (s *Service) startBlocksQueue(ctx context.Context, highestSlot primitives.S
 		highestExpectedSlot: highestSlot,
 		mode:                mode,
 		bs:                  summarizer,
+		bv:                  s.newBlobVerifier,
+		cv:                  s.newColumnVerifier,
 	}
 	queue := newBlocksQueue(ctx, cfg)
 	if err := queue.start(); err != nil {
@@ -174,7 +176,8 @@ func (s *Service) processFetchedDataRegSync(
 		return
 	}
 	if coreTime.PeerDASIsActive(startSlot) {
-		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, emptyVerifier{}, s.cfg.P2P.NodeID())
+		bv := verification.NewDataColumnBatchVerifier(s.newColumnVerifier, verification.InitsyncColumnSidecarRequirements)
+		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, bv, s.cfg.P2P.NodeID())
 		batchFields := logrus.Fields{
 			"firstSlot":        data.bwb[0].Block.Block().Slot(),
 			"firstUnprocessed": bwb[0].Block.Block().Slot(),
@@ -358,7 +361,8 @@ func (s *Service) processBatchedBlocks(ctx context.Context, genesis time.Time,
 	}
 	var aStore das.AvailabilityStore
 	if coreTime.PeerDASIsActive(first.Block().Slot()) {
-		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, emptyVerifier{}, s.cfg.P2P.NodeID())
+		bv := verification.NewDataColumnBatchVerifier(s.newColumnVerifier, verification.InitsyncColumnSidecarRequirements)
+		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, bv, s.cfg.P2P.NodeID())
 		s.logBatchSyncStatus(genesis, first, len(bwb))
 		for _, bb := range bwb {
 			if len(bb.Columns) == 0 {

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -424,15 +424,3 @@ func (s *Service) isProcessedBlock(ctx context.Context, blk blocks.ROBlock) bool
 	}
 	return false
 }
-
-type emptyVerifier struct {
-}
-
-func (_ emptyVerifier) VerifiedRODataColumns(_ context.Context, _ blocks.ROBlock, cols []blocks.RODataColumn) ([]blocks.VerifiedRODataColumn, error) {
-	var verCols []blocks.VerifiedRODataColumn
-	for _, col := range cols {
-		vCol := blocks.NewVerifiedRODataColumn(col)
-		verCols = append(verCols, vCol)
-	}
-	return verCols, nil
-}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -201,7 +201,7 @@ func (s *Service) sendAndSaveDataColumnSidecars(ctx context.Context, request typ
 		return err
 	}
 	for _, sidecar := range sidecars {
-		if err := verify.ColumnAlignsWithBlock(sidecar, RoBlock); err != nil {
+		if err := verify.ColumnAlignsWithBlock(sidecar, RoBlock, s.newColumnVerifier); err != nil {
 			return err
 		}
 		log.WithFields(columnFields(sidecar)).Debug("Received data column sidecar RPC")

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -362,7 +362,7 @@ func (s *Service) startTasksPostInitialSync() {
 
 		// Start data columns sampling if peerDAS is enabled.
 		if params.PeerDASEnabled() {
-			s.sampler = newDataColumnSampler1D(s.cfg.p2p, s.cfg.clock, s.ctxMap, s.cfg.stateNotifier)
+			s.sampler = newDataColumnSampler1D(s.cfg.p2p, s.cfg.clock, s.ctxMap, s.cfg.stateNotifier, s.newColumnVerifier)
 			go s.sampler.Run(s.ctx)
 		}
 

--- a/beacon-chain/sync/verify/BUILD.bazel
+++ b/beacon-chain/sync/verify/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/sync/verify",
     visibility = ["//visibility:public"],
     deps = [
-        "//beacon-chain/core/peerdas:go_default_library",
+        "//beacon-chain/verification:go_default_library",
         "//config/fieldparams:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//encoding/bytesutil:go_default_library",

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -40,11 +40,9 @@ var GossipColumnSidecarRequirements = requirementList(allColumnSidecarRequiremen
 var SpectestColumnSidecarRequirements = requirementList(GossipColumnSidecarRequirements).excluding(
 	RequireSidecarParentSeen, RequireSidecarParentValid)
 
-// InitsyncColumnSidecarRequirements is the list of verification requirements to be used by the init-sync service
-// for batch-mode syncing. Because we only perform batch verification as part of the IsDataAvailable method
-// for data columns after the block has been verified, and the blobs to be verified are keyed in the cache by the
-// block root, the list of required verifications is much shorter than gossip.
-var InitsyncColumnSidecarRequirements = requirementList(GossipColumnSidecarRequirements).excluding(
+// SamplingColumnSidecarRequirements are the column verification requirements that are necessary for columns
+// received via sampling.
+var SamplingColumnSidecarRequirements = requirementList(allColumnSidecarRequirements).excluding(
 	RequireNotFromFutureSlot,
 	RequireSlotAboveFinalized,
 	RequireSidecarParentSeen,
@@ -53,6 +51,12 @@ var InitsyncColumnSidecarRequirements = requirementList(GossipColumnSidecarRequi
 	RequireSidecarDescendsFromFinalized,
 	RequireSidecarProposerExpected,
 )
+
+// InitsyncColumnSidecarRequirements is the list of verification requirements to be used by the init-sync service
+// for batch-mode syncing. Because we only perform batch verification as part of the IsDataAvailable method
+// for data columns after the block has been verified, and the blobs to be verified are keyed in the cache by the
+// block root, the list of required verifications is much shorter than gossip.
+var InitsyncColumnSidecarRequirements = requirementList(SamplingColumnSidecarRequirements).excluding()
 
 // BackfillColumnSidecarRequirements is the same as InitsyncColumnSidecarRequirements.
 var BackfillColumnSidecarRequirements = requirementList(InitsyncColumnSidecarRequirements).excluding()


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR builds on from #14287 and uses the validation pipeline across prysm. Instead of calling kzg verification directly we specify a set of requirements to our verifier and use that across the repository. This is now used in normal verification, data column sampling and initial sync. 

**Which issues(s) does this PR fix?**

Part of #14129 

**Other notes for review**
