### PR TITLE
Rollback on errors from forkchoice insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Switch to compounding when consolidating with source==target.
 - Revert block db save when saving state fails.
 - Return false from HasBlock if the block is being synced. 
+- Cleanup forkchoice on failed insertions.
 
 ### Deprecated
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -3,6 +3,7 @@ package doublylinkedtree
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"testing"
 	"time"
 
@@ -886,4 +887,17 @@ func TestForkchoiceParentRoot(t *testing.T) {
 	root, err = f.ParentRoot(zeroHash)
 	require.NoError(t, err)
 	require.Equal(t, zeroHash, root)
+}
+
+func TestForkChoice_CleanupInserting(t *testing.T) {
+	f := setup(0, 0)
+	ctx := context.Background()
+	st, blkRoot, err := prepareForkchoiceState(ctx, 1, indexToHash(1), params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 2, 2)
+	f.SetBalancesByRooter(func(_ context.Context, _ [32]byte) ([]uint64, error) {
+		return f.justifiedBalances, errors.New("mock err")
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, f.InsertNode(ctx, st, blkRoot))
+	require.Equal(t, false, f.HasNode(blkRoot))
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
@@ -525,3 +525,12 @@ func TestStore_TargetRootForEpoch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, root4, target)
 }
+
+func TestStore_CleanupInserting(t *testing.T) {
+	f := setup(0, 0)
+	ctx := context.Background()
+	st, blkRoot, err := prepareForkchoiceState(ctx, 1, indexToHash(1), indexToHash(2), params.BeaconConfig().ZeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NotNil(t, f.InsertNode(ctx, st, blkRoot))
+	require.Equal(t, false, f.HasNode(blkRoot))
+}


### PR DESCRIPTION
In the event of errors when inserting a node in forkchoice, rollback all internal changes and remove the node before returning an error. This prevents forkchoice from erroneously keeping a node that couldn't be really processed. 