### PR TITLE
SSE implementation that sheds stuck clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Tests to ensure sepolia config matches the official upstream yaml
 - HTTP endpoint for PublishBlobs
 - GetBlockV2, GetBlindedBlock, ProduceBlockV2, ProduceBlockV3: add Electra case.
+- SSE implementation that sheds stuck clients. [pr](https://github.com/prysmaticlabs/prysm/pull/14413)
 
 ### Changed
 

--- a/api/headers.go
+++ b/api/headers.go
@@ -1,5 +1,7 @@
 package api
 
+import "net/http"
+
 const (
 	VersionHeader                 = "Eth-Consensus-Version"
 	ExecutionPayloadBlindedHeader = "Eth-Execution-Payload-Blinded"
@@ -10,3 +12,9 @@ const (
 	EventStreamMediaType          = "text/event-stream"
 	KeepAlive                     = "keep-alive"
 )
+
+// SetSSEHeaders sets the headers needed for a server-sent event response.
+func SetSSEHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", EventStreamMediaType)
+	w.Header().Set("Connection", KeepAlive)
+}

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/math"
 	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
+	ethv1 "github.com/prysmaticlabs/prysm/v5/proto/eth/v1"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 )
 
@@ -1507,4 +1508,38 @@ func PendingConsolidationsFromConsensus(cs []*eth.PendingConsolidation) []*Pendi
 		}
 	}
 	return consolidations
+}
+
+func HeadEventFromV1(event *ethv1.EventHead) *HeadEvent {
+	return &HeadEvent{
+		Slot:                      fmt.Sprintf("%d", event.Slot),
+		Block:                     hexutil.Encode(event.Block),
+		State:                     hexutil.Encode(event.State),
+		EpochTransition:           event.EpochTransition,
+		ExecutionOptimistic:       event.ExecutionOptimistic,
+		PreviousDutyDependentRoot: hexutil.Encode(event.PreviousDutyDependentRoot),
+		CurrentDutyDependentRoot:  hexutil.Encode(event.CurrentDutyDependentRoot),
+	}
+}
+
+func FinalizedCheckpointEventFromV1(event *ethv1.EventFinalizedCheckpoint) *FinalizedCheckpointEvent {
+	return &FinalizedCheckpointEvent{
+		Block:               hexutil.Encode(event.Block),
+		State:               hexutil.Encode(event.State),
+		Epoch:               fmt.Sprintf("%d", event.Epoch),
+		ExecutionOptimistic: event.ExecutionOptimistic,
+	}
+}
+
+func EventChainReorgFromV1(event *ethv1.EventChainReorg) *ChainReorgEvent {
+	return &ChainReorgEvent{
+		Slot:                fmt.Sprintf("%d", event.Slot),
+		Depth:               fmt.Sprintf("%d", event.Depth),
+		OldHeadBlock:        hexutil.Encode(event.OldHeadBlock),
+		NewHeadBlock:        hexutil.Encode(event.NewHeadBlock),
+		OldHeadState:        hexutil.Encode(event.OldHeadState),
+		NewHeadState:        hexutil.Encode(event.NewHeadState),
+		Epoch:               fmt.Sprintf("%d", event.Epoch),
+		ExecutionOptimistic: event.ExecutionOptimistic,
+	}
 }

--- a/async/event/BUILD.bazel
+++ b/async/event/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "feed.go",
+        "interface.go",
         "subscription.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/v5/async/event",

--- a/async/event/feed.go
+++ b/async/event/feed.go
@@ -22,3 +22,4 @@ import (
 
 // Feed is a re-export of the go-ethereum event feed.
 type Feed = geth_event.Feed
+type Subscription = geth_event.Subscription

--- a/async/event/interface.go
+++ b/async/event/interface.go
@@ -1,0 +1,8 @@
+package event
+
+// SubscriberSender is an abstract representation of an *event.Feed
+// to use in describing types that accept or return an *event.Feed.
+type SubscriberSender interface {
+	Subscribe(channel interface{}) Subscription
+	Send(value interface{}) (nsent int)
+}

--- a/async/event/subscription.go
+++ b/async/event/subscription.go
@@ -28,25 +28,6 @@ import (
 // request backoff time.
 const waitQuotient = 10
 
-// Subscription represents a stream of events. The carrier of the events is typically a
-// channel, but isn't part of the interface.
-//
-// Subscriptions can fail while established. Failures are reported through an error
-// channel. It receives a value if there is an issue with the subscription (e.g. the
-// network connection delivering the events has been closed). Only one value will ever be
-// sent.
-//
-// The error channel is closed when the subscription ends successfully (i.e. when the
-// source of events is closed). It is also closed when Unsubscribe is called.
-//
-// The Unsubscribe method cancels the sending of events. You must call Unsubscribe in all
-// cases to ensure that resources related to the subscription are released. It can be
-// called any number of times.
-type Subscription interface {
-	Err() <-chan error // returns the error channel
-	Unsubscribe()      // cancels sending of events, closing the error channel
-}
-
 // NewSubscription runs a producer function as a subscription in a new goroutine. The
 // channel given to the producer is closed when Unsubscribe is called. If fn returns an
 // error, it is sent on the subscription's error channel.

--- a/beacon-chain/blockchain/setup_test.go
+++ b/beacon-chain/blockchain/setup_test.go
@@ -32,7 +32,7 @@ type mockBeaconNode struct {
 }
 
 // StateFeed mocks the same method in the beacon node.
-func (mbn *mockBeaconNode) StateFeed() *event.Feed {
+func (mbn *mockBeaconNode) StateFeed() event.SubscriberSender {
 	mbn.mu.Lock()
 	defer mbn.mu.Unlock()
 	if mbn.stateFeed == nil {

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -98,6 +98,44 @@ func (s *ChainService) BlockNotifier() blockfeed.Notifier {
 	return s.blockNotifier
 }
 
+type EventFeedWrapper struct {
+	feed       *event.Feed
+	subscribed chan struct{} // this channel is closed once a subscription is made
+}
+
+func (w *EventFeedWrapper) Subscribe(channel interface{}) event.Subscription {
+	select {
+	case <-w.subscribed:
+		break // already closed
+	default:
+		close(w.subscribed)
+	}
+	return w.feed.Subscribe(channel)
+}
+
+func (w *EventFeedWrapper) Send(value interface{}) int {
+	return w.feed.Send(value)
+}
+
+// WAitForSubscription allows test to wait for the feed to have a subscription before beginning to send events.
+func (w *EventFeedWrapper) WaitForSubscription(ctx context.Context) error {
+	select {
+	case <-w.subscribed:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+var _ event.SubscriberSender = &EventFeedWrapper{}
+
+func NewEventFeedWrapper() *EventFeedWrapper {
+	return &EventFeedWrapper{
+		feed:       new(event.Feed),
+		subscribed: make(chan struct{}),
+	}
+}
+
 // MockBlockNotifier mocks the block notifier.
 type MockBlockNotifier struct {
 	feed *event.Feed
@@ -131,7 +169,7 @@ func (msn *MockStateNotifier) ReceivedEvents() []*feed.Event {
 }
 
 // StateFeed returns a state feed.
-func (msn *MockStateNotifier) StateFeed() *event.Feed {
+func (msn *MockStateNotifier) StateFeed() event.SubscriberSender {
 	msn.feedLock.Lock()
 	defer msn.feedLock.Unlock()
 
@@ -164,6 +202,18 @@ func NewSimpleStateNotifier() *MockStateNotifier {
 	return &MockStateNotifier{feed: new(event.Feed)}
 }
 
+type SimpleNotifier struct {
+	Feed event.SubscriberSender
+}
+
+func (n *SimpleNotifier) StateFeed() event.SubscriberSender {
+	return n.Feed
+}
+
+func (n *SimpleNotifier) OperationFeed() event.SubscriberSender {
+	return n.Feed
+}
+
 // OperationNotifier mocks the same method in the chain service.
 func (s *ChainService) OperationNotifier() opfeed.Notifier {
 	if s.opNotifier == nil {
@@ -178,7 +228,7 @@ type MockOperationNotifier struct {
 }
 
 // OperationFeed returns an operation feed.
-func (mon *MockOperationNotifier) OperationFeed() *event.Feed {
+func (mon *MockOperationNotifier) OperationFeed() event.SubscriberSender {
 	if mon.feed == nil {
 		mon.feed = new(event.Feed)
 	}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -117,7 +117,7 @@ func (w *EventFeedWrapper) Send(value interface{}) int {
 	return w.feed.Send(value)
 }
 
-// WAitForSubscription allows test to wait for the feed to have a subscription before beginning to send events.
+// WaitForSubscription allows test to wait for the feed to have a subscription before beginning to send events.
 func (w *EventFeedWrapper) WaitForSubscription(ctx context.Context) error {
 	select {
 	case <-w.subscribed:

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -159,6 +159,11 @@ func (msn *MockStateNotifier) StateFeed() *event.Feed {
 	return msn.feed
 }
 
+// NewSimpleStateNotifier makes a state feed without the custom mock feed machinery.
+func NewSimpleStateNotifier() *MockStateNotifier {
+	return &MockStateNotifier{feed: new(event.Feed)}
+}
+
 // OperationNotifier mocks the same method in the chain service.
 func (s *ChainService) OperationNotifier() opfeed.Notifier {
 	if s.opNotifier == nil {

--- a/beacon-chain/core/feed/operation/notifier.go
+++ b/beacon-chain/core/feed/operation/notifier.go
@@ -4,5 +4,5 @@ import "github.com/prysmaticlabs/prysm/v5/async/event"
 
 // Notifier interface defines the methods of the service that provides beacon block operation updates to consumers.
 type Notifier interface {
-	OperationFeed() *event.Feed
+	OperationFeed() event.SubscriberSender
 }

--- a/beacon-chain/core/feed/state/notifier.go
+++ b/beacon-chain/core/feed/state/notifier.go
@@ -4,5 +4,5 @@ import "github.com/prysmaticlabs/prysm/v5/async/event"
 
 // Notifier interface defines the methods of the service that provides state updates to consumers.
 type Notifier interface {
-	StateFeed() *event.Feed
+	StateFeed() event.SubscriberSender
 }

--- a/beacon-chain/execution/service_test.go
+++ b/beacon-chain/execution/service_test.go
@@ -73,7 +73,7 @@ type goodNotifier struct {
 	MockStateFeed *event.Feed
 }
 
-func (g *goodNotifier) StateFeed() *event.Feed {
+func (g *goodNotifier) StateFeed() event.SubscriberSender {
 	if g.MockStateFeed == nil {
 		g.MockStateFeed = new(event.Feed)
 	}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -398,7 +398,7 @@ func initSyncWaiter(ctx context.Context, complete chan struct{}) func() error {
 }
 
 // StateFeed implements statefeed.Notifier.
-func (b *BeaconNode) StateFeed() *event.Feed {
+func (b *BeaconNode) StateFeed() event.SubscriberSender {
 	return b.stateFeed
 }
 
@@ -408,7 +408,7 @@ func (b *BeaconNode) BlockFeed() *event.Feed {
 }
 
 // OperationFeed implements opfeed.Notifier.
-func (b *BeaconNode) OperationFeed() *event.Feed {
+func (b *BeaconNode) OperationFeed() event.SubscriberSender {
 	return b.opFeed
 }
 

--- a/beacon-chain/rpc/eth/events/BUILD.bazel
+++ b/beacon-chain/rpc/eth/events/BUILD.bazel
@@ -29,12 +29,16 @@ go_library(
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["events_test.go"],
+    srcs = [
+        "events_test.go",
+        "http_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
@@ -49,9 +53,9 @@ go_test(
         "//consensus-types/primitives:go_default_library",
         "//proto/eth/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
-        "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
+        "@com_github_r3labs_sse_v2//:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -66,6 +66,25 @@ const (
 	LightClientOptimisticUpdateTopic = "light_client_optimistic_update"
 )
 
+var (
+	errInvalidTopicName   = errors.New("invalid topic name")
+	errNoValidTopics      = errors.New("no valid topics specified")
+	errSlowReader         = errors.New("client failed to read fast enough to keep outgoing buffer below threshold")
+	errFinished           = errors.New("event received after streamer shut down")
+	errNotRequested       = errors.New("event not requested by client")
+	errUnhandledEventData = errors.New("unable to represent event data in the event stream")
+)
+
+// StreamingResponseWriter defines a type that can be used by the eventStreamer.
+// This must be an http.ResponseWriter that supports flushing and hijacking.
+type StreamingResponseWriter interface {
+	http.ResponseWriter
+	http.Flusher
+}
+
+// The eventStreamer uses lazyReaders to defer serialization until the moment the value is ready to be written to the client.
+type lazyReader func() io.Reader
+
 var opsFeedEventTopics = map[feed.EventType]string{
 	operation.AggregatedAttReceived:             AttestationTopic,
 	operation.UnaggregatedAttReceived:           AttestationTopic,
@@ -98,23 +117,33 @@ func topicsForFeed(em map[feed.EventType]string) map[string]bool {
 	return topics
 }
 
-func validateTopics(topics []string) (bool, bool, map[string]bool, error) {
-	var subState, subOps bool
-	requested := make(map[string]bool)
-	for _, topic := range topics {
-		if topicsForStateFeed[topic] {
-			subState = true
-			requested[topic] = true
-			continue
+type topicRequest struct {
+	topics        map[string]bool
+	needStateFeed bool
+	needOpsFeed   bool
+}
+
+func (req *topicRequest) requested(topic string) bool {
+	return req.topics[topic]
+}
+
+func newTopicRequest(topics []string) (*topicRequest, error) {
+	req := &topicRequest{topics: make(map[string]bool)}
+	for _, name := range topics {
+		if topicsForStateFeed[name] {
+			req.needStateFeed = true
+		} else if topicsForOpsFeed[name] {
+			req.needOpsFeed = true
+		} else {
+			return nil, errors.Wrapf(errInvalidTopicName, name)
 		}
-		if topicsForOpsFeed[topic] {
-			subOps = true
-			requested[topic] = true
-			continue
-		}
-		return false, false, nil, fmt.Errorf("invalid topic: %s", topic)
+		req.topics[name] = true
 	}
-	return subState, subOps, requested, nil
+	if len(req.topics) == 0 || (!req.needStateFeed && !req.needOpsFeed) {
+		return nil, errNoValidTopics
+	}
+
+	return req, nil
 }
 
 // StreamEvents provides an endpoint to subscribe to the beacon node Server-Sent-Events stream.
@@ -125,24 +154,18 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "events.StreamEvents")
 	defer span.End()
 
-	tq := r.URL.Query()["topics"]
-	subState, subOps, requestedTopics, err := validateTopics(tq)
+	topics, err := newTopicRequest(r.URL.Query()["topics"])
 	if err != nil {
 		httputil.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if (!subState && !subOps) || len(requestedTopics) == 0 {
-		httputil.HandleError(w, "No valid topics specified", http.StatusBadRequest)
-		return
-	}
 
-	// Subscribe to event feeds from information received in the beacon node runtime.
 	eventsChan := make(chan *feed.Event, chanBuffer)
-	if subOps {
+	if topics.needOpsFeed {
 		opsSub := s.OperationNotifier.OperationFeed().Subscribe(eventsChan)
 		defer opsSub.Unsubscribe()
 	}
-	if subState {
+	if topics.needStateFeed {
 		stateSub := s.StateNotifier.StateFeed().Subscribe(eventsChan)
 		defer stateSub.Unsubscribe()
 	}
@@ -160,13 +183,19 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 		case <-ctx.Done():
 			return
 		case event := <-eventsChan:
-			lr, err := s.lazyReaderForEvent(ctx, event, requestedTopics)
+			lr, err := s.lazyReaderForEvent(ctx, event, topics)
 			if err != nil {
-				if err != ErrNotRequested {
+				if !errors.Is(err, errNotRequested) {
 					log.WithError(err).Error("StreamEvents API endpoint received an event it was unable to handle.")
 				}
 				continue
 			}
+			// If the client can't keep up, the outbox will eventually completely fill, at which
+			// safeWrite will error, and we'll hit the below return statement, at which point the deferred
+			// Unsuscribe calls will be made and the event feed will stop writing to this channel.
+			// Since the outbox and event stream channels are separately buffered, the event subscription
+			// channel should stay relatively empty, which gives this loop time to unsubscribe
+			// and cleanup before the event stream channel fills and disrupts other readers.
 			if err := es.safeWrite(lr); err != nil {
 				log.WithField("event_type", fmt.Sprintf("%v", event.Data)).Warn("Unable to safely write event to stream, shutting down.")
 				return
@@ -175,33 +204,9 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-var (
-	ErrSlowReader = errors.New("client failed to read fast enough to keep outgoing buffer below threadhold")
-	ErrFinished   = errors.New("event received after streamer shut down")
-)
-
-// StreamingResponseWriter defines a type that can be used by the eventStreamer.
-// This must be an http.ResponseWriter that supports flushing and hijacking.
-type StreamingResponseWriter interface {
-	http.ResponseWriter
-	http.Flusher
-}
-
-type lazyReader func() io.Reader
-
-type eventStreamer struct {
-	sync.Mutex
-	ctx      context.Context
-	cancel   func()
-	w        StreamingResponseWriter
-	outbox   chan lazyReader
-	finished chan struct{}
-	kaDur    time.Duration
-}
-
-func NewEventStreamer(ctx context.Context, w http.ResponseWriter, buffSize int, kaDur time.Duration) (*eventStreamer, error) {
-	if kaDur == 0 {
-		kaDur = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+func NewEventStreamer(ctx context.Context, w http.ResponseWriter, buffSize int, ka time.Duration) (*eventStreamer, error) {
+	if ka == 0 {
+		ka = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
 	}
 	f, ok := w.(StreamingResponseWriter)
 	if !ok {
@@ -209,91 +214,127 @@ func NewEventStreamer(ctx context.Context, w http.ResponseWriter, buffSize int, 
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	return &eventStreamer{
-		ctx:    ctx,
-		cancel: cancel,
-		w:      f,
-		outbox: make(chan lazyReader, buffSize),
-		kaDur:  kaDur,
+		ctx:       ctx,
+		cancel:    cancel,
+		w:         f,
+		outbox:    make(chan lazyReader, buffSize),
+		keepAlive: ka,
 	}, nil
+}
+
+type eventStreamer struct {
+	sync.Mutex
+	ctx       context.Context
+	cancel    func()
+	w         StreamingResponseWriter
+	outbox    chan lazyReader
+	finished  chan struct{}
+	keepAlive time.Duration
+}
+
+func (es *eventStreamer) safeWrite(rf func() io.Reader) error {
+	if rf == nil {
+		return nil
+	}
+	select {
+	case <-es.finished:
+		return errFinished
+	case es.outbox <- rf:
+		return nil
+	default:
+		// If this is the case, the select case to write to the outbox could not proceed, meaning the outbox is full.
+		// If a reader can't keep up with the stream, we shut them down.
+		return errSlowReader
+	}
 }
 
 func (es *eventStreamer) Start() {
 	// Set up SSE response headers
 	es.w.Header().Set("Content-Type", api.EventStreamMediaType)
 	es.w.Header().Set("Connection", api.KeepAlive)
-	es.spawnWriteLoop()
+	go es.outboxWriteLoop()
 }
 
 func (es *eventStreamer) Stop() {
 	es.Cleanup(nil)
 }
 
+// newlineReader is used to write keep-alives to the client.
+// keep-alives in the sse protocol are a single ':' colon followed by 2 newlines.
 func newlineReader() io.Reader {
 	return bytes.NewBufferString(":\n\n")
 }
 
-// We main only care about this keep alive value in a real test setups and using a package var allows test
-// to modify it for convenience.
-var keepAliveInterval = time.Duration(12 * time.Second)
+// outboxWriteLoop runs in a separate goroutine. Its job is to write the values in the outbox to
+// the client as fast as the client can read them.
+func (es *eventStreamer) outboxWriteLoop() {
+	// There are multiple points in this loop where we can receive an error and break out of the loop.
+	// In all cases, we need to call Cleanup to ensure:
+	// - any error received is logged.
+	// - the context is cancelled and the .finished channel is closed.
+	//   - this signals the response handler to exit the handler func; stop reading events -> writing to the outbox.
+	var err error
+	defer es.Cleanup(err)
+	// Write a keepalive at the start to test the connection and simplify test setup.
+	if err := es.writeOutbox(nil); err != nil {
+		return
+	}
 
-func (es *eventStreamer) spawnWriteLoop() {
-	go func() {
-		var err error
-		kaT := time.NewTimer(es.kaDur)
-		defer func() {
+	kaT := time.NewTimer(es.keepAlive)
+	// Ensure the keepalive timer is stopped and drained if it has fired.
+	defer func() {
+		if !kaT.Stop() {
+			<-kaT.C
+		}
+	}()
+	for {
+		select {
+		case <-es.ctx.Done():
+			return
+		case <-kaT.C:
+			err = es.writeOutbox(nil)
+			if err != nil {
+				return
+			}
+			// In this case the timer doesn't need to be Stopped before the Reset call after the select statement,
+			// because the timer has already fired.
+		case lr := <-es.outbox:
+			err = es.writeOutbox(lr)
+			if err != nil {
+				return
+			}
+			// We don't know if the timer fired concurrently to this case being ready, so we need to check the return
+			// of Stop and drain the timer channel if it fired. We won't need to do this in go 1.23.
 			if !kaT.Stop() {
 				<-kaT.C
 			}
-		}()
-		defer es.Cleanup(err)
-		// Write a keepalive at the start to test the connection and simplify test setup.
-		if err := es.writeOutbox(nil); err != nil {
-			return
 		}
-		for {
-			select {
-			case <-es.ctx.Done():
-				return
-			case <-kaT.C:
-				err = es.writeOutbox(nil)
-				if err != nil {
-					return
-				}
-				// The timer has already fired here, so a call to Reset is safe.
-			case lr := <-es.outbox:
-				err = es.writeOutbox(lr)
-				if err != nil {
-					return
-				}
-				// We don't know if the timer fired concurrently to this case being ready, so we need to check the return
-				// of Stop and drain the timer channel if it fired.
-				if !kaT.Stop() {
-					<-kaT.C
-				}
-			}
-			kaT.Reset(es.kaDur)
-		}
-	}()
+		kaT.Reset(es.keepAlive)
+	}
 }
 
 func (es *eventStreamer) writeOutbox(first lazyReader) error {
-	written := 0
+	needKeepAlive := true
 	if first != nil {
 		if _, err := io.Copy(es.w, first()); err != nil {
 			return err
 		}
-		written += 1
+		needKeepAlive = false
 	}
+	// While the first event was being read by the client, further events may be queued in the outbox.
+	// We can drain them right away rather than go back out to the outer select statement, where the keepAlive timer
+	// may have fired, triggering an unnecessary extra keep-alive write and flush.
 	for {
 		select {
+		case <-es.ctx.Done():
+			return es.ctx.Err()
 		case rf := <-es.outbox:
 			if _, err := io.Copy(es.w, rf()); err != nil {
 				return err
 			}
-			written += 1
+			needKeepAlive = false
 		default:
-			if written == 0 {
-				// If nothing was written in the write cycle, send a keepalive.
+			if needKeepAlive {
 				if _, err := io.Copy(es.w, newlineReader()); err != nil {
 					return err
 				}
@@ -306,7 +347,7 @@ func (es *eventStreamer) writeOutbox(first lazyReader) error {
 
 func (es *eventStreamer) Cleanup(err error) {
 	if err != nil {
-		log.WithError(err).Error("Event streamer shutting down due to error.")
+		log.WithError(err).Debug("Event streamer shutting down due to error.")
 	}
 	select {
 	case <-es.finished:
@@ -320,22 +361,6 @@ func (es *eventStreamer) Cleanup(err error) {
 	}
 }
 
-func (es *eventStreamer) safeWrite(rf func() io.Reader) error {
-	if rf == nil {
-		return nil
-	}
-	select {
-	case <-es.finished:
-		return ErrFinished
-	case es.outbox <- rf:
-		return nil
-	default:
-		// If this is the case, the select case to write to the outbox could not proceed, meaning the outbox is full.
-		// If a reader can't keep up with the stream, we shut them down.
-		return ErrSlowReader
-	}
-}
-
 func jsonMarshalReader(name string, v any) io.Reader {
 	d, err := json.Marshal(v)
 	if err != nil {
@@ -344,8 +369,6 @@ func jsonMarshalReader(name string, v any) io.Reader {
 	}
 	return bytes.NewBufferString("event: " + name + "\ndata: " + string(d) + "\n\n")
 }
-
-var ErrUnhandledEventData = errors.New("unable to represent event data in the event stream")
 
 func topicForEvent(event *feed.Event) string {
 	switch event.Data.(type) {
@@ -385,12 +408,10 @@ func topicForEvent(event *feed.Event) string {
 	}
 }
 
-var ErrNotRequested = errors.New("event not requested by client")
-
-func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, req map[string]bool) (lazyReader, error) {
+func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topics *topicRequest) (lazyReader, error) {
 	eventName := topicForEvent(event)
-	if !req[eventName] {
-		return nil, ErrNotRequested
+	if !topics.requested(eventName) {
+		return nil, errNotRequested
 	}
 	if eventName == PayloadAttributesTopic {
 		return s.currentPayloadAttributes(ctx)
@@ -403,7 +424,7 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, req 
 			return jsonMarshalReader(eventName, structs.HeadEventFromV1(v))
 		}
 		// Don't do the expensive attr lookup unless the client requested it.
-		if !req[PayloadAttributesTopic] {
+		if !topics.requested(PayloadAttributesTopic) {
 			return headReader, nil
 		}
 		// Since payload attributes could change before the outbox is written, we need to do a blocking operation to
@@ -423,7 +444,7 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, req 
 	case *operation.UnAggregatedAttReceivedData:
 		att, ok := v.Attestation.(*eth.Attestation)
 		if !ok {
-			return nil, errors.Wrapf(ErrUnhandledEventData, "Unexpected type %T for the .Attestation field of UnAggregatedAttReceivedData", v.Attestation)
+			return nil, errors.Wrapf(errUnhandledEventData, "Unexpected type %T for the .Attestation field of UnAggregatedAttReceivedData", v.Attestation)
 		}
 		return func() io.Reader {
 			att := structs.AttFromConsensus(att)
@@ -455,7 +476,7 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, req 
 	case *operation.AttesterSlashingReceivedData:
 		slashing, ok := v.AttesterSlashing.(*eth.AttesterSlashing)
 		if !ok {
-			return nil, errors.Wrapf(ErrUnhandledEventData, "Unexpected type %T for the .AttesterSlashing field of AttesterSlashingReceivedData", v.AttesterSlashing)
+			return nil, errors.Wrapf(errUnhandledEventData, "Unexpected type %T for the .AttesterSlashing field of AttesterSlashingReceivedData", v.AttesterSlashing)
 		}
 		return func() io.Reader {
 			return jsonMarshalReader(eventName, structs.AttesterSlashingFromConsensus(slashing))
@@ -510,7 +531,7 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, req 
 			return jsonMarshalReader(eventName, blk)
 		}, nil
 	default:
-		return nil, errors.Wrapf(ErrUnhandledEventData, "event data type %T unsupported", v)
+		return nil, errors.Wrapf(errUnhandledEventData, "event data type %T unsupported", v)
 	}
 }
 

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -389,15 +389,15 @@ func topicForEvent(event *feed.Event) string {
 }
 
 func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topics *topicRequest) (lazyReader, error) {
-	if event == nil || event.Data == nil {
-		return nil, errors.New("event or event data is nil")
-	}
 	eventName := topicForEvent(event)
 	if !topics.requested(eventName) {
 		return nil, errNotRequested
 	}
 	if eventName == PayloadAttributesTopic {
 		return s.currentPayloadAttributes(ctx)
+	}
+	if event == nil || event.Data == nil {
+		return nil, errors.New("event or event data is nil")
 	}
 	switch v := event.Data.(type) {
 	case *ethpb.EventHead:

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -164,17 +164,17 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 		httputil.HandleError(w, msg, http.StatusInternalServerError)
 		return
 	}
-	es, err := NewEventStreamer(eventFeedDepth, s.KeepAliveInterval)
+	es, err := newEventStreamer(eventFeedDepth, s.KeepAliveInterval)
 	if err != nil {
 		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if err := es.StreamEvents(ctx, sw, topics, s); err != nil {
+	if err := es.streamEvents(ctx, sw, topics, s); err != nil {
 		log.WithError(err).Debug("Event streamer shutting down due to error.")
 	}
 }
 
-func NewEventStreamer(buffSize int, ka time.Duration) (*eventStreamer, error) {
+func newEventStreamer(buffSize int, ka time.Duration) (*eventStreamer, error) {
 	if ka == 0 {
 		ka = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
 	}
@@ -189,7 +189,7 @@ type eventStreamer struct {
 	keepAlive time.Duration
 }
 
-func (es *eventStreamer) StreamEvents(ctx context.Context, w StreamingResponseWriter, req *topicRequest, s *Server) error {
+func (es *eventStreamer) streamEvents(ctx context.Context, w StreamingResponseWriter, req *topicRequest, s *Server) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go es.recvEventLoop(ctx, cancel, req, s)

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -176,7 +176,7 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	api.SetSSEHeaders(w)
+	api.SetSSEHeaders(sw)
 	go es.outboxWriteLoop(ctx, cancel, sw)
 	if err := es.recvEventLoop(ctx, cancel, topics, s); err != nil {
 		log.WithError(err).Debug("Shutting down StreamEvents handler.")
@@ -389,6 +389,9 @@ func topicForEvent(event *feed.Event) string {
 }
 
 func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topics *topicRequest) (lazyReader, error) {
+	if event == nil || event.Data == nil {
+		return nil, errors.New("event or event data is nil")
+	}
 	eventName := topicForEvent(event)
 	if !topics.requested(eventName) {
 		return nil, errNotRequested

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -1,11 +1,14 @@
 package events
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
-	time2 "time"
+	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
@@ -16,7 +19,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/operation"
 	statefeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/time"
+	chaintime "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
@@ -26,9 +29,13 @@ import (
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
+	log "github.com/sirupsen/logrus"
 )
 
+const chanBuffer = 1000
+
 const (
+	InvalidTopic = "__invalid__"
 	// HeadTopic represents a new chain head event topic.
 	HeadTopic = "head"
 	// BlockTopic represents a new produced block event topic.
@@ -59,25 +66,55 @@ const (
 	LightClientOptimisticUpdateTopic = "light_client_optimistic_update"
 )
 
-const topicDataMismatch = "Event data type %T does not correspond to event topic %s"
+var opsFeedEventTopics = map[feed.EventType]string{
+	operation.AggregatedAttReceived:             AttestationTopic,
+	operation.UnaggregatedAttReceived:           AttestationTopic,
+	operation.ExitReceived:                      VoluntaryExitTopic,
+	operation.SyncCommitteeContributionReceived: SyncCommitteeContributionTopic,
+	operation.BLSToExecutionChangeReceived:      BLSToExecutionChangeTopic,
+	operation.BlobSidecarReceived:               BlobSidecarTopic,
+	operation.AttesterSlashingReceived:          AttesterSlashingTopic,
+	operation.ProposerSlashingReceived:          ProposerSlashingTopic,
+}
 
-const chanBuffer = 1000
+var stateFeedEventTopics = map[feed.EventType]string{
+	statefeed.NewHead:                     HeadTopic,
+	statefeed.MissedSlot:                  PayloadAttributesTopic,
+	statefeed.FinalizedCheckpoint:         FinalizedCheckpointTopic,
+	statefeed.LightClientFinalityUpdate:   LightClientFinalityUpdateTopic,
+	statefeed.LightClientOptimisticUpdate: LightClientOptimisticUpdateTopic,
+	statefeed.Reorg:                       ChainReorgTopic,
+	statefeed.BlockProcessed:              BlockTopic,
+}
 
-var casesHandled = map[string]bool{
-	HeadTopic:                        true,
-	BlockTopic:                       true,
-	AttestationTopic:                 true,
-	VoluntaryExitTopic:               true,
-	FinalizedCheckpointTopic:         true,
-	ChainReorgTopic:                  true,
-	SyncCommitteeContributionTopic:   true,
-	BLSToExecutionChangeTopic:        true,
-	PayloadAttributesTopic:           true,
-	BlobSidecarTopic:                 true,
-	ProposerSlashingTopic:            true,
-	AttesterSlashingTopic:            true,
-	LightClientFinalityUpdateTopic:   true,
-	LightClientOptimisticUpdateTopic: true,
+var topicsForStateFeed = topicsForFeed(stateFeedEventTopics)
+var topicsForOpsFeed = topicsForFeed(opsFeedEventTopics)
+
+func topicsForFeed(em map[feed.EventType]string) map[string]bool {
+	topics := make(map[string]bool, len(em))
+	for _, topic := range em {
+		topics[topic] = true
+	}
+	return topics
+}
+
+func validateTopics(topics []string) (bool, bool, map[string]bool, error) {
+	var subState, subOps bool
+	requested := make(map[string]bool)
+	for _, topic := range topics {
+		if topicsForStateFeed[topic] {
+			subState = true
+			requested[topic] = true
+			continue
+		}
+		if topicsForOpsFeed[topic] {
+			subOps = true
+			requested[topic] = true
+			continue
+		}
+		return false, false, nil, fmt.Errorf("invalid topic: %s", topic)
+	}
+	return subState, subOps, requested, nil
 }
 
 // StreamEvents provides an endpoint to subscribe to the beacon node Server-Sent-Events stream.
@@ -88,326 +125,435 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "events.StreamEvents")
 	defer span.End()
 
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		httputil.HandleError(w, "Streaming unsupported!", http.StatusInternalServerError)
+	tq := r.URL.Query()["topics"]
+	subState, subOps, requestedTopics, err := validateTopics(tq)
+	if err != nil {
+		httputil.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	topics := r.URL.Query()["topics"]
-	if len(topics) == 0 {
-		httputil.HandleError(w, "No topics specified to subscribe to", http.StatusBadRequest)
+	if (!subState && !subOps) || len(requestedTopics) == 0 {
+		httputil.HandleError(w, "No valid topics specified", http.StatusBadRequest)
 		return
-	}
-	topicsMap := make(map[string]bool)
-	for _, topic := range topics {
-		if _, ok := casesHandled[topic]; !ok {
-			httputil.HandleError(w, fmt.Sprintf("Invalid topic: %s", topic), http.StatusBadRequest)
-			return
-		}
-		topicsMap[topic] = true
 	}
 
 	// Subscribe to event feeds from information received in the beacon node runtime.
-	opsChan := make(chan *feed.Event, chanBuffer)
-	opsSub := s.OperationNotifier.OperationFeed().Subscribe(opsChan)
-	stateChan := make(chan *feed.Event, chanBuffer)
-	stateSub := s.StateNotifier.StateFeed().Subscribe(stateChan)
-	defer opsSub.Unsubscribe()
-	defer stateSub.Unsubscribe()
+	eventsChan := make(chan *feed.Event, chanBuffer)
+	if subOps {
+		opsSub := s.OperationNotifier.OperationFeed().Subscribe(eventsChan)
+		defer opsSub.Unsubscribe()
+	}
+	if subState {
+		stateSub := s.StateNotifier.StateFeed().Subscribe(eventsChan)
+		defer stateSub.Unsubscribe()
+	}
 
-	// Set up SSE response headers
-	w.Header().Set("Content-Type", api.EventStreamMediaType)
-	w.Header().Set("Connection", api.KeepAlive)
-
-	// Handle each event received and context cancellation.
-	// We send a keepalive dummy message immediately to prevent clients
-	// stalling while waiting for the first response chunk.
-	// After that we send a keepalive dummy message every SECONDS_PER_SLOT
-	// to prevent anyone (e.g. proxy servers) from closing connections.
-	if err := sendKeepalive(w, flusher); err != nil {
+	es, err := NewEventStreamer(ctx, w, chanBuffer, s.KeepAliveInterval)
+	if err != nil {
 		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	keepaliveTicker := time2.NewTicker(time2.Duration(params.BeaconConfig().SecondsPerSlot) * time2.Second)
-
+	es.Start()
 	for {
 		select {
-		case event := <-opsChan:
-			if err := handleBlockOperationEvents(w, flusher, topicsMap, event); err != nil {
-				httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-		case event := <-stateChan:
-			if err := s.handleStateEvents(ctx, w, flusher, topicsMap, event); err != nil {
-				httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-		case <-keepaliveTicker.C:
-			if err := sendKeepalive(w, flusher); err != nil {
-				httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
+		case <-es.finished: // The finished channel is closed when the streamer hits an unrecoverable error state.
+			return
 		case <-ctx.Done():
 			return
+		case event := <-eventsChan:
+			lr, err := s.lazyReaderForEvent(ctx, event, requestedTopics)
+			if err != nil {
+				if err != ErrNotRequested {
+					log.WithError(err).Error("StreamEvents API endpoint received an event it was unable to handle.")
+				}
+				continue
+			}
+			if err := es.safeWrite(lr); err != nil {
+				log.WithField("event_type", fmt.Sprintf("%v", event.Data)).Warn("Unable to safely write event to stream, shutting down.")
+				return
+			}
 		}
 	}
 }
 
-func handleBlockOperationEvents(w http.ResponseWriter, flusher http.Flusher, requestedTopics map[string]bool, event *feed.Event) error {
-	switch event.Type {
-	case operation.AggregatedAttReceived:
-		if _, ok := requestedTopics[AttestationTopic]; !ok {
-			return nil
-		}
-		attData, ok := event.Data.(*operation.AggregatedAttReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, AttestationTopic)
-		}
-		att := structs.AttFromConsensus(attData.Attestation.Aggregate)
-		return send(w, flusher, AttestationTopic, att)
-	case operation.UnaggregatedAttReceived:
-		if _, ok := requestedTopics[AttestationTopic]; !ok {
-			return nil
-		}
-		attData, ok := event.Data.(*operation.UnAggregatedAttReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, AttestationTopic)
-		}
-		a, ok := attData.Attestation.(*eth.Attestation)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, AttestationTopic)
-		}
-		att := structs.AttFromConsensus(a)
-		return send(w, flusher, AttestationTopic, att)
-	case operation.ExitReceived:
-		if _, ok := requestedTopics[VoluntaryExitTopic]; !ok {
-			return nil
-		}
-		exitData, ok := event.Data.(*operation.ExitReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, VoluntaryExitTopic)
-		}
-		exit := structs.SignedExitFromConsensus(exitData.Exit)
-		return send(w, flusher, VoluntaryExitTopic, exit)
-	case operation.SyncCommitteeContributionReceived:
-		if _, ok := requestedTopics[SyncCommitteeContributionTopic]; !ok {
-			return nil
-		}
-		contributionData, ok := event.Data.(*operation.SyncCommitteeContributionReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, SyncCommitteeContributionTopic)
-		}
-		contribution := structs.SignedContributionAndProofFromConsensus(contributionData.Contribution)
-		return send(w, flusher, SyncCommitteeContributionTopic, contribution)
-	case operation.BLSToExecutionChangeReceived:
-		if _, ok := requestedTopics[BLSToExecutionChangeTopic]; !ok {
-			return nil
-		}
-		changeData, ok := event.Data.(*operation.BLSToExecutionChangeReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, BLSToExecutionChangeTopic)
-		}
-		return send(w, flusher, BLSToExecutionChangeTopic, structs.SignedBLSChangeFromConsensus(changeData.Change))
-	case operation.BlobSidecarReceived:
-		if _, ok := requestedTopics[BlobSidecarTopic]; !ok {
-			return nil
-		}
-		blobData, ok := event.Data.(*operation.BlobSidecarReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, BlobSidecarTopic)
-		}
-		versionedHash := blockchain.ConvertKzgCommitmentToVersionedHash(blobData.Blob.KzgCommitment)
-		blobEvent := &structs.BlobSidecarEvent{
-			BlockRoot:     hexutil.Encode(blobData.Blob.BlockRootSlice()),
-			Index:         fmt.Sprintf("%d", blobData.Blob.Index),
-			Slot:          fmt.Sprintf("%d", blobData.Blob.Slot()),
-			VersionedHash: versionedHash.String(),
-			KzgCommitment: hexutil.Encode(blobData.Blob.KzgCommitment),
-		}
-		return send(w, flusher, BlobSidecarTopic, blobEvent)
-	case operation.AttesterSlashingReceived:
-		if _, ok := requestedTopics[AttesterSlashingTopic]; !ok {
-			return nil
-		}
-		attesterSlashingData, ok := event.Data.(*operation.AttesterSlashingReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, AttesterSlashingTopic)
-		}
-		slashing, ok := attesterSlashingData.AttesterSlashing.(*eth.AttesterSlashing)
-		if ok {
-			return send(w, flusher, AttesterSlashingTopic, structs.AttesterSlashingFromConsensus(slashing))
-		}
-		// TODO: extend to Electra
-	case operation.ProposerSlashingReceived:
-		if _, ok := requestedTopics[ProposerSlashingTopic]; !ok {
-			return nil
-		}
-		proposerSlashingData, ok := event.Data.(*operation.ProposerSlashingReceivedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, ProposerSlashingTopic)
-		}
-		return send(w, flusher, ProposerSlashingTopic, structs.ProposerSlashingFromConsensus(proposerSlashingData.ProposerSlashing))
-	}
-	return nil
+var (
+	ErrSlowReader = errors.New("client failed to read fast enough to keep outgoing buffer below threadhold")
+	ErrFinished   = errors.New("event received after streamer shut down")
+)
+
+// StreamingResponseWriter defines a type that can be used by the eventStreamer.
+// This must be an http.ResponseWriter that supports flushing and hijacking.
+type StreamingResponseWriter interface {
+	http.ResponseWriter
+	http.Flusher
 }
 
-func (s *Server) handleStateEvents(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, requestedTopics map[string]bool, event *feed.Event) error {
-	switch event.Type {
-	case statefeed.NewHead:
-		if _, ok := requestedTopics[HeadTopic]; ok {
-			headData, ok := event.Data.(*ethpb.EventHead)
-			if !ok {
-				return write(w, flusher, topicDataMismatch, event.Data, HeadTopic)
-			}
-			head := &structs.HeadEvent{
-				Slot:                      fmt.Sprintf("%d", headData.Slot),
-				Block:                     hexutil.Encode(headData.Block),
-				State:                     hexutil.Encode(headData.State),
-				EpochTransition:           headData.EpochTransition,
-				ExecutionOptimistic:       headData.ExecutionOptimistic,
-				PreviousDutyDependentRoot: hexutil.Encode(headData.PreviousDutyDependentRoot),
-				CurrentDutyDependentRoot:  hexutil.Encode(headData.CurrentDutyDependentRoot),
-			}
-			return send(w, flusher, HeadTopic, head)
-		}
-		if _, ok := requestedTopics[PayloadAttributesTopic]; ok {
-			return s.sendPayloadAttributes(ctx, w, flusher)
-		}
-	case statefeed.MissedSlot:
-		if _, ok := requestedTopics[PayloadAttributesTopic]; ok {
-			return s.sendPayloadAttributes(ctx, w, flusher)
-		}
-	case statefeed.FinalizedCheckpoint:
-		if _, ok := requestedTopics[FinalizedCheckpointTopic]; !ok {
-			return nil
-		}
-		checkpointData, ok := event.Data.(*ethpb.EventFinalizedCheckpoint)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, FinalizedCheckpointTopic)
-		}
-		checkpoint := &structs.FinalizedCheckpointEvent{
-			Block:               hexutil.Encode(checkpointData.Block),
-			State:               hexutil.Encode(checkpointData.State),
-			Epoch:               fmt.Sprintf("%d", checkpointData.Epoch),
-			ExecutionOptimistic: checkpointData.ExecutionOptimistic,
-		}
-		return send(w, flusher, FinalizedCheckpointTopic, checkpoint)
-	case statefeed.LightClientFinalityUpdate:
-		if _, ok := requestedTopics[LightClientFinalityUpdateTopic]; !ok {
-			return nil
-		}
-		updateData, ok := event.Data.(*ethpbv2.LightClientFinalityUpdateWithVersion)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, LightClientFinalityUpdateTopic)
-		}
-		update, err := structs.LightClientFinalityUpdateFromConsensus(updateData.Data)
-		if err != nil {
-			return err
-		}
-		updateEvent := &structs.LightClientFinalityUpdateEvent{
-			Version: version.String(int(updateData.Version)),
-			Data:    update,
-		}
-		return send(w, flusher, LightClientFinalityUpdateTopic, updateEvent)
-	case statefeed.LightClientOptimisticUpdate:
-		if _, ok := requestedTopics[LightClientOptimisticUpdateTopic]; !ok {
-			return nil
-		}
-		updateData, ok := event.Data.(*ethpbv2.LightClientOptimisticUpdateWithVersion)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, LightClientOptimisticUpdateTopic)
-		}
-		update, err := structs.LightClientOptimisticUpdateFromConsensus(updateData.Data)
-		if err != nil {
-			return err
-		}
-		updateEvent := &structs.LightClientOptimisticUpdateEvent{
-			Version: version.String(int(updateData.Version)),
-			Data:    update,
-		}
-		return send(w, flusher, LightClientOptimisticUpdateTopic, updateEvent)
-	case statefeed.Reorg:
-		if _, ok := requestedTopics[ChainReorgTopic]; !ok {
-			return nil
-		}
-		reorgData, ok := event.Data.(*ethpb.EventChainReorg)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, ChainReorgTopic)
-		}
-		reorg := &structs.ChainReorgEvent{
-			Slot:                fmt.Sprintf("%d", reorgData.Slot),
-			Depth:               fmt.Sprintf("%d", reorgData.Depth),
-			OldHeadBlock:        hexutil.Encode(reorgData.OldHeadBlock),
-			NewHeadBlock:        hexutil.Encode(reorgData.NewHeadBlock),
-			OldHeadState:        hexutil.Encode(reorgData.OldHeadState),
-			NewHeadState:        hexutil.Encode(reorgData.NewHeadState),
-			Epoch:               fmt.Sprintf("%d", reorgData.Epoch),
-			ExecutionOptimistic: reorgData.ExecutionOptimistic,
-		}
-		return send(w, flusher, ChainReorgTopic, reorg)
-	case statefeed.BlockProcessed:
-		if _, ok := requestedTopics[BlockTopic]; !ok {
-			return nil
-		}
-		blkData, ok := event.Data.(*statefeed.BlockProcessedData)
-		if !ok {
-			return write(w, flusher, topicDataMismatch, event.Data, BlockTopic)
-		}
-		blockRoot, err := blkData.SignedBlock.Block().HashTreeRoot()
-		if err != nil {
-			return write(w, flusher, "Could not get block root: "+err.Error())
-		}
-		blk := &structs.BlockEvent{
-			Slot:                fmt.Sprintf("%d", blkData.Slot),
-			Block:               hexutil.Encode(blockRoot[:]),
-			ExecutionOptimistic: blkData.Optimistic,
-		}
-		return send(w, flusher, BlockTopic, blk)
+type lazyReader func() io.Reader
+
+type eventStreamer struct {
+	sync.Mutex
+	ctx      context.Context
+	cancel   func()
+	w        StreamingResponseWriter
+	outbox   chan lazyReader
+	finished chan struct{}
+	kaDur    time.Duration
+}
+
+func NewEventStreamer(ctx context.Context, w http.ResponseWriter, buffSize int, kaDur time.Duration) (*eventStreamer, error) {
+	if kaDur == 0 {
+		kaDur = time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
 	}
-	return nil
+	f, ok := w.(StreamingResponseWriter)
+	if !ok {
+		return nil, errors.New("beacon node misconfiguration: http stack may not support required response handling features, like flushing")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	return &eventStreamer{
+		ctx:    ctx,
+		cancel: cancel,
+		w:      f,
+		outbox: make(chan lazyReader, buffSize),
+		kaDur:  kaDur,
+	}, nil
+}
+
+func (es *eventStreamer) Start() {
+	// Set up SSE response headers
+	es.w.Header().Set("Content-Type", api.EventStreamMediaType)
+	es.w.Header().Set("Connection", api.KeepAlive)
+	es.spawnWriteLoop()
+}
+
+func (es *eventStreamer) Stop() {
+	es.Cleanup(nil)
+}
+
+func newlineReader() io.Reader {
+	return bytes.NewBufferString(":\n\n")
+}
+
+// We main only care about this keep alive value in a real test setups and using a package var allows test
+// to modify it for convenience.
+var keepAliveInterval = time.Duration(12 * time.Second)
+
+func (es *eventStreamer) spawnWriteLoop() {
+	go func() {
+		var err error
+		kaT := time.NewTimer(es.kaDur)
+		defer func() {
+			if !kaT.Stop() {
+				<-kaT.C
+			}
+		}()
+		defer es.Cleanup(err)
+		// Write a keepalive at the start to test the connection and simplify test setup.
+		if err := es.writeOutbox(nil); err != nil {
+			return
+		}
+		for {
+			select {
+			case <-es.ctx.Done():
+				return
+			case <-kaT.C:
+				err = es.writeOutbox(nil)
+				if err != nil {
+					return
+				}
+				// The timer has already fired here, so a call to Reset is safe.
+			case lr := <-es.outbox:
+				err = es.writeOutbox(lr)
+				if err != nil {
+					return
+				}
+				// We don't know if the timer fired concurrently to this case being ready, so we need to check the return
+				// of Stop and drain the timer channel if it fired.
+				if !kaT.Stop() {
+					<-kaT.C
+				}
+			}
+			kaT.Reset(es.kaDur)
+		}
+	}()
+}
+
+func (es *eventStreamer) writeOutbox(first lazyReader) error {
+	written := 0
+	if first != nil {
+		if _, err := io.Copy(es.w, first()); err != nil {
+			return err
+		}
+		written += 1
+	}
+	for {
+		select {
+		case rf := <-es.outbox:
+			if _, err := io.Copy(es.w, rf()); err != nil {
+				return err
+			}
+			written += 1
+		default:
+			if written == 0 {
+				// If nothing was written in the write cycle, send a keepalive.
+				if _, err := io.Copy(es.w, newlineReader()); err != nil {
+					return err
+				}
+			}
+			es.w.Flush()
+			return nil
+		}
+	}
+}
+
+func (es *eventStreamer) Cleanup(err error) {
+	if err != nil {
+		log.WithError(err).Error("Event streamer shutting down due to error.")
+	}
+	select {
+	case <-es.finished:
+		return
+	default:
+		es.cancel()
+		close(es.finished)
+		// note: we could hijack the connection and close it here. Does that cause issues? What are the benefits?
+		// A benefit of hijack and close is that it may force an error on the remote end, however just closing the context of the
+		// http handler may be sufficient to cause the remote http response reader to close.
+	}
+}
+
+func (es *eventStreamer) safeWrite(rf func() io.Reader) error {
+	if rf == nil {
+		return nil
+	}
+	select {
+	case <-es.finished:
+		return ErrFinished
+	case es.outbox <- rf:
+		return nil
+	default:
+		// If this is the case, the select case to write to the outbox could not proceed, meaning the outbox is full.
+		// If a reader can't keep up with the stream, we shut them down.
+		return ErrSlowReader
+	}
+}
+
+func jsonMarshalReader(name string, v any) io.Reader {
+	d, err := json.Marshal(v)
+	if err != nil {
+		log.WithError(err).WithField("type_name", fmt.Sprintf("%T", v)).Error("Could not marshal event data.")
+		return nil
+	}
+	return bytes.NewBufferString("event: " + name + "\ndata: " + string(d) + "\n\n")
+}
+
+var ErrUnhandledEventData = errors.New("unable to represent event data in the event stream")
+
+func topicForEvent(event *feed.Event) string {
+	switch event.Data.(type) {
+	case *operation.AggregatedAttReceivedData:
+		return AttestationTopic
+	case *operation.UnAggregatedAttReceivedData:
+		return AttestationTopic
+	case *operation.ExitReceivedData:
+		return VoluntaryExitTopic
+	case *operation.SyncCommitteeContributionReceivedData:
+		return SyncCommitteeContributionTopic
+	case *operation.BLSToExecutionChangeReceivedData:
+		return BLSToExecutionChangeTopic
+	case *operation.BlobSidecarReceivedData:
+		return BlobSidecarTopic
+	case *operation.AttesterSlashingReceivedData:
+		return AttesterSlashingTopic
+	case *operation.ProposerSlashingReceivedData:
+		return ProposerSlashingTopic
+	case *ethpb.EventHead:
+		return HeadTopic
+	case *ethpb.EventFinalizedCheckpoint:
+		return FinalizedCheckpointTopic
+	case *ethpbv2.LightClientFinalityUpdateWithVersion:
+		return LightClientFinalityUpdateTopic
+	case *ethpbv2.LightClientOptimisticUpdateWithVersion:
+		return LightClientOptimisticUpdateTopic
+	case *ethpb.EventChainReorg:
+		return ChainReorgTopic
+	case *statefeed.BlockProcessedData:
+		return BlockTopic
+	default:
+		if event.Type == statefeed.MissedSlot {
+			return PayloadAttributesTopic
+		}
+		return InvalidTopic
+	}
+}
+
+var ErrNotRequested = errors.New("event not requested by client")
+
+func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, req map[string]bool) (lazyReader, error) {
+	eventName := topicForEvent(event)
+	if !req[eventName] {
+		return nil, ErrNotRequested
+	}
+	if eventName == PayloadAttributesTopic {
+		return s.currentPayloadAttributes(ctx)
+	}
+	switch v := event.Data.(type) {
+	case *ethpb.EventHead:
+		// The head event is a special case because, if the client requested the payload attributes topic,
+		// we send two event messages in reaction; the head event and the payload attributes.
+		headReader := func() io.Reader {
+			return jsonMarshalReader(eventName, structs.HeadEventFromV1(v))
+		}
+		// Don't do the expensive attr lookup unless the client requested it.
+		if !req[PayloadAttributesTopic] {
+			return headReader, nil
+		}
+		// Since payload attributes could change before the outbox is written, we need to do a blocking operation to
+		// get the current payload attributes right here.
+		attrReader, err := s.currentPayloadAttributes(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get payload attributes for head event")
+		}
+		return func() io.Reader {
+			return io.MultiReader(headReader(), attrReader())
+		}, nil
+	case *operation.AggregatedAttReceivedData:
+		return func() io.Reader {
+			att := structs.AttFromConsensus(v.Attestation.Aggregate)
+			return jsonMarshalReader(eventName, att)
+		}, nil
+	case *operation.UnAggregatedAttReceivedData:
+		att, ok := v.Attestation.(*eth.Attestation)
+		if !ok {
+			return nil, errors.Wrapf(ErrUnhandledEventData, "Unexpected type %T for the .Attestation field of UnAggregatedAttReceivedData", v.Attestation)
+		}
+		return func() io.Reader {
+			att := structs.AttFromConsensus(att)
+			return jsonMarshalReader(eventName, att)
+		}, nil
+	case *operation.ExitReceivedData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.SignedExitFromConsensus(v.Exit))
+		}, nil
+	case *operation.SyncCommitteeContributionReceivedData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.SignedContributionAndProofFromConsensus(v.Contribution))
+		}, nil
+	case *operation.BLSToExecutionChangeReceivedData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.SignedBLSChangeFromConsensus(v.Change))
+		}, nil
+	case *operation.BlobSidecarReceivedData:
+		return func() io.Reader {
+			versionedHash := blockchain.ConvertKzgCommitmentToVersionedHash(v.Blob.KzgCommitment)
+			return jsonMarshalReader(eventName, &structs.BlobSidecarEvent{
+				BlockRoot:     hexutil.Encode(v.Blob.BlockRootSlice()),
+				Index:         fmt.Sprintf("%d", v.Blob.Index),
+				Slot:          fmt.Sprintf("%d", v.Blob.Slot()),
+				VersionedHash: versionedHash.String(),
+				KzgCommitment: hexutil.Encode(v.Blob.KzgCommitment),
+			})
+		}, nil
+	case *operation.AttesterSlashingReceivedData:
+		slashing, ok := v.AttesterSlashing.(*eth.AttesterSlashing)
+		if !ok {
+			return nil, errors.Wrapf(ErrUnhandledEventData, "Unexpected type %T for the .AttesterSlashing field of AttesterSlashingReceivedData", v.AttesterSlashing)
+		}
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.AttesterSlashingFromConsensus(slashing))
+		}, nil
+	case *operation.ProposerSlashingReceivedData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.ProposerSlashingFromConsensus(v.ProposerSlashing))
+		}, nil
+	case *ethpb.EventFinalizedCheckpoint:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.FinalizedCheckpointEventFromV1(v))
+		}, nil
+	case *ethpbv2.LightClientFinalityUpdateWithVersion:
+		cv, err := structs.LightClientFinalityUpdateFromConsensus(v.Data)
+		if err != nil {
+			return nil, errors.Wrap(err, "LightClientFinalityUpdateWithVersion event conversion failure")
+		}
+		ev := &structs.LightClientFinalityUpdateEvent{
+			Version: version.String(int(v.Version)),
+			Data:    cv,
+		}
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, ev)
+		}, nil
+	case *ethpbv2.LightClientOptimisticUpdateWithVersion:
+		cv, err := structs.LightClientOptimisticUpdateFromConsensus(v.Data)
+		if err != nil {
+			return nil, errors.Wrap(err, "LightClientOptimisticUpdateWithVersion event conversion failure")
+		}
+		ev := &structs.LightClientOptimisticUpdateEvent{
+			Version: version.String(int(v.Version)),
+			Data:    cv,
+		}
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, ev)
+		}, nil
+	case *ethpb.EventChainReorg:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.EventChainReorgFromV1(v))
+		}, nil
+	case *statefeed.BlockProcessedData:
+		blockRoot, err := v.SignedBlock.Block().HashTreeRoot()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not compute block root for BlockProcessedData state feed event")
+		}
+		return func() io.Reader {
+			blk := &structs.BlockEvent{
+				Slot:                fmt.Sprintf("%d", v.Slot),
+				Block:               hexutil.Encode(blockRoot[:]),
+				ExecutionOptimistic: v.Optimistic,
+			}
+			return jsonMarshalReader(eventName, blk)
+		}, nil
+	default:
+		return nil, errors.Wrapf(ErrUnhandledEventData, "event data type %T unsupported", v)
+	}
 }
 
 // This event stream is intended to be used by builders and relays.
 // Parent fields are based on state at N_{current_slot}, while the rest of fields are based on state of N_{current_slot + 1}
-func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWriter, flusher http.Flusher) error {
+func (s *Server) currentPayloadAttributes(ctx context.Context) (lazyReader, error) {
 	headRoot, err := s.HeadFetcher.HeadRoot(ctx)
 	if err != nil {
-		return write(w, flusher, "Could not get head root: "+err.Error())
+		return nil, errors.Wrap(err, "could not get head root")
 	}
 	st, err := s.HeadFetcher.HeadState(ctx)
 	if err != nil {
-		return write(w, flusher, "Could not get head state: "+err.Error())
+		return nil, errors.Wrap(err, "could not get head state")
 	}
 	// advance the head state
 	headState, err := transition.ProcessSlotsIfPossible(ctx, st, s.ChainInfoFetcher.CurrentSlot()+1)
 	if err != nil {
-		return write(w, flusher, "Could not advance head state: "+err.Error())
+		return nil, errors.Wrap(err, "could not advance head state")
 	}
 
 	headBlock, err := s.HeadFetcher.HeadBlock(ctx)
 	if err != nil {
-		return write(w, flusher, "Could not get head block: "+err.Error())
+		return nil, errors.Wrap(err, "could not get head block")
 	}
 
 	headPayload, err := headBlock.Block().Body().Execution()
 	if err != nil {
-		return write(w, flusher, "Could not get execution payload: "+err.Error())
+		return nil, errors.Wrap(err, "could not get execution payload")
 	}
 
 	t, err := slots.ToTime(headState.GenesisTime(), headState.Slot())
 	if err != nil {
-		return write(w, flusher, "Could not get head state slot time: "+err.Error())
+		return nil, errors.Wrap(err, "could not get head state slot time")
 	}
 
-	prevRando, err := helpers.RandaoMix(headState, time.CurrentEpoch(headState))
+	prevRando, err := helpers.RandaoMix(headState, chaintime.CurrentEpoch(headState))
 	if err != nil {
-		return write(w, flusher, "Could not get head state randao mix: "+err.Error())
+		return nil, errors.Wrap(err, "could not get head state randao mix")
 	}
 
 	proposerIndex, err := helpers.BeaconProposerIndex(ctx, headState)
 	if err != nil {
-		return write(w, flusher, "Could not get head state proposer index: "+err.Error())
+		return nil, errors.Wrap(err, "could not get head state proposer index")
 	}
 	feeRecipient := params.BeaconConfig().DefaultFeeRecipient.Bytes()
 	tValidator, exists := s.TrackedValidatorsCache.Validator(proposerIndex)
@@ -425,7 +571,7 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 	case version.Capella:
 		withdrawals, _, err := headState.ExpectedWithdrawals()
 		if err != nil {
-			return write(w, flusher, "Could not get head state expected withdrawals: "+err.Error())
+			return nil, errors.Wrap(err, "could not get head state expected withdrawals")
 		}
 		attributes = &structs.PayloadAttributesV2{
 			Timestamp:             fmt.Sprintf("%d", t.Unix()),
@@ -436,11 +582,11 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 	case version.Deneb, version.Electra:
 		withdrawals, _, err := headState.ExpectedWithdrawals()
 		if err != nil {
-			return write(w, flusher, "Could not get head state expected withdrawals: "+err.Error())
+			return nil, errors.Wrap(err, "could not get head state expected withdrawals")
 		}
 		parentRoot, err := headBlock.Block().HashTreeRoot()
 		if err != nil {
-			return write(w, flusher, "Could not get head block root: "+err.Error())
+			return nil, errors.Wrap(err, "could not get head block root")
 		}
 		attributes = &structs.PayloadAttributesV3{
 			Timestamp:             fmt.Sprintf("%d", t.Unix()),
@@ -450,12 +596,12 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 			ParentBeaconBlockRoot: hexutil.Encode(parentRoot[:]),
 		}
 	default:
-		return write(w, flusher, "Payload version %s is not supported", version.String(headState.Version()))
+		return nil, errors.Wrapf(err, "Payload version %s is not supported", version.String(headState.Version()))
 	}
 
 	attributesBytes, err := json.Marshal(attributes)
 	if err != nil {
-		return write(w, flusher, err.Error())
+		return nil, errors.Wrap(err, "errors marshaling payload attributes to json")
 	}
 	eventData := structs.PayloadAttributesEventData{
 		ProposerIndex:     fmt.Sprintf("%d", proposerIndex),
@@ -467,31 +613,12 @@ func (s *Server) sendPayloadAttributes(ctx context.Context, w http.ResponseWrite
 	}
 	eventDataBytes, err := json.Marshal(eventData)
 	if err != nil {
-		return write(w, flusher, err.Error())
+		return nil, errors.Wrap(err, "errors marshaling payload attributes event data to json")
 	}
-	return send(w, flusher, PayloadAttributesTopic, &structs.PayloadAttributesEvent{
-		Version: version.String(headState.Version()),
-		Data:    eventDataBytes,
-	})
-}
-
-func send(w http.ResponseWriter, flusher http.Flusher, name string, data interface{}) error {
-	j, err := json.Marshal(data)
-	if err != nil {
-		return write(w, flusher, "Could not marshal event to JSON: "+err.Error())
-	}
-	return write(w, flusher, "event: %s\ndata: %s\n\n", name, string(j))
-}
-
-func sendKeepalive(w http.ResponseWriter, flusher http.Flusher) error {
-	return write(w, flusher, ":\n\n")
-}
-
-func write(w http.ResponseWriter, flusher http.Flusher, format string, a ...any) error {
-	_, err := fmt.Fprintf(w, format, a...)
-	if err != nil {
-		return errors.Wrap(err, "could not write to response writer")
-	}
-	flusher.Flush()
-	return nil
+	return func() io.Reader {
+		return jsonMarshalReader(PayloadAttributesTopic, &structs.PayloadAttributesEvent{
+			Version: version.String(headState.Version()),
+			Data:    eventDataBytes,
+		})
+	}, nil
 }

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -29,21 +29,6 @@ import (
 	sse "github.com/r3labs/sse/v2"
 )
 
-type flushableResponseRecorder struct {
-	*httptest.ResponseRecorder
-	flushed bool
-}
-
-func (f *flushableResponseRecorder) Flush() {
-	f.flushed = true
-}
-
-func NewFlushabaleResponseRecorder() *flushableResponseRecorder {
-	return &flushableResponseRecorder{
-		ResponseRecorder: httptest.NewRecorder(),
-	}
-}
-
 func requireAllEventsReceived(t *testing.T, stn, opn *mockChain.EventFeedWrapper, events []*feed.Event, req *topicRequest, s *Server, w *StreamingResponseWriterRecorder) {
 	// maxBufferSize param copied from sse lib client code
 	sseR := sse.NewEventStreamReader(w.Body(), 1<<24)

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -47,7 +47,7 @@ func NewFlushabaleResponseRecorder() *flushableResponseRecorder {
 func requireAllEventsReceived(t *testing.T, stn, opn *mockChain.EventFeedWrapper, events []*feed.Event, req *topicRequest, s *Server, w *StreamingResponseWriterRecorder) {
 	// maxBufferSize param copied from sse lib client code
 	sseR := sse.NewEventStreamReader(w.Body(), 1<<24)
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	expected := make(map[string]bool)
@@ -62,14 +62,15 @@ func requireAllEventsReceived(t *testing.T, stn, opn *mockChain.EventFeedWrapper
 		exs := string(exb[0 : len(exb)-2]) // remove trailing double newline
 
 		if topicsForOpsFeed[top] {
-			opn.WaitForSubscription(ctx)
+			if err := opn.WaitForSubscription(ctx); err != nil {
+				t.Fatal(err)
+			}
 			// Send the event on the feed.
 			s.OperationNotifier.OperationFeed().Send(ev)
 		} else {
-			if !topicsForStateFeed[top] {
-				t.Fatalf("could not determine feed for topic: %s", top)
+			if err := stn.WaitForSubscription(ctx); err != nil {
+				t.Fatal(err)
 			}
-			stn.WaitForSubscription(ctx)
 			// Send the event on the feed.
 			s.StateNotifier.StateFeed().Send(ev)
 		}
@@ -108,6 +109,147 @@ func (tr *topicRequest) testHttpRequest(_ *testing.T) *http.Request {
 	return httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com/eth/v1/events?%s", strings.Join(tq, "&")), nil)
 }
 
+func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
+	topics, err := newTopicRequest([]string{
+		AttestationTopic,
+		VoluntaryExitTopic,
+		SyncCommitteeContributionTopic,
+		BLSToExecutionChangeTopic,
+		BlobSidecarTopic,
+		AttesterSlashingTopic,
+		ProposerSlashingTopic,
+	})
+	require.NoError(t, err)
+	ro, err := blocks.NewROBlob(util.HydrateBlobSidecar(&eth.BlobSidecar{}))
+	require.NoError(t, err)
+	vblob := blocks.NewVerifiedROBlob(ro)
+
+	return topics, []*feed.Event{
+		&feed.Event{
+			Type: operation.UnaggregatedAttReceived,
+			Data: &operation.UnAggregatedAttReceivedData{
+				Attestation: util.HydrateAttestation(&eth.Attestation{}),
+			},
+		},
+		&feed.Event{
+			Type: operation.AggregatedAttReceived,
+			Data: &operation.AggregatedAttReceivedData{
+				Attestation: &eth.AggregateAttestationAndProof{
+					AggregatorIndex: 0,
+					Aggregate:       util.HydrateAttestation(&eth.Attestation{}),
+					SelectionProof:  make([]byte, 96),
+				},
+			},
+		},
+		&feed.Event{
+			Type: operation.ExitReceived,
+			Data: &operation.ExitReceivedData{
+				Exit: &eth.SignedVoluntaryExit{
+					Exit: &eth.VoluntaryExit{
+						Epoch:          0,
+						ValidatorIndex: 0,
+					},
+					Signature: make([]byte, 96),
+				},
+			},
+		},
+		&feed.Event{
+			Type: operation.SyncCommitteeContributionReceived,
+			Data: &operation.SyncCommitteeContributionReceivedData{
+				Contribution: &eth.SignedContributionAndProof{
+					Message: &eth.ContributionAndProof{
+						AggregatorIndex: 0,
+						Contribution: &eth.SyncCommitteeContribution{
+							Slot:              0,
+							BlockRoot:         make([]byte, 32),
+							SubcommitteeIndex: 0,
+							AggregationBits:   make([]byte, 16),
+							Signature:         make([]byte, 96),
+						},
+						SelectionProof: make([]byte, 96),
+					},
+					Signature: make([]byte, 96),
+				},
+			},
+		},
+		&feed.Event{
+			Type: operation.BLSToExecutionChangeReceived,
+			Data: &operation.BLSToExecutionChangeReceivedData{
+				Change: &eth.SignedBLSToExecutionChange{
+					Message: &eth.BLSToExecutionChange{
+						ValidatorIndex:     0,
+						FromBlsPubkey:      make([]byte, 48),
+						ToExecutionAddress: make([]byte, 20),
+					},
+					Signature: make([]byte, 96),
+				},
+			},
+		},
+		&feed.Event{
+			Type: operation.BlobSidecarReceived,
+			Data: &operation.BlobSidecarReceivedData{
+				Blob: &vblob,
+			},
+		},
+		&feed.Event{
+			Type: operation.AttesterSlashingReceived,
+			Data: &operation.AttesterSlashingReceivedData{
+				AttesterSlashing: &eth.AttesterSlashing{
+					Attestation_1: &eth.IndexedAttestation{
+						AttestingIndices: []uint64{0, 1},
+						Data: &eth.AttestationData{
+							BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+							Source: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+							Target: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+						},
+						Signature: make([]byte, fieldparams.BLSSignatureLength),
+					},
+					Attestation_2: &eth.IndexedAttestation{
+						AttestingIndices: []uint64{0, 1},
+						Data: &eth.AttestationData{
+							BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+							Source: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+							Target: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+						},
+						Signature: make([]byte, fieldparams.BLSSignatureLength),
+					},
+				},
+			},
+		},
+		&feed.Event{
+			Type: operation.ProposerSlashingReceived,
+			Data: &operation.ProposerSlashingReceivedData{
+				ProposerSlashing: &eth.ProposerSlashing{
+					Header_1: &eth.SignedBeaconBlockHeader{
+						Header: &eth.BeaconBlockHeader{
+							ParentRoot: make([]byte, fieldparams.RootLength),
+							StateRoot:  make([]byte, fieldparams.RootLength),
+							BodyRoot:   make([]byte, fieldparams.RootLength),
+						},
+						Signature: make([]byte, fieldparams.BLSSignatureLength),
+					},
+					Header_2: &eth.SignedBeaconBlockHeader{
+						Header: &eth.BeaconBlockHeader{
+							ParentRoot: make([]byte, fieldparams.RootLength),
+							StateRoot:  make([]byte, fieldparams.RootLength),
+							BodyRoot:   make([]byte, fieldparams.RootLength),
+						},
+						Signature: make([]byte, fieldparams.BLSSignatureLength),
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestStreamEvents_OperationsEvents(t *testing.T) {
 	t.Run("operations", func(t *testing.T) {
 		stn := mockChain.NewEventFeedWrapper()
@@ -117,16 +259,7 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 			OperationNotifier: &mockChain.SimpleNotifier{Feed: opn},
 		}
 
-		topics, err := newTopicRequest([]string{
-			AttestationTopic,
-			VoluntaryExitTopic,
-			SyncCommitteeContributionTopic,
-			BLSToExecutionChangeTopic,
-			BlobSidecarTopic,
-			AttesterSlashingTopic,
-			ProposerSlashingTopic,
-		})
-		require.NoError(t, err)
+		topics, events := operationEventsFixtures(t)
 		request := topics.testHttpRequest(t)
 		w := NewStreamingResponseWriterRecorder()
 
@@ -134,134 +267,6 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 			s.StreamEvents(w, request)
 		}()
 
-		ro, err := blocks.NewROBlob(util.HydrateBlobSidecar(&eth.BlobSidecar{}))
-		require.NoError(t, err)
-		vblob := blocks.NewVerifiedROBlob(ro)
-
-		events := []*feed.Event{
-			&feed.Event{
-				Type: operation.UnaggregatedAttReceived,
-				Data: &operation.UnAggregatedAttReceivedData{
-					Attestation: util.HydrateAttestation(&eth.Attestation{}),
-				},
-			},
-			&feed.Event{
-				Type: operation.AggregatedAttReceived,
-				Data: &operation.AggregatedAttReceivedData{
-					Attestation: &eth.AggregateAttestationAndProof{
-						AggregatorIndex: 0,
-						Aggregate:       util.HydrateAttestation(&eth.Attestation{}),
-						SelectionProof:  make([]byte, 96),
-					},
-				},
-			},
-			&feed.Event{
-				Type: operation.ExitReceived,
-				Data: &operation.ExitReceivedData{
-					Exit: &eth.SignedVoluntaryExit{
-						Exit: &eth.VoluntaryExit{
-							Epoch:          0,
-							ValidatorIndex: 0,
-						},
-						Signature: make([]byte, 96),
-					},
-				},
-			},
-			&feed.Event{
-				Type: operation.SyncCommitteeContributionReceived,
-				Data: &operation.SyncCommitteeContributionReceivedData{
-					Contribution: &eth.SignedContributionAndProof{
-						Message: &eth.ContributionAndProof{
-							AggregatorIndex: 0,
-							Contribution: &eth.SyncCommitteeContribution{
-								Slot:              0,
-								BlockRoot:         make([]byte, 32),
-								SubcommitteeIndex: 0,
-								AggregationBits:   make([]byte, 16),
-								Signature:         make([]byte, 96),
-							},
-							SelectionProof: make([]byte, 96),
-						},
-						Signature: make([]byte, 96),
-					},
-				},
-			},
-			&feed.Event{
-				Type: operation.BLSToExecutionChangeReceived,
-				Data: &operation.BLSToExecutionChangeReceivedData{
-					Change: &eth.SignedBLSToExecutionChange{
-						Message: &eth.BLSToExecutionChange{
-							ValidatorIndex:     0,
-							FromBlsPubkey:      make([]byte, 48),
-							ToExecutionAddress: make([]byte, 20),
-						},
-						Signature: make([]byte, 96),
-					},
-				},
-			},
-			&feed.Event{
-				Type: operation.BlobSidecarReceived,
-				Data: &operation.BlobSidecarReceivedData{
-					Blob: &vblob,
-				},
-			},
-			&feed.Event{
-				Type: operation.AttesterSlashingReceived,
-				Data: &operation.AttesterSlashingReceivedData{
-					AttesterSlashing: &eth.AttesterSlashing{
-						Attestation_1: &eth.IndexedAttestation{
-							AttestingIndices: []uint64{0, 1},
-							Data: &eth.AttestationData{
-								BeaconBlockRoot: make([]byte, fieldparams.RootLength),
-								Source: &eth.Checkpoint{
-									Root: make([]byte, fieldparams.RootLength),
-								},
-								Target: &eth.Checkpoint{
-									Root: make([]byte, fieldparams.RootLength),
-								},
-							},
-							Signature: make([]byte, fieldparams.BLSSignatureLength),
-						},
-						Attestation_2: &eth.IndexedAttestation{
-							AttestingIndices: []uint64{0, 1},
-							Data: &eth.AttestationData{
-								BeaconBlockRoot: make([]byte, fieldparams.RootLength),
-								Source: &eth.Checkpoint{
-									Root: make([]byte, fieldparams.RootLength),
-								},
-								Target: &eth.Checkpoint{
-									Root: make([]byte, fieldparams.RootLength),
-								},
-							},
-							Signature: make([]byte, fieldparams.BLSSignatureLength),
-						},
-					},
-				},
-			},
-			&feed.Event{
-				Type: operation.ProposerSlashingReceived,
-				Data: &operation.ProposerSlashingReceivedData{
-					ProposerSlashing: &eth.ProposerSlashing{
-						Header_1: &eth.SignedBeaconBlockHeader{
-							Header: &eth.BeaconBlockHeader{
-								ParentRoot: make([]byte, fieldparams.RootLength),
-								StateRoot:  make([]byte, fieldparams.RootLength),
-								BodyRoot:   make([]byte, fieldparams.RootLength),
-							},
-							Signature: make([]byte, fieldparams.BLSSignatureLength),
-						},
-						Header_2: &eth.SignedBeaconBlockHeader{
-							Header: &eth.BeaconBlockHeader{
-								ParentRoot: make([]byte, fieldparams.RootLength),
-								StateRoot:  make([]byte, fieldparams.RootLength),
-								BodyRoot:   make([]byte, fieldparams.RootLength),
-							},
-							Signature: make([]byte, fieldparams.BLSSignatureLength),
-						},
-					},
-				},
-			},
-		}
 		requireAllEventsReceived(t, stn, opn, events, topics, s, w)
 	})
 	t.Run("state", func(t *testing.T) {
@@ -281,10 +286,6 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 		require.NoError(t, err)
 		request := topics.testHttpRequest(t)
 		w := NewStreamingResponseWriterRecorder()
-
-		go func() {
-			s.StreamEvents(w, request)
-		}()
 
 		b, err := blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlock(&eth.SignedBeaconBlock{}))
 		require.NoError(t, err)
@@ -334,6 +335,11 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 				},
 			},
 		}
+
+		go func() {
+			s.StreamEvents(w, request)
+		}()
+
 		requireAllEventsReceived(t, stn, opn, events, topics, s, w)
 	})
 	t.Run("payload attributes", func(t *testing.T) {
@@ -443,4 +449,64 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 			requireAllEventsReceived(t, stn, opn, events, topics, s, w)
 		}
 	})
+}
+
+func TestStuckReader(t *testing.T) {
+	topics, events := operationEventsFixtures(t)
+	require.Equal(t, 8, len(events))
+	// set eventFeedDepth to a number lower than the events we intend to send to force the server to drop the reader.
+	stn := mockChain.NewEventFeedWrapper()
+	opn := mockChain.NewEventFeedWrapper()
+	s := &Server{
+		StateNotifier:     &mockChain.SimpleNotifier{Feed: stn},
+		OperationNotifier: &mockChain.SimpleNotifier{Feed: opn},
+		EventFeedDepth:    len(events) - 1,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	eventsWritten := make(chan struct{})
+	go func() {
+		for i := range events {
+			ev := events[i]
+			top := topicForEvent(ev)
+			if topicsForOpsFeed[top] {
+				err := opn.WaitForSubscription(ctx)
+				require.NoError(t, err)
+				s.OperationNotifier.OperationFeed().Send(ev)
+			} else {
+				err := stn.WaitForSubscription(ctx)
+				require.NoError(t, err)
+				s.StateNotifier.StateFeed().Send(ev)
+			}
+		}
+		close(eventsWritten)
+	}()
+
+	request := topics.testHttpRequest(t)
+	w := NewStreamingResponseWriterRecorder()
+
+	handlerFinished := make(chan struct{})
+	go func() {
+		s.StreamEvents(w, request)
+		close(handlerFinished)
+	}()
+
+	// Make sure that the stream writer shut down when the reader failed to clear the write buffer.
+	select {
+	case <-handlerFinished:
+		// We expect the stream handler to max out the queue buffer and exit gracefully.
+		return
+	case <-ctx.Done():
+		t.Fatalf("context canceled / timed out waiting for handler completion, err=%v", ctx.Err())
+	}
+
+	// Also make sure all the events were written.
+	select {
+	case <-eventsWritten:
+		// We expect the stream handler to max out the queue buffer and exit gracefully.
+		return
+	case <-ctx.Done():
+		t.Fatalf("context canceled / timed out waiting to write all events, err=%v", ctx.Err())
+	}
 }

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -23,9 +24,9 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/eth/v1"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
-	"github.com/prysmaticlabs/prysm/v5/testing/assert"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"github.com/prysmaticlabs/prysm/v5/testing/util"
+	sse "github.com/r3labs/sse/v2"
 )
 
 type flushableResponseRecorder struct {
@@ -37,255 +38,315 @@ func (f *flushableResponseRecorder) Flush() {
 	f.flushed = true
 }
 
+func NewFlushabaleResponseRecorder() *flushableResponseRecorder {
+	return &flushableResponseRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+	}
+}
+
+func requireAllEventsReceived(t *testing.T, events []*feed.Event, req map[string]bool, s *Server, w *StreamingResponseWriterRecorder) {
+	// maxBufferSize param copied from sse lib client code
+	sseR := sse.NewEventStreamReader(w.Body(), 1<<24)
+	testTimeout := time.NewTimer(60 * time.Second)
+	// Wait for the initial write and flush which will write the http header.
+	// This is also a signal that the server side has subscribed to the feed,
+	// so the setup code below can proceed with writing events.
+	select {
+	case status := <-w.StatusChan():
+		if status != http.StatusOK {
+			t.Fatalf("expected status OK, got %d", status)
+		}
+	case <-testTimeout.C:
+		t.Fatal("timed out waiting for events")
+	}
+
+	expected := make(map[string]bool)
+	for i := range events {
+		ev := events[i]
+		// serialize the event the same way the server will so that we can compare expectation to results.
+		top := topicForEvent(ev)
+		eb, err := s.lazyReaderForEvent(context.Background(), ev, req)
+		require.NoError(t, err)
+		exb, err := io.ReadAll(eb())
+		require.NoError(t, err)
+		exs := string(exb[0 : len(exb)-2]) // remove trailing double newline
+
+		if topicsForOpsFeed[top] {
+			// Send the event on the feed.
+			s.OperationNotifier.OperationFeed().Send(ev)
+		} else {
+			if !topicsForStateFeed[top] {
+				t.Fatalf("could not determine feed for topic: %s", top)
+			}
+			// Send the event on the feed.
+			s.StateNotifier.StateFeed().Send(ev)
+		}
+		expected[exs] = true
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			ev, err := sseR.ReadEvent()
+			if err == io.EOF {
+				return
+			}
+			require.NoError(t, err)
+			str := string(ev)
+			delete(expected, str)
+			if len(expected) == 0 {
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+		break
+	case <-testTimeout.C:
+		t.Fatal("timed out waiting for events")
+	}
+	// Clean up the timeout timer.
+	if !testTimeout.Stop() {
+		<-testTimeout.C
+	}
+	require.Equal(t, 0, len(expected), "expected events not seen")
+}
+
 func TestStreamEvents_OperationsEvents(t *testing.T) {
 	t.Run("operations", func(t *testing.T) {
 		s := &Server{
-			StateNotifier:     &mockChain.MockStateNotifier{},
+			StateNotifier:     mockChain.NewSimpleStateNotifier(),
 			OperationNotifier: &mockChain.MockOperationNotifier{},
 		}
 
-		topics := []string{
-			AttestationTopic,
-			VoluntaryExitTopic,
-			SyncCommitteeContributionTopic,
-			BLSToExecutionChangeTopic,
-			BlobSidecarTopic,
-			AttesterSlashingTopic,
-			ProposerSlashingTopic,
+		topics := map[string]bool{
+			AttestationTopic:               true,
+			VoluntaryExitTopic:             true,
+			SyncCommitteeContributionTopic: true,
+			BLSToExecutionChangeTopic:      true,
+			BlobSidecarTopic:               true,
+			AttesterSlashingTopic:          true,
+			ProposerSlashingTopic:          true,
 		}
-		for i, topic := range topics {
-			topics[i] = "topics=" + topic
+		tq := make([]string, 0, len(topics))
+		for topic := range topics {
+			tq = append(tq, "topics="+topic)
 		}
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com/eth/v1/events?%s", strings.Join(topics, "&")), nil)
-		w := &flushableResponseRecorder{
-			ResponseRecorder: httptest.NewRecorder(),
-		}
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com/eth/v1/events?%s", strings.Join(tq, "&")), nil)
+		w := NewStreamingResponseWriterRecorder()
 
 		go func() {
 			s.StreamEvents(w, request)
 		}()
-		// wait for initiation of StreamEvents
-		time.Sleep(100 * time.Millisecond)
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.UnaggregatedAttReceived,
-			Data: &operation.UnAggregatedAttReceivedData{
-				Attestation: util.HydrateAttestation(&eth.Attestation{}),
-			},
-		})
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.AggregatedAttReceived,
-			Data: &operation.AggregatedAttReceivedData{
-				Attestation: &eth.AggregateAttestationAndProof{
-					AggregatorIndex: 0,
-					Aggregate:       util.HydrateAttestation(&eth.Attestation{}),
-					SelectionProof:  make([]byte, 96),
-				},
-			},
-		})
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.ExitReceived,
-			Data: &operation.ExitReceivedData{
-				Exit: &eth.SignedVoluntaryExit{
-					Exit: &eth.VoluntaryExit{
-						Epoch:          0,
-						ValidatorIndex: 0,
-					},
-					Signature: make([]byte, 96),
-				},
-			},
-		})
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.SyncCommitteeContributionReceived,
-			Data: &operation.SyncCommitteeContributionReceivedData{
-				Contribution: &eth.SignedContributionAndProof{
-					Message: &eth.ContributionAndProof{
-						AggregatorIndex: 0,
-						Contribution: &eth.SyncCommitteeContribution{
-							Slot:              0,
-							BlockRoot:         make([]byte, 32),
-							SubcommitteeIndex: 0,
-							AggregationBits:   make([]byte, 16),
-							Signature:         make([]byte, 96),
-						},
-						SelectionProof: make([]byte, 96),
-					},
-					Signature: make([]byte, 96),
-				},
-			},
-		})
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.BLSToExecutionChangeReceived,
-			Data: &operation.BLSToExecutionChangeReceivedData{
-				Change: &eth.SignedBLSToExecutionChange{
-					Message: &eth.BLSToExecutionChange{
-						ValidatorIndex:     0,
-						FromBlsPubkey:      make([]byte, 48),
-						ToExecutionAddress: make([]byte, 20),
-					},
-					Signature: make([]byte, 96),
-				},
-			},
-		})
+
 		ro, err := blocks.NewROBlob(util.HydrateBlobSidecar(&eth.BlobSidecar{}))
 		require.NoError(t, err)
 		vblob := blocks.NewVerifiedROBlob(ro)
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.BlobSidecarReceived,
-			Data: &operation.BlobSidecarReceivedData{
-				Blob: &vblob,
-			},
-		})
 
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.AttesterSlashingReceived,
-			Data: &operation.AttesterSlashingReceivedData{
-				AttesterSlashing: &eth.AttesterSlashing{
-					Attestation_1: &eth.IndexedAttestation{
-						AttestingIndices: []uint64{0, 1},
-						Data: &eth.AttestationData{
-							BeaconBlockRoot: make([]byte, fieldparams.RootLength),
-							Source: &eth.Checkpoint{
-								Root: make([]byte, fieldparams.RootLength),
-							},
-							Target: &eth.Checkpoint{
-								Root: make([]byte, fieldparams.RootLength),
-							},
-						},
-						Signature: make([]byte, fieldparams.BLSSignatureLength),
-					},
-					Attestation_2: &eth.IndexedAttestation{
-						AttestingIndices: []uint64{0, 1},
-						Data: &eth.AttestationData{
-							BeaconBlockRoot: make([]byte, fieldparams.RootLength),
-							Source: &eth.Checkpoint{
-								Root: make([]byte, fieldparams.RootLength),
-							},
-							Target: &eth.Checkpoint{
-								Root: make([]byte, fieldparams.RootLength),
-							},
-						},
-						Signature: make([]byte, fieldparams.BLSSignatureLength),
+		events := []*feed.Event{
+			&feed.Event{
+				Type: operation.UnaggregatedAttReceived,
+				Data: &operation.UnAggregatedAttReceivedData{
+					Attestation: util.HydrateAttestation(&eth.Attestation{}),
+				},
+			},
+			&feed.Event{
+				Type: operation.AggregatedAttReceived,
+				Data: &operation.AggregatedAttReceivedData{
+					Attestation: &eth.AggregateAttestationAndProof{
+						AggregatorIndex: 0,
+						Aggregate:       util.HydrateAttestation(&eth.Attestation{}),
+						SelectionProof:  make([]byte, 96),
 					},
 				},
 			},
-		})
-
-		s.OperationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.ProposerSlashingReceived,
-			Data: &operation.ProposerSlashingReceivedData{
-				ProposerSlashing: &eth.ProposerSlashing{
-					Header_1: &eth.SignedBeaconBlockHeader{
-						Header: &eth.BeaconBlockHeader{
-							ParentRoot: make([]byte, fieldparams.RootLength),
-							StateRoot:  make([]byte, fieldparams.RootLength),
-							BodyRoot:   make([]byte, fieldparams.RootLength),
+			&feed.Event{
+				Type: operation.ExitReceived,
+				Data: &operation.ExitReceivedData{
+					Exit: &eth.SignedVoluntaryExit{
+						Exit: &eth.VoluntaryExit{
+							Epoch:          0,
+							ValidatorIndex: 0,
 						},
-						Signature: make([]byte, fieldparams.BLSSignatureLength),
-					},
-					Header_2: &eth.SignedBeaconBlockHeader{
-						Header: &eth.BeaconBlockHeader{
-							ParentRoot: make([]byte, fieldparams.RootLength),
-							StateRoot:  make([]byte, fieldparams.RootLength),
-							BodyRoot:   make([]byte, fieldparams.RootLength),
-						},
-						Signature: make([]byte, fieldparams.BLSSignatureLength),
+						Signature: make([]byte, 96),
 					},
 				},
 			},
-		})
-
-		time.Sleep(1 * time.Second)
-		request.Context().Done()
-
-		resp := w.Result()
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		require.NotNil(t, body)
-		assert.Equal(t, operationsResult, string(body))
+			&feed.Event{
+				Type: operation.SyncCommitteeContributionReceived,
+				Data: &operation.SyncCommitteeContributionReceivedData{
+					Contribution: &eth.SignedContributionAndProof{
+						Message: &eth.ContributionAndProof{
+							AggregatorIndex: 0,
+							Contribution: &eth.SyncCommitteeContribution{
+								Slot:              0,
+								BlockRoot:         make([]byte, 32),
+								SubcommitteeIndex: 0,
+								AggregationBits:   make([]byte, 16),
+								Signature:         make([]byte, 96),
+							},
+							SelectionProof: make([]byte, 96),
+						},
+						Signature: make([]byte, 96),
+					},
+				},
+			},
+			&feed.Event{
+				Type: operation.BLSToExecutionChangeReceived,
+				Data: &operation.BLSToExecutionChangeReceivedData{
+					Change: &eth.SignedBLSToExecutionChange{
+						Message: &eth.BLSToExecutionChange{
+							ValidatorIndex:     0,
+							FromBlsPubkey:      make([]byte, 48),
+							ToExecutionAddress: make([]byte, 20),
+						},
+						Signature: make([]byte, 96),
+					},
+				},
+			},
+			&feed.Event{
+				Type: operation.BlobSidecarReceived,
+				Data: &operation.BlobSidecarReceivedData{
+					Blob: &vblob,
+				},
+			},
+			&feed.Event{
+				Type: operation.AttesterSlashingReceived,
+				Data: &operation.AttesterSlashingReceivedData{
+					AttesterSlashing: &eth.AttesterSlashing{
+						Attestation_1: &eth.IndexedAttestation{
+							AttestingIndices: []uint64{0, 1},
+							Data: &eth.AttestationData{
+								BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+								Source: &eth.Checkpoint{
+									Root: make([]byte, fieldparams.RootLength),
+								},
+								Target: &eth.Checkpoint{
+									Root: make([]byte, fieldparams.RootLength),
+								},
+							},
+							Signature: make([]byte, fieldparams.BLSSignatureLength),
+						},
+						Attestation_2: &eth.IndexedAttestation{
+							AttestingIndices: []uint64{0, 1},
+							Data: &eth.AttestationData{
+								BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+								Source: &eth.Checkpoint{
+									Root: make([]byte, fieldparams.RootLength),
+								},
+								Target: &eth.Checkpoint{
+									Root: make([]byte, fieldparams.RootLength),
+								},
+							},
+							Signature: make([]byte, fieldparams.BLSSignatureLength),
+						},
+					},
+				},
+			},
+			&feed.Event{
+				Type: operation.ProposerSlashingReceived,
+				Data: &operation.ProposerSlashingReceivedData{
+					ProposerSlashing: &eth.ProposerSlashing{
+						Header_1: &eth.SignedBeaconBlockHeader{
+							Header: &eth.BeaconBlockHeader{
+								ParentRoot: make([]byte, fieldparams.RootLength),
+								StateRoot:  make([]byte, fieldparams.RootLength),
+								BodyRoot:   make([]byte, fieldparams.RootLength),
+							},
+							Signature: make([]byte, fieldparams.BLSSignatureLength),
+						},
+						Header_2: &eth.SignedBeaconBlockHeader{
+							Header: &eth.BeaconBlockHeader{
+								ParentRoot: make([]byte, fieldparams.RootLength),
+								StateRoot:  make([]byte, fieldparams.RootLength),
+								BodyRoot:   make([]byte, fieldparams.RootLength),
+							},
+							Signature: make([]byte, fieldparams.BLSSignatureLength),
+						},
+					},
+				},
+			},
+		}
+		requireAllEventsReceived(t, events, topics, s, w)
 	})
 	t.Run("state", func(t *testing.T) {
 		s := &Server{
-			StateNotifier:     &mockChain.MockStateNotifier{},
+			StateNotifier:     mockChain.NewSimpleStateNotifier(),
 			OperationNotifier: &mockChain.MockOperationNotifier{},
 		}
 
-		topics := []string{HeadTopic, FinalizedCheckpointTopic, ChainReorgTopic, BlockTopic}
-		for i, topic := range topics {
-			topics[i] = "topics=" + topic
+		topics := map[string]bool{
+			HeadTopic:                true,
+			FinalizedCheckpointTopic: true,
+			ChainReorgTopic:          true,
+			BlockTopic:               true,
 		}
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com/eth/v1/events?%s", strings.Join(topics, "&")), nil)
-		w := &flushableResponseRecorder{
-			ResponseRecorder: httptest.NewRecorder(),
+		tq := make([]string, 0, len(topics))
+		for topic := range topics {
+			tq = append(tq, "topics="+topic)
 		}
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com/eth/v1/events?%s", strings.Join(tq, "&")), nil)
+		w := NewStreamingResponseWriterRecorder()
 
 		go func() {
 			s.StreamEvents(w, request)
 		}()
-		// wait for initiation of StreamEvents
-		time.Sleep(100 * time.Millisecond)
-		s.StateNotifier.StateFeed().Send(&feed.Event{
-			Type: statefeed.NewHead,
-			Data: &ethpb.EventHead{
-				Slot:                      0,
-				Block:                     make([]byte, 32),
-				State:                     make([]byte, 32),
-				EpochTransition:           true,
-				PreviousDutyDependentRoot: make([]byte, 32),
-				CurrentDutyDependentRoot:  make([]byte, 32),
-				ExecutionOptimistic:       false,
-			},
-		})
-		s.StateNotifier.StateFeed().Send(&feed.Event{
-			Type: statefeed.FinalizedCheckpoint,
-			Data: &ethpb.EventFinalizedCheckpoint{
-				Block:               make([]byte, 32),
-				State:               make([]byte, 32),
-				Epoch:               0,
-				ExecutionOptimistic: false,
-			},
-		})
-		s.StateNotifier.StateFeed().Send(&feed.Event{
-			Type: statefeed.Reorg,
-			Data: &ethpb.EventChainReorg{
-				Slot:                0,
-				Depth:               0,
-				OldHeadBlock:        make([]byte, 32),
-				NewHeadBlock:        make([]byte, 32),
-				OldHeadState:        make([]byte, 32),
-				NewHeadState:        make([]byte, 32),
-				Epoch:               0,
-				ExecutionOptimistic: false,
-			},
-		})
+
 		b, err := blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlock(&eth.SignedBeaconBlock{}))
 		require.NoError(t, err)
-		s.StateNotifier.StateFeed().Send(&feed.Event{
-			Type: statefeed.BlockProcessed,
-			Data: &statefeed.BlockProcessedData{
-				Slot:        0,
-				BlockRoot:   [32]byte{},
-				SignedBlock: b,
-				Verified:    true,
-				Optimistic:  false,
+		events := []*feed.Event{
+			&feed.Event{
+				Type: statefeed.BlockProcessed,
+				Data: &statefeed.BlockProcessedData{
+					Slot:        0,
+					BlockRoot:   [32]byte{},
+					SignedBlock: b,
+					Verified:    true,
+					Optimistic:  false,
+				},
 			},
-		})
-
-		// wait for feed
-		time.Sleep(1 * time.Second)
-		request.Context().Done()
-
-		resp := w.Result()
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		require.NotNil(t, body)
-		assert.Equal(t, stateResult, string(body))
+			&feed.Event{
+				Type: statefeed.NewHead,
+				Data: &ethpb.EventHead{
+					Slot:                      0,
+					Block:                     make([]byte, 32),
+					State:                     make([]byte, 32),
+					EpochTransition:           true,
+					PreviousDutyDependentRoot: make([]byte, 32),
+					CurrentDutyDependentRoot:  make([]byte, 32),
+					ExecutionOptimistic:       false,
+				},
+			},
+			&feed.Event{
+				Type: statefeed.Reorg,
+				Data: &ethpb.EventChainReorg{
+					Slot:                0,
+					Depth:               0,
+					OldHeadBlock:        make([]byte, 32),
+					NewHeadBlock:        make([]byte, 32),
+					OldHeadState:        make([]byte, 32),
+					NewHeadState:        make([]byte, 32),
+					Epoch:               0,
+					ExecutionOptimistic: false,
+				},
+			},
+			&feed.Event{
+				Type: statefeed.FinalizedCheckpoint,
+				Data: &ethpb.EventFinalizedCheckpoint{
+					Block:               make([]byte, 32),
+					State:               make([]byte, 32),
+					Epoch:               0,
+					ExecutionOptimistic: false,
+				},
+			},
+		}
+		requireAllEventsReceived(t, events, topics, s, w)
 	})
 	t.Run("payload attributes", func(t *testing.T) {
 		type testCase struct {
 			name                      string
 			getState                  func() state.BeaconState
 			getBlock                  func() interfaces.SignedBeaconBlock
-			expected                  string
 			SetTrackedValidatorsCache func(*cache.TrackedValidatorsCache)
 		}
 		testCases := []testCase{
@@ -301,7 +362,6 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 					require.NoError(t, err)
 					return b
 				},
-				expected: payloadAttributesBellatrixResult,
 			},
 			{
 				name: "capella",
@@ -315,7 +375,6 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 					require.NoError(t, err)
 					return b
 				},
-				expected: payloadAttributesCapellaResult,
 			},
 			{
 				name: "deneb",
@@ -329,7 +388,6 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 					require.NoError(t, err)
 					return b
 				},
-				expected: payloadAttributesDenebResult,
 			},
 			{
 				name: "electra",
@@ -343,7 +401,6 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 					require.NoError(t, err)
 					return b
 				},
-				expected: payloadAttributesElectraResultWithTVC,
 				SetTrackedValidatorsCache: func(c *cache.TrackedValidatorsCache) {
 					c.Set(cache.TrackedValidator{
 						Active:       true,
@@ -369,7 +426,7 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 			}
 
 			s := &Server{
-				StateNotifier:          &mockChain.MockStateNotifier{},
+				StateNotifier:          mockChain.NewSimpleStateNotifier(),
 				OperationNotifier:      &mockChain.MockOperationNotifier{},
 				HeadFetcher:            mockChainService,
 				ChainInfoFetcher:       mockChainService,
@@ -379,99 +436,15 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 				tc.SetTrackedValidatorsCache(s.TrackedValidatorsCache)
 			}
 
+			rt := map[string]bool{PayloadAttributesTopic: true}
 			request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com/eth/v1/events?topics=%s", PayloadAttributesTopic), nil)
-			w := &flushableResponseRecorder{
-				ResponseRecorder: httptest.NewRecorder(),
-			}
+			w := NewStreamingResponseWriterRecorder()
+			events := []*feed.Event{&feed.Event{Type: statefeed.MissedSlot}}
 
 			go func() {
 				s.StreamEvents(w, request)
 			}()
-			// wait for initiation of StreamEvents
-			time.Sleep(100 * time.Millisecond)
-			s.StateNotifier.StateFeed().Send(&feed.Event{Type: statefeed.MissedSlot})
-
-			// wait for feed
-			time.Sleep(1 * time.Second)
-			request.Context().Done()
-
-			resp := w.Result()
-			body, err := io.ReadAll(resp.Body)
-			require.NoError(t, err)
-			require.NotNil(t, body)
-			assert.Equal(t, tc.expected, string(body), "wrong result for "+tc.name)
+			requireAllEventsReceived(t, events, rt, s, w)
 		}
 	})
 }
-
-const operationsResult = `:
-
-event: attestation
-data: {"aggregation_bits":"0x00","data":{"slot":"0","index":"0","beacon_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","source":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"},"target":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"}},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}
-
-event: attestation
-data: {"aggregation_bits":"0x00","data":{"slot":"0","index":"0","beacon_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","source":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"},"target":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"}},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}
-
-event: voluntary_exit
-data: {"message":{"epoch":"0","validator_index":"0"},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}
-
-event: contribution_and_proof
-data: {"message":{"aggregator_index":"0","contribution":{"slot":"0","beacon_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","subcommittee_index":"0","aggregation_bits":"0x00000000000000000000000000000000","signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},"selection_proof":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}
-
-event: bls_to_execution_change
-data: {"message":{"validator_index":"0","from_bls_pubkey":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","to_execution_address":"0x0000000000000000000000000000000000000000"},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}
-
-event: blob_sidecar
-data: {"block_root":"0xc78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c","index":"0","slot":"0","kzg_commitment":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","versioned_hash":"0x01b0761f87b081d5cf10757ccc89f12be355c70e2e29df288b65b30710dcbcd1"}
-
-event: attester_slashing
-data: {"attestation_1":{"attesting_indices":["0","1"],"data":{"slot":"0","index":"0","beacon_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","source":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"},"target":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"}},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},"attestation_2":{"attesting_indices":["0","1"],"data":{"slot":"0","index":"0","beacon_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","source":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"},"target":{"epoch":"0","root":"0x0000000000000000000000000000000000000000000000000000000000000000"}},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}}
-
-event: proposer_slashing
-data: {"signed_header_1":{"message":{"slot":"0","proposer_index":"0","parent_root":"0x0000000000000000000000000000000000000000000000000000000000000000","state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","body_root":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"},"signed_header_2":{"message":{"slot":"0","proposer_index":"0","parent_root":"0x0000000000000000000000000000000000000000000000000000000000000000","state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","body_root":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}}
-
-`
-
-const stateResult = `:
-
-event: head
-data: {"slot":"0","block":"0x0000000000000000000000000000000000000000000000000000000000000000","state":"0x0000000000000000000000000000000000000000000000000000000000000000","epoch_transition":true,"execution_optimistic":false,"previous_duty_dependent_root":"0x0000000000000000000000000000000000000000000000000000000000000000","current_duty_dependent_root":"0x0000000000000000000000000000000000000000000000000000000000000000"}
-
-event: finalized_checkpoint
-data: {"block":"0x0000000000000000000000000000000000000000000000000000000000000000","state":"0x0000000000000000000000000000000000000000000000000000000000000000","epoch":"0","execution_optimistic":false}
-
-event: chain_reorg
-data: {"slot":"0","depth":"0","old_head_block":"0x0000000000000000000000000000000000000000000000000000000000000000","old_head_state":"0x0000000000000000000000000000000000000000000000000000000000000000","new_head_block":"0x0000000000000000000000000000000000000000000000000000000000000000","new_head_state":"0x0000000000000000000000000000000000000000000000000000000000000000","epoch":"0","execution_optimistic":false}
-
-event: block
-data: {"slot":"0","block":"0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4","execution_optimistic":false}
-
-`
-
-const payloadAttributesBellatrixResult = `:
-
-event: payload_attributes
-data: {"version":"bellatrix","data":{"proposer_index":"0","proposal_slot":"1","parent_block_number":"0","parent_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","parent_block_hash":"0x0000000000000000000000000000000000000000000000000000000000000000","payload_attributes":{"timestamp":"12","prev_randao":"0x0000000000000000000000000000000000000000000000000000000000000000","suggested_fee_recipient":"0x0000000000000000000000000000000000000000"}}}
-
-`
-
-const payloadAttributesCapellaResult = `:
-
-event: payload_attributes
-data: {"version":"capella","data":{"proposer_index":"0","proposal_slot":"1","parent_block_number":"0","parent_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","parent_block_hash":"0x0000000000000000000000000000000000000000000000000000000000000000","payload_attributes":{"timestamp":"12","prev_randao":"0x0000000000000000000000000000000000000000000000000000000000000000","suggested_fee_recipient":"0x0000000000000000000000000000000000000000","withdrawals":[]}}}
-
-`
-
-const payloadAttributesDenebResult = `:
-
-event: payload_attributes
-data: {"version":"deneb","data":{"proposer_index":"0","proposal_slot":"1","parent_block_number":"0","parent_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","parent_block_hash":"0x0000000000000000000000000000000000000000000000000000000000000000","payload_attributes":{"timestamp":"12","prev_randao":"0x0000000000000000000000000000000000000000000000000000000000000000","suggested_fee_recipient":"0x0000000000000000000000000000000000000000","withdrawals":[],"parent_beacon_block_root":"0xbef96cb938fd48b2403d3e662664325abb0102ed12737cbb80d717520e50cf4a"}}}
-
-`
-
-const payloadAttributesElectraResultWithTVC = `:
-
-event: payload_attributes
-data: {"version":"electra","data":{"proposer_index":"0","proposal_slot":"1","parent_block_number":"0","parent_block_root":"0x0000000000000000000000000000000000000000000000000000000000000000","parent_block_hash":"0x0000000000000000000000000000000000000000000000000000000000000000","payload_attributes":{"timestamp":"12","prev_randao":"0x0000000000000000000000000000000000000000000000000000000000000000","suggested_fee_recipient":"0xd2dbd02e4efe087d7d195de828b9dd25f19a89c9","withdrawals":[],"parent_beacon_block_root":"0xf2110e448638f41cb34514ecdbb49c055536cd5f715f1cb259d1287bb900853e"}}}
-
-`

--- a/beacon-chain/rpc/eth/events/http_test.go
+++ b/beacon-chain/rpc/eth/events/http_test.go
@@ -1,0 +1,75 @@
+package events
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+)
+
+type StreamingResponseWriterRecorder struct {
+	http.ResponseWriter
+	r             io.Reader
+	w             io.Writer
+	statusWritten *int
+	status        chan int
+	bodyRecording []byte
+	flushed       bool
+}
+
+func (w *StreamingResponseWriterRecorder) StatusChan() chan int {
+	return w.status
+}
+
+func NewStreamingResponseWriterRecorder() *StreamingResponseWriterRecorder {
+	r, w := io.Pipe()
+	return &StreamingResponseWriterRecorder{
+		ResponseWriter: httptest.NewRecorder(),
+		r:              r,
+		w:              w,
+		status:         make(chan int, 1),
+	}
+}
+
+// Write implements http.ResponseWriter.
+func (w *StreamingResponseWriterRecorder) Write(data []byte) (int, error) {
+	w.WriteHeader(http.StatusOK)
+	n, err := w.w.Write(data)
+	if err != nil {
+		return n, err
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+// WriteHeader implements http.ResponseWriter.
+func (w *StreamingResponseWriterRecorder) WriteHeader(statusCode int) {
+	if w.statusWritten != nil {
+		return
+	}
+	w.statusWritten = &statusCode
+	w.status <- statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *StreamingResponseWriterRecorder) Body() io.Reader {
+	return w.r
+}
+
+func (w *StreamingResponseWriterRecorder) RequireStatus(t *testing.T, status int) {
+	if w.statusWritten == nil {
+		t.Fatal("WriteHeader was not called")
+	}
+	require.Equal(t, status, *w.statusWritten)
+}
+
+func (w *StreamingResponseWriterRecorder) Flush() {
+	fw, ok := w.ResponseWriter.(http.Flusher)
+	if ok {
+		fw.Flush()
+	}
+	w.flushed = true
+}
+
+var _ http.ResponseWriter = &StreamingResponseWriterRecorder{}

--- a/beacon-chain/rpc/eth/events/server.go
+++ b/beacon-chain/rpc/eth/events/server.go
@@ -4,6 +4,8 @@
 package events
 
 import (
+	"time"
+
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
 	opfeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/operation"
@@ -18,4 +20,5 @@ type Server struct {
 	HeadFetcher            blockchain.HeadFetcher
 	ChainInfoFetcher       blockchain.ChainInfoFetcher
 	TrackedValidatorsCache *cache.TrackedValidatorsCache
+	KeepAliveInterval      time.Duration
 }

--- a/beacon-chain/rpc/eth/events/server.go
+++ b/beacon-chain/rpc/eth/events/server.go
@@ -21,4 +21,5 @@ type Server struct {
 	ChainInfoFetcher       blockchain.ChainInfoFetcher
 	TrackedValidatorsCache *cache.TrackedValidatorsCache
 	KeepAliveInterval      time.Duration
+	EventFeedDepth         int
 }

--- a/deps.bzl
+++ b/deps.bzl
@@ -2834,6 +2834,12 @@ def prysm_deps():
         version = "v0.8.0",
     )
     go_repository(
+        name = "com_github_r3labs_sse_v2",
+        importpath = "github.com/r3labs/sse/v2",
+        sum = "h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=",
+        version = "v2.10.0",
+    )
+    go_repository(
         name = "com_github_raulk_go_watchdog",
         importpath = "github.com/raulk/go-watchdog",
         sum = "h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=",
@@ -4303,6 +4309,12 @@ def prysm_deps():
         importpath = "gopkg.in/bsm/ratelimit.v1",
         sum = "h1:stTHdEoWg1pQ8riaP5ROrjS6zy6wewH/Q2iwnLCQUXY=",
         version = "v1.0.0-20160220154919-db14e161995a",
+    )
+    go_repository(
+        name = "in_gopkg_cenkalti_backoff_v1",
+        importpath = "gopkg.in/cenkalti/backoff.v1",
+        sum = "h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=",
+        version = "v1.1.0",
     )
     go_repository(
         name = "in_gopkg_check_v1",

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20240328144219-a1caa50c3a1e
 	github.com/prysmaticlabs/prombbolt v0.0.0-20210126082820-9b7adba6db7c
 	github.com/prysmaticlabs/protoc-gen-go-cast v0.0.0-20230228205207-28762a7b9294
+	github.com/r3labs/sse/v2 v2.10.0
 	github.com/rs/cors v1.7.0
 	github.com/schollz/progressbar/v3 v3.3.4
 	github.com/sirupsen/logrus v1.9.0
@@ -259,6 +260,7 @@ require (
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
+	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -914,6 +914,8 @@ github.com/quic-go/quic-go v0.46.0 h1:uuwLClEEyk1DNvchH8uCByQVjo3yKL9opKulExNDs7
 github.com/quic-go/quic-go v0.46.0/go.mod h1:1dLehS7TIR64+vxGR70GDcatWTOtMX2PUtnKsjbTurI=
 github.com/quic-go/webtransport-go v0.8.0 h1:HxSrwun11U+LlmwpgM1kEqIqH90IT4N8auv/cD7QFJg=
 github.com/quic-go/webtransport-go v0.8.0/go.mod h1:N99tjprW432Ut5ONql/aUhSLT0YVSlwHohQsuac9WaM=
+github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
+github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -1223,6 +1225,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1607,6 +1610,8 @@ google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6h
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a/go.mod h1:KF9sEfUPAXdG8Oev9e99iLGnl2uJMjc5B+4y3O7x610=
+gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
+gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR separates event stream api processing across 2 staged queues. First is a channel where event subscriptions are buffered, and second is an "outbox" with a capped size. The send to the outbox is protected by a select statement, so if the outbox can't be written, the event is dropped on the floor and a cleanup sequence is triggered, ending the event stream. Validation and filtering happens before the write to the outbox, but serialization is deferred via a closure until the event is ready to be written to the client.

A separate goroutine processes the outbox, draining the queue and calling flush on the response writer only once all events have been written to the client, removing the need for unnecessary flushing and regaining the benefits of connection buffering. If the keep-alive timer has fired, a keep-alive message is sent before flushing, but only if no events have been written. Rather than using a ticker, the keep-alive is tracked by a timer which is reset after the client flush completes.

Runtime errors like the wrong type being on a particular feed are logged as server-side errors and no longer pushed to the client as messages.

The unit test now uses what appears to be the popular golang the sse event client library to test that expected events are received. 

This is still WIP; TODOs (before PR is merged):
- fix other unit tests (only operations feed test fixed so far) and check if we want to add more coverage
- rework the test response writer to internally use `io.Pipe` to more accurately mirror the way the sse library will scan the byte stream. Otherwise the test will be flaky due to the scanner hitting the end of an internal byte buffer and caching an `io.EOF` error.
- self-review and cleanup
- update CHANGELOG
- do some testing by hand - maybe add a prysmctl command to stream remote events to stdout



**Which issues(s) does this PR fix?**

Slow readers of the event stream api can cause issues in the node when the queue backs up. The previous algorithm was for a select loop to read from event channels and write each event to the http ResponseWriter followed by a flush. A separate ticker would trigger http keep-alive without knowledge of what other writes or flushes were ongoing. This could result in unwanted backpressure on the event queue. 

The stream would subscribe to both state feed and operation event channels, regardless of whether topics for those channels had been requested. It would perform a lot of duplicate error checking for conditions that would indicate bugs in the node code itself and treat them as runtime errors to be pushed to the client. 

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
