### PR TITLE
keymanager API: bug fixes and inconsistencies 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fixed an issue where the length check between block body KZG commitments and the existing cache from the database was incompatible.
 - Fix `--backfill-oldest-slot` handling - this flag was totally broken, the code would always backfill to the default slot [pr](https://github.com/prysmaticlabs/prysm/pull/14584)
 - Fix keymanager API should return corrected error format for malformed tokens
-- Fix keymanager API should return empty instead of error on get keys API when using the unsupported keystore instead of failing with 500 error
+- Fix keymanager API so that get keys returns an empty response instead of a 500 error when using an unsupported keystore.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   cache impossible. This has been fixed with updates to rules_oci and bazel-lib.
 - Fixed an issue where the length check between block body KZG commitments and the existing cache from the database was incompatible.
 - Fix `--backfill-oldest-slot` handling - this flag was totally broken, the code would always backfill to the default slot [pr](https://github.com/prysmaticlabs/prysm/pull/14584)
+- Fix keymanager API should return corrected error format for malformed tokens
+- Fix keymanager API should return empty instead of error on get keys API when using the unsupported keystore instead of failing with 500 error
 
 ### Security
 

--- a/validator/rpc/BUILD.bazel
+++ b/validator/rpc/BUILD.bazel
@@ -117,6 +117,7 @@ go_test(
         "//encoding/bytesutil:go_default_library",
         "//io/file:go_default_library",
         "//io/logs/mock:go_default_library",
+        "//network/httputil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",

--- a/validator/rpc/handlers_keymanager.go
+++ b/validator/rpc/handlers_keymanager.go
@@ -50,7 +50,7 @@ func (s *Server) ListKeystores(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.wallet.KeymanagerKind() != keymanager.Derived && s.wallet.KeymanagerKind() != keymanager.Local {
-		log.Debugf("List keystores keymanager api was but got wallet type %s and wanted %s", s.wallet.KeymanagerKind().String(), keymanager.Local.String())
+		log.Debugf("List keystores keymanager api expected wallet type %s but got %s", s.wallet.KeymanagerKind().String(), keymanager.Local.String())
 		response := &ListKeystoresResponse{
 			Data: make([]*Keystore, 0),
 		}

--- a/validator/rpc/handlers_keymanager.go
+++ b/validator/rpc/handlers_keymanager.go
@@ -50,7 +50,11 @@ func (s *Server) ListKeystores(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.wallet.KeymanagerKind() != keymanager.Derived && s.wallet.KeymanagerKind() != keymanager.Local {
-		httputil.HandleError(w, errors.Wrap(err, "Prysm validator keys are not stored locally with this keymanager type").Error(), http.StatusInternalServerError)
+		log.Debugf("List keystores keymanager api was but got wallet type %s and wanted %s", s.wallet.KeymanagerKind().String(), keymanager.Local.String())
+		response := &ListKeystoresResponse{
+			Data: make([]*Keystore, 0),
+		}
+		httputil.WriteJson(w, response)
 		return
 	}
 	pubKeys, err := km.FetchValidatingPublicKeys(ctx)
@@ -402,7 +406,11 @@ func (s *Server) ListRemoteKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.wallet.KeymanagerKind() != keymanager.Web3Signer {
-		httputil.HandleError(w, "Prysm Wallet is not of type Web3Signer. Please execute validator client with web3signer flags.", http.StatusInternalServerError)
+		log.Debugf("List remote keys keymanager api was but got wallet type %s and wanted %s", s.wallet.KeymanagerKind().String(), keymanager.Web3Signer.String())
+		response := &ListKeystoresResponse{
+			Data: make([]*Keystore, 0),
+		}
+		httputil.WriteJson(w, response)
 		return
 	}
 	pubKeys, err := km.FetchValidatingPublicKeys(ctx)

--- a/validator/rpc/handlers_keymanager.go
+++ b/validator/rpc/handlers_keymanager.go
@@ -406,7 +406,7 @@ func (s *Server) ListRemoteKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.wallet.KeymanagerKind() != keymanager.Web3Signer {
-		log.Debugf("List remote keys keymanager api was but got wallet type %s and wanted %s", s.wallet.KeymanagerKind().String(), keymanager.Web3Signer.String())
+		log.Debugf("List remote keys keymanager api expected wallet type %s but got %s", s.wallet.KeymanagerKind().String(), keymanager.Web3Signer.String())
 		response := &ListKeystoresResponse{
 			Data: make([]*Keystore, 0),
 		}

--- a/validator/rpc/handlers_keymanager_test.go
+++ b/validator/rpc/handlers_keymanager_test.go
@@ -119,6 +119,16 @@ func TestServer_ListKeystores(t *testing.T) {
 			)
 		}
 	})
+	t.Run("calling list remote while using a local wallet returns empty", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/eth/v1/remotekeys"), nil)
+		wr := httptest.NewRecorder()
+		wr.Body = &bytes.Buffer{}
+		s.ListRemoteKeys(wr, req)
+		require.Equal(t, http.StatusOK, wr.Code)
+		resp := &ListRemoteKeysResponse{}
+		require.NoError(t, json.Unmarshal(wr.Body.Bytes(), resp))
+		require.Equal(t, 0, len(resp.Data))
+	})
 }
 
 func TestServer_ImportKeystores(t *testing.T) {
@@ -1365,6 +1375,16 @@ func TestServer_ListRemoteKeys(t *testing.T) {
 		for i := 0; i < len(resp.Data); i++ {
 			require.DeepEqual(t, hexutil.Encode(expectedKeys[i][:]), resp.Data[i].Pubkey)
 		}
+	})
+	t.Run("calling list keystores while using a remote wallet returns empty", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/eth/v1/keystores"), nil)
+		wr := httptest.NewRecorder()
+		wr.Body = &bytes.Buffer{}
+		s.ListKeystores(wr, req)
+		require.Equal(t, http.StatusOK, wr.Code)
+		resp := &ListKeystoresResponse{}
+		require.NoError(t, json.Unmarshal(wr.Body.Bytes(), resp))
+		require.Equal(t, 0, len(resp.Data))
 	})
 }
 

--- a/validator/rpc/intercepter.go
+++ b/validator/rpc/intercepter.go
@@ -42,7 +42,7 @@ func (s *Server) AuthTokenHandler(next http.Handler) http.Handler {
 			// ignore some routes
 			reqToken := r.Header.Get("Authorization")
 			if reqToken == "" {
-				httputil.HandleError(w, "unauthorized: no Authorization header passed. Please use an Authorization header with the jwt created in the prysm wallet", http.StatusUnauthorized)
+				httputil.HandleError(w, "Unauthorized: no Authorization header passed. Please use an Authorization header with the jwt created in the prysm wallet", http.StatusUnauthorized)
 				return
 			}
 			tokenParts := strings.Split(reqToken, "Bearer ")

--- a/validator/rpc/intercepter.go
+++ b/validator/rpc/intercepter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/prysmaticlabs/prysm/v5/api"
+	"github.com/prysmaticlabs/prysm/v5/network/httputil"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -41,18 +42,18 @@ func (s *Server) AuthTokenHandler(next http.Handler) http.Handler {
 			// ignore some routes
 			reqToken := r.Header.Get("Authorization")
 			if reqToken == "" {
-				http.Error(w, "unauthorized: no Authorization header passed. Please use an Authorization header with the jwt created in the prysm wallet", http.StatusUnauthorized)
+				httputil.HandleError(w, "unauthorized: no Authorization header passed. Please use an Authorization header with the jwt created in the prysm wallet", http.StatusUnauthorized)
 				return
 			}
 			tokenParts := strings.Split(reqToken, "Bearer ")
 			if len(tokenParts) != 2 {
-				http.Error(w, "Invalid token format", http.StatusBadRequest)
+				httputil.HandleError(w, "Invalid token format", http.StatusBadRequest)
 				return
 			}
 
 			token := tokenParts[1]
 			if strings.TrimSpace(token) != s.authToken || strings.TrimSpace(s.authToken) == "" {
-				http.Error(w, "Forbidden: token value is invalid", http.StatusForbidden)
+				httputil.HandleError(w, "Forbidden: token value is invalid", http.StatusForbidden)
 				return
 			}
 		}

--- a/validator/rpc/intercepter_test.go
+++ b/validator/rpc/intercepter_test.go
@@ -105,7 +105,7 @@ func TestServer_AuthTokenHandler(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, rr.Code)
 		errJson := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), errJson))
-		require.StringContains(t, "unauthorized", errJson.Message)
+		require.StringContains(t, "Unauthorized", errJson.Message)
 	})
 	t.Run("initialize does not need auth", func(t *testing.T) {
 		rr := httptest.NewRecorder()

--- a/validator/rpc/intercepter_test.go
+++ b/validator/rpc/intercepter_test.go
@@ -76,7 +76,7 @@ func TestServer_AuthTokenHandler(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, rr.Code)
 		errJson := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), errJson))
-		require.StringContains(t, "unauthorized", errJson.Message)
+		require.StringContains(t, "Unauthorized", errJson.Message)
 	})
 	t.Run("wrong auth token was sent", func(t *testing.T) {
 		rr := httptest.NewRecorder()

--- a/validator/rpc/intercepter_test.go
+++ b/validator/rpc/intercepter_test.go
@@ -2,11 +2,13 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v5/api"
+	"github.com/prysmaticlabs/prysm/v5/network/httputil"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -72,6 +74,9 @@ func TestServer_AuthTokenHandler(t *testing.T) {
 		require.NoError(t, err)
 		testHandler.ServeHTTP(rr, req)
 		require.Equal(t, http.StatusUnauthorized, rr.Code)
+		errJson := &httputil.DefaultJsonError{}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), errJson))
+		require.StringContains(t, "unauthorized", errJson.Message)
 	})
 	t.Run("wrong auth token was sent", func(t *testing.T) {
 		rr := httptest.NewRecorder()
@@ -80,6 +85,9 @@ func TestServer_AuthTokenHandler(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer YOUR_JWT_TOKEN") // Replace with a valid JWT token
 		testHandler.ServeHTTP(rr, req)
 		require.Equal(t, http.StatusForbidden, rr.Code)
+		errJson := &httputil.DefaultJsonError{}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), errJson))
+		require.StringContains(t, "token value is invalid", errJson.Message)
 	})
 	t.Run("good auth token was sent", func(t *testing.T) {
 		rr := httptest.NewRecorder()
@@ -95,6 +103,9 @@ func TestServer_AuthTokenHandler(t *testing.T) {
 		require.NoError(t, err)
 		testHandler.ServeHTTP(rr, req)
 		require.Equal(t, http.StatusUnauthorized, rr.Code)
+		errJson := &httputil.DefaultJsonError{}
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), errJson))
+		require.StringContains(t, "unauthorized", errJson.Message)
 	})
 	t.Run("initialize does not need auth", func(t *testing.T) {
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

fixes some reported inconsistencies and errors with keymanager APIs 

does not solve
> I'm not sure if this is a bug since the spec is a bit vague on it. Prysm returns a fee-recipient for each and every pubkey which is put into the endpoint /eth/v1/validator/<pubkey>/feerecipient. In my understanding it should only return the fee recipient for managed validators.

it's my belief that since we can set the suggested fee recipient if a new key is added it would just default to that value. its not clear what should be the correct response. 

**Which issues(s) does this PR fix?**

Fixes #14577

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
