### PR TITLE
Update default scrape-interval to 2 minutes for Beaconcha.in API rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Moved `ConvertKzgCommitmentToVersionedHash` to the `primitives` package.
 - reversed the boolean return on `BatchVerifyDepositsSignatures`, from need verification, to all keys successfully verified
 - Fix `engine_exchangeCapabilities` implementation.
+- Updated the default `scrape-interval` in `Client-stats` to 2 minutes to accommodate Beaconcha.in API rate limits.
 
 ### Deprecated
 - `--disable-grpc-gateway` flag is deprecated due to grpc gateway removal.

--- a/cmd/client-stats/flags/flags.go
+++ b/cmd/client-stats/flags/flags.go
@@ -28,6 +28,6 @@ var (
 	ScrapeIntervalFlag = &cli.DurationFlag{
 		Name:  "scrape-interval",
 		Usage: "Frequency of scraping expressed as a duration, eg 2m or 1m5s.",
-		Value: 60 * time.Second,
+		Value: 120 * time.Second,
 	}
 )


### PR DESCRIPTION

**What type of PR is this?**

~~Bug fix~~
~~Feature~~
~~Documentation~~
Other

**What does this PR do? Why is it needed?**

This PR adjusts the default value for the `scrape-interval` in the `Client-stats` app. The default scrape interval is currently set to 1 minute (60 seconds), which can cause users on the free plan of the Beaconcha.in API to exceed the rate limit of 30,000 requests per month. By increasing the default scrape-interval to 2 minutes (120 seconds), the number of requests is reduced, helping users avoid hitting the rate limit.

**Which issues(s) does this PR fix?**

Fixes #14536

**Other notes for review**

The current scrape-interval of 1 minute leads to rate-limiting issues (HTTP 429) for users on the free tier of the Beaconcha.in API. This change will ensure better compliance with the API limits without affecting the functionality of the Client-stats app.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
