### PR TITLE
PR to update workflow check dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
           id: go
 
       - name: Golangci-lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
       - name: Run Gosec Security Scanner
         run: | # https://github.com/securego/gosec/issues/469
           export PATH=$PATH:$(go env GOPATH)/bin
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
           id: go
 
       - name: Golangci-lint
@@ -62,9 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Go mod tidy checker
         id: gomodtidy
@@ -27,9 +27,9 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Go 1.22
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.22.3'
       - name: Run Gosec Security Scanner
@@ -43,16 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go 1.22
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.22.3'
           id: go
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
           version: v1.55.2
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,7 +68,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go 1.23
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
           id: go
 
       - name: Golangci-lint
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.23.0'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.55.2
+          version: v1.60.3
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.55.2
+          version: v1.60.2
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Go 1.23
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23.0'
       - name: Run Gosec Security Scanner
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go 1.23
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23.0'
           id: go
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23.0'
         id: go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.22.6'
       - name: Run Gosec Security Scanner
         run: | # https://github.com/securego/gosec/issues/469
           export PATH=$PATH:$(go env GOPATH)/bin
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.22.6'
           id: go
 
       - name: Golangci-lint
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.22.6'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,16 +45,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.23
+      - name: Set up Go 1.22
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23.0'
+          go-version: '1.22.4'
           id: go
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.60.3
+          version: v1.56.1
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number
 
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.3'
+          go-version: '1.22.4'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go 1.23
-        uses: actions/setup-go@v5
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.23.0'
+          go-version: '1.22.3'
       - name: Run Gosec Security Scanner
         run: | # https://github.com/securego/gosec/issues/469
           export PATH=$PATH:$(go env GOPATH)/bin
@@ -45,16 +45,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.23
-        uses: actions/setup-go@v5
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.23.0'
+          go-version: '1.22.3'
           id: go
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.60.2
+          version: v1.55.2
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number
 
   build:
@@ -62,9 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.23.0'
+          go-version: '1.22.3'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.4'
+          go-version: '1.22.3'
           id: go
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.56.1
+          version: v1.55.2
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number
 
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.4'
+          go-version: '1.22.3'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.60.3
+          version: v1.55.2
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go 1.23
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23.0'
+          go-version: '1.22.3'
           id: go
 
       - name: Golangci-lint
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23.0'
+          go-version: '1.22.3'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,6 @@ linters:
     - lll
     - maintidx
     - makezero
-    - mnd
     - musttag
     - nakedret
     - nestif

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ run:
     - proto
     - tools/analyzers
   timeout: 10m
-  go: '1.22.3'
+  go: '1.23.0'
 
 linters:
   enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ run:
     - proto
     - tools/analyzers
   timeout: 10m
-  go: '1.22.4'
+  go: '1.22.6'
 
 linters:
   enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ run:
     - proto
     - tools/analyzers
   timeout: 10m
-  go: '1.23.0'
+  go: '1.22.4'
 
 linters:
   enable-all: true
@@ -58,6 +58,7 @@ linters:
     - lll
     - maintidx
     - makezero
+    - mnd
     - musttag
     - nakedret
     - nestif


### PR DESCRIPTION
This PR is updating the following dependencies in go CI checks:

- Update Lint to go 1.22.6 
- Update checkout and setup-go version to v4
- Update .golangci.yml to 1.22.6