### PR TITLE
recover from panics when writing the event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Fixed mesh size by appending `gParams.Dhi = gossipSubDhi`
 - Fix skipping partial withdrawals count.
+- recover from panics when writing the event stream [pr](https://github.com/prysmaticlabs/prysm/pull/14545)
 
 ### Security
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

There is a panic race condition that seems to involve sudden disconnects from a backlogged stream events queue. This PR adds a recover() call as a band-aid to prevent the node crashing when that condition is triggered. Another PR will attempt to address the root cause of the panic.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
