### PR TITLE
Initialize Larger Precompute For The Trusted Setup

### DIFF
--- a/beacon-chain/blockchain/kzg/trusted_setup.go
+++ b/beacon-chain/blockchain/kzg/trusted_setup.go
@@ -53,7 +53,7 @@ func Start() error {
 	}
 	if !kzgLoaded {
 		// TODO: Provide a configuration option for this.
-		var precompute uint = 0
+		var precompute uint = 8
 
 		// Free the current trusted setup before running this method. CKZG
 		// panics if the same setup is run multiple times.


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

This sets a non-zero number for the precompute step when loading the trusted setup. A number of 8 has been chosen according to the table here: https://notes.ethereum.org/@jtraglia/windowed_multiplications

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**
