### PR TITLE
Add ePBS fork schedule to config

### DIFF
--- a/beacon-chain/rpc/eth/config/handlers_test.go
+++ b/beacon-chain/rpc/eth/config/handlers_test.go
@@ -83,6 +83,8 @@ func TestGetSpec(t *testing.T) {
 	config.DenebForkEpoch = 105
 	config.ElectraForkVersion = []byte("ElectraForkVersion")
 	config.ElectraForkEpoch = 107
+	config.EPBSForkVersion = []byte("EPBSForkVersion")
+	config.EPBSForkEpoch = 109
 	config.BLSWithdrawalPrefixByte = byte('b')
 	config.ETH1AddressWithdrawalPrefixByte = byte('c')
 	config.GenesisDelay = 24
@@ -196,7 +198,7 @@ func TestGetSpec(t *testing.T) {
 	data, ok := resp.Data.(map[string]interface{})
 	require.Equal(t, true, ok)
 
-	assert.Equal(t, 163, len(data))
+	assert.Equal(t, 165, len(data))
 	for k, v := range data {
 		t.Run(k, func(t *testing.T) {
 			switch k {
@@ -274,6 +276,10 @@ func TestGetSpec(t *testing.T) {
 				assert.Equal(t, "0x"+hex.EncodeToString([]byte("ElectraForkVersion")), v)
 			case "ELECTRA_FORK_EPOCH":
 				assert.Equal(t, "107", v)
+			case "EPBS_FORK_VERSION":
+				assert.Equal(t, "0x"+hex.EncodeToString([]byte("EPBSForkVersion")), v)
+			case "EPBS_FORK_EPOCH":
+				assert.Equal(t, "109", v)
 			case "MIN_ANCHOR_POW_BLOCK_DIFFICULTY":
 				assert.Equal(t, "1000", v)
 			case "BLS_WITHDRAWAL_PREFIX":

--- a/beacon-chain/sync/backfill/verify.go
+++ b/beacon-chain/sync/backfill/verify.go
@@ -154,3 +154,15 @@ func (dc *domainCache) forEpoch(e primitives.Epoch) ([]byte, error) {
 	}
 	return d, nil
 }
+
+func (dc *domainCache) forName(n string) ([]byte, error) {
+	fork, err := dc.fsched.VersionForName(n)
+	if err != nil {
+		return nil, err
+	}
+	d, ok := dc.forkDomains[fork]
+	if !ok {
+		return nil, errors.Wrapf(errUnknownDomain, "fork version=%#x, name=%s", fork, n)
+	}
+	return d, nil
+}

--- a/beacon-chain/sync/backfill/verify_test.go
+++ b/beacon-chain/sync/backfill/verify_test.go
@@ -30,8 +30,8 @@ func TestDomainCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(fsched), len(dc.forkDomains))
 	for i := range fsched {
-		e := fsched[i].Epoch
-		ad, err := dc.forEpoch(e)
+		n := fsched[i].Name
+		ad, err := dc.forName(n)
 		require.NoError(t, err)
 		ed, err := signing.ComputeDomain(dType, fsched[i].Version[:], vRoot)
 		require.NoError(t, err)

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -174,8 +174,8 @@ type BeaconChainConfig struct {
 	DenebForkEpoch       primitives.Epoch `yaml:"DENEB_FORK_EPOCH" spec:"true"`       // DenebForkEpoch is used to represent the assigned fork epoch for deneb.
 	ElectraForkVersion   []byte           `yaml:"ELECTRA_FORK_VERSION" spec:"true"`   // ElectraForkVersion is used to represent the fork version for deneb.
 	ElectraForkEpoch     primitives.Epoch `yaml:"ELECTRA_FORK_EPOCH" spec:"true"`     // ElectraForkEpoch is used to represent the assigned fork epoch for deneb.
-	EPBSForkVersion      []byte           // EPBSForkVersion is used to represent the fork version for ePBS.
-	EPBSForkEpoch        primitives.Epoch // EPBSForkEpoch is used to represent the assigned fork epoch for ePBS.
+	EPBSForkVersion      []byte           `yaml:"EPBS_FORK_VERSION" spec:"true"`      // EPBSForkVersion is used to represent the fork version for ePBS.
+	EPBSForkEpoch        primitives.Epoch `yaml:"EPBS_FORK_EPOCH" spec:"true"`        // EPBSForkEpoch is used to represent the assigned fork epoch for ePBS.
 
 	ForkVersionSchedule map[[fieldparams.VersionLength]byte]primitives.Epoch // Schedule of fork epochs by version.
 	ForkVersionNames    map[[fieldparams.VersionLength]byte]string           // Human-readable names of fork versions.
@@ -305,6 +305,7 @@ func configForkSchedule(b *BeaconChainConfig) map[[fieldparams.VersionLength]byt
 	fvs[bytesutil.ToBytes4(b.CapellaForkVersion)] = b.CapellaForkEpoch
 	fvs[bytesutil.ToBytes4(b.DenebForkVersion)] = b.DenebForkEpoch
 	fvs[bytesutil.ToBytes4(b.ElectraForkVersion)] = b.ElectraForkEpoch
+	fvs[bytesutil.ToBytes4(b.EPBSForkVersion)] = b.EPBSForkEpoch
 	return fvs
 }
 

--- a/config/params/interop.go
+++ b/config/params/interop.go
@@ -12,6 +12,7 @@ func InteropConfig() *BeaconChainConfig {
 	c.CapellaForkVersion = []byte{3, 0, 0, 235}
 	c.DenebForkVersion = []byte{4, 0, 0, 235}
 	c.ElectraForkVersion = []byte{5, 0, 0, 235}
+	c.EPBSForkVersion = []byte{6, 0, 0, 235}
 
 	c.InitializeForkSchedule()
 	return c

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -217,6 +217,8 @@ func ConfigToYaml(cfg *BeaconChainConfig) []byte {
 		fmt.Sprintf("DENEB_FORK_VERSION: %#x", cfg.DenebForkVersion),
 		fmt.Sprintf("ELECTRA_FORK_EPOCH: %d", cfg.ElectraForkEpoch),
 		fmt.Sprintf("ELECTRA_FORK_VERSION: %#x", cfg.ElectraForkVersion),
+		fmt.Sprintf("EPBS_FORK_EPOCH: %d", cfg.EPBSForkEpoch),
+		fmt.Sprintf("EPBS_FORK_VERSION: %#x", cfg.EPBSForkVersion),
 		fmt.Sprintf("EPOCHS_PER_SUBNET_SUBSCRIPTION: %d", cfg.EpochsPerSubnetSubscription),
 		fmt.Sprintf("ATTESTATION_SUBNET_EXTRA_BITS: %d", cfg.AttestationSubnetExtraBits),
 		fmt.Sprintf("ATTESTATION_SUBNET_PREFIX_BITS: %d", cfg.AttestationSubnetPrefixBits),
@@ -233,8 +235,6 @@ func ConfigToYaml(cfg *BeaconChainConfig) []byte {
 		fmt.Sprintf("MESSAGE_DOMAIN_INVALID_SNAPPY:  %#x", cfg.MessageDomainInvalidSnappy),
 		fmt.Sprintf("MESSAGE_DOMAIN_VALID_SNAPPY: %#x", cfg.MessageDomainValidSnappy),
 		fmt.Sprintf("MIN_EPOCHS_FOR_BLOCK_REQUESTS: %d", int(cfg.MinEpochsForBlockRequests)),
-		fmt.Sprintf("ELECTRA_FORK_EPOCH: %d", cfg.ElectraForkEpoch),
-		fmt.Sprintf("ELECTRA_FORK_VERSION: %#x", cfg.ElectraForkVersion),
 	}
 
 	yamlFile := []byte(strings.Join(lines, "\n"))

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -150,6 +150,7 @@ func assertEqualConfigs(t *testing.T, name string, fields []string, expected, ac
 	assert.Equal(t, expected.CapellaForkEpoch, actual.CapellaForkEpoch, "%s: CapellaForkEpoch", name)
 	assert.Equal(t, expected.DenebForkEpoch, actual.DenebForkEpoch, "%s: DenebForkEpoch", name)
 	assert.Equal(t, expected.ElectraForkEpoch, actual.ElectraForkEpoch, "%s: ElectraForkEpoch", name)
+	assert.Equal(t, expected.EPBSForkEpoch, actual.EPBSForkEpoch, "%s: EPBSForkEpoch", name)
 	assert.Equal(t, expected.SqrRootSlotsPerEpoch, actual.SqrRootSlotsPerEpoch, "%s: SqrRootSlotsPerEpoch", name)
 	assert.DeepEqual(t, expected.GenesisForkVersion, actual.GenesisForkVersion, "%s: GenesisForkVersion", name)
 	assert.DeepEqual(t, expected.AltairForkVersion, actual.AltairForkVersion, "%s: AltairForkVersion", name)
@@ -157,6 +158,7 @@ func assertEqualConfigs(t *testing.T, name string, fields []string, expected, ac
 	assert.DeepEqual(t, expected.CapellaForkVersion, actual.CapellaForkVersion, "%s: CapellaForkVersion", name)
 	assert.DeepEqual(t, expected.DenebForkVersion, actual.DenebForkVersion, "%s: DenebForkVersion", name)
 	assert.DeepEqual(t, expected.ElectraForkVersion, actual.ElectraForkVersion, "%s: ElectraForkVersion", name)
+	assert.DeepEqual(t, expected.EPBSForkVersion, actual.EPBSForkVersion, "%s: EPBSForkVersion", name)
 
 	assertYamlFieldsMatch(t, name, fields, expected, actual)
 }

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -30,7 +30,7 @@ const (
 	// Electra Fork Epoch for mainnet config
 	mainnetElectraForkEpoch = math.MaxUint64 // Far future / to be defined
 	// ePBS Fork Epoch for mainnet config.
-	mainnetEPBSForkEpoch = math.MaxUint64
+	mainnetEPBSForkEpoch = math.MaxUint64 // Far future / to be defined
 )
 
 var mainnetNetworkConfig = &NetworkConfig{

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -96,6 +96,8 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.DenebForkEpoch = math.MaxUint64
 	minimalConfig.ElectraForkVersion = []byte{5, 0, 0, 1}
 	minimalConfig.ElectraForkEpoch = math.MaxUint64
+	minimalConfig.EPBSForkVersion = []byte{6, 0, 0, 1}
+	minimalConfig.EPBSForkEpoch = math.MaxUint64
 
 	minimalConfig.SyncCommitteeSize = 32
 	minimalConfig.InactivityScoreBias = 4

--- a/config/params/testdata/e2e_config.yaml
+++ b/config/params/testdata/e2e_config.yaml
@@ -47,7 +47,9 @@ DENEB_FORK_EPOCH: 12
 # Electra
 ELECTRA_FORK_VERSION: 0x050000fd
 ELECTRA_FORK_EPOCH: 18446744073709551615
-
+# EPBS
+EPBS_FORK_VERSION: 0x060000fd
+EPBS_FORK_EPOCH: 18446744073709551615
 
 # Time parameters
 # ---------------------------------------------------------------

--- a/config/params/testnet_e2e_config.go
+++ b/config/params/testnet_e2e_config.go
@@ -8,6 +8,7 @@ const (
 	CapellaE2EForkEpoch   = 10
 	DenebE2EForkEpoch     = 12
 	ElectraE2EForkEpoch   = math.MaxUint64
+	EPBSE2EForkEpoch      = math.MaxUint64
 )
 
 // E2ETestConfig retrieves the configurations made specifically for E2E testing.
@@ -44,6 +45,7 @@ func E2ETestConfig() *BeaconChainConfig {
 	e2eConfig.CapellaForkEpoch = CapellaE2EForkEpoch
 	e2eConfig.DenebForkEpoch = DenebE2EForkEpoch
 	e2eConfig.ElectraForkEpoch = ElectraE2EForkEpoch
+	e2eConfig.EPBSForkEpoch = EPBSE2EForkEpoch
 
 	// Terminal Total Difficulty.
 	e2eConfig.TerminalTotalDifficulty = "480"
@@ -56,6 +58,7 @@ func E2ETestConfig() *BeaconChainConfig {
 	e2eConfig.CapellaForkVersion = []byte{3, 0, 0, 253}
 	e2eConfig.DenebForkVersion = []byte{4, 0, 0, 253}
 	e2eConfig.ElectraForkVersion = []byte{5, 0, 0, 253}
+	e2eConfig.EPBSForkVersion = []byte{6, 0, 0, 253}
 
 	e2eConfig.InitializeForkSchedule()
 	return e2eConfig
@@ -88,6 +91,7 @@ func E2EMainnetTestConfig() *BeaconChainConfig {
 	e2eConfig.CapellaForkEpoch = CapellaE2EForkEpoch
 	e2eConfig.DenebForkEpoch = DenebE2EForkEpoch
 	e2eConfig.ElectraForkEpoch = ElectraE2EForkEpoch
+	e2eConfig.EPBSForkEpoch = EPBSE2EForkEpoch
 
 	// Terminal Total Difficulty.
 	e2eConfig.TerminalTotalDifficulty = "480"
@@ -100,6 +104,7 @@ func E2EMainnetTestConfig() *BeaconChainConfig {
 	e2eConfig.CapellaForkVersion = []byte{3, 0, 0, 254}
 	e2eConfig.DenebForkVersion = []byte{4, 0, 0, 254}
 	e2eConfig.ElectraForkVersion = []byte{5, 0, 0, 254}
+	e2eConfig.EPBSForkVersion = []byte{6, 0, 0, 254}
 
 	// Deneb changes.
 	e2eConfig.MinPerEpochChurnLimit = 2

--- a/config/params/testnet_holesky_config.go
+++ b/config/params/testnet_holesky_config.go
@@ -40,6 +40,8 @@ func HoleskyConfig() *BeaconChainConfig {
 	cfg.DenebForkVersion = []byte{0x05, 0x1, 0x70, 0x0}
 	cfg.ElectraForkEpoch = math.MaxUint64
 	cfg.ElectraForkVersion = []byte{0x06, 0x1, 0x70, 0x0} // TODO: Define holesky fork version for electra. This is a placeholder value.
+	cfg.EPBSForkEpoch = math.MaxUint64
+	cfg.EPBSForkVersion = []byte{0x07, 0x1, 0x70, 0x0} // TODO: Define holesky fork version for ePBS. This is a placeholder value.
 	cfg.TerminalTotalDifficulty = "0"
 	cfg.DepositContractAddress = "0x4242424242424242424242424242424242424242"
 	cfg.EjectionBalance = 28000000000

--- a/config/params/testnet_sepolia_config.go
+++ b/config/params/testnet_sepolia_config.go
@@ -41,6 +41,8 @@ func SepoliaConfig() *BeaconChainConfig {
 	cfg.DenebForkVersion = []byte{0x90, 0x00, 0x00, 0x73}
 	cfg.ElectraForkEpoch = math.MaxUint64
 	cfg.ElectraForkVersion = []byte{0x90, 0x00, 0x00, 0x74} // TODO: Define sepolia fork version for electra. This is a placeholder value.
+	cfg.EPBSForkEpoch = math.MaxUint64
+	cfg.EPBSForkVersion = []byte{0x90, 0x00, 0x00, 0x75} // TODO: Define sepolia fork version for ePBS. This is a placeholder value.
 	cfg.TerminalTotalDifficulty = "17000000000000000"
 	cfg.DepositContractAddress = "0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"
 	cfg.InitializeForkSchedule()


### PR DESCRIPTION
**What type of PR is this?**
This PR adds ePBS fork schedule to config. I guess it was omitted as Electra fork epoch is not defined yet, making both `cfg.ElectraForkEpoch` and `cfg.EPBSForkEpoch` have `math.MaxUint64` in `HoleskyConfig` and `SepoliaConfig` after adding ePBS fork. If it ought to be added later, please feel free to close this PR.