### PR TITLE
gateway flag changes breaking release e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - "Submitted builder validator registration settings for custom builders" log message moved to debug level.
 - config: Genesis validator root is now hardcoded in params.BeaconConfig()
 - `grpc-gateway-host` is renamed to http-host. The old name can still be used as an alias.
-- `grpc-gateway-port` is renamed to http-port.
-- `grpc-gateway-corsdomain` is renamed to http-cors-domain.
+- `grpc-gateway-port` is renamed to http-port. The old name can still be used as an alias.
+- `grpc-gateway-corsdomain` is renamed to http-cors-domain. The old name can still be used as an alias.
 - `api-timeout` is changed from int flag to duration flag, default value updated.
 
 ### Deprecated

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -230,19 +230,13 @@ func TestConfigureInterop(t *testing.T) {
 }
 
 func TestAliasFlag(t *testing.T) {
-	// Define the flag with an alias
-	myFlag := &cli.StringFlag{
-		Name:    "config",
-		Aliases: []string{"c"},
-		Usage:   "Load configuration from `FILE`",
-	}
 
 	// Create a new app with the flag
 	app := &cli.App{
-		Flags: []cli.Flag{myFlag},
+		Flags: []cli.Flag{flags.HTTPServerHost},
 		Action: func(c *cli.Context) error {
-			// Test if the alias ("c") works and sets the flag correctly
-			if c.IsSet("config") {
+			// Test if the alias works and sets the flag correctly
+			if c.IsSet("grpc-gateway-host") && c.IsSet("http-host") {
 				return nil
 			}
 			return cli.Exit("Alias or flag not set", 1)
@@ -250,7 +244,7 @@ func TestAliasFlag(t *testing.T) {
 	}
 
 	// Simulate command line arguments that include the alias
-	args := []string{"app", "--c", "config.yml"}
+	args := []string{"app", "--grpc-gateway-host", "config.yml"}
 
 	// Run the app with the simulated arguments
 	err := app.Run(args)

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -228,3 +228,33 @@ func TestConfigureInterop(t *testing.T) {
 		})
 	}
 }
+
+func TestAliasFlag(t *testing.T) {
+	// Define the flag with an alias
+	myFlag := &cli.StringFlag{
+		Name:    "config",
+		Aliases: []string{"c"},
+		Usage:   "Load configuration from `FILE`",
+	}
+
+	// Create a new app with the flag
+	app := &cli.App{
+		Flags: []cli.Flag{myFlag},
+		Action: func(c *cli.Context) error {
+			// Test if the alias ("c") works and sets the flag correctly
+			if c.IsSet("config") {
+				return nil
+			}
+			return cli.Exit("Alias or flag not set", 1)
+		},
+	}
+
+	// Simulate command line arguments that include the alias
+	args := []string{"app", "--c", "config.yml"}
+
+	// Run the app with the simulated arguments
+	err := app.Run(args)
+
+	// Check if the alias set the flag correctly
+	assert.NoError(t, err)
+}

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -230,7 +230,6 @@ func TestConfigureInterop(t *testing.T) {
 }
 
 func TestAliasFlag(t *testing.T) {
-
 	// Create a new app with the flag
 	app := &cli.App{
 		Flags: []cli.Flag{flags.HTTPServerHost},

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -120,7 +120,7 @@ var (
 	}
 	// HTTPServerCorsDomain adds accepted cross origin request addresses.
 	HTTPServerCorsDomain = &cli.StringFlag{
-		Name:    "corsdomain",
+		Name:    "http-cors-domain",
 		Usage:   `Comma separated list of domains from which to accept cross origin requests (browser enforced).`,
 		Value:   "http://localhost:7500,http://127.0.0.1:7500,http://0.0.0.0:7500,http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200,http://0.0.0.0:4242,http://127.0.0.1:4200,http://0.0.0.0:4200,http://localhost:3000,http://0.0.0.0:3000,http://127.0.0.1:3000",
 		Aliases: []string{"grpc-gateway-corsdomain"},

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -106,24 +106,24 @@ var (
 	}
 	// HTTPServerHost specifies a HTTP server host for the validator client.
 	HTTPServerHost = &cli.StringFlag{
-		Name:    "http-host",
+		Name:    "grpc-gateway-host",
 		Usage:   "Host on which the HTTP server runs on.",
 		Value:   DefaultHTTPServerHost,
-		Aliases: []string{"grpc-gateway-host"},
+		Aliases: []string{"http-host"},
 	}
 	// HTTPServerPort enables a HTTP server port to be exposed for the validator client.
 	HTTPServerPort = &cli.IntFlag{
-		Name:    "http-port",
+		Name:    "grpc-gateway-port",
 		Usage:   "Port on which the HTTP server runs on.",
 		Value:   7500,
-		Aliases: []string{"grpc-gateway-port"},
+		Aliases: []string{"http-port"},
 	}
 	// HTTPServerCorsDomain adds accepted cross origin request addresses.
 	HTTPServerCorsDomain = &cli.StringFlag{
-		Name:    "corsdomain",
+		Name:    "grpc-gateway-corsdomain",
 		Usage:   `Comma separated list of domains from which to accept cross origin requests (browser enforced).`,
 		Value:   "http://localhost:7500,http://127.0.0.1:7500,http://0.0.0.0:7500,http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200,http://0.0.0.0:4242,http://127.0.0.1:4200,http://0.0.0.0:4200,http://localhost:3000,http://0.0.0.0:3000,http://127.0.0.1:3000",
-		Aliases: []string{"grpc-gateway-corsdomain"},
+		Aliases: []string{"corsdomain"},
 	}
 	// MonitoringPortFlag defines the http port used to serve prometheus metrics.
 	MonitoringPortFlag = &cli.IntFlag{

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -106,24 +106,24 @@ var (
 	}
 	// HTTPServerHost specifies a HTTP server host for the validator client.
 	HTTPServerHost = &cli.StringFlag{
-		Name:    "grpc-gateway-host",
+		Name:    "http-host",
 		Usage:   "Host on which the HTTP server runs on.",
 		Value:   DefaultHTTPServerHost,
-		Aliases: []string{"http-host"},
+		Aliases: []string{"grpc-gateway-host"},
 	}
 	// HTTPServerPort enables a HTTP server port to be exposed for the validator client.
 	HTTPServerPort = &cli.IntFlag{
-		Name:    "grpc-gateway-port",
+		Name:    "http-port",
 		Usage:   "Port on which the HTTP server runs on.",
 		Value:   7500,
-		Aliases: []string{"http-port"},
+		Aliases: []string{"grpc-gateway-port"},
 	}
 	// HTTPServerCorsDomain adds accepted cross origin request addresses.
 	HTTPServerCorsDomain = &cli.StringFlag{
-		Name:    "grpc-gateway-corsdomain",
+		Name:    "corsdomain",
 		Usage:   `Comma separated list of domains from which to accept cross origin requests (browser enforced).`,
 		Value:   "http://localhost:7500,http://127.0.0.1:7500,http://0.0.0.0:7500,http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200,http://0.0.0.0:4242,http://127.0.0.1:4200,http://0.0.0.0:4200,http://localhost:3000,http://0.0.0.0:3000,http://127.0.0.1:3000",
-		Aliases: []string{"corsdomain"},
+		Aliases: []string{"grpc-gateway-corsdomain"},
 	}
 	// MonitoringPortFlag defines the http port used to serve prometheus metrics.
 	MonitoringPortFlag = &cli.IntFlag{

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -221,12 +221,13 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	portFlagName := "grpc-gateway-port" // TODO: replace port flag name with flags.HTTPServerPort.Name in a future release
 	args := []string{
 		fmt.Sprintf("--%s=%s/eth2-val-%d", cmdshared.DataDirFlag.Name, e2e.TestParams.TestPath, index),
 		fmt.Sprintf("--%s=%s", cmdshared.LogFileName.Name, logFile.Name()),
 		fmt.Sprintf("--%s=%s", flags.GraffitiFileFlag.Name, gFile),
 		fmt.Sprintf("--%s=%d", flags.MonitoringPortFlag.Name, e2e.TestParams.Ports.ValidatorMetricsPort+index),
-		fmt.Sprintf("--%s=%d", flags.HTTPServerPort.Name, e2e.TestParams.Ports.ValidatorHTTPPort+index),
+		fmt.Sprintf("--%s=%d", portFlagName, e2e.TestParams.Ports.ValidatorHTTPPort+index),
 		fmt.Sprintf("--%s=localhost:%d", flags.BeaconRPCProviderFlag.Name, beaconRPCPort),
 
 		fmt.Sprintf("--%s=%s", flags.GRPCHeadersFlag.Name, "dummy=value,foo=bar"), // Sending random headers shouldn't break anything.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

https://github.com/prysmaticlabs/prysm/pull/14089 changed the flags for gateway, the release e2e uses the previous version to run e2e so that we know settings did not change. in this case the default name of the flag changed and a temporary use of the alias in the e2e test will be needed in the mean time until a future release where the updated name can then be used.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
