### PR TITLE
Disable Data Column Witholding For E2E

### DIFF
--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -280,7 +280,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 		"--" + cmdshared.AcceptTosFlag.Name,
 		"--" + features.EnableQUIC.Name,
 		"--" + flags.SubscribeToAllSubnets.Name,
-		fmt.Sprintf("--%s=%d", features.DataColumnsWithholdCount.Name, 3),
+		// fmt.Sprintf("--%s=%d", features.DataColumnsWithholdCount.Name, 3),
 	}
 	if config.UsePprof {
 		args = append(args, "--pprof", fmt.Sprintf("--pprofport=%d", e2e.TestParams.Ports.PrysmBeaconNodePprofPort+index))


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

We withold data columns in our E2E runs to test data reconstruction, unfortunately this is a very intensive process which constantly causes our E2E runs to fail. This PR disables it so that we can have a usable E2E build pipeline.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**