### PR TITLE
rollback on SaveState error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fix `engine_exchangeCapabilities` implementation.
 - Updated the default `scrape-interval` in `Client-stats` to 2 minutes to accommodate Beaconcha.in API rate limits.
 - Switch to compounding when consolidating with source==target.
+- Revert block db save when saving state fails.
+- Return false from HasBlock if the block is being synced. 
 
 ### Deprecated
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -404,6 +404,10 @@ func (s *Service) savePostStateInfo(ctx context.Context, r [32]byte, b interface
 		return errors.Wrapf(err, "could not save block from slot %d", b.Block().Slot())
 	}
 	if err := s.cfg.StateGen.SaveState(ctx, r, st); err != nil {
+		log.Warnf("Rolling back insertion of block with root %#x", r)
+		if err := s.cfg.BeaconDB.DeleteBlock(ctx, r); err != nil {
+			log.WithError(err).Errorf("Could not delete block with block root %#x", r)
+		}
 		return errors.Wrap(err, "could not save state")
 	}
 	return nil

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -349,6 +349,9 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []blocks.ROBlock
 
 // HasBlock returns true if the block of the input root exists in initial sync blocks cache or DB.
 func (s *Service) HasBlock(ctx context.Context, root [32]byte) bool {
+	if s.BlockBeingSynced(root) {
+		return false
+	}
 	return s.hasBlockInInitSyncOrDB(ctx, root)
 }
 

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -278,6 +278,8 @@ func TestService_HasBlock(t *testing.T) {
 	r, err = b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	require.Equal(t, true, s.HasBlock(context.Background(), r))
+	s.blockBeingSynced.set(r)
+	require.Equal(t, false, s.HasBlock(context.Background(), r))
 }
 
 func TestCheckSaveHotStateDB_Enabling(t *testing.T) {


### PR DESCRIPTION
This PR adds two core logic changes

- `HasBlock` returns false in the event that the block is being synced at the current time. 
- If there is an error after saving the block to db but before saving the state to db, then rollback the block insertion to db. 