### PR TITLE
PeerDAS: Improve logging and reduce the number of needed goroutines for reconstruction

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -657,9 +658,8 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 		return errors.Wrap(err, "custody columns")
 	}
 
-	// Expected is the number of custody data columnns a node is expected to have.
-	expected := len(colMap)
-	if expected == 0 {
+	// colMap represents the data columnns a node is expected to custody.
+	if len(colMap) == 0 {
 		return nil
 	}
 
@@ -683,14 +683,14 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 	}
 
 	// Get a map of data column indices that are not currently available.
-	missing, err := missingDataColumns(s.blobStorage, root, colMap)
+	missingMap, err := missingDataColumns(s.blobStorage, root, colMap)
 	if err != nil {
 		return err
 	}
 
 	// If there are no missing indices, all data column sidecars are available.
 	// This is the happy path.
-	if len(missing) == 0 {
+	if len(missingMap) == 0 {
 		return nil
 	}
 
@@ -698,8 +698,24 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 	nextSlot := slots.BeginsAt(signed.Block().Slot()+1, s.genesisTime)
 	// Avoid logging if DA check is called after next slot start.
 	if nextSlot.After(time.Now()) {
+		// Compute sorted slice of expected columns.
+		expected := make([]uint64, 0, len(colMap))
+		for col := range colMap {
+			expected = append(expected, col)
+		}
+
+		slices.Sort[[]uint64](expected)
+
+		// Compute sorted slice of missing columns.
+		missing := make([]uint64, 0, len(missingMap))
+		for col := range missingMap {
+			missing = append(missing, col)
+		}
+
+		slices.Sort[[]uint64](missing)
+
 		nst := time.AfterFunc(time.Until(nextSlot), func() {
-			if len(missing) == 0 {
+			if len(missingMap) == 0 {
 				return
 			}
 
@@ -707,7 +723,7 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 				"slot":            signed.Block().Slot(),
 				"root":            fmt.Sprintf("%#x", root),
 				"columnsExpected": expected,
-				"columnsWaiting":  len(missing),
+				"columnsWaiting":  missing,
 			}).Error("Still waiting for data columns DA check at slot end.")
 		})
 		defer nst.Stop()
@@ -722,7 +738,7 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 			}
 
 			// This is a data column we are expecting.
-			if _, ok := missing[rootIndex.Index]; ok {
+			if _, ok := missingMap[rootIndex.Index]; ok {
 				retrievedDataColumnsCount++
 			}
 
@@ -733,15 +749,15 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 			}
 
 			// Remove the index from the missing map.
-			delete(missing, rootIndex.Index)
+			delete(missingMap, rootIndex.Index)
 
 			// Exit if there is no more missing data columns.
-			if len(missing) == 0 {
+			if len(missingMap) == 0 {
 				return nil
 			}
 		case <-ctx.Done():
-			missingIndexes := make([]uint64, 0, len(missing))
-			for val := range missing {
+			missingIndexes := make([]uint64, 0, len(missingMap))
+			for val := range missingMap {
 				copiedVal := val
 				missingIndexes = append(missingIndexes, copiedVal)
 			}

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -126,6 +126,7 @@ go_library(
         "//proto/prysm/v1alpha1/attestation:go_default_library",
         "//proto/prysm/v1alpha1/metadata:go_default_library",
         "//runtime:go_default_library",
+        "//runtime/logging:go_default_library",
         "//runtime/messagehandler:go_default_library",
         "//runtime/version:go_default_library",
         "//time:go_default_library",

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -214,7 +214,7 @@ func (s *Service) scheduleReconstructedDataColumnsBroadcast(
 			"slot":         slot,
 			"timeIntoSlot": broadCastMissingDataColumnsTimeIntoSlot,
 			"columns":      missingColumnsList,
-		}).Debug("Broadcasting not seen via gossip but reconstructed data columns.")
+		}).Debug("Broadcasting not seen via gossip but reconstructed data columns")
 	})
 
 	return nil

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -20,10 +20,6 @@ import (
 const broadCastMissingDataColumnsTimeIntoSlot = 3 * time.Second
 
 func (s *Service) reconstructDataColumns(ctx context.Context, verifiedRODataColumn blocks.VerifiedRODataColumn) error {
-	// Lock to prevent concurrent reconstruction.
-	s.dataColumsnReconstructionLock.Lock()
-	defer s.dataColumsnReconstructionLock.Unlock()
-
 	// Get the block root.
 	blockRoot := verifiedRODataColumn.BlockRoot()
 
@@ -41,6 +37,18 @@ func (s *Service) reconstructDataColumns(ctx context.Context, verifiedRODataColu
 	if storedColumnsCount < numberOfColumns/2 || storedColumnsCount == numberOfColumns {
 		return nil
 	}
+
+	// Reconstruction is possible.
+	// Lock to prevent concurrent reconstruction.
+	if !s.dataColumsnReconstructionLock.TryLock() {
+		// If the mutex is already locked, it means that another goroutine is already reconstructing the data columns.
+		// In this case, no need to reconstruct again.
+		// TODO: Implement the (pathological) case where we want to reconstruct data columns corresponding to different blocks at the same time.
+		//       This should be a rare case and we can ignore it for now, but it needs to be addressed in the future.
+		return nil
+	}
+
+	defer s.dataColumsnReconstructionLock.Unlock()
 
 	// Retrieve the custodied columns.
 	custodiedColumns, err := peerdas.CustodyColumns(s.cfg.p2p.NodeID(), peerdas.CustodySubnetCount())

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/runtime/logging"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
@@ -204,7 +205,7 @@ func (s *Service) sendAndSaveDataColumnSidecars(ctx context.Context, request typ
 		if err := verify.ColumnAlignsWithBlock(sidecar, RoBlock, s.newColumnVerifier); err != nil {
 			return err
 		}
-		log.WithFields(columnFields(sidecar)).Debug("Received data column sidecar RPC")
+		log.WithFields(logging.DataColumnFields(sidecar)).Debug("Received data column sidecar RPC")
 	}
 
 	for i := range sidecars {

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -89,12 +89,19 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		return custodiedColumnsList[i] < custodiedColumnsList[j]
 	})
 
-	log.WithFields(logrus.Fields{
-		"custodied":      custodiedColumnsList,
+	fields := logrus.Fields{
 		"requested":      requestedColumnsList,
 		"custodiedCount": len(custodiedColumnsList),
 		"requestedCount": len(requestedColumnsList),
-	}).Debug("Data column sidecar by root request received")
+	}
+
+	if uint64(len(custodiedColumnsList)) == params.BeaconConfig().NumberOfColumns {
+		fields["custodied"] = "all"
+	} else {
+		fields["custodied"] = custodiedColumnsList
+	}
+
+	log.WithFields(fields).Debug("Data column sidecar by root request received")
 
 	// Subscribe to the data column feed.
 	rootIndexChan := make(chan filesystem.RootIndexPair)

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -678,7 +678,7 @@ func (s *Service) subscribeColumnSubnet(
 	// subnet
 	topic := p2p.GossipTypeMapping[reflect.TypeOf(&ethpb.DataColumnSidecar{})]
 	subnetTopic := fmt.Sprintf(topic, digest, idx)
-	// check if subscription exists and if not sub scribe the relevant subnet.
+	// check if subscription exists and if not subscribe the relevant subnet.
 	if _, exists := subscriptions[idx]; !exists {
 		subscriptions[idx] = s.subscribeWithBase(subnetTopic, validate, handle)
 	}

--- a/beacon-chain/sync/validate_blob.go
+++ b/beacon-chain/sync/validate_blob.go
@@ -169,16 +169,6 @@ func blobFields(b blocks.ROBlob) logrus.Fields {
 	}
 }
 
-func columnFields(b blocks.RODataColumn) logrus.Fields {
-	return logrus.Fields{
-		"slot":           b.Slot(),
-		"proposerIndex":  b.ProposerIndex(),
-		"blockRoot":      fmt.Sprintf("%#x", b.BlockRoot()),
-		"kzgCommitments": fmt.Sprintf("%#x", b.KzgCommitments),
-		"columnIndex":    b.ColumnIndex,
-	}
-}
-
 func computeSubnetForBlobSidecar(index uint64) uint64 {
 	return index % params.BeaconConfig().BlobsidecarSubnetCount
 }

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/crypto/rand"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/runtime/logging"
 	prysmTime "github.com/prysmaticlabs/prysm/v5/time"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
@@ -51,13 +52,15 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		log.WithField("message", m).Error("Message is not of type *eth.DataColumnSidecar")
 		return pubsub.ValidationReject, errWrongMessage
 	}
+
 	ds, err := blocks.NewRODataColumn(dspb)
 	if err != nil {
 		return pubsub.ValidationReject, errors.Wrap(err, "roDataColumn conversion failure")
 	}
-	vf := s.newColumnVerifier(ds, verification.GossipColumnSidecarRequirements)
 
-	if err := vf.DataColumnIndexInBounds(); err != nil {
+	verifier := s.newColumnVerifier(ds, verification.GossipColumnSidecarRequirements)
+
+	if err := verifier.DataColumnIndexInBounds(); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
@@ -68,7 +71,7 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		return pubsub.ValidationReject, fmt.Errorf("wrong topic name: %s", *msg.Topic)
 	}
 
-	if err := vf.NotFromFutureSlot(); err != nil {
+	if err := verifier.NotFromFutureSlot(); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 
@@ -77,40 +80,40 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		return pubsub.ValidationIgnore, nil
 	}
 
-	if err := vf.SlotAboveFinalized(); err != nil {
+	if err := verifier.SlotAboveFinalized(); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	if err := vf.SidecarParentSeen(s.hasBadBlock); err != nil {
+	if err := verifier.SidecarParentSeen(s.hasBadBlock); err != nil {
 		go func() {
 			if err := s.sendBatchRootRequest(context.Background(), [][32]byte{ds.ParentRoot()}, rand.NewGenerator()); err != nil {
-				log.WithError(err).WithFields(columnFields(ds)).Debug("Failed to send batch root request")
+				log.WithError(err).WithFields(logging.DataColumnFields(ds)).Debug("Failed to send batch root request")
 			}
 		}()
 		return pubsub.ValidationIgnore, err
 	}
-	if err := vf.SidecarParentValid(s.hasBadBlock); err != nil {
+	if err := verifier.SidecarParentValid(s.hasBadBlock); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
-	if err := vf.SidecarParentSlotLower(); err != nil {
+	if err := verifier.SidecarParentSlotLower(); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
-	if err := vf.SidecarDescendsFromFinalized(); err != nil {
+	if err := verifier.SidecarDescendsFromFinalized(); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
-	if err := vf.SidecarInclusionProven(); err != nil {
+	if err := verifier.SidecarInclusionProven(); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
-	if err := vf.SidecarKzgProofVerified(); err != nil {
+	if err := verifier.SidecarKzgProofVerified(); err != nil {
 		return pubsub.ValidationReject, err
 	}
-	if err := vf.ValidProposerSignature(ctx); err != nil {
+	if err := verifier.ValidProposerSignature(ctx); err != nil {
 		return pubsub.ValidationReject, err
 	}
-	if err := vf.SidecarProposerExpected(ctx); err != nil {
+	if err := verifier.SidecarProposerExpected(ctx); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
@@ -120,19 +123,20 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		return pubsub.ValidationIgnore, err
 	}
 
-	fields := columnFields(ds)
-	sinceSlotStartTime := receivedTime.Sub(startTime)
-	validationTime := s.cfg.clock.Now().Sub(receivedTime)
-	fields["sinceSlotStartTime"] = sinceSlotStartTime
-	fields["validationTime"] = validationTime
-	log.WithFields(fields).Debug("Received data column sidecar gossip")
-
-	verifiedRODataColumn, err := vf.VerifiedRODataColumn()
+	verifiedRODataColumn, err := verifier.VerifiedRODataColumn()
 	if err != nil {
 		return pubsub.ValidationReject, err
 	}
 
 	msg.ValidatorData = verifiedRODataColumn
+
+	fields := logging.DataColumnFields(ds)
+	sinceSlotStartTime := receivedTime.Sub(startTime)
+	validationTime := s.cfg.clock.Now().Sub(receivedTime)
+	fields["intoSlotTime"] = sinceSlotStartTime
+	fields["valTime"] = validationTime
+
+	log.WithFields(fields).Debug("Accepted data column sidecar gossip")
 	return pubsub.ValidationAccept, nil
 }
 

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -133,8 +133,8 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 	fields := logging.DataColumnFields(ds)
 	sinceSlotStartTime := receivedTime.Sub(startTime)
 	validationTime := s.cfg.clock.Now().Sub(receivedTime)
-	fields["intoSlotTime"] = sinceSlotStartTime
-	fields["valTime"] = validationTime
+	fields["sinceSlotStartTime"] = sinceSlotStartTime
+	fields["validationTime"] = validationTime
 
 	log.WithFields(fields).Debug("Accepted data column sidecar gossip")
 	return pubsub.ValidationAccept, nil

--- a/beacon-chain/verification/BUILD.bazel
+++ b/beacon-chain/verification/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "fake.go",
         "initializer.go",
         "interface.go",
+        "log.go",
         "metrics.go",
         "mock.go",
         "result.go",

--- a/beacon-chain/verification/blob.go
+++ b/beacon-chain/verification/blob.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/runtime/logging"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/beacon-chain/verification/cache.go
+++ b/beacon-chain/verification/cache.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/network/forks"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -50,8 +50,8 @@ type SignatureData struct {
 	Slot      primitives.Slot
 }
 
-func (d SignatureData) logFields() log.Fields {
-	return log.Fields{
+func (d SignatureData) logFields() logrus.Fields {
+	return logrus.Fields{
 		"root":       fmt.Sprintf("%#x", d.Root),
 		"parentRoot": fmt.Sprintf("%#x", d.Parent),
 		"signature":  fmt.Sprintf("%#x", d.Signature),

--- a/beacon-chain/verification/log.go
+++ b/beacon-chain/verification/log.go
@@ -1,0 +1,5 @@
+package verification
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("prefix", "verification")

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -83,7 +83,7 @@ type Flags struct {
 	KeystoreImportDebounceInterval time.Duration
 
 	// DataColumnsWithholdCount specifies the likelihood of withholding a data column sidecar when proposing a block (percentage)
-	DataColumnsWithholdCount int
+	DataColumnsWithholdCount uint64
 
 	// AggregateIntervals specifies the time durations at which we aggregate attestations preparing for forkchoice.
 	AggregateIntervals [3]time.Duration
@@ -265,7 +265,7 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 
 	if ctx.IsSet(DataColumnsWithholdCount.Name) {
 		logEnabled(DataColumnsWithholdCount)
-		cfg.DataColumnsWithholdCount = ctx.Int(DataColumnsWithholdCount.Name)
+		cfg.DataColumnsWithholdCount = ctx.Uint64(DataColumnsWithholdCount.Name)
 	}
 
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -176,7 +176,7 @@ var (
 		Usage: "Enables Prysm to run with the experimental peer data availability sampling scheme.",
 	}
 	// DataColumnsWithholdCount is a flag for withholding data columns when proposing a block.
-	DataColumnsWithholdCount = &cli.IntFlag{
+	DataColumnsWithholdCount = &cli.Uint64Flag{
 		Name:   "data-columns-withhold-count",
 		Usage:  "Number of columns to withhold when proposing a block. DO NOT USE IN PRODUCTION.",
 		Value:  0,

--- a/runtime/logging/data_column.go
+++ b/runtime/logging/data_column.go
@@ -10,13 +10,18 @@ import (
 // DataColumnFields extracts a standard set of fields from a DataColumnSidecar into a logrus.Fields struct
 // which can be passed to log.WithFields.
 func DataColumnFields(column blocks.RODataColumn) logrus.Fields {
+	kzgCommitmentsShort := make([][]byte, 0, len(column.KzgCommitments))
+	for _, kzgCommitment := range column.KzgCommitments {
+		kzgCommitmentsShort = append(kzgCommitmentsShort, kzgCommitment[:3])
+	}
+
 	return logrus.Fields{
 		"slot":           column.Slot(),
-		"proposerIndex":  column.ProposerIndex(),
-		"blockRoot":      fmt.Sprintf("%#x", column.BlockRoot()),
-		"parentRoot":     fmt.Sprintf("%#x", column.ParentRoot()),
-		"kzgCommitments": fmt.Sprintf("%#x", column.KzgCommitments),
-		"index":          column.ColumnIndex,
+		"propIdx":        column.ProposerIndex(),
+		"blockRoot":      fmt.Sprintf("%#x", column.BlockRoot())[:8],
+		"parentRoot":     fmt.Sprintf("%#x", column.ParentRoot())[:8],
+		"kzgCommitments": fmt.Sprintf("%#x", kzgCommitmentsShort),
+		"colIdx":         column.ColumnIndex,
 	}
 }
 


### PR DESCRIPTION
Please read commits by commits.

All commits expect the last one are for logging.
The last one reduces the number of goroutines for reconstruction.

New logs:

```
[2024-08-29 11:58:28]  INFO rpc/validator: Updated fee recipient addresses for validator indices validatorCount=25
[2024-08-29 11:58:28]  DEBUG sync: Received block blockSlot=173 graffiti=1-geth-prysm proposerIndex=1 sinceSlotStartTime=0.818789s validationTime=0.003129s
[2024-08-29 11:58:28]  DEBUG sync: Accepted data column sidecar gossip blockRoot=0x654884 colIdx=97 intoSlotTime=0.817572s kzgCommitments=[0x8a113c 0xa5492f] parentRoot=0xd5aa9c propIdx=1 slot=173 valTime=0.004918s
[2024-08-29 11:58:28]  DEBUG sync: Accepted data column sidecar gossip blockRoot=0x654884 colIdx=64 intoSlotTime=0.819443s kzgCommitments=[0x8a113c 0xa5492f] parentRoot=0xd5aa9c propIdx=1 slot=173 valTime=0.004135s
[2024-08-29 11:58:28]  DEBUG sync: Accepted data column sidecar gossip blockRoot=0x654884 colIdx=88 intoSlotTime=0.820813s kzgCommitments=[0x8a113c 0xa5492f] parentRoot=0xd5aa9c propIdx=1 slot=173 valTime=0.003366s
[2024-08-29 11:58:31]  DEBUG sync: Accepted data column sidecar gossip blockRoot=0x654884 colIdx=51 intoSlotTime=3.010919s kzgCommitments=[0x8a113c 0xa5492f] parentRoot=0xd5aa9c propIdx=1 slot=173 valTime=0.003934s
```