### PR TITLE
Flip committee aware packing flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Update light client helper functions to reference `dev` branch of CL specs
 - Updated Libp2p Dependencies to allow prysm to use gossipsub v1.2 .
 - Updated Sepolia bootnodes.
+- Make committee aware packing the default by deprecating `--enable-committee-aware-packing`.
 
 ### Deprecated
 - `--disable-grpc-gateway` flag is deprecated due to grpc gateway removal.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -217,10 +217,10 @@ func (a proposerAtts) sort() (proposerAtts, error) {
 		return a, nil
 	}
 
-	if features.Get().EnableCommitteeAwarePacking {
-		return a.sortBySlotAndCommittee()
+	if features.Get().DisableCommitteeAwarePacking {
+		return a.sortByProfitabilityUsingMaxCover()
 	}
-	return a.sortByProfitabilityUsingMaxCover()
+	return a.sortBySlotAndCommittee()
 }
 
 // Separate attestations by slot, as slot number takes higher precedence when sorting.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -21,6 +21,11 @@ import (
 )
 
 func TestProposer_ProposerAtts_sort(t *testing.T) {
+	feat := features.Get()
+	feat.DisableCommitteeAwarePacking = true
+	reset := features.InitWithReset(feat)
+	defer reset()
+
 	type testData struct {
 		slot primitives.Slot
 		bits bitfield.Bitlist
@@ -35,11 +40,6 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	}
 
 	t.Run("no atts", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{})
 		want := getAtts([]testData{})
 		atts, err := atts.sort()
@@ -50,11 +50,6 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("single att", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
 		})
@@ -69,11 +64,6 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("single att per slot", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -90,11 +80,6 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("two atts on one of the slots", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -116,11 +101,6 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 		// The max-cover based approach will select 0b00001100 instead, despite lower bit count
 		// (since it has two new/unknown bits).
 		t.Run("max-cover", func(t *testing.T) {
-			feat := features.Get()
-			feat.DisableCommitteeAwarePacking = true
-			reset := features.InitWithReset(feat)
-			defer reset()
-
 			atts := getAtts([]testData{
 				{1, bitfield.Bitlist{0b11000011, 0b1}},
 				{1, bitfield.Bitlist{0b11001000, 0b1}},
@@ -140,11 +120,6 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("multiple slots", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{2, bitfield.Bitlist{0b11100000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -169,11 +144,6 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("follows max-cover", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		// Items at slot 4, must be first split into two lists by max-cover, with
 		// 0b10000011 scoring higher (as it provides more info in addition to already selected
 		// attestations) than 0b11100001 (despite naive bit count suggesting otherwise). Then,
@@ -261,6 +231,11 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("two atts on one of the slots", func(t *testing.T) {
+		p := features.Get().DisableCommitteeAwarePacking
+		if p == true {
+
+		}
+
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -350,11 +325,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 
 func TestProposer_sort_DifferentCommittees(t *testing.T) {
 	t.Run("one att per committee", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		c1_a1 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11111000, 0b1}, Data: &ethpb.AttestationData{CommitteeIndex: 1}})
 		c2_a1 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11100000, 0b1}, Data: &ethpb.AttestationData{CommitteeIndex: 2}})
 		atts := proposerAtts{c1_a1, c2_a1}
@@ -364,11 +334,6 @@ func TestProposer_sort_DifferentCommittees(t *testing.T) {
 		assert.DeepEqual(t, want, atts)
 	})
 	t.Run("multiple atts per committee", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		c1_a1 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11111100, 0b1}, Data: &ethpb.AttestationData{CommitteeIndex: 1}})
 		c1_a2 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b10000010, 0b1}, Data: &ethpb.AttestationData{CommitteeIndex: 1}})
 		c2_a1 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11110000, 0b1}, Data: &ethpb.AttestationData{CommitteeIndex: 2}})
@@ -381,11 +346,6 @@ func TestProposer_sort_DifferentCommittees(t *testing.T) {
 		assert.DeepEqual(t, want, atts)
 	})
 	t.Run("multiple atts per committee, multiple slots", func(t *testing.T) {
-		feat := features.Get()
-		feat.DisableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		s2_c1_a1 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11111100, 0b1}, Data: &ethpb.AttestationData{Slot: 2, CommitteeIndex: 1}})
 		s2_c1_a2 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b10000010, 0b1}, Data: &ethpb.AttestationData{Slot: 2, CommitteeIndex: 1}})
 		s2_c2_a1 := util.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11110000, 0b1}, Data: &ethpb.AttestationData{Slot: 2, CommitteeIndex: 2}})

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -231,10 +231,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("two atts on one of the slots", func(t *testing.T) {
-		p := features.Get().DisableCommitteeAwarePacking
-		if p == true {
-
-		}
 
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -35,6 +35,11 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	}
 
 	t.Run("no atts", func(t *testing.T) {
+		feat := features.Get()
+		feat.DisableCommitteeAwarePacking = true
+		reset := features.InitWithReset(feat)
+		defer reset()
+
 		atts := getAtts([]testData{})
 		want := getAtts([]testData{})
 		atts, err := atts.sort()
@@ -45,6 +50,11 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("single att", func(t *testing.T) {
+		feat := features.Get()
+		feat.DisableCommitteeAwarePacking = true
+		reset := features.InitWithReset(feat)
+		defer reset()
+
 		atts := getAtts([]testData{
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
 		})
@@ -59,6 +69,11 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("single att per slot", func(t *testing.T) {
+		feat := features.Get()
+		feat.DisableCommitteeAwarePacking = true
+		reset := features.InitWithReset(feat)
+		defer reset()
+
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -75,6 +90,11 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("two atts on one of the slots", func(t *testing.T) {
+		feat := features.Get()
+		feat.DisableCommitteeAwarePacking = true
+		reset := features.InitWithReset(feat)
+		defer reset()
+
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -96,6 +116,11 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 		// The max-cover based approach will select 0b00001100 instead, despite lower bit count
 		// (since it has two new/unknown bits).
 		t.Run("max-cover", func(t *testing.T) {
+			feat := features.Get()
+			feat.DisableCommitteeAwarePacking = true
+			reset := features.InitWithReset(feat)
+			defer reset()
+
 			atts := getAtts([]testData{
 				{1, bitfield.Bitlist{0b11000011, 0b1}},
 				{1, bitfield.Bitlist{0b11001000, 0b1}},
@@ -115,6 +140,11 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("multiple slots", func(t *testing.T) {
+		feat := features.Get()
+		feat.DisableCommitteeAwarePacking = true
+		reset := features.InitWithReset(feat)
+		defer reset()
+
 		atts := getAtts([]testData{
 			{2, bitfield.Bitlist{0b11100000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -139,6 +169,11 @@ func TestProposer_ProposerAtts_sort(t *testing.T) {
 	})
 
 	t.Run("follows max-cover", func(t *testing.T) {
+		feat := features.Get()
+		feat.DisableCommitteeAwarePacking = true
+		reset := features.InitWithReset(feat)
+		defer reset()
+
 		// Items at slot 4, must be first split into two lists by max-cover, with
 		// 0b10000011 scoring higher (as it provides more info in addition to already selected
 		// attestations) than 0b11100001 (despite naive bit count suggesting otherwise). Then,
@@ -186,11 +221,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	}
 
 	t.Run("no atts", func(t *testing.T) {
-		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{})
 		want := getAtts([]testData{})
 		atts, err := atts.sort()
@@ -201,11 +231,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("single att", func(t *testing.T) {
-		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
 		})
@@ -220,11 +245,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("single att per slot", func(t *testing.T) {
-		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -241,11 +261,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("two atts on one of the slots", func(t *testing.T) {
-		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{1, bitfield.Bitlist{0b11000000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -263,11 +278,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("compare to native sort", func(t *testing.T) {
-		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		// The max-cover based approach will select 0b00001100 instead, despite lower bit count
 		// (since it has two new/unknown bits).
 		t.Run("max-cover", func(t *testing.T) {
@@ -289,11 +299,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("multiple slots", func(t *testing.T) {
-		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		atts := getAtts([]testData{
 			{2, bitfield.Bitlist{0b11100000, 0b1}},
 			{4, bitfield.Bitlist{0b11100000, 0b1}},
@@ -316,11 +321,6 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 	})
 
 	t.Run("follows max-cover", func(t *testing.T) {
-		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
-		reset := features.InitWithReset(feat)
-		defer reset()
-
 		// Items at slot 4 must be first split into two lists by max-cover, with
 		// 0b10000011 being selected and 0b11100001 being leftover (despite naive bit count suggesting otherwise).
 		atts := getAtts([]testData{
@@ -351,7 +351,7 @@ func TestProposer_ProposerAtts_committeeAwareSort(t *testing.T) {
 func TestProposer_sort_DifferentCommittees(t *testing.T) {
 	t.Run("one att per committee", func(t *testing.T) {
 		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
+		feat.DisableCommitteeAwarePacking = true
 		reset := features.InitWithReset(feat)
 		defer reset()
 
@@ -365,7 +365,7 @@ func TestProposer_sort_DifferentCommittees(t *testing.T) {
 	})
 	t.Run("multiple atts per committee", func(t *testing.T) {
 		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
+		feat.DisableCommitteeAwarePacking = true
 		reset := features.InitWithReset(feat)
 		defer reset()
 
@@ -382,7 +382,7 @@ func TestProposer_sort_DifferentCommittees(t *testing.T) {
 	})
 	t.Run("multiple atts per committee, multiple slots", func(t *testing.T) {
 		feat := features.Get()
-		feat.EnableCommitteeAwarePacking = true
+		feat.DisableCommitteeAwarePacking = true
 		reset := features.InitWithReset(feat)
 		defer reset()
 

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -48,7 +48,7 @@ type Flags struct {
 	EnableDoppelGanger                  bool // EnableDoppelGanger enables doppelganger protection on startup for the validator.
 	EnableHistoricalSpaceRepresentation bool // EnableHistoricalSpaceRepresentation enables the saving of registry validators in separate buckets to save space
 	EnableBeaconRESTApi                 bool // EnableBeaconRESTApi enables experimental usage of the beacon REST API by the validator when querying a beacon node
-	EnableCommitteeAwarePacking         bool // EnableCommitteeAwarePacking TODO
+	DisableCommitteeAwarePacking        bool // DisableCommitteeAwarePacking changes the attestation packing algorithm to one that is not aware of attesting committees.
 	// Logging related toggles.
 	DisableGRPCConnectionLogs bool // Disables logging when a new grpc client has connected.
 	EnableFullSSZDataLogging  bool // Enables logging for full ssz data on rejected gossip messages
@@ -256,9 +256,9 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(EnableQUIC)
 		cfg.EnableQUIC = true
 	}
-	if ctx.IsSet(EnableCommitteeAwarePacking.Name) {
-		logEnabled(EnableCommitteeAwarePacking)
-		cfg.EnableCommitteeAwarePacking = true
+	if ctx.IsSet(DisableCommitteeAwarePacking.Name) {
+		logEnabled(DisableCommitteeAwarePacking)
+		cfg.DisableCommitteeAwarePacking = true
 	}
 
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -100,7 +100,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedBeaconRPCGatewayProviderFlag,
 	deprecatedDisableGRPCGateway,
 	deprecatedEnableExperimentalState,
-	DisableCommitteeAwarePacking,
+	deprecatedEnableCommitteeAwarePacking,
 }
 
 // deprecatedBeaconFlags contains flags that are still used by other components

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -77,6 +77,12 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+
+	deprecatedEnableCommitteeAwarePacking = &cli.BoolFlag{
+		Name:   "enable-committee-aware-packing",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.
@@ -94,6 +100,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedBeaconRPCGatewayProviderFlag,
 	deprecatedDisableGRPCGateway,
 	deprecatedEnableExperimentalState,
+	DisableCommitteeAwarePacking,
 }
 
 // deprecatedBeaconFlags contains flags that are still used by other components

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -166,9 +166,9 @@ var (
 		Name:  "enable-quic",
 		Usage: "Enables connection using the QUIC protocol for peers which support it.",
 	}
-	EnableCommitteeAwarePacking = &cli.BoolFlag{
-		Name:  "enable-committee-aware-packing",
-		Usage: "Changes the attestation packing algorithm to one that is aware of attesting committees.",
+	DisableCommitteeAwarePacking = &cli.BoolFlag{
+		Name:  "disable-committee-aware-packing",
+		Usage: "Changes the attestation packing algorithm to one that is not aware of attesting committees.",
 	}
 )
 
@@ -226,7 +226,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	EnableLightClient,
 	BlobSaveFsync,
 	EnableQUIC,
-	EnableCommitteeAwarePacking,
+	DisableCommitteeAwarePacking,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Makes committee aware packing the default. This flag will become obsolete after Electra, so the sooner we flip it, the more impact it will have. It does improve attestation inclusion for blocks with max number of atts. Below are results I got when applying the flag on Holesky testnet.

> Since then we deployed the new algorithm to our Holesky REST nodes on Aug 7th at around block 2,085,350. I backfilled my Holesky DB to slot ~1,864,000 and synced to ~2,330,000. Then I extracted data for all blocks that have 128 attestations in them (the new algorithm doesnt make a difference if the block is not full). In total I have 421,647 such blocks, which is a big majority of all blocks on the Holesky network. Out of these blocks 650 blocks were proposed by our REST VC before switching to the new algorithm and 696 were proposed after switching. I counted the average of the total number of bits in all attestations and the results are:
> - old algorithm: 62886
> - new algorithm: 63939
>
> That's a ~1.67% improvement.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
