### PR TITLE
Switch to compounding when consolidating with source==target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Updated k8s-io/client-go to v0.30.4 and k8s-io/apimachinery to v0.30.4
 - Migrated tracing library from opencensus to opentelemetry for both the beacon node and validator.
 - Refactored light client code to make it more readable and make future PRs easier.
+- Switch to compounding when consolidating with source==target.
 
 ### Deprecated
 - `--disable-grpc-gateway` flag is deprecated due to grpc gateway removal.

--- a/beacon-chain/core/electra/validator.go
+++ b/beacon-chain/core/electra/validator.go
@@ -3,7 +3,6 @@ package electra
 import (
 	"errors"
 
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
@@ -78,12 +77,10 @@ func ValidatorFromDeposit(pubKey []byte, withdrawalCredentials []byte) *ethpb.Va
 // SwitchToCompoundingValidator
 //
 // Spec definition:
-//
 //	 def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -> None:
 //		validator = state.validators[index]
-//		if has_eth1_withdrawal_credential(validator):
-//		    validator.withdrawal_credentials = COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
-//		    queue_excess_active_balance(state, index)
+//		validator.withdrawal_credentials = COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
+//		queue_excess_active_balance(state, index)
 func SwitchToCompoundingValidator(s state.BeaconState, idx primitives.ValidatorIndex) error {
 	v, err := s.ValidatorAtIndex(idx)
 	if err != nil {
@@ -92,14 +89,12 @@ func SwitchToCompoundingValidator(s state.BeaconState, idx primitives.ValidatorI
 	if len(v.WithdrawalCredentials) == 0 {
 		return errors.New("validator has no withdrawal credentials")
 	}
-	if helpers.HasETH1WithdrawalCredential(v) {
-		v.WithdrawalCredentials[0] = params.BeaconConfig().CompoundingWithdrawalPrefixByte
-		if err := s.UpdateValidatorAtIndex(idx, v); err != nil {
-			return err
-		}
-		return QueueExcessActiveBalance(s, idx)
+
+	v.WithdrawalCredentials[0] = params.BeaconConfig().CompoundingWithdrawalPrefixByte
+	if err := s.UpdateValidatorAtIndex(idx, v); err != nil {
+		return err
 	}
-	return nil
+	return QueueExcessActiveBalance(s, idx)
 }
 
 // QueueExcessActiveBalance queues validators with balances above the min activation balance and adds to pending balance deposit.


### PR DESCRIPTION
This PR modifies the handling of switching validators to compounding credentials by consolidating the logic into the `process_consolidation_request` flow. Key code changes include:

- Removed `switch_to_compounding_validator` from `process_pending_consolidations`.
- Removed `switch_to_compounding_validator` from `apply_deposit`.
- Added a helper function `is_valid_switch_to_compounding_request`.
- Updated `process_consolidation_request` to check `is_valid_switch_to_compounding_request`, and if valid, switch the source index validator to compounding.
- Updated `process_consolidation_request` to automatically switch the target validator to compounding if it has an eth1 credential.

Reference: https://github.com/ethereum/consensus-specs/pull/3918