### PR TITLE
PeerDAS: Fix initial sync with super nodes

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -1018,7 +1018,8 @@ func (f *blocksFetcher) retrieveMissingDataColumnsFromPeers(
 	peers []peer.ID,
 ) error {
 	const (
-		delay = 5 * time.Second
+		delay     = 5 * time.Second
+		batchSize = 512
 	)
 
 	start := time.Now()
@@ -1056,6 +1057,11 @@ func (f *blocksFetcher) retrieveMissingDataColumnsFromPeers(
 
 		if missingDataColumnsCount < numberOfColumns {
 			requestedColumnsLog = missingDataColumnsSlice
+		}
+
+		// Reduce blocks count until the total number of elements is less than the batch size.
+		for missingDataColumnsCount*blocksCount > batchSize {
+			blocksCount /= 2
 		}
 
 		// Filter peers.

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -354,14 +354,14 @@ func SendDataColumnsByRangeRequest(
 		columnsLog = columns
 	}
 
-	log.WithFields(logrus.Fields{
+	log := log.WithFields(logrus.Fields{
 		"peer":       pid,
 		"topic":      topic,
 		"startSlot":  req.StartSlot,
 		"count":      req.Count,
 		"columns":    columnsLog,
 		"totalCount": req.Count * uint64(len(req.Columns)),
-	}).Debug("Sending data column by range request")
+	})
 
 	stream, err := p2pApi.Send(ctx, req, topic, pid)
 	if err != nil {
@@ -391,19 +391,19 @@ func SendDataColumnsByRangeRequest(
 		}
 
 		if err != nil {
-			log.WithError(err).WithField("peer", pid).Debug("Error reading chunked data column sidecar")
+			log.WithError(err).Debug("Error reading chunked data column sidecar")
 			break
 		}
 
 		if roDataColumn == nil {
-			log.WithError(err).WithField("peer", pid).Debug("Validation error")
+			log.WithError(err).Debug("Validation error")
 			continue
 		}
 
 		if i >= max {
 			// The response MUST contain no more than `reqCount` blocks.
 			// (`reqCount` is already capped by `maxRequestDataColumnSideCar`.)
-			log.WithError(err).WithField("peer", pid).Debug("Response contains more data column sidecars than maximum")
+			log.WithError(err).Debug("Response contains more data column sidecars than maximum")
 			break
 		}
 

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -191,7 +191,7 @@ func (s *Service) reValidatePeer(ctx context.Context, id peer.ID) error {
 	}
 	// Do not return an error for ping requests.
 	if err := s.sendPingRequest(ctx, id); err != nil && !isUnwantedError(err) {
-		log.WithError(err).Debug("Could not ping peer")
+		log.WithError(err).WithField("pid", id).Debug("Could not ping peer")
 	}
 	return nil
 }


### PR DESCRIPTION
**Please read commit by commit.**

Mainly, this pull request reduces any data columns by range requests to 512 items.
This value lets all other clients enough time to respond and does not trigger "too large request" error response.