### PR TITLE
updating log to print tracked validators size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Revert block db save when saving state fails.
 - Return false from HasBlock if the block is being synced. 
 - Cleanup forkchoice on failed insertions.
+- Fee Recipient log also prints total tracked validators cache size. 
 
 ### Deprecated
 

--- a/beacon-chain/cache/tracked_validators.go
+++ b/beacon-chain/cache/tracked_validators.go
@@ -47,3 +47,9 @@ func (t *TrackedValidatorsCache) Validating() bool {
 	defer t.Unlock()
 	return len(t.trackedValidators) > 0
 }
+
+func (t *TrackedValidatorsCache) Size() int {
+	t.Lock()
+	defer t.Unlock()
+	return len(t.trackedValidators)
+}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -404,7 +404,7 @@ func (vs *Server) PrepareBeaconProposer(
 	_ context.Context, request *ethpb.PrepareBeaconProposerRequest,
 ) (*emptypb.Empty, error) {
 	var validatorIndices []primitives.ValidatorIndex
-
+	beforeCacheSize := vs.TrackedValidatorsCache.Size()
 	for _, r := range request.Recipients {
 		recipient := hexutil.Encode(r.FeeRecipient)
 		if !common.IsHexAddress(recipient) {
@@ -428,7 +428,9 @@ func (vs *Server) PrepareBeaconProposer(
 	}
 	if len(validatorIndices) != 0 {
 		log.WithFields(logrus.Fields{
-			"validatorCount": len(validatorIndices),
+			"validatorCount":                 len(validatorIndices),
+			"previousTotalTrackedValidators": beforeCacheSize,
+			"totalTrackedValidators":         vs.TrackedValidatorsCache.Size(),
 		}).Debug("Updated fee recipient addresses for validator indices")
 	}
 	return &emptypb.Empty{}, nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Other

**What does this PR do? Why is it needed?**

a suggestion to help find how many validators have been connected with the beacon node. the cache does not prune so there may be some discrepancies as the cache does not prune disconnected or removed validators.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
