### PR TITLE
Set fields of wrapped proto object in light client setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fix skipping partial withdrawals count.
 - recover from panics when writing the event stream [pr](https://github.com/prysmaticlabs/prysm/pull/14545)
 - Return the correct light client payload proof. [PR](https://github.com/prysmaticlabs/prysm/pull/14565)
+- Set fields of wrapped proto object in light client setters. [PR](https://github.com/prysmaticlabs/prysm/pull/14573)
 
 ### Security
 

--- a/beacon-chain/core/light-client/lightclient.go
+++ b/beacon-chain/core/light-client/lightclient.go
@@ -169,7 +169,9 @@ func NewLightClientUpdateFromBeaconState(
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get attested light client header")
 	}
-	result.SetAttestedHeader(attestedLightClientHeader)
+	if err = result.SetAttestedHeader(attestedLightClientHeader); err != nil {
+		return nil, errors.Wrap(err, "could not set attested header")
+	}
 
 	// if update_attested_period == update_signature_period
 	if updateAttestedPeriod == updateSignaturePeriod {
@@ -208,7 +210,9 @@ func NewLightClientUpdateFromBeaconState(
 			if err != nil {
 				return nil, errors.Wrap(err, "could not get finalized light client header")
 			}
-			result.SetFinalizedHeader(finalizedLightClientHeader)
+			if err = result.SetFinalizedHeader(finalizedLightClientHeader); err != nil {
+				return nil, errors.Wrap(err, "could not set finalized header")
+			}
 		} else {
 			// assert attested_state.finalized_checkpoint.root == Bytes32()
 			if !bytes.Equal(attestedState.FinalizedCheckpoint().Root, make([]byte, 32)) {

--- a/consensus-types/interfaces/light_client.go
+++ b/consensus-types/interfaces/light_client.go
@@ -36,7 +36,7 @@ type LightClientUpdate interface {
 	Proto() proto.Message
 	Version() int
 	AttestedHeader() LightClientHeader
-	SetAttestedHeader(header LightClientHeader)
+	SetAttestedHeader(header LightClientHeader) error
 	NextSyncCommittee() *pb.SyncCommittee
 	SetNextSyncCommittee(sc *pb.SyncCommittee)
 	NextSyncCommitteeBranch() (LightClientSyncCommitteeBranch, error)
@@ -44,7 +44,7 @@ type LightClientUpdate interface {
 	NextSyncCommitteeBranchElectra() (LightClientSyncCommitteeBranchElectra, error)
 	SetNextSyncCommitteeBranchElectra(branch [][]byte) error
 	FinalizedHeader() LightClientHeader
-	SetFinalizedHeader(header LightClientHeader)
+	SetFinalizedHeader(header LightClientHeader) error
 	FinalityBranch() LightClientFinalityBranch
 	SetFinalityBranch(branch [][]byte) error
 	SyncAggregate() *pb.SyncAggregate

--- a/consensus-types/light-client/update.go
+++ b/consensus-types/light-client/update.go
@@ -30,6 +30,9 @@ func NewWrappedUpdate(m proto.Message) (interfaces.LightClientUpdate, error) {
 	}
 }
 
+// In addition to the proto object being wrapped, we store some fields that have to be
+// constructed from the proto, so that we don't have to reconstruct them every time
+// in getters.
 type updateAltair struct {
 	p                       *pb.LightClientUpdateAltair
 	attestedHeader          interfaces.LightClientHeader
@@ -107,8 +110,19 @@ func (u *updateAltair) AttestedHeader() interfaces.LightClientHeader {
 	return u.attestedHeader
 }
 
-func (u *updateAltair) SetAttestedHeader(header interfaces.LightClientHeader) {
+func (u *updateAltair) SetAttestedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Altair {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Altair))
+	}
 	u.attestedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderAltair)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderAltair{})
+	}
+	u.p.AttestedHeader = proto
+
+	return nil
 }
 
 func (u *updateAltair) NextSyncCommittee() *pb.SyncCommittee {
@@ -129,6 +143,9 @@ func (u *updateAltair) SetNextSyncCommitteeBranch(branch [][]byte) error {
 		return err
 	}
 	u.nextSyncCommitteeBranch = b
+
+	u.p.NextSyncCommitteeBranch = branch
+
 	return nil
 }
 
@@ -144,8 +161,19 @@ func (u *updateAltair) FinalizedHeader() interfaces.LightClientHeader {
 	return u.finalizedHeader
 }
 
-func (u *updateAltair) SetFinalizedHeader(header interfaces.LightClientHeader) {
+func (u *updateAltair) SetFinalizedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Altair {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Altair))
+	}
 	u.finalizedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderAltair)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderAltair{})
+	}
+	u.p.FinalizedHeader = proto
+
+	return nil
 }
 
 func (u *updateAltair) FinalityBranch() interfaces.LightClientFinalityBranch {
@@ -158,6 +186,9 @@ func (u *updateAltair) SetFinalityBranch(branch [][]byte) error {
 		return err
 	}
 	u.finalityBranch = b
+
+	u.p.FinalityBranch = branch
+
 	return nil
 }
 
@@ -177,6 +208,9 @@ func (u *updateAltair) SetSignatureSlot(slot primitives.Slot) {
 	u.p.SignatureSlot = slot
 }
 
+// In addition to the proto object being wrapped, we store some fields that have to be
+// constructed from the proto, so that we don't have to reconstruct them every time
+// in getters.
 type updateCapella struct {
 	p                       *pb.LightClientUpdateCapella
 	attestedHeader          interfaces.LightClientHeader
@@ -254,8 +288,19 @@ func (u *updateCapella) AttestedHeader() interfaces.LightClientHeader {
 	return u.attestedHeader
 }
 
-func (u *updateCapella) SetAttestedHeader(header interfaces.LightClientHeader) {
+func (u *updateCapella) SetAttestedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Capella {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Capella))
+	}
 	u.attestedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderCapella)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderCapella{})
+	}
+	u.p.AttestedHeader = proto
+
+	return nil
 }
 
 func (u *updateCapella) NextSyncCommittee() *pb.SyncCommittee {
@@ -276,6 +321,9 @@ func (u *updateCapella) SetNextSyncCommitteeBranch(branch [][]byte) error {
 		return err
 	}
 	u.nextSyncCommitteeBranch = b
+
+	u.p.NextSyncCommitteeBranch = branch
+
 	return nil
 }
 
@@ -291,8 +339,19 @@ func (u *updateCapella) FinalizedHeader() interfaces.LightClientHeader {
 	return u.finalizedHeader
 }
 
-func (u *updateCapella) SetFinalizedHeader(header interfaces.LightClientHeader) {
+func (u *updateCapella) SetFinalizedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Capella {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Capella))
+	}
 	u.finalizedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderCapella)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderCapella{})
+	}
+	u.p.FinalizedHeader = proto
+
+	return nil
 }
 
 func (u *updateCapella) FinalityBranch() interfaces.LightClientFinalityBranch {
@@ -305,6 +364,9 @@ func (u *updateCapella) SetFinalityBranch(branch [][]byte) error {
 		return err
 	}
 	u.finalityBranch = b
+
+	u.p.FinalityBranch = branch
+
 	return nil
 }
 
@@ -324,6 +386,9 @@ func (u *updateCapella) SetSignatureSlot(slot primitives.Slot) {
 	u.p.SignatureSlot = slot
 }
 
+// In addition to the proto object being wrapped, we store some fields that have to be
+// constructed from the proto, so that we don't have to reconstruct them every time
+// in getters.
 type updateDeneb struct {
 	p                       *pb.LightClientUpdateDeneb
 	attestedHeader          interfaces.LightClientHeader
@@ -401,8 +466,19 @@ func (u *updateDeneb) AttestedHeader() interfaces.LightClientHeader {
 	return u.attestedHeader
 }
 
-func (u *updateDeneb) SetAttestedHeader(header interfaces.LightClientHeader) {
+func (u *updateDeneb) SetAttestedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Deneb {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Deneb))
+	}
 	u.attestedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderDeneb)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderDeneb{})
+	}
+	u.p.AttestedHeader = proto
+
+	return nil
 }
 
 func (u *updateDeneb) NextSyncCommittee() *pb.SyncCommittee {
@@ -423,6 +499,9 @@ func (u *updateDeneb) SetNextSyncCommitteeBranch(branch [][]byte) error {
 		return err
 	}
 	u.nextSyncCommitteeBranch = b
+
+	u.p.NextSyncCommitteeBranch = branch
+
 	return nil
 }
 
@@ -438,8 +517,19 @@ func (u *updateDeneb) FinalizedHeader() interfaces.LightClientHeader {
 	return u.finalizedHeader
 }
 
-func (u *updateDeneb) SetFinalizedHeader(header interfaces.LightClientHeader) {
+func (u *updateDeneb) SetFinalizedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Deneb {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Deneb))
+	}
 	u.finalizedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderDeneb)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderDeneb{})
+	}
+	u.p.FinalizedHeader = proto
+
+	return nil
 }
 
 func (u *updateDeneb) FinalityBranch() interfaces.LightClientFinalityBranch {
@@ -452,6 +542,9 @@ func (u *updateDeneb) SetFinalityBranch(branch [][]byte) error {
 		return err
 	}
 	u.finalityBranch = b
+
+	u.p.FinalityBranch = branch
+
 	return nil
 }
 
@@ -471,6 +564,9 @@ func (u *updateDeneb) SetSignatureSlot(slot primitives.Slot) {
 	u.p.SignatureSlot = slot
 }
 
+// In addition to the proto object being wrapped, we store some fields that have to be
+// constructed from the proto, so that we don't have to reconstruct them every time
+// in getters.
 type updateElectra struct {
 	p                       *pb.LightClientUpdateElectra
 	attestedHeader          interfaces.LightClientHeader
@@ -548,8 +644,19 @@ func (u *updateElectra) AttestedHeader() interfaces.LightClientHeader {
 	return u.attestedHeader
 }
 
-func (u *updateElectra) SetAttestedHeader(header interfaces.LightClientHeader) {
+func (u *updateElectra) SetAttestedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Electra {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Electra))
+	}
 	u.attestedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderDeneb)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderDeneb{})
+	}
+	u.p.AttestedHeader = proto
+
+	return nil
 }
 
 func (u *updateElectra) NextSyncCommittee() *pb.SyncCommittee {
@@ -578,6 +685,9 @@ func (u *updateElectra) SetNextSyncCommitteeBranchElectra(branch [][]byte) error
 		return err
 	}
 	u.nextSyncCommitteeBranch = b
+
+	u.p.NextSyncCommitteeBranch = branch
+
 	return nil
 }
 
@@ -585,8 +695,19 @@ func (u *updateElectra) FinalizedHeader() interfaces.LightClientHeader {
 	return u.finalizedHeader
 }
 
-func (u *updateElectra) SetFinalizedHeader(header interfaces.LightClientHeader) {
+func (u *updateElectra) SetFinalizedHeader(header interfaces.LightClientHeader) error {
+	if header.Version() != version.Electra {
+		return fmt.Errorf("header version %s is not %s", version.String(header.Version()), version.String(version.Electra))
+	}
 	u.finalizedHeader = header
+
+	proto, ok := header.Proto().(*pb.LightClientHeaderDeneb)
+	if !ok {
+		return fmt.Errorf("header type %T is not %T", proto, &pb.LightClientHeaderDeneb{})
+	}
+	u.p.FinalizedHeader = proto
+
+	return nil
 }
 
 func (u *updateElectra) FinalityBranch() interfaces.LightClientFinalityBranch {
@@ -599,6 +720,9 @@ func (u *updateElectra) SetFinalityBranch(branch [][]byte) error {
 		return err
 	}
 	u.finalityBranch = b
+
+	u.p.FinalityBranch = branch
+
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`LightClientUpdate` setters only updated fields of the wrapper type without changing fields of the wrapped proto object. Marshaling the wrapper into SSZ, which in turn marshals the wrapped proto object, would return the incorrect result.

Shout out to @Inspector-Butters for finding this issue. 

**Which issues(s) does this PR fix?**

Part of #12991 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
