### PR TITLE
Add POST `/eth/v2/beacon/pool/attester_slashings`

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -690,6 +690,16 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodPost},
 		},
 		{
+			template: "/eth/v2/beacon/pool/attester_slashings",
+			name:     namespace + ".SubmitAttesterSlashing",
+			middleware: []middleware.Middleware{
+				middleware.ContentTypeHandler([]string{api.JsonMediaType}),
+				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
+			},
+			handler: server.SubmitAttesterSlashingV2,
+			methods: []string{http.MethodPost},
+		},
+		{
 			template: "/eth/v1/beacon/pool/proposer_slashings",
 			name:     namespace + ".GetProposerSlashings",
 			middleware: []middleware.Middleware{

--- a/beacon-chain/rpc/endpoints_test.go
+++ b/beacon-chain/rpc/endpoints_test.go
@@ -40,6 +40,7 @@ func Test_endpoints(t *testing.T) {
 		"/eth/v1/beacon/blinded_blocks/{block_id}":                   {http.MethodGet},
 		"/eth/v1/beacon/pool/attestations":                           {http.MethodGet, http.MethodPost},
 		"/eth/v1/beacon/pool/attester_slashings":                     {http.MethodGet, http.MethodPost},
+		"/eth/v2/beacon/pool/attester_slashings":                     {http.MethodPost},
 		"/eth/v1/beacon/pool/proposer_slashings":                     {http.MethodGet, http.MethodPost},
 		"/eth/v1/beacon/pool/sync_committees":                        {http.MethodPost},
 		"/eth/v1/beacon/pool/voluntary_exits":                        {http.MethodGet, http.MethodPost},


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Beacon API Electra alignment, add missing endpoint for `/eth/v2/beacon/blocks/{block_id}/attestations`.
As described in the spec https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttesterSlashingsV2

**Which issues(s) does this PR fix?**

Part of #14476

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
