### PR TITLE
Fix partial withdrawals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Testing: added custom matcher for better push settings testing.
 - Registered `GetDepositSnapshot` Beacon API endpoint.
 - Fixed mesh size by appending `gParams.Dhi = gossipSubDhi`
+- Fix skipping partial withdrawals count.
 
 ### Security
 

--- a/beacon-chain/state/state-native/getters_withdrawal.go
+++ b/beacon-chain/state/state-native/getters_withdrawal.go
@@ -113,6 +113,7 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, uint64, err
 	epoch := slots.ToEpoch(b.slot)
 
 	// Electra partial withdrawals functionality.
+	var partialWithdrawalsCount uint64
 	if b.version >= version.Electra {
 		for _, w := range b.pendingPartialWithdrawals {
 			if w.WithdrawableEpoch > epoch || len(withdrawals) >= int(params.BeaconConfig().MaxPendingPartialsPerWithdrawalsSweep) {
@@ -139,9 +140,9 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, uint64, err
 				})
 				withdrawalIndex++
 			}
+			partialWithdrawalsCount++
 		}
 	}
-	partialWithdrawalsCount := uint64(len(withdrawals))
 
 	validatorsLen := b.validatorsLen()
 	bound := mathutil.Min(uint64(validatorsLen), params.BeaconConfig().MaxValidatorsPerWithdrawalsSweep)

--- a/testing/spectest/mainnet/electra/operations/withdrawals_test.go
+++ b/testing/spectest/mainnet/electra/operations/withdrawals_test.go
@@ -7,6 +7,5 @@ import (
 )
 
 func TestMainnet_Electra_Operations_Withdrawals(t *testing.T) {
-	t.Skip("TODO: add back in after all spec test features are in.")
 	operations.RunWithdrawalsTest(t, "mainnet")
 }

--- a/testing/spectest/minimal/electra/operations/withdrawals_test.go
+++ b/testing/spectest/minimal/electra/operations/withdrawals_test.go
@@ -7,6 +7,5 @@ import (
 )
 
 func TestMinimal_Electra_Operations_Withdrawals(t *testing.T) {
-	t.Skip("TODO: add back in after all spec test features are in.")
 	operations.RunWithdrawalsTest(t, "minimal")
 }


### PR DESCRIPTION
Blocked by #14430 for spec tests

Bug description: https://hackmd.io/@ttsao/S13TVqkA0
Fix: reference: https://github.com/ethereum/consensus-specs/pull/3943

The bug in Electra occurs during the processing of partial withdrawals. When a pending partial withdrawal is skipped due to insufficient effective or excess balance, an offset is created because the `partial_withdrawals_count` doesn't account for the skipped withdrawal. This leads to the same withdrawal being processed twice, as skipped withdrawals aren't properly counted. The solution is to increment `partial_withdrawals_count` even for skipped withdrawals to ensure accurate pruning of `pending_partial_withdrawals`.