### PR TITLE
Update behaviour of `/eth/v1/node/version` if unknown.

### DIFF
--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -11,11 +11,15 @@ import (
 	"time"
 )
 
+const unknown = "Unknown"
+
 // The value of these vars are set through linker options.
-var gitCommit = "Local build"
-var buildDate = "Moments ago"
-var buildDateUnix = "0"
-var gitTag = "Unknown"
+var (
+	gitCommit     = "Local build"
+	buildDate     = "Moments ago"
+	buildDateUnix = "0"
+	gitTag        = unknown
+)
 
 // Version returns the version string of this build.
 func Version() string {
@@ -31,6 +35,10 @@ func Version() string {
 
 // SemanticVersion returns the Major.Minor.Patch version of this build.
 func SemanticVersion() string {
+	if gitTag == unknown {
+		return BuildData()
+	}
+
 	return gitTag
 }
 


### PR DESCRIPTION
This commit is a little bit hacky, and do not necessarily need to be eventually really merged into develop.

Currently, for some reason, on the devnet, `eth/v1/node/version` returns:

![image](https://github.com/user-attachments/assets/01834014-f7f5-45d3-bdc9-00946f5e9e97)

It is hard to track which version is running.

In such a case (Unknown build), `eth/v1/node/version` now returns:
`"Prysm/Prysm/v5.1.1/2ab8c3b8c7ad947e1df934163cf7a1fd1af87731 (darwin arm64)`