### PR TITLE
Return the correct light client payload proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fixed mesh size by appending `gParams.Dhi = gossipSubDhi`
 - Fix skipping partial withdrawals count.
 - recover from panics when writing the event stream [pr](https://github.com/prysmaticlabs/prysm/pull/14545)
+- Return the correct light client payload proof. [PR](https://github.com/prysmaticlabs/prysm/pull/14565)
 
 ### Security
 

--- a/consensus-types/blocks/proofs.go
+++ b/consensus-types/blocks/proofs.go
@@ -240,23 +240,13 @@ func PayloadProof(ctx context.Context, block interfaces.ReadOnlyBeaconBlock) ([]
 		return nil, errors.New("failed to cast block body")
 	}
 
-	blockBodyFieldRoots, err := ComputeBlockBodyFieldRoots(ctx, blockBody)
+	fieldRoots, err := ComputeBlockBodyFieldRoots(ctx, blockBody)
 	if err != nil {
 		return nil, err
 	}
 
-	blockBodyFieldRootsTrie := stateutil.Merkleize(blockBodyFieldRoots)
-	blockBodyProof := trie.ProofFromMerkleLayers(blockBodyFieldRootsTrie, payloadFieldIndex)
+	fieldRootsTrie := stateutil.Merkleize(fieldRoots)
+	proof := trie.ProofFromMerkleLayers(fieldRootsTrie, payloadFieldIndex)
 
-	beaconBlockFieldRoots, err := ComputeBlockFieldRoots(ctx, block)
-	if err != nil {
-		return nil, err
-	}
-
-	beaconBlockFieldRootsTrie := stateutil.Merkleize(beaconBlockFieldRoots)
-	beaconBlockProof := trie.ProofFromMerkleLayers(beaconBlockFieldRootsTrie, bodyFieldIndex)
-
-	finalProof := append(blockBodyProof, beaconBlockProof...)
-
-	return finalProof, nil
+	return proof, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The description of https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/light-client/sync-protocol.md#custom-types says

> Merkle branch of `execution_payload` within `BeaconBlockBody`

The _**body**_, not the full block. We currently prove the payload within the entire block.

**Which issues(s) does this PR fix?**

Part of #12991 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
