### PR TITLE
Fix panic when stream events connection is abruptly closed

### DIFF
--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -312,7 +312,12 @@ func (es *eventStreamer) outboxWriteLoop(ctx context.Context, cancel context.Can
 func (es *eventStreamer) writeOutbox(ctx context.Context, w StreamingResponseWriter, first lazyReader) error {
 	needKeepAlive := true
 	if first != nil {
-		if _, err := io.Copy(w, first()); err != nil {
+		b, err := io.ReadAll(first())
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		if err != nil {
 			return err
 		}
 		needKeepAlive = false


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

This fixes a panic that occurs when an http client abruptly closes the connection to the StreamEvents endpoint.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
