### PR TITLE
Data columns initial sync: Refactor

### DIFF
--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -81,11 +81,12 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		requestedColumnsByRoot[root][columnIndex] = true
 	}
 
-	requestedColumnsByRootLog := make(map[[fieldparams.RootLength]byte]interface{})
+	requestedColumnsByRootLog := make(map[string]interface{})
 	for root, columns := range requestedColumnsByRoot {
-		requestedColumnsByRootLog[root] = "all"
+		rootStr := fmt.Sprintf("%#x", root)
+		requestedColumnsByRootLog[rootStr] = "all"
 		if uint64(len(columns)) != numberOfColumns {
-			requestedColumnsByRootLog[root] = uint64MapToSortedSlice(columns)
+			requestedColumnsByRootLog[rootStr] = uint64MapToSortedSlice(columns)
 		}
 	}
 
@@ -124,17 +125,8 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 	log := log.WithFields(logrus.Fields{
 		"peer":    remotePeer,
 		"custody": custody,
+		"columns": requestedColumnsByRootLog,
 	})
-
-	i := 0
-	for root, columns := range requestedColumnsByRootLog {
-		log = log.WithFields(logrus.Fields{
-			fmt.Sprintf("root%d", i):    fmt.Sprintf("%#x", root),
-			fmt.Sprintf("columns%d", i): columns,
-		})
-
-		i++
-	}
 
 	log.Debug("Serving data column sidecar by root request")
 

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -157,12 +157,15 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 	validationTime := s.cfg.clock.Now().Sub(receivedTime)
 
 	peerGossipScore := s.cfg.p2p.Peers().Scorers().GossipScorer().Score(pid)
+
+	pidString := pid.String()
+
 	log.
 		WithFields(logging.DataColumnFields(ds)).
 		WithFields(logrus.Fields{
 			"sinceSlotStartTime": sinceSlotStartTime,
 			"validationTime":     validationTime,
-			"peer":               pid[len(pid)-6:],
+			"peer":               pidString[len(pidString)-6:],
 			"peerGossipScore":    peerGossipScore,
 		}).
 		Debug("Accepted data column sidecar gossip")


### PR DESCRIPTION
This pull requests rework the way data columns sidecars are retrieved from peers.


**Before this PR:**
If in `bwb` we needed to retrieve columns `[1, 3]` for block `[12, 13]` and columns `[8,9]` for block `20`, then, we sent a data column sidecar by range request corresponding to columns `[1, 3, 8, 9]` for blocks `[12, 13, 14, 15, 16, 17, 18, 19, 20]`.

So, 
- columns `[8, 9]` for blocks `[12, 13]`, 
- columns `[1, 3]` for blocks `20`, and
- columns `[1, 3, 8, 9]` for blocks `[14, 15, 16, 17, 18, 19]`

were returned by our peer for strictly no usage at all.
==> This occurs a useless bandwidth usage and a higher initial sync time (especially in small devnets) due to our internal rate limiting.

**With this PR:**
We carefully craft columns by range requests to ask peers to return exactly the columns we need.
(We take into account missed blocks and blocks without commitments, to minimise the number of generated requests.)

**Remaining tasks regarding initial syncing:**
- Do not verify KZG proofs, inclusion proofs etc... for finalized blocks
- Do run KZG proofs verification by batch
- Manage the case where an orphaned block has been requested, and no peers is able to serve data columns for it
- Use all peers for columns, and not only super nodes