### PR TITLE
Add GetPTCVote helpers

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -114,6 +114,7 @@ go_test(
         "chain_info_norace_test.go",
         "chain_info_test.go",
         "checktags_test.go",
+        "epbs_test.go",
         "error_test.go",
         "execution_engine_test.go",
         "forkchoice_update_execution_test.go",

--- a/beacon-chain/blockchain/epbs_test.go
+++ b/beacon-chain/blockchain/epbs_test.go
@@ -1,0 +1,18 @@
+package blockchain
+
+import (
+	"testing"
+
+	doublylinkedtree "github.com/prysmaticlabs/prysm/v5/beacon-chain/forkchoice/doubly-linked-tree"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+)
+
+func TestServiceGetPTCVote(t *testing.T) {
+	c := &currentlySyncingPayload{roots: make(map[[32]byte]primitives.PTCStatus)}
+	s := &Service{cfg: &config{ForkChoiceStore: doublylinkedtree.New()}, payloadBeingSynced: c}
+	r := [32]byte{'r'}
+	require.Equal(t, primitives.PAYLOAD_ABSENT, s.GetPTCVote(r))
+	c.roots[r] = primitives.PAYLOAD_WITHHELD
+	require.Equal(t, primitives.PAYLOAD_WITHHELD, s.GetPTCVote(r))
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/epbs.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/epbs.go
@@ -1,9 +1,31 @@
 package doublylinkedtree
 
+import (
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/time/slots"
+)
+
 func (n *Node) isParentFull() bool {
 	// Finalized checkpoint is considered full
 	if n.parent == nil || n.parent.parent == nil {
 		return true
 	}
 	return n.parent.payloadHash != [32]byte{}
+}
+
+func (f *ForkChoice) GetPTCVote() primitives.PTCStatus {
+	highestNode := f.store.highestReceivedNode
+	if highestNode == nil {
+		return primitives.PAYLOAD_ABSENT
+	}
+	if slots.CurrentSlot(f.store.genesisTime) > highestNode.slot {
+		return primitives.PAYLOAD_ABSENT
+	}
+	if highestNode.payloadHash == [32]byte{} {
+		return primitives.PAYLOAD_ABSENT
+	}
+	if highestNode.withheld {
+		return primitives.PAYLOAD_WITHHELD
+	}
+	return primitives.PAYLOAD_PRESENT
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/epbs_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/epbs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 )
 
@@ -76,4 +77,24 @@ func TestStore_Insert_PayloadContent(t *testing.T) {
 	n2, err := s.insert(ctx, 3, ggfr, gr, ggfp, gp, 0, 0)
 	require.NoError(t, err)
 	require.Equal(t, n, n2)
+}
+
+func TestGetPTCVote(t *testing.T) {
+	ctx := context.Background()
+	f := setup(0, 0)
+	s := f.store
+	require.NotNil(t, s.highestReceivedNode)
+	fr := [32]byte{}
+
+	// Insert a child with a payload
+	cr := [32]byte{'a'}
+	cp := [32]byte{'p'}
+	n, err := s.insert(ctx, 1, cr, fr, cp, fr, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, n, s.highestReceivedNode)
+	require.Equal(t, primitives.PAYLOAD_ABSENT, f.GetPTCVote())
+	driftGenesisTime(f, 1, 0)
+	require.Equal(t, primitives.PAYLOAD_PRESENT, f.GetPTCVote())
+	n.withheld = true
+	require.Equal(t, primitives.PAYLOAD_WITHHELD, f.GetPTCVote())
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -62,9 +62,10 @@ type Node struct {
 	balance                  uint64                       // the balance that voted for this node directly
 	weight                   uint64                       // weight of this node: the total balance including children
 	bestDescendant           *Node                        // bestDescendant node of this node.
-	optimistic               bool                         // whether the block has been fully validated or not
 	timestamp                uint64                       // The timestamp when the node was inserted.
 	ptcVote                  []primitives.PTCStatus       // tracks the Payload Timeliness Committee (PTC) votes for the node
+	withheld                 bool                         // whether the builder sent a withheld message for this payload
+	optimistic               bool                         // whether the block has been fully validated or not
 }
 
 // Vote defines an individual validator's vote.

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -82,6 +82,7 @@ type FastGetter interface {
 	UnrealizedJustifiedPayloadBlockHash() [32]byte
 	Weight(root [32]byte) (uint64, error)
 	ParentRoot(root [32]byte) ([32]byte, error)
+	GetPTCVote() primitives.PTCStatus
 }
 
 // Setter allows to set forkchoice information

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -183,3 +183,10 @@ func (ro *ROForkChoice) ParentRoot(root [32]byte) ([32]byte, error) {
 	defer ro.l.RUnlock()
 	return ro.getter.ParentRoot(root)
 }
+
+// GetPTCVote delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) GetPTCVote() primitives.PTCStatus {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.GetPTCVote()
+}

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -39,6 +39,7 @@ const (
 	lastRootCalled
 	targetRootForEpochCalled
 	parentRootCalled
+	getPTCVoteCalled
 )
 
 func _discard(t *testing.T, e error) {
@@ -302,4 +303,9 @@ func (ro *mockROForkchoice) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) (
 func (ro *mockROForkchoice) ParentRoot(_ [32]byte) ([32]byte, error) {
 	ro.calls = append(ro.calls, parentRootCalled)
 	return [32]byte{}, nil
+}
+
+func (ro *mockROForkchoice) GetPTCVote() primitives.PTCStatus {
+	ro.calls = append(ro.calls, getPTCVoteCalled)
+	return primitives.PAYLOAD_ABSENT
 }


### PR DESCRIPTION
This PR adds 

- A forkchoice helper to determine the PTC status of the current slot. 
- A `withheld` boolean to forkchoice nodes to signal that we have synced succesfully a `PAYLOAD_WITHHELD` message
- A chain info wrapper that checks on forkchoice and otherwise returns information from the current cache if it's being synced.  