### PR TITLE
Update c-kzg-4844 to v2.0.1

### DIFF
--- a/beacon-chain/blockchain/kzg/kzg.go
+++ b/beacon-chain/blockchain/kzg/kzg.go
@@ -3,7 +3,7 @@ package kzg
 import (
 	"errors"
 
-	ckzg4844 "github.com/ethereum/c-kzg-4844/bindings/go"
+	ckzg4844 "github.com/ethereum/c-kzg-4844/v2/bindings/go"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 )
 

--- a/beacon-chain/blockchain/kzg/trusted_setup.go
+++ b/beacon-chain/blockchain/kzg/trusted_setup.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 
 	GoKZG "github.com/crate-crypto/go-kzg-4844"
-	CKZG "github.com/ethereum/c-kzg-4844/bindings/go"
+	CKZG "github.com/ethereum/c-kzg-4844/v2/bindings/go"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 )

--- a/deps.bzl
+++ b/deps.bzl
@@ -857,11 +857,11 @@ def prysm_deps():
         build_directives = [
             "gazelle:resolve go github.com/supranational/blst/bindings/go @com_github_supranational_blst//:go_default_library",
         ],
-        importpath = "github.com/ethereum/c-kzg-4844",
+        importpath = "github.com/ethereum/c-kzg-4844/v2",
         patch_args = ["-p1"],
         patches = ["//third_party:com_github_ethereum_c_kzg_4844.patch"],
-        sum = "h1:GR54UuHLwl7tCA527fdLSj2Rk0aUVK8bLJZPWSIv79Q=",
-        version = "v1.0.3-0.20240715192038-0e753e2603db",
+        sum = "h1:NuErvd0Ha5gLvvZ1m9Id9UZ11kcqMBUUXsbm7yXcAYI=",
+        version = "v2.0.1",
     )
     go_repository(
         name = "com_github_ethereum_go_ethereum",

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dgraph-io/ristretto v0.0.4-0.20210318174700-74754f61e018
 	github.com/dustin/go-humanize v1.0.0
 	github.com/emicklei/dot v0.11.0
-	github.com/ethereum/c-kzg-4844 v1.0.3-0.20240715192038-0e753e2603db
+	github.com/ethereum/c-kzg-4844/v2 v2.0.1
 	github.com/ethereum/go-ethereum v1.13.5
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/fsnotify/fsnotify v1.6.0
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/afero v1.10.0
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.9.0
-	github.com/supranational/blst v0.3.11
+	github.com/supranational/blst v0.3.12
 	github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e
 	github.com/trailofbits/go-mutexasserts v0.0.0-20230328101604-8cdbc5f3d279
 	github.com/tyler-smith/go-bip39 v1.1.0
@@ -135,6 +135,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect
+	github.com/ethereum/c-kzg-4844 v1.0.3-0.20240715192038-0e753e2603db // indirect
 	github.com/ferranbt/fastssz v0.0.0-20210120143747-11b9eff30ea9 // indirect
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/c-kzg-4844 v1.0.3-0.20240715192038-0e753e2603db h1:GR54UuHLwl7tCA527fdLSj2Rk0aUVK8bLJZPWSIv79Q=
 github.com/ethereum/c-kzg-4844 v1.0.3-0.20240715192038-0e753e2603db/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
+github.com/ethereum/c-kzg-4844/v2 v2.0.1 h1:NuErvd0Ha5gLvvZ1m9Id9UZ11kcqMBUUXsbm7yXcAYI=
+github.com/ethereum/c-kzg-4844/v2 v2.0.1/go.mod h1:urP+cLBtKCW4BS5bnA2IXYs1PRGPpXmdotqpBuU6/5s=
 github.com/ethereum/go-ethereum v1.13.5 h1:U6TCRciCqZRe4FPXmy1sMGxTfuk8P7u2UoinF3VbaFk=
 github.com/ethereum/go-ethereum v1.13.5/go.mod h1:yMTu38GSuyxaYzQMViqNmQ1s3cE84abZexQmTgenWk0=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1098,8 +1100,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=
-github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.12 h1:Vfas2U2CFHhniv2QkUm2OVa1+pGTdqtpqm9NnhUUbZ8=
+github.com/supranational/blst v0.3.12/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/third_party/com_github_ethereum_c_kzg_4844.patch
+++ b/third_party/com_github_ethereum_c_kzg_4844.patch
@@ -17,7 +17,8 @@ index 7e49df7..1d476f7 100644
 +        "-Iexternal/com_github_ethereum_c_kzg_4844/src",
 +        "-Iexternal/com_github_ethereum_c_kzg_4844/bindings/go/blst_headers",
      ],
-     importpath = "github.com/ethereum/c-kzg-4844/bindings/go",
+     importpath = "github.com/ethereum/c-kzg-4844/v2/bindings/go",
+     importpath_aliases = ["github.com/ethereum/c-kzg-4844/bindings/go"],
      visibility = ["//visibility:public"],
 diff --git a/bindings/go/blst_headers/BUILD.bazel b/bindings/go/blst_headers/BUILD.bazel
 new file mode 100644
@@ -35,12 +36,9 @@ new file mode 100644
 index 0000000..b3f845d
 --- /dev/null
 +++ b/src/BUILD.bazel
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,5 @@
 +cc_library(
 +    name = "kzg",
-+    hdrs = [
-+        "c_kzg_4844.c",
-+        "c_kzg_4844.h",
-+    ],
++    hdrs = glob(["ckzg.*", "*/*.c", "*/*.h"]),
 +    visibility = ["//visibility:public"],
 +)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR updates the c-kzg-4844 dependency to the latest version:

* https://github.com/ethereum/c-kzg-4844/releases/tag/v2.0.1

**Other notes for review**

I'm pretty sure I did the patch correctly, but please double check.

The new c-kzg-4844 version uses blst v0.3.12, so that's why that changed.

Also, we split the implementation into several files, hence the updated `hdrs` line in the patch.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
