### PR TITLE
E2E: fixing builder route registration after gorilla mux removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - `api-timeout` is changed from int flag to duration flag, default value updated.
 - Light client support: abstracted out the light client headers with different versions.
 - `ApplyToEveryValidator` has been changed to prevent misuse bugs, it takes a closure that takes a `ReadOnlyValidator` and returns a raw pointer to a `Validator`. 
--  Removed gorilla mux library and replaced it with net/http updates in go 1.22
+- Removed gorilla mux library and replaced it with net/http updates in go 1.22.
 
 ### Deprecated
 - `--disable-grpc-gateway` flag is deprecated due to grpc gateway removal.

--- a/testing/middleware/builder/BUILD.bazel
+++ b/testing/middleware/builder/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//api/client/builder:go_default_library",
         "//api/server/structs:go_default_library",
         "//beacon-chain/core/signing:go_default_library",
+        "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",

--- a/testing/middleware/builder/builder.go
+++ b/testing/middleware/builder/builder.go
@@ -24,6 +24,7 @@ import (
 	builderAPI "github.com/prysmaticlabs/prysm/v5/api/client/builder"
 	"github.com/prysmaticlabs/prysm/v5/api/server/structs"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/signing"
+	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
@@ -38,10 +39,10 @@ import (
 )
 
 const (
-	statusPath   = "/eth/v1/builder/status"
-	registerPath = "/eth/v1/builder/validators"
-	headerPath   = "/eth/v1/builder/header/{slot:[0-9]+}/{parent_hash:0x[a-fA-F0-9]+}/{pubkey:0x[a-fA-F0-9]+}"
-	blindedPath  = "/eth/v1/builder/blinded_blocks"
+	statusPath   = "GET /eth/v1/builder/status"
+	registerPath = "POST /eth/v1/builder/validators"
+	headerPath   = "GET /eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}"
+	blindedPath  = "POST /eth/v1/builder/blinded_blocks"
 
 	// ForkchoiceUpdatedMethod v1 request string for JSON-RPC.
 	ForkchoiceUpdatedMethod = "engine_forkchoiceUpdatedV1"
@@ -306,6 +307,11 @@ func (p *Builder) handleHeaderRequest(w http.ResponseWriter, req *http.Request) 
 		http.Error(w, "no valid parent hash", http.StatusBadRequest)
 		return
 	}
+	_, err := bytesutil.DecodeHexWithLength(pHash, common.HashLength)
+	if err != nil {
+		http.Error(w, "invalid parent hash", http.StatusBadRequest)
+		return
+	}
 	reqSlot := req.PathValue("slot")
 	if reqSlot == "" {
 		http.Error(w, "no valid slot provided", http.StatusBadRequest)
@@ -314,6 +320,16 @@ func (p *Builder) handleHeaderRequest(w http.ResponseWriter, req *http.Request) 
 	slot, err := strconv.Atoi(reqSlot)
 	if err != nil {
 		http.Error(w, "invalid slot provided", http.StatusBadRequest)
+		return
+	}
+	reqPubkey := req.PathValue("pubkey")
+	if reqPubkey == "" {
+		http.Error(w, "no valid pubkey provided", http.StatusBadRequest)
+		return
+	}
+	_, err = bytesutil.DecodeHexWithLength(reqPubkey, fieldparams.BLSPubkeyLength)
+	if err != nil {
+		http.Error(w, "invalid pubkey", http.StatusBadRequest)
 		return
 	}
 	ax := types.Slot(slot)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

PR https://github.com/prysmaticlabs/prysm/pull/14416 removed gorilla mux which included a regex pathing feature that now broke post upgrade. This PR migrates the builder API registration to something that is supported by the standard HTTP package.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
