### PR TITLE
el_offline should be false when it is syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fixed mesh size by appending `gParams.Dhi = gossipSubDhi`
 - Fix skipping partial withdrawals count.
 - recover from panics when writing the event stream [pr](https://github.com/prysmaticlabs/prysm/pull/14545)
+- `/eth/v1/node/syncing` returns `el_offline` false while the el is syncing.
 
 ### Security
 

--- a/beacon-chain/execution/testing/mock_execution_chain.go
+++ b/beacon-chain/execution/testing/mock_execution_chain.go
@@ -131,6 +131,10 @@ func (m *Chain) ExecutionClientConnectionErr() error {
 	return m.CurrError
 }
 
+func (m *Chain) IsExecutionClientSyncing(_ context.Context) (bool, error) {
+	return false, nil
+}
+
 func (m *Chain) ETH1Endpoints() []string {
 	return m.Endpoints
 }

--- a/beacon-chain/rpc/eth/node/BUILD.bazel
+++ b/beacon-chain/rpc/eth/node/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/testutil/mock_exec_chain_info_fetcher.go
+++ b/beacon-chain/rpc/testutil/mock_exec_chain_info_fetcher.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"math/big"
 )
 
@@ -8,14 +9,16 @@ import (
 type MockExecutionChainInfoFetcher struct {
 	CurrEndpoint string
 	CurrError    error
+	Syncing      bool
+	Connected    bool
 }
 
 func (*MockExecutionChainInfoFetcher) GenesisExecutionChainInfo() (uint64, *big.Int) {
 	return uint64(0), &big.Int{}
 }
 
-func (*MockExecutionChainInfoFetcher) ExecutionClientConnected() bool {
-	return true
+func (m *MockExecutionChainInfoFetcher) ExecutionClientConnected() bool {
+	return m.Connected
 }
 
 func (m *MockExecutionChainInfoFetcher) ExecutionClientEndpoint() string {
@@ -24,4 +27,8 @@ func (m *MockExecutionChainInfoFetcher) ExecutionClientEndpoint() string {
 
 func (m *MockExecutionChainInfoFetcher) ExecutionClientConnectionErr() error {
 	return m.CurrError
+}
+
+func (m *MockExecutionChainInfoFetcher) IsExecutionClientSyncing(_ context.Context) (bool, error) {
+	return m.Syncing, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Other

**What does this PR do? Why is it needed?**

this PR seeks to find more consistency across clients for the `/eth/v1/node/syncing` endpoint. currently any connection error with the el results in `el_offline:true` including syncing, this PR attempts to be more aligned by having a check for sync status and seeing el_offline to false if successfully syncing. 

**Which issues(s) does this PR fix?**

Fixes #14226
**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
