### PR TITLE
Deprecate `pb.gw.go` files

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -26,7 +26,6 @@ approval_rules:
       only_changed_files:
         paths:
           - "*pb.go"
-          - "*pb.gw.go"
           - "*.bazel"
     options:
       ignore_commits_by:
@@ -69,7 +68,6 @@ approval_rules:
       changed_files:
         ignore:
           - "*pb.go"
-          - "*pb.gw.go"
           - "*.bazel"
     options:
       ignore_commits_by:

--- a/hack/README.md
+++ b/hack/README.md
@@ -5,6 +5,6 @@ This subproject contains useful bash scripts for working with our repository. We
 
 ## update-go-pbs.sh
 
-This script generates the *.pb.go and *.pb.gw.go files from the *.proto files.
-After running `update-go-pbs.sh` keep only the *.pb.go and *pb.gw.go for the protos that have changed before checking in.
+This script generates the *.pb.go files from the *.proto files.
+After running `update-go-pbs.sh` keep only the *.pb.go for the protos that have changed before checking in.
 *Note*: the generated files may not have imports correctly linted and will need to be fixed to remote associated errors. 

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -19,7 +19,7 @@ cygwin*) system="windows" ;;
 esac
 readonly system
 
-# Get locations of pb.go and pb.gw.go files.
+# Get locations of pb.go files.
 findutil="find"
 # On OSX `find` is not GNU find compatible, so require "findutils" package.
 if [ "$system" == "darwin" ]; then

--- a/hack/update-go-pbs.sh
+++ b/hack/update-go-pbs.sh
@@ -9,7 +9,7 @@ bazel query 'attr(testonly, 0, //proto/...)' | xargs bazel build $@
 file_list=()
 while IFS= read -d $'\0' -r file; do
     file_list=("${file_list[@]}" "$file")
-done < <($findutil -L "$(bazel info bazel-bin)"/proto -type f -regextype sed -regex ".*pb\.\(gw\.\)\?go$" -print0)
+done < <($findutil -L "$(bazel info bazel-bin)"/proto -type f -regextype sed -regex ".*pb\.go$" -print0)
 
 arraylength=${#file_list[@]}
 searchstring="prysmaticlabs/prysm/v5/"

--- a/proto/eth/v1/attestation.pb.gw.go
+++ b/proto/eth/v1/attestation.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v1/beacon_block.pb.gw.go
+++ b/proto/eth/v1/beacon_block.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v1/beacon_chain.pb.gw.go
+++ b/proto/eth/v1/beacon_chain.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v1/events.pb.gw.go
+++ b/proto/eth/v1/events.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v1/node.pb.gw.go
+++ b/proto/eth/v1/node.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v1/validator.pb.gw.go
+++ b/proto/eth/v1/validator.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/beacon_block.pb.gw.go
+++ b/proto/eth/v2/beacon_block.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/beacon_chain.pb.gw.go
+++ b/proto/eth/v2/beacon_chain.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/beacon_lightclient.pb.gw.go
+++ b/proto/eth/v2/beacon_lightclient.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/custom.go
+++ b/proto/eth/v2/custom.go
@@ -3,8 +3,9 @@ package eth
 import (
 	"bytes"
 	"fmt"
-	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
 	"math/bits"
+
+	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
 
 	v1 "github.com/prysmaticlabs/prysm/v5/proto/eth/v1"
 )

--- a/proto/eth/v2/ssz.pb.gw.go
+++ b/proto/eth/v2/ssz.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/sync_committee.pb.gw.go
+++ b/proto/eth/v2/sync_committee.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/validator.pb.gw.go
+++ b/proto/eth/v2/validator.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/version.pb.gw.go
+++ b/proto/eth/v2/version.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore

--- a/proto/eth/v2/withdrawals.pb.gw.go
+++ b/proto/eth/v2/withdrawals.pb.gw.go
@@ -1,4 +1,0 @@
-//go:build ignore
-// +build ignore
-
-package ignore


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

_*Farewell to gateway files*_

#14089 deprecates `*pb.gw.go` files, but there are some dregs around `*pb.gw.go` file supports. This PR fully deprecates those supports, which will help newcomers investigate this project.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
