### PR TITLE
prevent panic by returning on connection error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Simplified `ExitedValidatorIndices`.
 - Simplified `EjectedValidatorIndices`.
 - `engine_newPayloadV4`,`engine_getPayloadV4` are changes due to new execution request serialization decisions, [PR](https://github.com/prysmaticlabs/prysm/pull/14580)
+- Fixed panic when http request to subscribe to event stream fails
 
 ### Deprecated
 

--- a/api/client/event/event_stream.go
+++ b/api/client/event/event_stream.go
@@ -93,6 +93,8 @@ func (h *EventStream) Subscribe(eventsChannel chan<- *Event) {
 			EventType: EventConnectionError,
 			Data:      []byte(errors.Wrap(err, client.ErrConnectionIssue.Error()).Error()),
 		}
+		close(eventsChannel)
+		return
 	}
 
 	defer func() {

--- a/api/client/event/event_stream.go
+++ b/api/client/event/event_stream.go
@@ -93,7 +93,6 @@ func (h *EventStream) Subscribe(eventsChannel chan<- *Event) {
 			EventType: EventConnectionError,
 			Data:      []byte(errors.Wrap(err, client.ErrConnectionIssue.Error()).Error()),
 		}
-		close(eventsChannel)
 		return
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Returns from Subscribe before accessing nil response body if the http request fails.

**Which issues(s) does this PR fix?**
Prevents a panic that occurs when subscribing to EventStream if request fails resulting in a nil response body

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
