### PR TITLE
Peerdas: Full subnet sampling and `sendBatchRootRequest` fix.

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -546,7 +546,7 @@ func missingDataColumns(bs *filesystem.BlobStorage, root [32]byte, expected map[
 // closed, the context hits cancellation/timeout, or notifications have been received for all the missing sidecars.
 func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed interfaces.ReadOnlySignedBeaconBlock) error {
 	if coreTime.PeerDASIsActive(signed.Block().Slot()) {
-		return s.isDataColumnsAvailable(ctx, root, signed)
+		return s.areDataColumnsAvailable(ctx, root, signed)
 	}
 
 	if signed.Version() < version.Deneb {
@@ -625,7 +625,17 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 	}
 }
 
-func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, signed interfaces.ReadOnlySignedBeaconBlock) error {
+// uint64MapToSortedSlice produces a sorted uint64 slice from a map.
+func uint64MapToSortedSlice(input map[uint64]bool) []uint64 {
+	output := make([]uint64, 0, len(input))
+	for idx := range input {
+		output = append(output, idx)
+	}
+	slices.Sort[[]uint64](output)
+	return output
+}
+
+func (s *Service) areDataColumnsAvailable(ctx context.Context, root [32]byte, signed interfaces.ReadOnlySignedBeaconBlock) error {
 	if signed.Version() < version.Deneb {
 		return nil
 	}
@@ -704,25 +714,27 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 	nextSlot := slots.BeginsAt(signed.Block().Slot()+1, s.genesisTime)
 	// Avoid logging if DA check is called after next slot start.
 	if nextSlot.After(time.Now()) {
-		// Compute sorted slice of expected columns.
-		expected := make([]uint64, 0, len(colMap))
-		for col := range colMap {
-			expected = append(expected, col)
-		}
-
-		slices.Sort[[]uint64](expected)
-
-		// Compute sorted slice of missing columns.
-		missing := make([]uint64, 0, len(missingMap))
-		for col := range missingMap {
-			missing = append(missing, col)
-		}
-
-		slices.Sort[[]uint64](missing)
-
 		nst := time.AfterFunc(time.Until(nextSlot), func() {
-			if len(missingMap) == 0 {
+			missingMapCount := uint64(len(missingMap))
+
+			if missingMapCount == 0 {
 				return
+			}
+
+			var (
+				expected interface{} = "all"
+				missing  interface{} = "all"
+			)
+
+			numberOfColumns := params.BeaconConfig().NumberOfColumns
+			colMapCount := uint64(len(colMap))
+
+			if colMapCount < numberOfColumns {
+				expected = uint64MapToSortedSlice(colMap)
+			}
+
+			if missingMapCount < numberOfColumns {
+				missing = uint64MapToSortedSlice(missingMap)
 			}
 
 			log.WithFields(logrus.Fields{
@@ -730,8 +742,9 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 				"root":            fmt.Sprintf("%#x", root),
 				"columnsExpected": expected,
 				"columnsWaiting":  missing,
-			}).Error("Still waiting for data columns DA check at slot end.")
+			}).Error("Some data columns are still unavailable at slot end.")
 		})
+
 		defer nst.Stop()
 	}
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -548,6 +548,7 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 	if coreTime.PeerDASIsActive(signed.Block().Slot()) {
 		return s.isDataColumnsAvailable(ctx, root, signed)
 	}
+
 	if signed.Version() < version.Deneb {
 		return nil
 	}
@@ -653,7 +654,12 @@ func (s *Service) isDataColumnsAvailable(ctx context.Context, root [32]byte, sig
 		return nil
 	}
 
-	colMap, err := peerdas.CustodyColumns(s.cfg.P2P.NodeID(), peerdas.CustodySubnetCount())
+	// All columns to sample need to be available for the block to be considered available.
+	// https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip7594/das-core.md#subnet-sampling
+	nodeID := s.cfg.P2P.NodeID()
+	subnetSamplingSize := peerdas.SubnetSamplingSize()
+
+	colMap, err := peerdas.CustodyColumns(nodeID, subnetSamplingSize)
 	if err != nil {
 		return errors.Wrap(err, "custody columns")
 	}

--- a/beacon-chain/core/peerdas/helpers.go
+++ b/beacon-chain/core/peerdas/helpers.go
@@ -431,11 +431,20 @@ func VerifyDataColumnSidecarKZGProofs(sc blocks.RODataColumn) (bool, error) {
 
 // CustodySubnetCount returns the number of subnets the node should participate in for custody.
 func CustodySubnetCount() uint64 {
-	count := params.BeaconConfig().CustodyRequirement
 	if flags.Get().SubscribeToAllSubnets {
-		count = params.BeaconConfig().DataColumnSidecarSubnetCount
+		return params.BeaconConfig().DataColumnSidecarSubnetCount
 	}
-	return count
+
+	return params.BeaconConfig().CustodyRequirement
+}
+
+// SubnetSamplingSize returns the number of subnets the node should sample from.
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip7594/das-core.md#subnet-sampling
+func SubnetSamplingSize() uint64 {
+	samplesPerSlot := params.BeaconConfig().SamplesPerSlot
+	custodySubnetCount := CustodySubnetCount()
+
+	return max(samplesPerSlot, custodySubnetCount)
 }
 
 // CustodyColumnCount returns the number of columns the node should custody.

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -380,7 +380,8 @@ func (s *Service) createLocalNode(
 	}
 
 	if params.PeerDASEnabled() {
-		localNode.Set(peerdas.Csc(peerdas.CustodySubnetCount()))
+		custodySubnetCount := peerdas.CustodySubnetCount()
+		localNode.Set(peerdas.Csc(custodySubnetCount))
 	}
 
 	localNode.SetFallbackIP(ipAddr)

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -306,55 +306,106 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 	ctx, span := trace.StartSpan(ctx, "sendBatchRootRequest")
 	defer span.End()
 
-	roots = dedupRoots(roots)
-	s.pendingQueueLock.RLock()
-	for i := len(roots) - 1; i >= 0; i-- {
-		r := roots[i]
-		if s.seenPendingBlocks[r] || s.cfg.chain.BlockBeingSynced(r) {
-			roots = append(roots[:i], roots[i+1:]...)
-		} else {
-			log.WithField("blockRoot", fmt.Sprintf("%#x", r)).Debug("Requesting block by root")
-		}
-	}
-	s.pendingQueueLock.RUnlock()
-
+	// Exit early if there are no roots to request.
 	if len(roots) == 0 {
 		return nil
 	}
-	bestPeers := s.getBestPeers()
-	if len(bestPeers) == 0 {
+
+	// Remove duplicates (if any) from the list of roots.
+	roots = dedupRoots(roots)
+
+	// Reversly iterate through the list of roots to request blocks, and filter out roots that are already
+	// seen in pending blocks or being synced.
+	func() {
+		s.pendingQueueLock.RLock()
+		defer s.pendingQueueLock.RUnlock()
+
+		for i := len(roots) - 1; i >= 0; i-- {
+			r := roots[i]
+			if s.seenPendingBlocks[r] || s.cfg.chain.BlockBeingSynced(r) {
+				roots = append(roots[:i], roots[i+1:]...)
+				continue
+			}
+
+			log.WithField("blockRoot", fmt.Sprintf("%#x", r)).Debug("Requesting block by root")
+		}
+	}()
+
+	// Nothing to do, exit early.
+	if len(roots) == 0 {
 		return nil
 	}
-	// Randomly choose a peer to query from our best peers. If that peer cannot return
-	// all the requested blocks, we randomly select another peer.
-	pid := bestPeers[randGen.Int()%len(bestPeers)]
-	for i := 0; i < numOfTries; i++ {
+
+	// Fetch best peers to request blocks from.
+	bestPeers := s.getBestPeers()
+
+	// No suitable peer, exit early.
+	if len(bestPeers) == 0 {
+		log.WithField("roots", fmt.Sprintf("%#x", roots)).Debug("Send batch root request: No suited peers")
+		return nil
+	}
+
+	// Randomly choose a peer to query from our best peers.
+	// If that peer cannot return all the requested blocks,
+	// we randomly select another peer.
+	randomIndex := randGen.Int() % len(bestPeers)
+	pid := bestPeers[randomIndex]
+
+	for range numOfTries {
 		req := p2ptypes.BeaconBlockByRootsReq(roots)
-		currentEpoch := slots.ToEpoch(s.cfg.clock.CurrentSlot())
+
+		// Get the current epoch.
+		currentSlot := s.cfg.clock.CurrentSlot()
+		currentEpoch := slots.ToEpoch(currentSlot)
+
+		// Trim the request to the maximum number of blocks we can request if needed.
 		maxReqBlock := params.MaxRequestBlock(currentEpoch)
-		if uint64(len(roots)) > maxReqBlock {
+		rootCount := uint64(len(roots))
+		if rootCount > maxReqBlock {
 			req = roots[:maxReqBlock]
 		}
+
+		// Send the request to the peer.
 		if err := s.sendRecentBeaconBlocksRequest(ctx, &req, pid); err != nil {
 			tracing.AnnotateError(span, err)
 			log.WithError(err).Debug("Could not send recent block request")
 		}
-		newRoots := make([][32]byte, 0, len(roots))
-		s.pendingQueueLock.RLock()
-		for _, rt := range roots {
-			if !s.seenPendingBlocks[rt] {
-				newRoots = append(newRoots, rt)
+
+		// Filter out roots that are already seen in pending blocks.
+		newRoots := make([][32]byte, 0, rootCount)
+		func() {
+			s.pendingQueueLock.RLock()
+			defer s.pendingQueueLock.RUnlock()
+
+			for _, rt := range roots {
+				if !s.seenPendingBlocks[rt] {
+					newRoots = append(newRoots, rt)
+				}
 			}
-		}
-		s.pendingQueueLock.RUnlock()
+		}()
+
+		// Exit early if all roots have been seen.
+		// This is the happy path.
 		if len(newRoots) == 0 {
-			break
+			return nil
 		}
-		// Choosing a new peer with the leftover set of
-		// roots to request.
+
+		// There is still some roots that have not been seen.
+		// Choosing a new peer with the leftover set of oots to request.
 		roots = newRoots
-		pid = bestPeers[randGen.Int()%len(bestPeers)]
+
+		// Choose a new peer to query.
+		randomIndex = randGen.Int() % len(bestPeers)
+		pid = bestPeers[randomIndex]
 	}
+
+	// Some roots are still missing after all allowed tries.
+	// This is the unhappy path.
+	log.WithFields(logrus.Fields{
+		"roots": fmt.Sprintf("%#x", roots),
+		"tries": numOfTries,
+	}).Debug("Send batch root request: Some roots are still missing after all allowed tries")
+
 	return nil
 }
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -170,7 +170,6 @@ type Service struct {
 	receivedDataColumnsFromRoot      map[[fieldparams.RootLength]byte]map[uint64]bool
 	receivedDataColumnsFromRootLock  sync.RWMutex
 	ctxMap                           ContextByteVersions
-	sampler                          DataColumnSampler
 }
 
 // NewService initializes new regular sync service.
@@ -359,12 +358,6 @@ func (s *Service) startTasksPostInitialSync() {
 
 		// Start the fork watcher.
 		go s.forkWatcher()
-
-		// Start data columns sampling if peerDAS is enabled.
-		if params.PeerDASEnabled() {
-			s.sampler = newDataColumnSampler1D(s.cfg.p2p, s.cfg.clock, s.ctxMap, s.cfg.stateNotifier, s.newColumnVerifier)
-			go s.sampler.Run(s.ctx)
-		}
 
 	case <-s.ctx.Done():
 		log.Debug("Context closed, exiting goroutine")


### PR DESCRIPTION
**Please read commit by commit.**

This PR:
- For columns, stops using peer sampling and use subnet sampling only.
- Modifies `sendBatchRootRequest` so we stop sending columns by root requests to peers which do not custody them.
- Improve logs

Full node logs - subscribed to `SAMPLES_PER_SLOT` (8) subnets:

```
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_84/ssz_snappy
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_63/ssz_snappy
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_31/ssz_snappy
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_29/ssz_snappy
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_47/ssz_snappy
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_30/ssz_snappy
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_114/ssz_snappy
[2024-09-14 12:38:06.00]  INFO sync: Subscribed to topic=/eth2/aabc67ec/data_column_sidecar_61/ssz_snappy
```

Full node `csc` - still `custody_subnet_count` (4):

```
decode-enr enr:-Me4QG6Zhq7YBe64kwuYdEPbVIM-hKL2QjlOmt1uivJ7ssFtWsZdOPzMYbYqtA5gXAStajhEvmXcwI7iFEWudvJ8d0SGAZHwihpAh2F0dG5ldHOIAAAAAAAAAGCDY3NjBIRldGgykKq8Z-xgAAA4AOH1BQAAAACCaWSCdjSCaXCErBAAE4lzZWNwMjU2azGhAuHvKn4kLVZbhwPbuDOxN1ApUGxnmxEhc2FUTBq2Q1U2iHN5bmNuZXRzD4N0Y3CCMsiDdWRwgjLI

Sequence number: 1726317468224
Signature: 0x6e9986aed805eeb8930b987443db54833e84a2f642394e9add6e8af27bb2c16d5ac65d38fccc61b62ab40e605c04ad6a3844be65dcc08ee21445ae76f27c7744
Node ID: 0xc8b9fb8e513d8007063b9170aa4d532a29388262caca54cdb444f03bb8aa082c

                                      Entries
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃       Key ┃ Value                                                                ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│   attnets │ 0x0000000000000060                                                   │
│       csc │ 4                                                                    │
│      eth2 │ 0xaabc67ec6000003800e1f50500000000                                   │
│        id │ v4                                                                   │
│        ip │ 172.16.0.19                                                          │
│ secp256k1 │ 0x02e1ef2a7e242d565b8703dbb833b1375029506c679b11217361544c1ab6435536 │
│  syncnets │ 0x0f                                                                 │
│       tcp │ 13000                                                                │
│       udp │ 13000                                                                │
└───────────┴──────────────────────────────────────────────────────────────────────┘
Warning: The ENR contains invalid leading zeroes.
```

(Same for `custody_subnet_count` in `MetadataV3`.)

No change for super node (`csc` is 128 and the node is subscribed to all data column subnets).