### PR TITLE
Optimize Message ID Computation

### DIFF
--- a/beacon-chain/p2p/message_id.go
+++ b/beacon-chain/p2p/message_id.go
@@ -1,8 +1,6 @@
 package p2p
 
 import (
-	"unsafe"
-
 	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/encoder"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
@@ -31,7 +29,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 		// never be hit.
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return castToString(msg)
+		return bytesutil.UnsafeCastToString(msg)
 	}
 	digest, err := ExtractGossipDigest(*pmsg.Topic)
 	if err != nil {
@@ -39,7 +37,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 		// never be hit.
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return castToString(msg)
+		return bytesutil.UnsafeCastToString(msg)
 	}
 	_, fEpoch, err := forks.RetrieveForkDataFromDigest(digest, genesisValidatorsRoot)
 	if err != nil {
@@ -47,7 +45,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 		// never be hit.
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return castToString(msg)
+		return bytesutil.UnsafeCastToString(msg)
 	}
 	if fEpoch >= params.BeaconConfig().AltairForkEpoch {
 		return postAltairMsgID(pmsg, fEpoch)
@@ -56,11 +54,11 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 	if err != nil {
 		combinedData := append(params.BeaconConfig().MessageDomainInvalidSnappy[:], pmsg.Data...)
 		h := hash.Hash(combinedData)
-		return castToString(h[:20])
+		return bytesutil.UnsafeCastToString(h[:20])
 	}
 	combinedData := append(params.BeaconConfig().MessageDomainValidSnappy[:], decodedData...)
 	h := hash.Hash(combinedData)
-	return castToString(h[:20])
+	return bytesutil.UnsafeCastToString(h[:20])
 }
 
 // Spec:
@@ -95,13 +93,13 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 			// should never happen
 			msg := make([]byte, 20)
 			copy(msg, "invalid")
-			return castToString(msg)
+			return bytesutil.UnsafeCastToString(msg)
 		}
 		if uint64(totalLength) > gossipPubSubSize {
 			// this should never happen
 			msg := make([]byte, 20)
 			copy(msg, "invalid")
-			return castToString(msg)
+			return bytesutil.UnsafeCastToString(msg)
 		}
 		combinedData := make([]byte, 0, totalLength)
 		combinedData = append(combinedData, params.BeaconConfig().MessageDomainInvalidSnappy[:]...)
@@ -109,7 +107,7 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 		combinedData = append(combinedData, topic...)
 		combinedData = append(combinedData, pmsg.Data...)
 		h := hash.Hash(combinedData)
-		return castToString(h[:20])
+		return bytesutil.UnsafeCastToString(h[:20])
 	}
 	totalLength, err := math.AddInt(
 		len(params.BeaconConfig().MessageDomainValidSnappy),
@@ -122,7 +120,7 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 		// should never happen
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return castToString(msg)
+		return bytesutil.UnsafeCastToString(msg)
 	}
 	combinedData := make([]byte, 0, totalLength)
 	combinedData = append(combinedData, params.BeaconConfig().MessageDomainValidSnappy[:]...)
@@ -130,12 +128,5 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 	combinedData = append(combinedData, topic...)
 	combinedData = append(combinedData, decodedData...)
 	h := hash.Hash(combinedData)
-	return castToString(h[:20])
-}
-
-// This method casts a byte slice to a string object without performing a copy. The
-// assumption is that any byte slice provided as an argument will no longer be modified
-// further.
-func castToString(byteSlice []byte) string {
-	return unsafe.String(&byteSlice[0], len(byteSlice))
+	return bytesutil.UnsafeCastToString(h[:20])
 }

--- a/beacon-chain/p2p/message_id.go
+++ b/beacon-chain/p2p/message_id.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"unsafe"
+
 	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/encoder"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
@@ -29,7 +31,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 		// never be hit.
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return string(msg)
+		return castToString(msg)
 	}
 	digest, err := ExtractGossipDigest(*pmsg.Topic)
 	if err != nil {
@@ -37,7 +39,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 		// never be hit.
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return string(msg)
+		return castToString(msg)
 	}
 	_, fEpoch, err := forks.RetrieveForkDataFromDigest(digest, genesisValidatorsRoot)
 	if err != nil {
@@ -45,7 +47,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 		// never be hit.
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return string(msg)
+		return castToString(msg)
 	}
 	if fEpoch >= params.BeaconConfig().AltairForkEpoch {
 		return postAltairMsgID(pmsg, fEpoch)
@@ -54,11 +56,11 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 	if err != nil {
 		combinedData := append(params.BeaconConfig().MessageDomainInvalidSnappy[:], pmsg.Data...)
 		h := hash.Hash(combinedData)
-		return string(h[:20])
+		return castToString(h[:20])
 	}
 	combinedData := append(params.BeaconConfig().MessageDomainValidSnappy[:], decodedData...)
 	h := hash.Hash(combinedData)
-	return string(h[:20])
+	return castToString(h[:20])
 }
 
 // Spec:
@@ -93,13 +95,13 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 			// should never happen
 			msg := make([]byte, 20)
 			copy(msg, "invalid")
-			return string(msg)
+			return castToString(msg)
 		}
 		if uint64(totalLength) > gossipPubSubSize {
 			// this should never happen
 			msg := make([]byte, 20)
 			copy(msg, "invalid")
-			return string(msg)
+			return castToString(msg)
 		}
 		combinedData := make([]byte, 0, totalLength)
 		combinedData = append(combinedData, params.BeaconConfig().MessageDomainInvalidSnappy[:]...)
@@ -107,7 +109,7 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 		combinedData = append(combinedData, topic...)
 		combinedData = append(combinedData, pmsg.Data...)
 		h := hash.Hash(combinedData)
-		return string(h[:20])
+		return castToString(h[:20])
 	}
 	totalLength, err := math.AddInt(
 		len(params.BeaconConfig().MessageDomainValidSnappy),
@@ -120,7 +122,7 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 		// should never happen
 		msg := make([]byte, 20)
 		copy(msg, "invalid")
-		return string(msg)
+		return castToString(msg)
 	}
 	combinedData := make([]byte, 0, totalLength)
 	combinedData = append(combinedData, params.BeaconConfig().MessageDomainValidSnappy[:]...)
@@ -128,5 +130,12 @@ func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
 	combinedData = append(combinedData, topic...)
 	combinedData = append(combinedData, decodedData...)
 	h := hash.Hash(combinedData)
-	return string(h[:20])
+	return castToString(h[:20])
+}
+
+// This method casts a byte slice to a string object without performing a copy. The
+// assumption is that any byte slice provided as an argument will no longer be modified
+// further.
+func castToString(byteSlice []byte) string {
+	return unsafe.String(&byteSlice[0], len(byteSlice))
 }

--- a/encoding/bytesutil/bytes.go
+++ b/encoding/bytesutil/bytes.go
@@ -3,6 +3,7 @@ package bytesutil
 
 import (
 	"fmt"
+	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
@@ -144,4 +145,11 @@ func ReverseByteOrder(input []byte) []byte {
 		b[i], b[len(b)-i-1] = b[len(b)-i-1], b[i]
 	}
 	return b
+}
+
+// UnsafeCastToString casts a byte slice to a string object without performing a copy. The
+// assumption is that any byte slice provided as an argument will no longer be modified
+// further.
+func UnsafeCastToString(byteSlice []byte) string {
+	return unsafe.String(&byteSlice[0], len(byteSlice))
 }

--- a/encoding/bytesutil/bytes_test.go
+++ b/encoding/bytesutil/bytes_test.go
@@ -217,6 +217,19 @@ func TestToBytes20(t *testing.T) {
 	}
 }
 
+func TestCastToString(t *testing.T) {
+	bSlice := []byte{'a', 'b', 'c'}
+	bString := bytesutil.UnsafeCastToString(bSlice)
+
+	originalString := "abc"
+
+	// Mutate original slice to make sure that a copy was not performed.
+	bSlice[0] = 'd'
+	assert.NotEqual(t, originalString, bString)
+	assert.Equal(t, "abc", originalString)
+	assert.Equal(t, "dbc", bString)
+}
+
 func BenchmarkToBytes32(b *testing.B) {
 	x := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Each slot, a prysm node will process thousands of messages via gossip and as a result have to compute the message id of that message. Computing the message id can take up a lot of memory if many subnets are subscribed to. In order to reduce the memory allocated at the message ID computation step, we cast the hash to a string in a more efficient manner. 

- [x] Helper added to `bytesutil` to allow for unsafe casting.
- [x] Unit test to validate that it works as expected.


**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
