### PR TITLE
Add Electra case for GetBeaconStateV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Light client support: Add light client database changes.
 - Light client support: Implement capella and deneb changes.
 - Light client support: Implement `BlockToLightClientHeaderXXX` functions upto Deneb
+- GetBeaconStateV2: add Electra case.
 
 ### Changed
 
@@ -2673,7 +2674,7 @@ on your validators.
 **Beacon chain node**
 
 | Metric                                           | Description                                                                                           | References |
-|--------------------------------------------------|-------------------------------------------------------------------------------------------------------|------------|
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ---------- |
 | `p2p_message_ignored_validation_total`           | Count of messages that were ignored in validation                                                     |            |
 | `beacon_current_active_validators`               | Current total active validators                                                                       |            |
 | `beacon_processed_deposits_total`                | Total number of deposits processed                                                                    |            |
@@ -2724,9 +2725,9 @@ on your validators.
 #### Changed Metrics
 
 **Beacon chain node**
-| Metric | Old Name | Description | References |
-|-----------------------|----------------------|------------------------------------------------------|------------|
-| `beacon_reorgs_total` | `beacon_reorg_total` | Count the number of times a beacon chain has a reorg | |
+| Metric                | Old Name             | Description                                          | References |
+| --------------------- | -------------------- | ---------------------------------------------------- | ---------- |
+| `beacon_reorgs_total` | `beacon_reorg_total` | Count the number of times a beacon chain has a reorg |            |
 
 ### Deprecated
 

--- a/beacon-chain/rpc/eth/debug/handlers.go
+++ b/beacon-chain/rpc/eth/debug/handlers.go
@@ -88,6 +88,12 @@ func (s *Server) getBeaconStateV2(ctx context.Context, w http.ResponseWriter, id
 			httputil.HandleError(w, errMsgStateFromConsensus+": "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+	case version.Electra:
+		respSt, err = structs.BeaconStateElectraFromConsensus(st)
+		if err != nil {
+			httputil.HandleError(w, errMsgStateFromConsensus+": "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 	default:
 		httputil.HandleError(w, "Unsupported state version", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR addresses an issue when trying `/eth/v2/debug/beacon/states/{state_id}`. Since `version.Electra` is not in the case, it will return "Unsupported spec version" after Electra fork epoch.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
