### PR TITLE
Prysm rpc: submit signed execution payload header

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_epbs.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_epbs.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// SubmitSignedExecutionPayloadEnvelope submits a signed execution payload envelope to the network.
 func (vs *Server) SubmitSignedExecutionPayloadEnvelope(ctx context.Context, env *enginev1.SignedExecutionPayloadEnvelope) (*emptypb.Empty, error) {
 	if err := vs.P2P.Broadcast(ctx, env); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to broadcast signed execution payload envelope: %v", err)
@@ -23,6 +24,17 @@ func (vs *Server) SubmitSignedExecutionPayloadEnvelope(ctx context.Context, env 
 	if err := vs.ExecutionPayloadReceiver.ReceiveExecutionPayloadEnvelope(ctx, m, nil); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to receive execution payload envelope: %v", err)
 	}
+
+	return nil, nil
+}
+
+// SubmitSignedExecutionPayloadHeader submits a signed execution payload header to the beacon node.
+func (vs *Server) SubmitSignedExecutionPayloadHeader(ctx context.Context, h *enginev1.SignedExecutionPayloadHeader) (*emptypb.Empty, error) {
+	if vs.TimeFetcher.CurrentSlot() != h.Message.Slot {
+		return nil, status.Errorf(codes.InvalidArgument, "current slot mismatch: expected %d, got %d", vs.TimeFetcher.CurrentSlot(), h.Message.Slot)
+	}
+
+	vs.signedExecutionPayloadHeader = h
 
 	return nil, nil
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_epbs_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_epbs_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	mockChain "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/testing"
 	p2ptest "github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/testing"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"github.com/prysmaticlabs/prysm/v5/testing/util"
@@ -39,5 +40,29 @@ func TestServer_SubmitSignedExecutionPayloadEnvelope(t *testing.T) {
 		}
 		_, err := s.SubmitSignedExecutionPayloadEnvelope(context.Background(), env)
 		require.ErrorContains(t, "failed to receive execution payload envelope: receive failed", err)
+	})
+}
+
+func TestServer_SubmitSignedExecutionPayloadHeader(t *testing.T) {
+	h := &enginev1.SignedExecutionPayloadHeader{
+		Message: &enginev1.ExecutionPayloadHeaderEPBS{
+			Slot: 1,
+		},
+	}
+	slot := primitives.Slot(1)
+	server := &Server{
+		TimeFetcher: &mockChain.ChainService{Slot: &slot},
+	}
+
+	t.Run("Happy case", func(t *testing.T) {
+		_, err := server.SubmitSignedExecutionPayloadHeader(context.Background(), h)
+		require.NoError(t, err)
+		require.DeepEqual(t, server.signedExecutionPayloadHeader, h)
+	})
+
+	t.Run("Incorrect slot", func(t *testing.T) {
+		h.Message.Slot = 2
+		_, err := server.SubmitSignedExecutionPayloadHeader(context.Background(), h)
+		require.ErrorContains(t, "current slot mismatch: expected 1, got 2", err)
 	})
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/network/forks"
+	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
@@ -43,44 +44,45 @@ import (
 // and committees in which particular validators need to perform their responsibilities,
 // and more.
 type Server struct {
-	Ctx                        context.Context
-	PayloadIDCache             *cache.PayloadIDCache
-	TrackedValidatorsCache     *cache.TrackedValidatorsCache
-	HeadFetcher                blockchain.HeadFetcher
-	ForkFetcher                blockchain.ForkFetcher
-	ForkchoiceFetcher          blockchain.ForkchoiceFetcher
-	GenesisFetcher             blockchain.GenesisFetcher
-	FinalizationFetcher        blockchain.FinalizationFetcher
-	TimeFetcher                blockchain.TimeFetcher
-	BlockFetcher               execution.POWBlockFetcher
-	DepositFetcher             cache.DepositFetcher
-	ChainStartFetcher          execution.ChainStartFetcher
-	Eth1InfoFetcher            execution.ChainInfoFetcher
-	OptimisticModeFetcher      blockchain.OptimisticModeFetcher
-	SyncChecker                sync.Checker
-	StateNotifier              statefeed.Notifier
-	BlockNotifier              blockfeed.Notifier
-	P2P                        p2p.Broadcaster
-	AttPool                    attestations.Pool
-	SlashingsPool              slashings.PoolManager
-	ExitPool                   voluntaryexits.PoolManager
-	SyncCommitteePool          synccommittee.Pool
-	BlockReceiver              blockchain.BlockReceiver
-	BlobReceiver               blockchain.BlobReceiver
-	PayloadAttestationReceiver blockchain.PayloadAttestationReceiver
-	ExecutionPayloadReceiver   blockchain.ExecutionPayloadReceiver
-	MockEth1Votes              bool
-	Eth1BlockFetcher           execution.POWBlockFetcher
-	PendingDepositsFetcher     depositsnapshot.PendingDepositsFetcher
-	OperationNotifier          opfeed.Notifier
-	StateGen                   stategen.StateManager
-	ReplayerBuilder            stategen.ReplayerBuilder
-	BeaconDB                   db.HeadAccessDatabase
-	ExecutionEngineCaller      execution.EngineCaller
-	BlockBuilder               builder.BlockBuilder
-	BLSChangesPool             blstoexec.PoolManager
-	ClockWaiter                startup.ClockWaiter
-	CoreService                *core.Service
+	Ctx                          context.Context
+	PayloadIDCache               *cache.PayloadIDCache
+	TrackedValidatorsCache       *cache.TrackedValidatorsCache
+	HeadFetcher                  blockchain.HeadFetcher
+	ForkFetcher                  blockchain.ForkFetcher
+	ForkchoiceFetcher            blockchain.ForkchoiceFetcher
+	GenesisFetcher               blockchain.GenesisFetcher
+	FinalizationFetcher          blockchain.FinalizationFetcher
+	TimeFetcher                  blockchain.TimeFetcher
+	BlockFetcher                 execution.POWBlockFetcher
+	DepositFetcher               cache.DepositFetcher
+	ChainStartFetcher            execution.ChainStartFetcher
+	Eth1InfoFetcher              execution.ChainInfoFetcher
+	OptimisticModeFetcher        blockchain.OptimisticModeFetcher
+	SyncChecker                  sync.Checker
+	StateNotifier                statefeed.Notifier
+	BlockNotifier                blockfeed.Notifier
+	P2P                          p2p.Broadcaster
+	AttPool                      attestations.Pool
+	SlashingsPool                slashings.PoolManager
+	ExitPool                     voluntaryexits.PoolManager
+	SyncCommitteePool            synccommittee.Pool
+	BlockReceiver                blockchain.BlockReceiver
+	BlobReceiver                 blockchain.BlobReceiver
+	PayloadAttestationReceiver   blockchain.PayloadAttestationReceiver
+	ExecutionPayloadReceiver     blockchain.ExecutionPayloadReceiver
+	MockEth1Votes                bool
+	Eth1BlockFetcher             execution.POWBlockFetcher
+	PendingDepositsFetcher       depositsnapshot.PendingDepositsFetcher
+	OperationNotifier            opfeed.Notifier
+	StateGen                     stategen.StateManager
+	ReplayerBuilder              stategen.ReplayerBuilder
+	BeaconDB                     db.HeadAccessDatabase
+	ExecutionEngineCaller        execution.EngineCaller
+	BlockBuilder                 builder.BlockBuilder
+	BLSChangesPool               blstoexec.PoolManager
+	ClockWaiter                  startup.ClockWaiter
+	CoreService                  *core.Service
+	signedExecutionPayloadHeader *enginev1.SignedExecutionPayloadHeader
 }
 
 // WaitForActivation checks if a validator public key exists in the active validator registry of the current

--- a/proto/prysm/v1alpha1/validator.proto
+++ b/proto/prysm/v1alpha1/validator.proto
@@ -356,7 +356,9 @@ service BeaconNodeValidator {
     rpc GetPayloadAttestationData(GetPayloadAttestationDataRequest) returns (PayloadAttestationData) {}
     rpc SubmitPayloadAttestation(PayloadAttestationMessage) returns (google.protobuf.Empty) {}
 
+    // ePBS RPC endpoints
     rpc SubmitSignedExecutionPayloadEnvelope(ethereum.engine.v1.SignedExecutionPayloadEnvelope) returns (google.protobuf.Empty) {}
+    rpc SubmitSignedExecutionPayloadHeader(ethereum.engine.v1.SignedExecutionPayloadHeader) returns (google.protobuf.Empty) {}
 }
 
 message GetPayloadAttestationDataRequest {

--- a/testing/mock/beacon_validator_client_mock.go
+++ b/testing/mock/beacon_validator_client_mock.go
@@ -484,26 +484,6 @@ func (mr *MockBeaconNodeValidatorClientMockRecorder) SubmitAggregateSelectionPro
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitAggregateSelectionProofElectra", reflect.TypeOf((*MockBeaconNodeValidatorClient)(nil).SubmitAggregateSelectionProofElectra), varargs...)
 }
 
-// SubmitSignedExecutionPayloadEnvelope mocks base method.
-func (m *MockBeaconNodeValidatorClient) SubmitSignedExecutionPayloadEnvelope(arg0 context.Context, arg1 *enginev1.SignedExecutionPayloadEnvelope, arg2 ...grpc.CallOption) (*emptypb.Empty, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "SubmitSignedExecutionPayloadEnvelope", varargs...)
-	ret0, _ := ret[0].(*emptypb.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SubmitSignedExecutionPayloadEnvelope indicates an expected call of SubmitSignedExecutionPayloadEnvelope.
-func (mr *MockBeaconNodeValidatorClientMockRecorder) SubmitSignedExecutionPayloadEnvelope(arg0, arg1 any, arg2 ...any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedExecutionPayloadEnvelope", reflect.TypeOf((*MockBeaconNodeValidatorClient)(nil).SubmitSignedExecutionPayloadEnvelope), varargs...)
-}
-
 // SubmitPayloadAttestation mocks base method.
 func (m *MockBeaconNodeValidatorClient) SubmitPayloadAttestation(arg0 context.Context, arg1 *eth.PayloadAttestationMessage, arg2 ...grpc.CallOption) (*emptypb.Empty, error) {
 	m.ctrl.T.Helper()
@@ -582,6 +562,26 @@ func (mr *MockBeaconNodeValidatorClientMockRecorder) SubmitSignedContributionAnd
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedContributionAndProof", reflect.TypeOf((*MockBeaconNodeValidatorClient)(nil).SubmitSignedContributionAndProof), varargs...)
+}
+
+// SubmitSignedExecutionPayloadEnvelope mocks base method.
+func (m *MockBeaconNodeValidatorClient) SubmitSignedExecutionPayloadEnvelope(arg0 context.Context, arg1 *enginev1.SignedExecutionPayloadEnvelope, arg2 ...grpc.CallOption) (*emptypb.Empty, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SubmitSignedExecutionPayloadEnvelope", varargs...)
+	ret0, _ := ret[0].(*emptypb.Empty)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubmitSignedExecutionPayloadEnvelope indicates an expected call of SubmitSignedExecutionPayloadEnvelope.
+func (mr *MockBeaconNodeValidatorClientMockRecorder) SubmitSignedExecutionPayloadEnvelope(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedExecutionPayloadEnvelope", reflect.TypeOf((*MockBeaconNodeValidatorClient)(nil).SubmitSignedExecutionPayloadEnvelope), varargs...)
 }
 
 // SubmitSyncMessage mocks base method.

--- a/testing/mock/beacon_validator_server_mock.go
+++ b/testing/mock/beacon_validator_server_mock.go
@@ -371,21 +371,6 @@ func (mr *MockBeaconNodeValidatorServerMockRecorder) SubmitAggregateSelectionPro
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitAggregateSelectionProofElectra", reflect.TypeOf((*MockBeaconNodeValidatorServer)(nil).SubmitAggregateSelectionProofElectra), arg0, arg1)
 }
 
-// SubmitSignedExecutionPayloadEnvelope mocks base method.
-func (m *MockBeaconNodeValidatorServer) SubmitSignedExecutionPayloadEnvelope(arg0 context.Context, arg1 *enginev1.SignedExecutionPayloadEnvelope) (*emptypb.Empty, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitSignedExecutionPayloadEnvelope", arg0, arg1)
-	ret0, _ := ret[0].(*emptypb.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SubmitSignedExecutionPayloadEnvelope indicates an expected call of SubmitSignedExecutionPayloadEnvelope.
-func (mr *MockBeaconNodeValidatorServerMockRecorder) SubmitSignedExecutionPayloadEnvelope(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedExecutionPayloadEnvelope", reflect.TypeOf((*MockBeaconNodeValidatorServer)(nil).SubmitSignedExecutionPayloadEnvelope), arg0, arg1)
-}
-
 // SubmitPayloadAttestation mocks base method.
 func (m *MockBeaconNodeValidatorServer) SubmitPayloadAttestation(arg0 context.Context, arg1 *eth.PayloadAttestationMessage) (*emptypb.Empty, error) {
 	m.ctrl.T.Helper()
@@ -444,6 +429,21 @@ func (m *MockBeaconNodeValidatorServer) SubmitSignedContributionAndProof(arg0 co
 func (mr *MockBeaconNodeValidatorServerMockRecorder) SubmitSignedContributionAndProof(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedContributionAndProof", reflect.TypeOf((*MockBeaconNodeValidatorServer)(nil).SubmitSignedContributionAndProof), arg0, arg1)
+}
+
+// SubmitSignedExecutionPayloadEnvelope mocks base method.
+func (m *MockBeaconNodeValidatorServer) SubmitSignedExecutionPayloadEnvelope(arg0 context.Context, arg1 *enginev1.SignedExecutionPayloadEnvelope) (*emptypb.Empty, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubmitSignedExecutionPayloadEnvelope", arg0, arg1)
+	ret0, _ := ret[0].(*emptypb.Empty)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubmitSignedExecutionPayloadEnvelope indicates an expected call of SubmitSignedExecutionPayloadEnvelope.
+func (mr *MockBeaconNodeValidatorServerMockRecorder) SubmitSignedExecutionPayloadEnvelope(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedExecutionPayloadEnvelope", reflect.TypeOf((*MockBeaconNodeValidatorServer)(nil).SubmitSignedExecutionPayloadEnvelope), arg0, arg1)
 }
 
 // SubmitSyncMessage mocks base method.


### PR DESCRIPTION
This PR adds a Prysm RPC endpoint for the validator to submit a signed execution payload header. The beacon node will cache the signed execution payload header, with the condition that the slot must be the current slot, and only one header will be cached, updating to the latest one