### PR TITLE
PeerDAS: Batch columns verifications

### DIFF
--- a/beacon-chain/core/peerdas/helpers_test.go
+++ b/beacon-chain/core/peerdas/helpers_test.go
@@ -93,7 +93,7 @@ func TestVerifyDataColumnSidecarKZGProofs(t *testing.T) {
 	for i, sidecar := range sCars {
 		roCol, err := blocks.NewRODataColumn(sidecar)
 		require.NoError(t, err)
-		verified, err := peerdas.VerifyDataColumnSidecarKZGProofs(roCol)
+		verified, err := peerdas.VerifyDataColumnsSidecarKZGProofs([]blocks.RODataColumn{roCol})
 		require.NoError(t, err)
 		require.Equal(t, true, verified, fmt.Sprintf("sidecar %d failed", i))
 	}

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -211,6 +211,7 @@ go_test(
         "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/operation:go_default_library",
+        "//beacon-chain/core/feed/state:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/peerdas:go_default_library",
         "//beacon-chain/core/signing:go_default_library",

--- a/beacon-chain/sync/data_columns_sampling.go
+++ b/beacon-chain/sync/data_columns_sampling.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/sync/verify"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/verification"
 	"github.com/sirupsen/logrus"
 
@@ -265,7 +266,7 @@ func (d *dataColumnSampler1D) handleStateNotification(ctx context.Context, event
 	samplesCount := min(params.BeaconConfig().SamplesPerSlot, uint64(len(d.nonCustodyColumns))-params.BeaconConfig().NumberOfColumns/2)
 
 	// TODO: Use the first output of `incrementalDAS` as input of the fork choice rule.
-	_, _, err = d.incrementalDAS(ctx, data.BlockRoot, randomizedColumns, samplesCount)
+	_, _, err = d.incrementalDAS(ctx, data, randomizedColumns, samplesCount)
 	if err != nil {
 		log.WithError(err).Error("Failed to run incremental DAS")
 	}
@@ -276,13 +277,14 @@ func (d *dataColumnSampler1D) handleStateNotification(ctx context.Context, event
 // According to https://github.com/ethereum/consensus-specs/issues/3825, we're going to select query samples exclusively from the non custody columns.
 func (d *dataColumnSampler1D) incrementalDAS(
 	ctx context.Context,
-	root [fieldparams.RootLength]byte,
+	blockProcessedData *statefeed.BlockProcessedData,
 	columns []uint64,
 	sampleCount uint64,
 ) (bool, []roundSummary, error) {
 	allowedFailures := uint64(0)
 	firstColumnToSample, extendedSampleCount := uint64(0), peerdas.ExtendedSampleCount(sampleCount, allowedFailures)
 	roundSummaries := make([]roundSummary, 0, 1) // We optimistically allocate only one round summary.
+	blockRoot := blockProcessedData.BlockRoot
 
 	start := time.Now()
 
@@ -290,7 +292,7 @@ func (d *dataColumnSampler1D) incrementalDAS(
 		if extendedSampleCount > uint64(len(columns)) {
 			// We already tried to sample all possible columns, this is the unhappy path.
 			log.WithFields(logrus.Fields{
-				"root":  fmt.Sprintf("%#x", root),
+				"root":  fmt.Sprintf("%#x", blockRoot),
 				"round": round - 1,
 			}).Warning("Some columns are still missing after trying to sample all possible columns")
 			return false, roundSummaries, nil
@@ -301,13 +303,13 @@ func (d *dataColumnSampler1D) incrementalDAS(
 		columnsToSampleCount := extendedSampleCount - firstColumnToSample
 
 		log.WithFields(logrus.Fields{
-			"root":    fmt.Sprintf("%#x", root),
+			"root":    fmt.Sprintf("%#x", blockRoot),
 			"columns": columnsToSample,
 			"round":   round,
 		}).Debug("Start data columns sampling")
 
 		// Sample data columns from peers in parallel.
-		retrievedSamples := d.sampleDataColumns(ctx, root, columnsToSample)
+		retrievedSamples := d.sampleDataColumns(ctx, blockProcessedData, columnsToSample)
 
 		missingSamples := make(map[uint64]bool)
 		for _, column := range columnsToSample {
@@ -325,7 +327,7 @@ func (d *dataColumnSampler1D) incrementalDAS(
 		if retrievedSampleCount == columnsToSampleCount {
 			// All columns were correctly sampled, this is the happy path.
 			log.WithFields(logrus.Fields{
-				"root":         fmt.Sprintf("%#x", root),
+				"root":         fmt.Sprintf("%#x", blockRoot),
 				"neededRounds": round,
 				"duration":     time.Since(start),
 			}).Debug("All columns were successfully sampled")
@@ -344,7 +346,7 @@ func (d *dataColumnSampler1D) incrementalDAS(
 		extendedSampleCount = peerdas.ExtendedSampleCount(sampleCount, allowedFailures)
 
 		log.WithFields(logrus.Fields{
-			"root":                fmt.Sprintf("%#x", root),
+			"root":                fmt.Sprintf("%#x", blockRoot),
 			"round":               round,
 			"missingColumnsCount": allowedFailures,
 			"currentSampleIndex":  oldExtendedSampleCount,
@@ -355,7 +357,7 @@ func (d *dataColumnSampler1D) incrementalDAS(
 
 func (d *dataColumnSampler1D) sampleDataColumns(
 	ctx context.Context,
-	root [fieldparams.RootLength]byte,
+	blockProcessedData *statefeed.BlockProcessedData,
 	columns []uint64,
 ) map[uint64]bool {
 	// distribute samples to peer
@@ -365,10 +367,12 @@ func (d *dataColumnSampler1D) sampleDataColumns(
 		mu sync.Mutex
 		wg sync.WaitGroup
 	)
+
 	res := make(map[uint64]bool)
+
 	sampleFromPeer := func(pid peer.ID, cols map[uint64]bool) {
 		defer wg.Done()
-		retrieved := d.sampleDataColumnsFromPeer(ctx, pid, root, cols)
+		retrieved := d.sampleDataColumnsFromPeer(ctx, pid, blockProcessedData, cols)
 
 		mu.Lock()
 		for col := range retrieved {
@@ -414,7 +418,7 @@ func (d *dataColumnSampler1D) distributeSamplesToPeer(
 func (d *dataColumnSampler1D) sampleDataColumnsFromPeer(
 	ctx context.Context,
 	pid peer.ID,
-	root [fieldparams.RootLength]byte,
+	blockProcessedData *statefeed.BlockProcessedData,
 	requestedColumns map[uint64]bool,
 ) map[uint64]bool {
 	retrievedColumns := make(map[uint64]bool)
@@ -422,7 +426,7 @@ func (d *dataColumnSampler1D) sampleDataColumnsFromPeer(
 	req := make(types.DataColumnSidecarsByRootReq, 0)
 	for col := range requestedColumns {
 		req = append(req, &eth.DataColumnIdentifier{
-			BlockRoot:   root[:],
+			BlockRoot:   blockProcessedData.BlockRoot[:],
 			ColumnIndex: col,
 		})
 	}
@@ -434,8 +438,9 @@ func (d *dataColumnSampler1D) sampleDataColumnsFromPeer(
 		return nil
 	}
 
+	// TODO: Once peer sampling is used, we should verify all sampled data columns in a single batch instead of looping over columns.
 	for _, roDataColumn := range roDataColumns {
-		if verifyColumn(roDataColumn, root, pid, requestedColumns, d.columnVerifier) {
+		if verifyColumn(roDataColumn, blockProcessedData, pid, requestedColumns, d.columnVerifier) {
 			retrievedColumns[roDataColumn.ColumnIndex] = true
 		}
 	}
@@ -443,13 +448,13 @@ func (d *dataColumnSampler1D) sampleDataColumnsFromPeer(
 	if len(retrievedColumns) == len(requestedColumns) {
 		log.WithFields(logrus.Fields{
 			"peerID":           pid,
-			"root":             fmt.Sprintf("%#x", root),
+			"root":             fmt.Sprintf("%#x", blockProcessedData.BlockRoot),
 			"requestedColumns": sortedSliceFromMap(requestedColumns),
 		}).Debug("Sampled columns from peer successfully")
 	} else {
 		log.WithFields(logrus.Fields{
 			"peerID":           pid,
-			"root":             fmt.Sprintf("%#x", root),
+			"root":             fmt.Sprintf("%#x", blockProcessedData.BlockRoot),
 			"requestedColumns": sortedSliceFromMap(requestedColumns),
 			"retrievedColumns": sortedSliceFromMap(retrievedColumns),
 		}).Debug("Sampled columns from peer with some errors")
@@ -506,7 +511,7 @@ func selectRandomPeer(peers map[peer.ID]bool) peer.ID {
 // the KZG inclusion and the KZG proof.
 func verifyColumn(
 	roDataColumn blocks.RODataColumn,
-	root [32]byte,
+	blockProcessedData *statefeed.BlockProcessedData,
 	pid peer.ID,
 	requestedColumns map[uint64]bool,
 	dataColumnsVerifier verification.NewDataColumnsVerifier,
@@ -514,12 +519,14 @@ func verifyColumn(
 	retrievedColumn := roDataColumn.ColumnIndex
 
 	// Filter out columns with incorrect root.
-	actualRoot := roDataColumn.BlockRoot()
-	if actualRoot != root {
+	columnRoot := roDataColumn.BlockRoot()
+	blockRoot := blockProcessedData.BlockRoot
+
+	if columnRoot != blockRoot {
 		log.WithFields(logrus.Fields{
 			"peerID":        pid,
-			"requestedRoot": fmt.Sprintf("%#x", root),
-			"actualRoot":    fmt.Sprintf("%#x", actualRoot),
+			"requestedRoot": fmt.Sprintf("%#x", blockRoot),
+			"columnRoot":    fmt.Sprintf("%#x", columnRoot),
 		}).Debug("Retrieved root does not match requested root")
 
 		return false
@@ -538,27 +545,18 @@ func verifyColumn(
 		return false
 	}
 
-	// TODO: Once peer sampling is used, we should verify all sampled data columns in a single batch.
-	verifier := dataColumnsVerifier([]blocks.RODataColumn{roDataColumn}, verification.SamplingColumnSidecarRequirements)
+	roBlock := blockProcessedData.SignedBlock.Block()
 
-	// Filter out columns which did not pass the KZG inclusion proof verification.
-	if err := verifier.SidecarInclusionProven(); err != nil {
-		log.WithFields(logrus.Fields{
-			"peerID": pid,
-			"root":   fmt.Sprintf("%#x", root),
-			"index":  retrievedColumn,
-		}).WithError(err).Debug("Failed to verify KZG inclusion proof for retrieved column")
+	wrappedBlockDataColumns := []verify.WrappedBlockDataColumn{
+		{
+			ROBlock:      roBlock,
+			RODataColumn: roDataColumn,
+		},
+	}
+
+	if err := verify.DataColumnsAlignWithBlock(wrappedBlockDataColumns, dataColumnsVerifier); err != nil {
 		return false
 	}
 
-	// Filter out columns which did not pass the KZG proof verification.
-	if err := verifier.SidecarKzgProofVerified(); err != nil {
-		log.WithFields(logrus.Fields{
-			"peerID": pid,
-			"root":   fmt.Sprintf("%#x", root),
-			"index":  retrievedColumn,
-		}).WithError(err).Debug("Failed to verify KZG proof for retrieved column")
-		return false
-	}
 	return true
 }

--- a/beacon-chain/sync/data_columns_sampling_test.go
+++ b/beacon-chain/sync/data_columns_sampling_test.go
@@ -202,7 +202,7 @@ func setupDataColumnSamplerTest(t *testing.T, blobCount uint64) (*dataSamplerTes
 	iniWaiter := verification.NewInitializerWaiter(clockSync, nil, nil)
 	ini, err := iniWaiter.WaitForInitializer(context.Background())
 	require.NoError(t, err)
-	sampler := newDataColumnSampler1D(p2pSvc, clock, test.ctxMap, nil, newColumnVerifierFromInitializer(ini))
+	sampler := newDataColumnSampler1D(p2pSvc, clock, test.ctxMap, nil, newDataColumnsVerifierFromInitializer(ini))
 
 	return test, sampler
 }

--- a/beacon-chain/sync/data_columns_sampling_test.go
+++ b/beacon-chain/sync/data_columns_sampling_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	kzg "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/kzg"
 	mock "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/testing"
+	statefeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/peerdas"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/peers"
@@ -127,7 +128,7 @@ type dataSamplerTest struct {
 	peers              []*p2ptest.TestP2P
 	ctxMap             map[[4]byte]int
 	chainSvc           *mock.ChainService
-	blockRoot          [32]byte
+	blockProcessedData *statefeed.BlockProcessedData
 	blobs              []kzg.Blob
 	kzgCommitments     [][]byte
 	kzgProofs          [][]byte
@@ -141,12 +142,16 @@ func setupDefaultDataColumnSamplerTest(t *testing.T) (*dataSamplerTest, *dataCol
 	)
 
 	test, sampler := setupDataColumnSamplerTest(t, blobCount)
+
 	// Custody columns: [6, 38, 70, 102]
 	p1 := createAndConnectPeer(t, test.p2pSvc, test.chainSvc, test.dataColumnSidecars, custodyRequirement, map[uint64]bool{}, 1)
+
 	// Custody columns: [3, 35, 67, 99]
 	p2 := createAndConnectPeer(t, test.p2pSvc, test.chainSvc, test.dataColumnSidecars, custodyRequirement, map[uint64]bool{}, 2)
+
 	// Custody columns: [12, 44, 76, 108]
 	p3 := createAndConnectPeer(t, test.p2pSvc, test.chainSvc, test.dataColumnSidecars, custodyRequirement, map[uint64]bool{}, 3)
+
 	test.peers = []*p2ptest.TestP2P{p1, p2, p3}
 
 	return test, sampler
@@ -182,6 +187,11 @@ func setupDataColumnSamplerTest(t *testing.T, blobCount uint64) (*dataSamplerTes
 	blockRoot, err := dataColumnSidecars[0].GetSignedBlockHeader().Header.HashTreeRoot()
 	require.NoError(t, err)
 
+	blockProcessedData := &statefeed.BlockProcessedData{
+		BlockRoot:   blockRoot,
+		SignedBlock: sBlock,
+	}
+
 	p2pSvc := p2ptest.NewTestP2P(t)
 	chainSvc, clock := defaultMockChain(t)
 
@@ -191,7 +201,7 @@ func setupDataColumnSamplerTest(t *testing.T, blobCount uint64) (*dataSamplerTes
 		peers:              []*p2ptest.TestP2P{},
 		ctxMap:             map[[4]byte]int{{245, 165, 253, 66}: version.Deneb},
 		chainSvc:           chainSvc,
-		blockRoot:          blockRoot,
+		blockProcessedData: blockProcessedData,
 		blobs:              blobs,
 		kzgCommitments:     kzgCommitments,
 		kzgProofs:          kzgProofs,
@@ -396,7 +406,7 @@ func TestDataColumnSampler1D_SampleDataColumns(t *testing.T) {
 
 	// Sample all columns.
 	sampleColumns := []uint64{6, 3, 12, 38, 35, 44, 70, 67, 76, 102, 99, 108}
-	retrieved := sampler.sampleDataColumns(test.ctx, test.blockRoot, sampleColumns)
+	retrieved := sampler.sampleDataColumns(test.ctx, test.blockProcessedData, sampleColumns)
 	require.Equal(t, 12, len(retrieved))
 	for _, column := range sampleColumns {
 		require.Equal(t, true, retrieved[column])
@@ -404,7 +414,7 @@ func TestDataColumnSampler1D_SampleDataColumns(t *testing.T) {
 
 	// Sample a subset of columns.
 	sampleColumns = []uint64{6, 3, 12, 38, 35, 44}
-	retrieved = sampler.sampleDataColumns(test.ctx, test.blockRoot, sampleColumns)
+	retrieved = sampler.sampleDataColumns(test.ctx, test.blockProcessedData, sampleColumns)
 	require.Equal(t, 6, len(retrieved))
 	for _, column := range sampleColumns {
 		require.Equal(t, true, retrieved[column])
@@ -412,7 +422,7 @@ func TestDataColumnSampler1D_SampleDataColumns(t *testing.T) {
 
 	// Sample a subset of columns with missing columns.
 	sampleColumns = []uint64{6, 3, 12, 127}
-	retrieved = sampler.sampleDataColumns(test.ctx, test.blockRoot, sampleColumns)
+	retrieved = sampler.sampleDataColumns(test.ctx, test.blockProcessedData, sampleColumns)
 	require.Equal(t, 3, len(retrieved))
 	require.DeepEqual(t, map[uint64]bool{6: true, 3: true, 12: true}, retrieved)
 }
@@ -489,7 +499,7 @@ func TestDataColumnSampler1D_IncrementalDAS(t *testing.T) {
 
 		sampler.refreshPeerInfo()
 
-		success, summaries, err := sampler.incrementalDAS(test.ctx, test.blockRoot, tc.possibleColumnsToRequest, tc.samplesCount)
+		success, summaries, err := sampler.incrementalDAS(test.ctx, test.blockProcessedData, tc.possibleColumnsToRequest, tc.samplesCount)
 		require.NoError(t, err)
 		require.Equal(t, tc.expectedSuccess, success)
 		require.DeepEqual(t, tc.expectedRoundSummaries, summaries)

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -1197,8 +1197,8 @@ func (f *blocksFetcher) processDataColumns(
 		}
 
 		wrappedBlockDataColumn := verify.WrappedBlockDataColumn{
-			ROBlock:    block,
-			DataColumn: dataColumn,
+			ROBlock:      block.Block(),
+			RODataColumn: dataColumn,
 		}
 
 		wrappedBlockDataColumns = append(wrappedBlockDataColumns, wrappedBlockDataColumn)
@@ -1217,7 +1217,7 @@ func (f *blocksFetcher) processDataColumns(
 	missingColumnsByRoot := wrappedBwbsMissingColumns.missingColumnsByRoot
 
 	for _, wrappedBlockDataColumn := range wrappedBlockDataColumns {
-		dataColumn := wrappedBlockDataColumn.DataColumn
+		dataColumn := wrappedBlockDataColumn.RODataColumn
 
 		// Extract the block root from the data column.
 		blockRoot := dataColumn.BlockRoot()
@@ -1312,7 +1312,7 @@ func (f *blocksFetcher) fetchDataColumnFromPeer(
 	}
 
 	// Send the request to the peer.
-	roDataColumns, err := prysmsync.SendDataColumnsByRangeRequest(ctx, f.clock, f.p2p, peer, f.ctxMap, request)
+	roDataColumns, err := prysmsync.SendDataColumnSidecarsByRangeRequest(ctx, f.clock, f.p2p, peer, f.ctxMap, request)
 	if err != nil {
 		log.WithError(err).Warning("Fetch data columns from peers - could not send data columns by range request")
 		return

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -82,7 +82,7 @@ type blocksFetcherConfig struct {
 	mode                     syncMode
 	bs                       filesystem.BlobStorageSummarizer
 	bv                       verification.NewBlobVerifier
-	cv                       verification.NewColumnVerifier
+	cv                       verification.NewDataColumnsVerifier
 }
 
 // blocksFetcher is a service to fetch chain data from peers.
@@ -100,7 +100,7 @@ type blocksFetcher struct {
 	db              db.ReadOnlyDatabase
 	bs              filesystem.BlobStorageSummarizer
 	bv              verification.NewBlobVerifier
-	cv              verification.NewColumnVerifier
+	cv              verification.NewDataColumnsVerifier
 	blocksPerPeriod uint64
 	rateLimiter     *leakybucket.Collector
 	peerLocks       map[peer.ID]*peerLock
@@ -1155,67 +1155,91 @@ func (f *blocksFetcher) waitForPeersForDataColumns(
 	return dataColumnsByAdmissiblePeer, nil
 }
 
-// processDataColumn mutates `bwbs` argument by adding the data column,
+// processDataColumns mutates `bwbs` argument by adding the data column,
 // and mutates `missingColumnsByRoot` by removing the data column if the
 // data column passes all the check.
-func processDataColumn(
+func (f *blocksFetcher) processDataColumns(
 	wrappedBwbsMissingColumns *bwbsMissingColumns,
-	columnVerifier verification.NewColumnVerifier,
-	blocksByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
+	blockByRoot map[[fieldparams.RootLength]byte]blocks.ROBlock,
 	indicesByRoot map[[fieldparams.RootLength]byte][]int,
-	dataColumn blocks.RODataColumn,
+	dataColumns []blocks.RODataColumn,
 ) bool {
-	// Extract the block root from the data column.
-	blockRoot := dataColumn.BlockRoot()
+	// Fiter out data columns:
+	// - that are not expected and,
+	// - which correspond to blocks before Deneb.
 
-	// Find the position of the block in `bwbs` that corresponds to this block root.
-	indices, ok := indicesByRoot[blockRoot]
-	if !ok {
-		// The peer returned a data column that we did not expect.
-		// This is among others possible when the peer is not on the same fork.
-		return false
+	// Not expected data columns are among others possible when
+	// the peer is not on the same fork, due to the nature of
+	// data columns by range requests.
+	wrappedBlockDataColumns := make([]verify.WrappedBlockDataColumn, 0, len(dataColumns))
+	for _, dataColumn := range dataColumns {
+		// Extract the block root from the data column.
+		blockRoot := dataColumn.BlockRoot()
+
+		// Skip if the block root is not expected.
+		// This is possible when the peer is not on the same fork.
+		_, ok := indicesByRoot[blockRoot]
+		if !ok {
+			continue
+		}
+
+		// Retrieve the block from the block root.
+		block, ok := blockByRoot[blockRoot]
+		if !ok {
+			// This should never happen.
+			log.WithField("blockRoot", fmt.Sprintf("%#x", blockRoot)).Error("Fetch data columns from peers - block not found for root")
+			return false
+		}
+
+		// Skip if the block is before Deneb.
+		if block.Version() < version.Deneb {
+			continue
+		}
+
+		wrappedBlockDataColumn := verify.WrappedBlockDataColumn{
+			ROBlock:    block,
+			DataColumn: dataColumn,
+		}
+
+		wrappedBlockDataColumns = append(wrappedBlockDataColumns, wrappedBlockDataColumn)
 	}
 
-	// Extract the block from the block root.
-	block, ok := blocksByRoot[blockRoot]
-	if !ok {
-		// This should never happen.
-		log.WithField("blockRoot", fmt.Sprintf("%#x", blockRoot)).Error("Fetch data columns from peers - block not found")
-		return false
-	}
-
-	// Verify the data column.
-	if err := verify.ColumnAlignsWithBlock(dataColumn, block, columnVerifier); err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
-			"root":   fmt.Sprintf("%#x", blockRoot),
-			"slot":   block.Block().Slot(),
-			"column": dataColumn.ColumnIndex,
-		}).Warning("Fetch data columns from peers - fetched data column does not align with block")
-
+	// Verify the data columns.
+	if err := verify.DataColumnsAlignWithBlock(wrappedBlockDataColumns, f.cv); err != nil {
 		// TODO: Should we downscore the peer for that?
 		return false
 	}
 
-	// Populate the corresponding items in `bwbs`.
-	func() {
-		mu := &wrappedBwbsMissingColumns.mu
+	wrappedBwbsMissingColumns.mu.Lock()
+	defer wrappedBwbsMissingColumns.mu.Unlock()
 
-		mu.Lock()
-		defer mu.Unlock()
+	bwbs := wrappedBwbsMissingColumns.bwbs
+	missingColumnsByRoot := wrappedBwbsMissingColumns.missingColumnsByRoot
 
-		bwbs := wrappedBwbsMissingColumns.bwbs
-		missingColumnsByRoot := wrappedBwbsMissingColumns.missingColumnsByRoot
+	for _, wrappedBlockDataColumn := range wrappedBlockDataColumns {
+		dataColumn := wrappedBlockDataColumn.DataColumn
 
+		// Extract the block root from the data column.
+		blockRoot := dataColumn.BlockRoot()
+
+		// Extract the indices in bwb corresponding to the block root.
+		indices, ok := indicesByRoot[blockRoot]
+		if !ok {
+			// This should never happen.
+			log.WithField("blockRoot", fmt.Sprintf("%#x", blockRoot)).Error("Fetch data columns from peers - indices not found for root")
+			return false
+		}
+
+		// Populate the corresponding items in `bwbs`.
 		for _, index := range indices {
 			bwbs[index].Columns = append(bwbs[index].Columns, dataColumn)
 		}
-
 		// Remove the column from the missing columns.
 		delete(missingColumnsByRoot[blockRoot], dataColumn.ColumnIndex)
 		if len(missingColumnsByRoot[blockRoot]) == 0 {
 			delete(missingColumnsByRoot, blockRoot)
 		}
-	}()
+	}
 
 	return true
 }
@@ -1299,17 +1323,8 @@ func (f *blocksFetcher) fetchDataColumnFromPeer(
 		return
 	}
 
-	globalSuccess := false
-
-	for _, dataColumn := range roDataColumns {
-		success := processDataColumn(wrappedBwbsMissingColumns, f.cv, blocksByRoot, indicesByRoot, dataColumn)
-		if success {
-			globalSuccess = true
-		}
-	}
-
-	if !globalSuccess {
-		log.Debug("Fetch data columns from peers - no valid data column returned")
+	if !f.processDataColumns(wrappedBwbsMissingColumns, blocksByRoot, indicesByRoot, roDataColumns) {
+		log.Warning("Fetch data columns from peers - at least one data column is invalid")
 		return
 	}
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -414,6 +414,7 @@ func TestBlocksFetcher_scheduleRequest(t *testing.T) {
 			fetcher.scheduleRequest(context.Background(), 1, blockBatchLimit))
 	})
 }
+
 func TestBlocksFetcher_handleRequest(t *testing.T) {
 	blockBatchLimit := flags.Get().BlockBatchLimit
 	chainConfig := struct {
@@ -1988,14 +1989,9 @@ func TestFetchDataColumnsFromPeers(t *testing.T) {
 								{slot: 38, columnIndex: 6, alterate: true},
 								{slot: 38, columnIndex: 70},
 							},
-						},
-						(&ethpb.DataColumnSidecarsByRangeRequest{
-							StartSlot: 38,
-							Count:     1,
-							Columns:   []uint64{6},
-						}).String(): {
 							{
 								{slot: 38, columnIndex: 6},
+								{slot: 38, columnIndex: 70},
 							},
 						},
 					},
@@ -2243,7 +2239,7 @@ func TestFetchDataColumnsFromPeers(t *testing.T) {
 				ctxMap: map[[4]byte]int{{245, 165, 253, 66}: version.Deneb},
 				p2p:    p2pSvc,
 				bs:     blobStorageSummarizer,
-				cv:     newColumnVerifierFromInitializer(ini),
+				cv:     newDataColumnsVerifierFromInitializer(ini),
 			})
 
 			// Fetch the data columns from the peers.

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -73,7 +73,7 @@ type blocksQueueConfig struct {
 	mode                syncMode
 	bs                  filesystem.BlobStorageSummarizer
 	bv                  verification.NewBlobVerifier
-	cv                  verification.NewColumnVerifier
+	cv                  verification.NewDataColumnsVerifier
 }
 
 // blocksQueue is a priority queue that serves as a intermediary between block fetchers (producers)

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -89,7 +89,7 @@ func (s *Service) startBlocksQueue(ctx context.Context, highestSlot primitives.S
 		mode:                mode,
 		bs:                  summarizer,
 		bv:                  s.newBlobVerifier,
-		cv:                  s.newColumnVerifier,
+		cv:                  s.newDataColumnsVerifier,
 	}
 	queue := newBlocksQueue(ctx, cfg)
 	if err := queue.start(); err != nil {
@@ -176,7 +176,7 @@ func (s *Service) processFetchedDataRegSync(
 		return
 	}
 	if coreTime.PeerDASIsActive(startSlot) {
-		bv := verification.NewDataColumnBatchVerifier(s.newColumnVerifier, verification.InitsyncColumnSidecarRequirements)
+		bv := verification.NewDataColumnBatchVerifier(s.newDataColumnsVerifier, verification.InitsyncColumnSidecarRequirements)
 		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, bv, s.cfg.P2P.NodeID())
 		batchFields := logrus.Fields{
 			"firstSlot":        data.bwb[0].Block.Block().Slot(),
@@ -367,7 +367,7 @@ func (s *Service) processBatchedBlocks(ctx context.Context, genesis time.Time,
 	}
 	var aStore das.AvailabilityStore
 	if coreTime.PeerDASIsActive(first.Block().Slot()) {
-		bv := verification.NewDataColumnBatchVerifier(s.newColumnVerifier, verification.InitsyncColumnSidecarRequirements)
+		bv := verification.NewDataColumnBatchVerifier(s.newDataColumnsVerifier, verification.InitsyncColumnSidecarRequirements)
 		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, bv, s.cfg.P2P.NodeID())
 		s.logBatchSyncStatus(genesis, first, len(bwb))
 		for _, bb := range bwb {

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -176,8 +176,7 @@ func (s *Service) processFetchedDataRegSync(
 		return
 	}
 	if coreTime.PeerDASIsActive(startSlot) {
-		bv := verification.NewDataColumnBatchVerifier(s.newDataColumnsVerifier, verification.InitsyncColumnSidecarRequirements)
-		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, bv, s.cfg.P2P.NodeID())
+		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage)
 		batchFields := logrus.Fields{
 			"firstSlot":        data.bwb[0].Block.Block().Slot(),
 			"firstUnprocessed": bwb[0].Block.Block().Slot(),
@@ -367,8 +366,7 @@ func (s *Service) processBatchedBlocks(ctx context.Context, genesis time.Time,
 	}
 	var aStore das.AvailabilityStore
 	if coreTime.PeerDASIsActive(first.Block().Slot()) {
-		bv := verification.NewDataColumnBatchVerifier(s.newDataColumnsVerifier, verification.InitsyncColumnSidecarRequirements)
-		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage, bv, s.cfg.P2P.NodeID())
+		avs := das.NewLazilyPersistentStoreColumn(s.cfg.BlobStorage)
 		s.logBatchSyncStatus(genesis, first, len(bwb))
 		for _, bb := range bwb {
 			if len(bb.Columns) == 0 {

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -495,8 +495,8 @@ func TestOriginOutsideRetention(t *testing.T) {
 	bdb := dbtest.SetupDB(t)
 	genesis := time.Unix(0, 0)
 	secsPerEpoch := params.BeaconConfig().SecondsPerSlot * uint64(params.BeaconConfig().SlotsPerEpoch)
-	retentionSeconds := time.Second * time.Duration(uint64(params.BeaconConfig().MinEpochsForBlobsSidecarsRequest+1)*secsPerEpoch)
-	outsideRetention := genesis.Add(retentionSeconds)
+	retentionDuration := time.Second * time.Duration(uint64(params.BeaconConfig().MinEpochsForBlobsSidecarsRequest+1)*secsPerEpoch)
+	outsideRetention := genesis.Add(retentionDuration)
 	now := func() time.Time {
 		return outsideRetention
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -240,18 +240,18 @@ func (s *Service) requestAndSaveDataColumnSidecars(
 	wrappedBlockDataColumns := make([]verify.WrappedBlockDataColumn, 0, len(sidecars))
 	for _, sidecar := range sidecars {
 		wrappedBlockDataColumn := verify.WrappedBlockDataColumn{
-			ROBlock:    roBlock,
-			DataColumn: sidecar,
+			ROBlock:      roBlock.Block(),
+			RODataColumn: sidecar,
 		}
 
 		wrappedBlockDataColumns = append(wrappedBlockDataColumns, wrappedBlockDataColumn)
 	}
 
-	for _, sidecar := range sidecars {
-		if err := verify.DataColumnsAlignWithBlock(wrappedBlockDataColumns, s.newColumnsVerifier); err != nil {
-			return errors.Wrap(err, "data columns align with block")
-		}
+	if err := verify.DataColumnsAlignWithBlock(wrappedBlockDataColumns, s.newColumnsVerifier); err != nil {
+		return errors.Wrap(err, "data columns align with block")
+	}
 
+	for _, sidecar := range sidecars {
 		log.WithFields(logging.DataColumnFields(sidecar)).Debug("Received data column sidecar RPC")
 	}
 

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -331,7 +331,9 @@ func dataColumnIndexValidatorFromRangeReq(req *pb.DataColumnSidecarsByRangeReque
 	}
 }
 
-func SendDataColumnsByRangeRequest(
+// SendDataColumnSidecarsByRangeRequest sends a request for data column sidecars by range
+// and returns the fetched data column sidecars.
+func SendDataColumnSidecarsByRangeRequest(
 	ctx context.Context,
 	tor blockchain.TemporalOracle,
 	p2pApi p2p.P2P,

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -163,7 +163,7 @@ type Service struct {
 	initialSyncComplete              chan struct{}
 	verifierWaiter                   *verification.InitializerWaiter
 	newBlobVerifier                  verification.NewBlobVerifier
-	newColumnVerifier                verification.NewColumnVerifier
+	newColumnsVerifier               verification.NewDataColumnsVerifier
 	availableBlocker                 coverage.AvailableBlocker
 	dataColumsnReconstructionLock    sync.Mutex
 	receivedDataColumnsFromRoot      *gcache.Cache
@@ -234,9 +234,9 @@ func newBlobVerifierFromInitializer(ini *verification.Initializer) verification.
 	}
 }
 
-func newColumnVerifierFromInitializer(ini *verification.Initializer) verification.NewColumnVerifier {
-	return func(d blocks.RODataColumn, reqs []verification.Requirement) verification.DataColumnVerifier {
-		return ini.NewColumnVerifier(d, reqs)
+func newDataColumnsVerifierFromInitializer(ini *verification.Initializer) verification.NewDataColumnsVerifier {
+	return func(roDataColumns []blocks.RODataColumn, reqs []verification.Requirement) verification.DataColumnsVerifier {
+		return ini.NewDataColumnsVerifier(roDataColumns, reqs)
 	}
 }
 
@@ -248,7 +248,7 @@ func (s *Service) Start() {
 		return
 	}
 	s.newBlobVerifier = newBlobVerifierFromInitializer(v)
-	s.newColumnVerifier = newColumnVerifierFromInitializer(v)
+	s.newColumnsVerifier = newDataColumnsVerifierFromInitializer(v)
 
 	go s.verifierRoutine()
 	go s.startTasksPostInitialSync()

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -56,33 +56,35 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		return pubsub.ValidationReject, errWrongMessage
 	}
 
-	ds, err := blocks.NewRODataColumn(dspb)
+	roDataColumn, err := blocks.NewRODataColumn(dspb)
 	if err != nil {
 		return pubsub.ValidationReject, errors.Wrap(err, "roDataColumn conversion failure")
 	}
 
 	// Voluntary ignore messages (for debugging purposes).
 	dataColumnsIgnoreSlotMultiple := features.Get().DataColumnsIgnoreSlotMultiple
-	blockSlot := uint64(ds.SignedBlockHeader.Header.Slot)
+	blockSlot := uint64(roDataColumn.SignedBlockHeader.Header.Slot)
 
 	if dataColumnsIgnoreSlotMultiple != 0 && blockSlot%dataColumnsIgnoreSlotMultiple == 0 {
 		log.WithFields(logrus.Fields{
 			"slot":        blockSlot,
-			"columnIndex": ds.ColumnIndex,
-			"blockRoot":   fmt.Sprintf("%#x", ds.BlockRoot()),
+			"columnIndex": roDataColumn.ColumnIndex,
+			"blockRoot":   fmt.Sprintf("%#x", roDataColumn.BlockRoot()),
 		}).Warning("Voluntary ignore data column sidecar gossip")
 
 		return pubsub.ValidationIgnore, err
 	}
 
-	verifier := s.newColumnVerifier(ds, verification.GossipColumnSidecarRequirements)
+	roDataColumns := []blocks.RODataColumn{roDataColumn}
 
-	if err := verifier.DataColumnIndexInBounds(); err != nil {
+	verifier := s.newColumnsVerifier(roDataColumns, verification.GossipColumnSidecarRequirements)
+
+	if err := verifier.DataColumnsIndexInBounds(); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
 	// [REJECT] The sidecar is for the correct subnet -- i.e. compute_subnet_for_data_column_sidecar(sidecar.index) == subnet_id.
-	want := fmt.Sprintf("data_column_sidecar_%d", computeSubnetForColumnSidecar(ds.ColumnIndex))
+	want := fmt.Sprintf("data_column_sidecar_%d", computeSubnetForColumnSidecar(roDataColumn.ColumnIndex))
 	if !strings.Contains(*msg.Topic, want) {
 		log.Debug("Column Sidecar index does not match topic")
 		return pubsub.ValidationReject, fmt.Errorf("wrong topic name: %s", *msg.Topic)
@@ -93,7 +95,7 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 	}
 
 	// [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index, sidecar.index) with valid header signature, sidecar inclusion proof, and kzg proof.
-	if s.hasSeenDataColumnIndex(ds.Slot(), ds.ProposerIndex(), ds.DataColumnSidecar.ColumnIndex) {
+	if s.hasSeenDataColumnIndex(roDataColumn.Slot(), roDataColumn.ProposerIndex(), roDataColumn.DataColumnSidecar.ColumnIndex) {
 		return pubsub.ValidationIgnore, nil
 	}
 
@@ -104,11 +106,11 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		// If we haven't seen the parent, request it asynchronously.
 		go func() {
 			customCtx := context.Background()
-			parentRoot := ds.ParentRoot()
+			parentRoot := roDataColumn.ParentRoot()
 			roots := [][fieldparams.RootLength]byte{parentRoot}
 			randGenerator := rand.NewGenerator()
 			if err := s.sendBatchRootRequest(customCtx, roots, randGenerator); err != nil {
-				log.WithError(err).WithFields(logging.DataColumnFields(ds)).Debug("Failed to send batch root request")
+				log.WithError(err).WithFields(logging.DataColumnFields(roDataColumn)).Debug("Failed to send batch root request")
 			}
 		}()
 
@@ -141,17 +143,22 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 	}
 
 	// Get the time at slot start.
-	startTime, err := slots.ToTime(uint64(s.cfg.chain.GenesisTime().Unix()), ds.SignedBlockHeader.Header.Slot)
+	startTime, err := slots.ToTime(uint64(s.cfg.chain.GenesisTime().Unix()), roDataColumn.SignedBlockHeader.Header.Slot)
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 
-	verifiedRODataColumn, err := verifier.VerifiedRODataColumn()
+	verifiedRODataColumns, err := verifier.VerifiedRODataColumns()
 	if err != nil {
 		return pubsub.ValidationReject, err
 	}
 
-	msg.ValidatorData = verifiedRODataColumn
+	if len(verifiedRODataColumns) != 1 {
+		// This should never happen.
+		return pubsub.ValidationIgnore, errors.New("Wrong number of verified data columns")
+	}
+
+	msg.ValidatorData = verifiedRODataColumns[0]
 
 	sinceSlotStartTime := receivedTime.Sub(startTime)
 	validationTime := s.cfg.clock.Now().Sub(receivedTime)
@@ -161,7 +168,7 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 	pidString := pid.String()
 
 	log.
-		WithFields(logging.DataColumnFields(ds)).
+		WithFields(logging.DataColumnFields(roDataColumn)).
 		WithFields(logrus.Fields{
 			"sinceSlotStartTime": sinceSlotStartTime,
 			"validationTime":     validationTime,

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -153,8 +153,11 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		return pubsub.ValidationReject, err
 	}
 
-	if len(verifiedRODataColumns) != 1 {
+	verifiedRODataColumnsCount := len(verifiedRODataColumns)
+
+	if verifiedRODataColumnsCount != 1 {
 		// This should never happen.
+		log.WithField("verifiedRODataColumnsCount", verifiedRODataColumnsCount).Error("Verified data columns count is not 1")
 		return pubsub.ValidationIgnore, errors.New("Wrong number of verified data columns")
 	}
 

--- a/beacon-chain/sync/verify/BUILD.bazel
+++ b/beacon-chain/sync/verify/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//beacon-chain/verification:go_default_library",
         "//config/fieldparams:go_default_library",
         "//consensus-types/blocks:go_default_library",
+        "//consensus-types/interfaces:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//runtime/version:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/beacon-chain/sync/verify/blob.go
+++ b/beacon-chain/sync/verify/blob.go
@@ -52,46 +52,66 @@ func BlobAlignsWithBlock(blob blocks.ROBlob, block blocks.ROBlock) error {
 	return nil
 }
 
-func ColumnAlignsWithBlock(col blocks.RODataColumn, block blocks.ROBlock, colVerifier verification.NewColumnVerifier) error {
-	// Exit early if the block is not at least a Deneb block.
-	if block.Version() < version.Deneb {
-		return nil
+type WrappedBlockDataColumn struct {
+	ROBlock    blocks.ROBlock
+	DataColumn blocks.RODataColumn
+}
+
+func DataColumnsAlignWithBlock(
+	wrappedBlockDataColumns []WrappedBlockDataColumn,
+	dataColumnsVerifier verification.NewDataColumnsVerifier,
+) error {
+	for _, wrappedBlockDataColumn := range wrappedBlockDataColumns {
+		dataColumn := wrappedBlockDataColumn.DataColumn
+		block := wrappedBlockDataColumn.ROBlock
+
+		// Extract the block root from the data column.
+		blockRoot := dataColumn.BlockRoot()
+
+		// Retrieve the KZG commitments from the block.
+		blockKZGCommitments, err := block.Block().Body().BlobKzgCommitments()
+		if err != nil {
+			return errors.Wrap(err, "blob KZG commitments")
+		}
+
+		// Retrieve the KZG commitments from the data column.
+		dataColumnKZGCommitments := dataColumn.KzgCommitments
+
+		// Verify the commitments in the block match the commitments in the data column.
+		if !reflect.DeepEqual(blockKZGCommitments, dataColumnKZGCommitments) {
+			// Retrieve the data columns slot.
+			dataColumSlot := dataColumn.Slot()
+
+			return errors.Wrapf(
+				ErrMismatchedColumnCommitments,
+				"data column commitments `%#v` != block commitments `%#v` for block root %#x at slot %d",
+				dataColumnKZGCommitments,
+				blockKZGCommitments,
+				blockRoot,
+				dataColumSlot,
+			)
+		}
 	}
 
-	// Check if the block root in the column sidecar matches the block root.
-	if col.BlockRoot() != block.Root() {
-		return ErrColumnBlockMisaligned
+	dataColumns := make([]blocks.RODataColumn, 0, len(wrappedBlockDataColumns))
+	for _, wrappedBlowrappedBlockDataColumn := range wrappedBlockDataColumns {
+		dataColumn := wrappedBlowrappedBlockDataColumn.DataColumn
+		dataColumns = append(dataColumns, dataColumn)
 	}
 
-	// Verify commitment byte values match
-	commitments, err := block.Block().Body().BlobKzgCommitments()
-	if err != nil {
-		return errors.Wrap(err, "blob KZG commitments")
+	// Verify if data columns index are in bounds.
+	verifier := dataColumnsVerifier(dataColumns, verification.InitsyncColumnSidecarRequirements)
+	if err := verifier.DataColumnsIndexInBounds(); err != nil {
+		return errors.Wrap(err, "data column index in bounds")
 	}
 
-	if !reflect.DeepEqual(commitments, col.KzgCommitments) {
-		return errors.Wrapf(
-			ErrMismatchedColumnCommitments,
-			"commitment %#v != block commitment %#v for block root %#x at slot %d ",
-			col.KzgCommitments,
-			commitments,
-			block.Root(),
-			col.Slot(),
-		)
-	}
-
-	vf := colVerifier(col, verification.InitsyncColumnSidecarRequirements)
-	if err := vf.DataColumnIndexInBounds(); err != nil {
-		return errors.Wrap(err, "data column index out of bounds")
-	}
-
-	// Filter out columns which did not pass the KZG inclusion proof verification.
-	if err := vf.SidecarInclusionProven(); err != nil {
+	// Verify the KZG inclusion proof verification.
+	if err := verifier.SidecarInclusionProven(); err != nil {
 		return errors.Wrap(err, "inclusion proof verification")
 	}
 
-	// Filter out columns which did not pass the KZG proof verification.
-	if err := vf.SidecarKzgProofVerified(); err != nil {
+	// Verify the KZG proof verification.
+	if err := verifier.SidecarKzgProofVerified(); err != nil {
 		return errors.Wrap(err, "KZG proof verification")
 	}
 

--- a/beacon-chain/sync/verify/blob.go
+++ b/beacon-chain/sync/verify/blob.go
@@ -70,7 +70,14 @@ func ColumnAlignsWithBlock(col blocks.RODataColumn, block blocks.ROBlock, colVer
 	}
 
 	if !reflect.DeepEqual(commitments, col.KzgCommitments) {
-		return errors.Wrapf(ErrMismatchedColumnCommitments, "commitment %#v != block commitment %#v for block root %#x at slot %d ", col.KzgCommitments, commitments, block.Root(), col.Slot())
+		return errors.Wrapf(
+			ErrMismatchedColumnCommitments,
+			"commitment %#v != block commitment %#v for block root %#x at slot %d ",
+			col.KzgCommitments,
+			commitments,
+			block.Root(),
+			col.Slot(),
+		)
 	}
 
 	vf := colVerifier(col, verification.InitsyncColumnSidecarRequirements)

--- a/beacon-chain/sync/verify/blob.go
+++ b/beacon-chain/sync/verify/blob.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/verification"
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 )
@@ -53,8 +54,8 @@ func BlobAlignsWithBlock(blob blocks.ROBlob, block blocks.ROBlock) error {
 }
 
 type WrappedBlockDataColumn struct {
-	ROBlock    blocks.ROBlock
-	DataColumn blocks.RODataColumn
+	ROBlock      interfaces.ReadOnlyBeaconBlock
+	RODataColumn blocks.RODataColumn
 }
 
 func DataColumnsAlignWithBlock(
@@ -62,14 +63,14 @@ func DataColumnsAlignWithBlock(
 	dataColumnsVerifier verification.NewDataColumnsVerifier,
 ) error {
 	for _, wrappedBlockDataColumn := range wrappedBlockDataColumns {
-		dataColumn := wrappedBlockDataColumn.DataColumn
+		dataColumn := wrappedBlockDataColumn.RODataColumn
 		block := wrappedBlockDataColumn.ROBlock
 
 		// Extract the block root from the data column.
 		blockRoot := dataColumn.BlockRoot()
 
 		// Retrieve the KZG commitments from the block.
-		blockKZGCommitments, err := block.Block().Body().BlobKzgCommitments()
+		blockKZGCommitments, err := block.Body().BlobKzgCommitments()
 		if err != nil {
 			return errors.Wrap(err, "blob KZG commitments")
 		}
@@ -95,7 +96,7 @@ func DataColumnsAlignWithBlock(
 
 	dataColumns := make([]blocks.RODataColumn, 0, len(wrappedBlockDataColumns))
 	for _, wrappedBlowrappedBlockDataColumn := range wrappedBlockDataColumns {
-		dataColumn := wrappedBlowrappedBlockDataColumn.DataColumn
+		dataColumn := wrappedBlowrappedBlockDataColumn.RODataColumn
 		dataColumns = append(dataColumns, dataColumn)
 	}
 

--- a/beacon-chain/verification/batch.go
+++ b/beacon-chain/verification/batch.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/kzg"
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/peerdas"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 )
@@ -92,86 +91,4 @@ func (batch *BlobBatchVerifier) verifyOneBlob(sc blocks.ROBlob) (blocks.Verified
 	}
 
 	return bv.VerifiedROBlob()
-}
-
-// NewDataColumnBatchVerifier initializes a data column batch verifier. It requires the caller to correctly specify
-// verification Requirements and to also pass in a NewColumnVerifier, which is a callback function that
-// returns a new ColumnVerifier for handling a single column in the batch.
-func NewDataColumnBatchVerifier(newVerifier NewDataColumnsVerifier, reqs []Requirement) *DataColumnBatchVerifier {
-	return &DataColumnBatchVerifier{
-		verifyKzg:   peerdas.VerifyDataColumnsSidecarKZGProofs,
-		newVerifier: newVerifier,
-		reqs:        reqs,
-	}
-}
-
-// DataColumnBatchVerifier solves problems that come from verifying batches of data columns from RPC.
-// First: we only update forkchoice after the entire batch has completed, so the n+1 elements in the batch
-// won't be in forkchoice yet.
-// Second: it is more efficient to batch some verifications, like kzg commitment verification. Batch adds a
-// method to ColumnVerifier to verify the kzg commitments of all data column sidecars for a block together, then using the cached
-// result of the batch verification when verifying the individual columns.
-type DataColumnBatchVerifier struct {
-	verifyKzg   rodataColumnsCommitmentVerifier
-	newVerifier NewDataColumnsVerifier
-	reqs        []Requirement
-}
-
-// VerifiedRODataColumns satisfies the das.ColumnBatchVerifier interface, used by das.AvailabilityStore.
-func (batch *DataColumnBatchVerifier) VerifiedRODataColumns(
-	_ context.Context,
-	block blocks.ROBlock,
-	roDataColumns []blocks.RODataColumn,
-) ([]blocks.VerifiedRODataColumn, error) {
-	if len(roDataColumns) == 0 {
-		return nil, nil
-	}
-
-	blockSignature := block.Signature()
-
-	// We assume the proposer is validated wrt. the block in batch block processing before performing the DA check.
-	// So at this stage we just need to make sure the value being signed and signature bytes match the block.
-	for _, roDataColumn := range roDataColumns {
-		dataColumnSignature := bytesutil.ToBytes96(roDataColumn.SignedBlockHeader.Signature)
-		if blockSignature != dataColumnSignature {
-			return nil, ErrBatchSignatureMismatch
-		}
-
-		// Extra defensive check to make sure the roots match. This should be unnecessary in practice since the root from
-		// the block should be used as the lookup key into the cache of sidecars.
-		if block.Root() != roDataColumn.BlockRoot() {
-			return nil, ErrBatchBlockRootMismatch
-		}
-	}
-
-	// Verify commitments for all columns at once. verifyOneColumn assumes it is only called once this check succeeds.
-	verified, err := batch.verifyKzg(roDataColumns)
-	if err != nil {
-		return nil, errors.Wrap(err, "verify KZG")
-	}
-
-	if !verified {
-		return nil, ErrSidecarKzgProofInvalid
-	}
-
-	dataColumnsVerifier := batch.newVerifier(roDataColumns, batch.reqs)
-	// We can satisfy the following 2 requirements immediately because VerifiedROColumns always verifies commitments
-	// and block signature for all columns in the batch before calling verifyOneColumn.
-	dataColumnsVerifier.SatisfyRequirement(RequireSidecarKzgProofVerified)
-	dataColumnsVerifier.SatisfyRequirement(RequireValidProposerSignature)
-
-	if err := dataColumnsVerifier.DataColumnsIndexInBounds(); err != nil {
-		return nil, errors.Wrap(err, "data columns index in bounds")
-	}
-
-	if err := dataColumnsVerifier.SidecarInclusionProven(); err != nil {
-		return nil, errors.Wrap(err, "sidecar inclusion proved")
-	}
-
-	verifiedRODataColumns, err := dataColumnsVerifier.VerifiedRODataColumns()
-	if err != nil {
-		return nil, errors.Wrap(err, "verified RO data columns")
-	}
-
-	return verifiedRODataColumns, nil
 }

--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -475,7 +475,7 @@ func TestSidecarProposerExpected(t *testing.T) {
 	t.Run("not cached, proposer matches", func(t *testing.T) {
 		pc := &mockProposerCache{
 			ProposerCB: pcReturnsNotFound(),
-			ComputeProposerCB: func(ctx context.Context, root [32]byte, slot primitives.Slot, pst state.BeaconState) (primitives.ValidatorIndex, error) {
+			ComputeProposerCB: func(_ context.Context, root [32]byte, slot primitives.Slot, _ state.BeaconState) (primitives.ValidatorIndex, error) {
 				require.Equal(t, b.ParentRoot(), root)
 				require.Equal(t, b.Slot(), slot)
 				return b.ProposerIndex(), nil
@@ -490,7 +490,7 @@ func TestSidecarProposerExpected(t *testing.T) {
 	t.Run("not cached, proposer does not match", func(t *testing.T) {
 		pc := &mockProposerCache{
 			ProposerCB: pcReturnsNotFound(),
-			ComputeProposerCB: func(ctx context.Context, root [32]byte, slot primitives.Slot, pst state.BeaconState) (primitives.ValidatorIndex, error) {
+			ComputeProposerCB: func(_ context.Context, root [32]byte, slot primitives.Slot, _ state.BeaconState) (primitives.ValidatorIndex, error) {
 				require.Equal(t, b.ParentRoot(), root)
 				require.Equal(t, b.Slot(), slot)
 				return b.ProposerIndex() + 1, nil
@@ -505,7 +505,7 @@ func TestSidecarProposerExpected(t *testing.T) {
 	t.Run("not cached, ComputeProposer fails", func(t *testing.T) {
 		pc := &mockProposerCache{
 			ProposerCB: pcReturnsNotFound(),
-			ComputeProposerCB: func(ctx context.Context, root [32]byte, slot primitives.Slot, pst state.BeaconState) (primitives.ValidatorIndex, error) {
+			ComputeProposerCB: func(_ context.Context, root [32]byte, slot primitives.Slot, _ state.BeaconState) (primitives.ValidatorIndex, error) {
 				require.Equal(t, b.ParentRoot(), root)
 				require.Equal(t, b.Slot(), slot)
 				return 0, errors.New("ComputeProposer failed")

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v5/beacon-chain/forkchoice/types"
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
@@ -69,26 +68,32 @@ var (
 	ErrColumnIndexInvalid = errors.New("incorrect column sidecar index")
 )
 
-type RODataColumnVerifier struct {
+type RODataColumnsVerifier struct {
 	*sharedResources
-	results                    *results
-	dataColumn                 blocks.RODataColumn
-	parent                     state.BeaconState
-	verifyDataColumnCommitment rodataColumnCommitmentVerifier
+	results                     *results
+	dataColumns                 []blocks.RODataColumn
+	verifyDataColumnsCommitment rodataColumnsCommitmentVerifier
 }
 
-type rodataColumnCommitmentVerifier func(blocks.RODataColumn) (bool, error)
+type rodataColumnsCommitmentVerifier func([]blocks.RODataColumn) (bool, error)
 
-var _ DataColumnVerifier = &RODataColumnVerifier{}
+var _ DataColumnsVerifier = &RODataColumnsVerifier{}
 
-// VerifiedRODataColumn "upgrades" the wrapped ROBlob to a VerifiedROBlob.
+// VerifiedRODataColumns "upgrades" the wrapped ROBlob to a VerifiedROBlob.
 // If any of the verifications ran against the blob failed, or some required verifications
 // were not run, an error will be returned.
-func (dv *RODataColumnVerifier) VerifiedRODataColumn() (blocks.VerifiedRODataColumn, error) {
+func (dv *RODataColumnsVerifier) VerifiedRODataColumns() ([]blocks.VerifiedRODataColumn, error) {
 	if dv.results.allSatisfied() {
-		return blocks.NewVerifiedRODataColumn(dv.dataColumn), nil
+		verifiedRODataColumns := make([]blocks.VerifiedRODataColumn, 0, len(dv.dataColumns))
+		for _, dataColumn := range dv.dataColumns {
+			verifiedRODataColumn := blocks.NewVerifiedRODataColumn(dataColumn)
+			verifiedRODataColumns = append(verifiedRODataColumns, verifiedRODataColumn)
+		}
+
+		return verifiedRODataColumns, nil
 	}
-	return blocks.VerifiedRODataColumn{}, dv.results.errors(ErrColumnInvalid)
+
+	return nil, dv.results.errors(ErrColumnInvalid)
 }
 
 // SatisfyRequirement allows the caller to assert that a requirement has been satisfied.
@@ -97,11 +102,11 @@ func (dv *RODataColumnVerifier) VerifiedRODataColumn() (blocks.VerifiedRODataCol
 // forkchoice, like descends from finalized or parent seen, would necessarily fail. Allowing the caller to
 // assert the requirement has been satisfied ensures we have an easy way to audit which piece of code is satisfying
 // a requirement outside of this package.
-func (dv *RODataColumnVerifier) SatisfyRequirement(req Requirement) {
+func (dv *RODataColumnsVerifier) SatisfyRequirement(req Requirement) {
 	dv.recordResult(req, nil)
 }
 
-func (dv *RODataColumnVerifier) recordResult(req Requirement, err *error) {
+func (dv *RODataColumnsVerifier) recordResult(req Requirement, err *error) {
 	if err == nil || *err == nil {
 		dv.results.record(req, nil)
 		return
@@ -109,162 +114,281 @@ func (dv *RODataColumnVerifier) recordResult(req Requirement, err *error) {
 	dv.results.record(req, *err)
 }
 
-// DataColumnIndexInBounds represents the follow spec verification:
+// DataColumnsIndexInBounds represents the follow spec verification:
 // [REJECT] The sidecar's index is consistent with NUMBER_OF_COLUMNS -- i.e. data_column_sidecar.index < NUMBER_OF_COLUMNS.
-func (dv *RODataColumnVerifier) DataColumnIndexInBounds() (err error) {
+func (dv *RODataColumnsVerifier) DataColumnsIndexInBounds() (err error) {
 	defer dv.recordResult(RequireDataColumnIndexInBounds, &err)
-	if dv.dataColumn.ColumnIndex >= fieldparams.NumberOfColumns {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Sidecar index >= NUMBER_OF_COLUMNS")
-		return columnErrBuilder(ErrColumnIndexInvalid)
+
+	for _, dataColumn := range dv.dataColumns {
+		if dataColumn.ColumnIndex >= fieldparams.NumberOfColumns {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithFields(fields).Debug("Sidecar index >= NUMBER_OF_COLUMNS")
+			return columnErrBuilder(ErrColumnIndexInvalid)
+		}
 	}
+
 	return nil
 }
 
 // NotFromFutureSlot represents the spec verification:
 // [IGNORE] The sidecar is not from a future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
 // -- i.e. validate that block_header.slot <= current_slot
-func (dv *RODataColumnVerifier) NotFromFutureSlot() (err error) {
+func (dv *RODataColumnsVerifier) NotFromFutureSlot() (err error) {
 	defer dv.recordResult(RequireNotFromFutureSlot, &err)
-	if dv.clock.CurrentSlot() == dv.dataColumn.Slot() {
-		return nil
+
+	// Retrieve the current slot.
+	currentSlot := dv.clock.CurrentSlot()
+
+	// Get the current time.
+	now := dv.clock.Now()
+
+	// Retrieve the maximum gossip clock disparity.
+	maximumGossipClockDisparity := params.BeaconConfig().MaximumGossipClockDisparityDuration()
+
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the data column slot.
+		dataColumnSlot := dataColumn.Slot()
+
+		// Skip if the data column slotis the same as the current slot.
+		if currentSlot == dataColumnSlot {
+			continue
+		}
+
+		// earliestStart represents the time the slot starts, lowered by MAXIMUM_GOSSIP_CLOCK_DISPARITY.
+		// We lower the time by MAXIMUM_GOSSIP_CLOCK_DISPARITY in case system time is running slightly behind real time.
+		earliestStart := dv.clock.SlotStart(dataColumnSlot).Add(-maximumGossipClockDisparity)
+
+		// If the system time is still before earliestStart, we consider the column from a future slot and return an error.
+		if now.Before(earliestStart) {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithFields(fields).Debug("Sidecar slot is too far in the future")
+
+			return columnErrBuilder(ErrFromFutureSlot)
+		}
 	}
-	// earliestStart represents the time the slot starts, lowered by MAXIMUM_GOSSIP_CLOCK_DISPARITY.
-	// We lower the time by MAXIMUM_GOSSIP_CLOCK_DISPARITY in case system time is running slightly behind real time.
-	earliestStart := dv.clock.SlotStart(dv.dataColumn.Slot()).Add(-1 * params.BeaconConfig().MaximumGossipClockDisparityDuration())
-	// If the system time is still before earliestStart, we consider the column from a future slot and return an error.
-	if dv.clock.Now().Before(earliestStart) {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Sidecar slot is too far in the future")
-		return columnErrBuilder(ErrFromFutureSlot)
-	}
+
 	return nil
 }
 
 // SlotAboveFinalized represents the spec verification:
 // [IGNORE] The sidecar is from a slot greater than the latest finalized slot
 // -- i.e. validate that block_header.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
-func (dv *RODataColumnVerifier) SlotAboveFinalized() (err error) {
+func (dv *RODataColumnsVerifier) SlotAboveFinalized() (err error) {
 	defer dv.recordResult(RequireSlotAboveFinalized, &err)
-	fcp := dv.fc.FinalizedCheckpoint()
-	fSlot, err := slots.EpochStart(fcp.Epoch)
+
+	// Retrieve the finalized checkpoint.
+	finalizedCheckpoint := dv.fc.FinalizedCheckpoint()
+
+	// Compute the first slot of the finalized checkpoint epoch.
+	startSlot, err := slots.EpochStart(finalizedCheckpoint.Epoch)
 	if err != nil {
-		return errors.Wrapf(columnErrBuilder(ErrSlotNotAfterFinalized), "error computing epoch start slot for finalized checkpoint (%d) %s", fcp.Epoch, err.Error())
+		return errors.Wrapf(
+			columnErrBuilder(ErrSlotNotAfterFinalized),
+			"error computing epoch start slot for finalized checkpoint (%d) %s",
+			finalizedCheckpoint.Epoch,
+			err.Error(),
+		)
 	}
-	if dv.dataColumn.Slot() <= fSlot {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Sidecar slot is not after finalized checkpoint")
-		return columnErrBuilder(ErrSlotNotAfterFinalized)
+
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the data column slot.
+		dataColumnSlot := dataColumn.Slot()
+
+		// Check if the data column slot is after first slot of the epoch corresponding to the finalized checkpoint.
+		if dataColumnSlot <= startSlot {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithFields(fields).Debug("Sidecar slot is not after finalized checkpoint")
+
+			return columnErrBuilder(ErrSlotNotAfterFinalized)
+		}
 	}
+
 	return nil
 }
 
 // ValidProposerSignature represents the spec verification:
 // [REJECT] The proposer signature of sidecar.signed_block_header, is valid with respect to the block_header.proposer_index pubkey.
-func (dv *RODataColumnVerifier) ValidProposerSignature(ctx context.Context) (err error) {
+func (dv *RODataColumnsVerifier) ValidProposerSignature(ctx context.Context) (err error) {
 	defer dv.recordResult(RequireValidProposerSignature, &err)
-	sd := columnToSignatureData(dv.dataColumn)
-	// First check if there is a cached verification that can be reused.
-	seen, err := dv.sc.SignatureVerified(sd)
-	if seen {
-		columnVerificationProposerSignatureCache.WithLabelValues("hit-valid").Inc()
+
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the signature data from the data column.
+		signatureData := columnToSignatureData(dataColumn)
+
+		// Get logging fields.
+		fields := logging.DataColumnFields(dataColumn)
+		log := log.WithFields(fields)
+
+		// First check if there is a cached verification that can be reused.
+		seen, err := dv.sc.SignatureVerified(signatureData)
 		if err != nil {
-			log.WithFields(logging.DataColumnFields(dv.dataColumn)).WithError(err).Debug("Reusing failed proposer signature validation from cache")
+			log.WithError(err).Debug("Reusing failed proposer signature validation from cache")
+
 			blobVerificationProposerSignatureCache.WithLabelValues("hit-invalid").Inc()
 			return columnErrBuilder(ErrInvalidProposerSignature)
 		}
-		return nil
-	}
-	columnVerificationProposerSignatureCache.WithLabelValues("miss").Inc()
 
-	// Retrieve the parent state to fallback to full verification.
-	parent, err := dv.parentState(ctx)
-	if err != nil {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).WithError(err).Debug("Could not replay parent state for column signature verification")
-		return columnErrBuilder(ErrInvalidProposerSignature)
+		// If yes, we can skip the full verification.
+		if seen {
+			columnVerificationProposerSignatureCache.WithLabelValues("hit-valid").Inc()
+			continue
+		}
+
+		columnVerificationProposerSignatureCache.WithLabelValues("miss").Inc()
+
+		// Retrieve the root of the parent block corresponding to the data column.
+		parentRoot := dataColumn.ParentRoot()
+
+		// Retrieve the parentState state to fallback to full verification.
+		parentState, err := dv.sr.StateByRoot(ctx, parentRoot)
+		if err != nil {
+			log.WithError(err).Debug("Could not replay parent state for column signature verification")
+			return columnErrBuilder(ErrInvalidProposerSignature)
+		}
+
+		// Full verification, which will subsequently be cached for anything sharing the signature cache.
+		if err = dv.sc.VerifySignature(signatureData, parentState); err != nil {
+			log.WithError(err).Debug("Signature verification failed")
+			return columnErrBuilder(ErrInvalidProposerSignature)
+		}
 	}
-	// Full verification, which will subsequently be cached for anything sharing the signature cache.
-	if err = dv.sc.VerifySignature(sd, parent); err != nil {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).WithError(err).Debug("Signature verification failed")
-		return columnErrBuilder(ErrInvalidProposerSignature)
-	}
+
 	return nil
 }
 
 // SidecarParentSeen represents the spec verification:
 // [IGNORE] The sidecar's block's parent (defined by block_header.parent_root) has been seen
 // (via both gossip and non-gossip sources) (a client MAY queue sidecars for processing once the parent block is retrieved).
-func (dv *RODataColumnVerifier) SidecarParentSeen(parentSeen func([32]byte) bool) (err error) {
+func (dv *RODataColumnsVerifier) SidecarParentSeen(parentSeen func([32]byte) bool) (err error) {
 	defer dv.recordResult(RequireSidecarParentSeen, &err)
-	if parentSeen != nil && parentSeen(dv.dataColumn.ParentRoot()) {
-		return nil
+
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the root of the parent block corresponding to the data column.
+		parentRoot := dataColumn.ParentRoot()
+
+		// Skip if the parent root has been seen.
+		if parentSeen != nil && parentSeen(parentRoot) {
+			continue
+		}
+
+		if !dv.fc.HasNode(parentRoot) {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithFields(fields).Debug("Parent root has not been seen")
+			return columnErrBuilder(ErrSidecarParentNotSeen)
+		}
 	}
-	if dv.fc.HasNode(dv.dataColumn.ParentRoot()) {
-		return nil
-	}
-	log.WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Parent root has not been seen")
-	return columnErrBuilder(ErrSidecarParentNotSeen)
+
+	return nil
 }
 
 // SidecarParentValid represents the spec verification:
 // [REJECT] The sidecar's block's parent (defined by block_header.parent_root) passes validation.
-func (dv *RODataColumnVerifier) SidecarParentValid(badParent func([32]byte) bool) (err error) {
+func (dv *RODataColumnsVerifier) SidecarParentValid(badParent func([32]byte) bool) (err error) {
 	defer dv.recordResult(RequireSidecarParentValid, &err)
-	if badParent != nil && badParent(dv.dataColumn.ParentRoot()) {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Parent root is invalid")
-		return columnErrBuilder(ErrSidecarParentInvalid)
+
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the root of the parent block corresponding to the data column.
+		parentRoot := dataColumn.ParentRoot()
+
+		if badParent != nil && badParent(parentRoot) {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithFields(fields).Debug("Parent root is invalid")
+			return columnErrBuilder(ErrSidecarParentInvalid)
+		}
 	}
+
 	return nil
 }
 
 // SidecarParentSlotLower represents the spec verification:
 // [REJECT] The sidecar is from a higher slot than the sidecar's block's parent (defined by block_header.parent_root).
-func (dv *RODataColumnVerifier) SidecarParentSlotLower() (err error) {
+func (dv *RODataColumnsVerifier) SidecarParentSlotLower() (err error) {
 	defer dv.recordResult(RequireSidecarParentSlotLower, &err)
-	parentSlot, err := dv.fc.Slot(dv.dataColumn.ParentRoot())
-	if err != nil {
-		return errors.Wrap(columnErrBuilder(ErrSlotNotAfterParent), "parent root not in forkchoice")
+
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the root of the parent block corresponding to the data column.
+		parentRoot := dataColumn.ParentRoot()
+
+		// Compute the slot of the parent block.
+		parentSlot, err := dv.fc.Slot(parentRoot)
+		if err != nil {
+			return errors.Wrap(columnErrBuilder(ErrSlotNotAfterParent), "parent root not in forkchoice")
+		}
+
+		// Extract the slot of the data column.
+		dataColumnSlot := dataColumn.Slot()
+
+		// Check if the data column slot is after the parent slot.
+		if parentSlot >= dataColumnSlot {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithFields(fields).Debug("Sidecar slot is not after parent slot")
+			return ErrSlotNotAfterParent
+		}
 	}
-	if parentSlot >= dv.dataColumn.Slot() {
-		return ErrSlotNotAfterParent
-	}
+
 	return nil
 }
 
 // SidecarDescendsFromFinalized represents the spec verification:
 // [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
 // -- i.e. get_checkpoint_block(store, block_header.parent_root, store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root.
-func (dv *RODataColumnVerifier) SidecarDescendsFromFinalized() (err error) {
+func (dv *RODataColumnsVerifier) SidecarDescendsFromFinalized() (err error) {
 	defer dv.recordResult(RequireSidecarDescendsFromFinalized, &err)
-	if !dv.fc.HasNode(dv.dataColumn.ParentRoot()) {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Parent root not in forkchoice")
-		return columnErrBuilder(ErrSidecarNotFinalizedDescendent)
+
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the root of the parent block corresponding to the data column.
+		parentRoot := dataColumn.ParentRoot()
+
+		if !dv.fc.HasNode(parentRoot) {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithFields(fields).Debug("Parent root not in forkchoice")
+			return columnErrBuilder(ErrSidecarNotFinalizedDescendent)
+		}
 	}
+
 	return nil
 }
 
 // SidecarInclusionProven represents the spec verification:
 // [REJECT] The sidecar's kzg_commitments field inclusion proof is valid as verified by verify_data_column_sidecar_inclusion_proof(sidecar).
-func (dv *RODataColumnVerifier) SidecarInclusionProven() (err error) {
+func (dv *RODataColumnsVerifier) SidecarInclusionProven() (err error) {
 	defer dv.recordResult(RequireSidecarInclusionProven, &err)
-	if err = blocks.VerifyKZGInclusionProofColumn(dv.dataColumn); err != nil {
-		log.WithError(err).WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Sidecar inclusion proof verification failed")
-		return columnErrBuilder(ErrSidecarInclusionProofInvalid)
+
+	for _, dataColumn := range dv.dataColumns {
+		if err = blocks.VerifyKZGInclusionProofColumn(dataColumn); err != nil {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithError(err).WithFields(fields).Debug("Sidecar inclusion proof verification failed")
+			return columnErrBuilder(ErrSidecarInclusionProofInvalid)
+		}
 	}
+
 	return nil
 }
 
 // SidecarKzgProofVerified represents the spec verification:
 // [REJECT] The sidecar's column data is valid as verified by verify_data_column_sidecar_kzg_proofs(sidecar).
-func (dv *RODataColumnVerifier) SidecarKzgProofVerified() (err error) {
+func (dv *RODataColumnsVerifier) SidecarKzgProofVerified() (err error) {
 	defer dv.recordResult(RequireSidecarKzgProofVerified, &err)
-	ok, err := dv.verifyDataColumnCommitment(dv.dataColumn)
+
+	ok, err := dv.verifyDataColumnsCommitment(dv.dataColumns)
 	if err != nil {
-		log.WithError(err).WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("KZG commitment proof verification failed")
+		for _, dataColumn := range dv.dataColumns {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithError(err).WithFields(fields).Debug("Error verifying KZG commitment proof in the batch containing this sidecar")
+		}
 		return columnErrBuilder(ErrSidecarKzgProofInvalid)
 	}
-	if !ok {
-		log.WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("KZG commitment proof verification failed")
-		return columnErrBuilder(ErrSidecarKzgProofInvalid)
+
+	if ok {
+		return nil
 	}
-	return nil
+
+	for _, dataColumn := range dv.dataColumns {
+		fields := logging.DataColumnFields(dataColumn)
+		log.WithFields(fields).Debug("KZG commitment proof verification failed in the batch containing this sidecar")
+	}
+
+	return columnErrBuilder(ErrSidecarKzgProofInvalid)
 }
 
 // SidecarProposerExpected represents the spec verification:
@@ -272,49 +396,66 @@ func (dv *RODataColumnVerifier) SidecarKzgProofVerified() (err error) {
 // in the context of the current shuffling (defined by block_header.parent_root/block_header.slot).
 // If the proposer_index cannot immediately be verified against the expected shuffling, the sidecar MAY be queued
 // for later processing while proposers for the block's branch are calculated -- in such a case do not REJECT, instead IGNORE this message.
-func (dv *RODataColumnVerifier) SidecarProposerExpected(ctx context.Context) (err error) {
+func (dv *RODataColumnsVerifier) SidecarProposerExpected(ctx context.Context) (err error) {
 	defer dv.recordResult(RequireSidecarProposerExpected, &err)
-	e := slots.ToEpoch(dv.dataColumn.Slot())
-	if e > 0 {
-		e = e - 1
-	}
-	r, err := dv.fc.TargetRootForEpoch(dv.dataColumn.ParentRoot(), e)
-	if err != nil {
-		return columnErrBuilder(ErrSidecarUnexpectedProposer)
-	}
-	c := &forkchoicetypes.Checkpoint{Root: r, Epoch: e}
-	idx, cached := dv.pc.Proposer(c, dv.dataColumn.Slot())
-	if !cached {
-		pst, err := dv.parentState(ctx)
-		if err != nil {
-			log.WithError(err).WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("State replay to parent_root failed")
-			return columnErrBuilder(ErrSidecarUnexpectedProposer)
-		}
-		idx, err = dv.pc.ComputeProposer(ctx, dv.dataColumn.ParentRoot(), dv.dataColumn.Slot(), pst)
-		if err != nil {
-			log.WithError(err).WithFields(logging.DataColumnFields(dv.dataColumn)).Debug("Error computing proposer index from parent state")
-			return columnErrBuilder(ErrSidecarUnexpectedProposer)
-		}
-	}
-	if idx != dv.dataColumn.ProposerIndex() {
-		log.WithError(columnErrBuilder(ErrSidecarUnexpectedProposer)).
-			WithFields(logging.DataColumnFields(dv.dataColumn)).WithField("expectedProposer", idx).
-			Debug("unexpected column proposer")
-		return columnErrBuilder(ErrSidecarUnexpectedProposer)
-	}
-	return nil
-}
 
-func (dv *RODataColumnVerifier) parentState(ctx context.Context) (state.BeaconState, error) {
-	if dv.parent != nil {
-		return dv.parent, nil
+	for _, dataColumn := range dv.dataColumns {
+		// Extract the slot of the data column.
+		dataColumnSlot := dataColumn.Slot()
+
+		// Compute the epoch of the data column slot.
+		dataColumnEpoch := slots.ToEpoch(dataColumnSlot)
+		if dataColumnEpoch > 0 {
+			dataColumnEpoch = dataColumnEpoch - 1
+		}
+
+		// Extract the root of the parent block corresponding to the data column.
+		parentRoot := dataColumn.ParentRoot()
+
+		// Compute the target root for the epoch.
+		targetRoot, err := dv.fc.TargetRootForEpoch(parentRoot, dataColumnEpoch)
+		if err != nil {
+			return columnErrBuilder(ErrSidecarUnexpectedProposer)
+		}
+
+		// Create a checkpoint for the target root.
+		checkpoint := &forkchoicetypes.Checkpoint{Root: targetRoot, Epoch: dataColumnEpoch}
+
+		// Try to extract the proposer index from the data column in the cache.
+		idx, cached := dv.pc.Proposer(checkpoint, dataColumnSlot)
+
+		if !cached {
+			// Retrieve the root of the parent block corresponding to the data column.
+			parentRoot := dataColumn.ParentRoot()
+
+			// Retrieve the parentState state to fallback to full verification.
+			parentState, err := dv.sr.StateByRoot(ctx, parentRoot)
+			if err != nil {
+				fields := logging.DataColumnFields(dataColumn)
+				log.WithError(err).WithFields(fields).Debug("State replay to parent_root failed")
+				return columnErrBuilder(ErrSidecarUnexpectedProposer)
+			}
+
+			idx, err = dv.pc.ComputeProposer(ctx, parentRoot, dataColumnSlot, parentState)
+			if err != nil {
+				fields := logging.DataColumnFields(dataColumn)
+				log.WithError(err).WithFields(fields).Debug("Error computing proposer index from parent state")
+				return columnErrBuilder(ErrSidecarUnexpectedProposer)
+			}
+		}
+
+		if idx != dataColumn.ProposerIndex() {
+			fields := logging.DataColumnFields(dataColumn)
+			log.WithError(columnErrBuilder(ErrSidecarUnexpectedProposer)).
+				WithFields(fields).
+				WithField("expectedProposer", idx).
+				Debug("Unexpected column proposer")
+
+			return columnErrBuilder(ErrSidecarUnexpectedProposer)
+		}
 	}
-	st, err := dv.sr.StateByRoot(ctx, dv.dataColumn.ParentRoot())
-	if err != nil {
-		return nil, err
-	}
-	dv.parent = st
-	return dv.parent, nil
+
+	return nil
 }
 
 func columnToSignatureData(d blocks.RODataColumn) SignatureData {

--- a/beacon-chain/verification/initializer.go
+++ b/beacon-chain/verification/initializer.go
@@ -58,13 +58,13 @@ func (ini *Initializer) NewBlobVerifier(b blocks.ROBlob, reqs []Requirement) *RO
 	}
 }
 
-// NewColumnVerifier creates a DataColumnVerifier for a single data column, with the given set of requirements.
-func (ini *Initializer) NewColumnVerifier(d blocks.RODataColumn, reqs []Requirement) *RODataColumnVerifier {
-	return &RODataColumnVerifier{
-		sharedResources:            ini.shared,
-		dataColumn:                 d,
-		results:                    newResults(reqs...),
-		verifyDataColumnCommitment: peerdas.VerifyDataColumnSidecarKZGProofs,
+// NewDataColumnsVerifier creates a DataColumnVerifier for a single data column, with the given set of requirements.
+func (ini *Initializer) NewDataColumnsVerifier(roDataColumns []blocks.RODataColumn, reqs []Requirement) *RODataColumnsVerifier {
+	return &RODataColumnsVerifier{
+		sharedResources:             ini.shared,
+		dataColumns:                 roDataColumns,
+		results:                     newResults(reqs...),
+		verifyDataColumnsCommitment: peerdas.VerifyDataColumnsSidecarKZGProofs,
 	}
 }
 

--- a/beacon-chain/verification/interface.go
+++ b/beacon-chain/verification/interface.go
@@ -30,11 +30,11 @@ type BlobVerifier interface {
 // able to mock Initializer.NewBlobVerifier without complex setup.
 type NewBlobVerifier func(b blocks.ROBlob, reqs []Requirement) BlobVerifier
 
-// DataColumnVerifier defines the methods implemented by the RODataColumnVerifier.
+// DataColumnsVerifier defines the methods implemented by the RODataColumnVerifier.
 // It serves a very similar purpose as the blob verifier interface for data columns.
-type DataColumnVerifier interface {
-	VerifiedRODataColumn() (blocks.VerifiedRODataColumn, error)
-	DataColumnIndexInBounds() (err error)
+type DataColumnsVerifier interface {
+	VerifiedRODataColumns() ([]blocks.VerifiedRODataColumn, error)
+	DataColumnsIndexInBounds() (err error)
 	NotFromFutureSlot() (err error)
 	SlotAboveFinalized() (err error)
 	ValidProposerSignature(ctx context.Context) (err error)
@@ -48,6 +48,6 @@ type DataColumnVerifier interface {
 	SatisfyRequirement(Requirement)
 }
 
-// NewColumnVerifier is a function signature that can be used to mock a setup where a
+// NewDataColumnsVerifier is a function signature that can be used to mock a setup where a
 // column verifier can be easily initialized.
-type NewColumnVerifier func(dc blocks.RODataColumn, reqs []Requirement) DataColumnVerifier
+type NewDataColumnsVerifier func(dataColumns []blocks.RODataColumn, reqs []Requirement) DataColumnsVerifier


### PR DESCRIPTION
This PR transforms `NewColumnVerifier` (1 column) into `NewDataColumnsVerifier` (multiple columns, `Data` has been added for consistency).

The purpose of this PR is to batch data columns verification, and especially `VerifyDataColumnsSidecarKZGProofs`, which is much more efficient when called by batch than when called columns by columns.

On my computer (ARM M-2), duration of KZG verification assuming a constant blob count per block, for 32 blocks:
- column by column: `~12-13 s`
- batch (all columns in the batch of 32 blocks): `~700 ms`

==> `x18` (!) improvement.

- [x] Able to sync a super node from genesis on `peerdas-devnet-3`
- [x] Able to sync a full node from genesis on `peerdas-devnet-3` (in progress)
