### PR TITLE
fix: fix slice init length

### DIFF
--- a/runtime/interop/generate_keys.go
+++ b/runtime/interop/generate_keys.go
@@ -64,7 +64,7 @@ func deterministicallyGenerateKeys(startIndex, numKeys uint64) ([]bls.SecretKey,
 		numBytes := num.Bytes()
 		// pad key at the start with zero bytes to make it into a 32 byte key
 		if len(numBytes) < 32 {
-			emptyBytes := make([]byte, 32-len(numBytes))
+			emptyBytes := make([]byte, 0, 32-len(numBytes))
 			numBytes = append(emptyBytes, numBytes...)
 		}
 		priv, err := bls.SecretKeyFromBytes(numBytes)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**


> Bug fix


**What does this PR do? Why is it needed?**

The intention here should be to initialize a slice with a capacity of `32-len(numBytes)` rather than initializing the length of this slice. 


The only demo: https://go.dev/play/p/q1BcVCmvidW



**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
