### PR TITLE
Use Read Only Head State When Computing Active Indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added missing Eth-Consensus-Version headers to GetBlockAttestationsV2 and GetAttesterSlashingsV2 endpoints.
 - Updated pgo profile for beacon chain with holesky data. This improves the profile guided
   optimizations in the go compiler.
+- Use read only state when computing the active validator list.
 
 ### Deprecated
 

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -243,7 +243,7 @@ func (s *Service) HeadValidatorsIndices(ctx context.Context, epoch primitives.Ep
 	if !s.hasHeadState() {
 		return []primitives.ValidatorIndex{}, nil
 	}
-	return helpers.ActiveValidatorIndices(ctx, s.headState(ctx), epoch)
+	return helpers.ActiveValidatorIndices(ctx, s.headStateReadOnly(ctx), epoch)
 }
 
 // HeadGenesisValidatorsRoot returns genesis validators root of the head state.


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

When computing the current active validator count, we do not need to perform a state copy. This is very expensive when it is run in high traffic paths. Instead we use a read only state to be able to perform the computation.
![image](https://github.com/user-attachments/assets/d67a7310-0df7-42fd-85dd-511e030145aa)


![image](https://github.com/user-attachments/assets/015afe19-ee27-4b5b-8eff-fcaa392634d2)

By reducing the number of state copies, we can reduce the amount of memory allocated in large networks such as holesky by about 500mb. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
