### PR TITLE
fix: update `metaData` file when it is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Electra: build blocks with blobs.
 - E2E: fixed gas limit at genesis
 - Light client support: use LightClientHeader instead of BeaconBlockHeader.
+- p2p: fixed metadata to be maintained when `--p2p-static-id` is true
 
 ### Security
 

--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -158,6 +158,7 @@ go_test(
         "//crypto/ecdsa:go_default_library",
         "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//io/file:go_default_library",
         "//network:go_default_library",
         "//network/forks:go_default_library",
         "//proto/eth/v1:go_default_library",

--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -116,7 +116,6 @@ func privKeyFromFile(path string) (*ecdsa.PrivateKey, error) {
 
 // Retrieves node p2p metadata from a set of configuration values
 // from the p2p service.
-// TODO: Figure out how to do a v1/v2 check.
 func metaDataFromConfig(cfg *Config) (metadata.Metadata, error) {
 	defaultKeyPath := path.Join(cfg.DataDir, metaDataPath)
 	metaDataPath := cfg.MetaDataDir

--- a/beacon-chain/p2p/utils_test.go
+++ b/beacon-chain/p2p/utils_test.go
@@ -85,7 +85,7 @@ func TestMetaDataFromFile(t *testing.T) {
 	metaData := wrapper.WrappedMetadataV1(md)
 
 	// Save to file
-	err := saveMetaDataToFile(path, metaData)
+	err := saveMetaDataToFile(path, metaData.Copy())
 	require.NoError(t, err)
 
 	// Load file, and compare
@@ -108,7 +108,7 @@ func TestMetaDataFromFile_V0(t *testing.T) {
 	metaData := wrapper.WrappedMetadataV0(md)
 
 	// Save to file
-	err := saveMetaDataToFile(path, metaData)
+	err := saveMetaDataToFile(path, metaData.Copy())
 	require.NoError(t, err)
 
 	// Load file, and compare

--- a/proto/prysm/v1alpha1/p2p_messages.proto
+++ b/proto/prysm/v1alpha1/p2p_messages.proto
@@ -51,6 +51,7 @@ message MetaDataV0 {
  (
  seq_number: uint64
  attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
+ syncnets: Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]
  )
 */
 message MetaDataV1 {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR addresses Issue #13586, where the beacon-chain does not update the metaData file as expected. The issue arises because there is currently no code to write to the `metaData` file after initialization. As a result, the sequence number stored on disk always remains **zero**. This behavior is acceptable when the `--p2p-static-id` flag is not provided. However, it causes significant issues in the P2P processes when a user intends to maintain the same peer ID across sessions.

**Which issues(s) does this PR fix?**

Fixes #13586

**Other notes for review**

- Initially, I considered adding code to update the `metaData` file when the P2P service stops. However, it appears unnecessary because the metadata is updated whenever the sequence number is incremented by `updateSubnetRecordWithMetadata` and `updateSubnetRecordWithMetadataV2` methods.
- A point of discussion: Should we handle potential errors when the P2P service encounters issues while writing to files? Currently, these errors are ignored. Feedback on this approach would be appreciated.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
