### PR TITLE
Fix length check between kzg commitments and exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - wait for the async StreamEvent writer to exit before leaving the http handler, avoiding race condition panics [pr](https://github.com/prysmaticlabs/prysm/pull/14557)
 - Certain deb files were returning a 404 which made building new docker images without an existing
   cache impossible. This has been fixed with updates to rules_oci and bazel-lib.
+- Fixed an issue where the length check between block body KZG commitments and the existing cache from the database was incompatible.
 
 ### Security
 

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -560,8 +560,8 @@ func (s *Service) ReconstructBlobSidecars(ctx context.Context, block interfaces.
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get blob KZG commitments")
 	}
-	if len(kzgCommitments) != len(exists) {
-		return nil, fmt.Errorf("mismatched lengths: KZG commitments %d, exists %d", len(kzgCommitments), len(exists))
+	if len(kzgCommitments) > len(exists) {
+		return nil, fmt.Errorf("length of KZG commitments (%d) is greater than length of exists (%d)", len(kzgCommitments), len(exists))
 	}
 
 	// Collect KZG hashes for non-existing blobs

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -2446,6 +2446,18 @@ func TestReconstructBlobSidecars(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 3, len(verifiedBlobs))
 	})
+
+	t.Run("kzg is longer than exist", func(t *testing.T) {
+		srv := createBlobServer(t, 3)
+		defer srv.Close()
+
+		rpcClient, client := setupRpcClient(t, srv.URL, client)
+		defer rpcClient.Close()
+
+		exists := []bool{true, false, true, false, true}
+		_, err := client.ReconstructBlobSidecars(ctx, sb, r, exists)
+		require.ErrorContains(t, "length of KZG commitments (6) is greater than length of exists (5)", err)
+	})
 }
 
 func createRandomKzgCommitments(t *testing.T, num int) [][]byte {


### PR DESCRIPTION
The `exists` array is always returned as `[6]bool`, with a fixed length of 6. Until this is made dynamically sized, we cannot assume it will always match the count of KZG commitments in the block body. 

The key requirement is ensuring that the block body's KZG length doesn’t exceed the bounds of `exists`, meeting this constraint:

```go
for i, commitment := range kzgCommitments {
	if !exists[i] {
		kzgHashes = append(kzgHashes, primitives.ConvertKzgCommitmentToVersionedHash(commitment))
	}
}
```

This PR modifies the check from an equality check to a greater-than check, so the body’s KZG count cannot be greater than the `exists` count.