### PR TITLE
Fix various small things in state-native code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Simplified `ExitedValidatorIndices`.
 - Simplified `EjectedValidatorIndices`.
 - `engine_newPayloadV4`,`engine_getPayloadV4` are changes due to new execution request serialization decisions, [PR](https://github.com/prysmaticlabs/prysm/pull/14580)
+- Fixed various small things in state-native code.
 
 ### Deprecated
 

--- a/beacon-chain/core/blocks/withdrawals.go
+++ b/beacon-chain/core/blocks/withdrawals.go
@@ -193,7 +193,7 @@ func ProcessWithdrawals(st state.BeaconState, executionData interfaces.Execution
 	}
 
 	if st.Version() >= version.Electra {
-		if err := st.DequeuePartialWithdrawals(processedPartialWithdrawalsCount); err != nil {
+		if err := st.DequeuePendingPartialWithdrawals(processedPartialWithdrawalsCount); err != nil {
 			return nil, fmt.Errorf("unable to dequeue partial withdrawals from state: %w", err)
 		}
 	}

--- a/beacon-chain/core/electra/deposits.go
+++ b/beacon-chain/core/electra/deposits.go
@@ -588,8 +588,8 @@ func processDepositRequest(beaconState state.BeaconState, request *enginev1.Depo
 	}
 	if err := beaconState.AppendPendingDeposit(&ethpb.PendingDeposit{
 		PublicKey:             bytesutil.SafeCopyBytes(request.Pubkey),
-		Amount:                request.Amount,
 		WithdrawalCredentials: bytesutil.SafeCopyBytes(request.WithdrawalCredentials),
+		Amount:                request.Amount,
 		Signature:             bytesutil.SafeCopyBytes(request.Signature),
 		Slot:                  beaconState.Slot(),
 	}); err != nil {

--- a/beacon-chain/core/electra/transition.go
+++ b/beacon-chain/core/electra/transition.go
@@ -29,7 +29,6 @@ var (
 	ProcessParticipationFlagUpdates      = altair.ProcessParticipationFlagUpdates
 	ProcessSyncCommitteeUpdates          = altair.ProcessSyncCommitteeUpdates
 	AttestationsDelta                    = altair.AttestationsDelta
-	ProcessSyncAggregate                 = altair.ProcessSyncAggregate
 )
 
 // ProcessEpoch describes the per epoch operations that are performed on the beacon state.

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -316,7 +316,7 @@ type WriteOnlySyncCommittee interface {
 
 type WriteOnlyWithdrawals interface {
 	AppendPendingPartialWithdrawal(ppw *ethpb.PendingPartialWithdrawal) error
-	DequeuePartialWithdrawals(num uint64) error
+	DequeuePendingPartialWithdrawals(num uint64) error
 	SetNextWithdrawalIndex(i uint64) error
 	SetNextWithdrawalValidatorIndex(i primitives.ValidatorIndex) error
 }

--- a/beacon-chain/state/state-native/beacon_state.go
+++ b/beacon-chain/state/state-native/beacon_state.go
@@ -29,7 +29,6 @@ type BeaconState struct {
 	stateRoots                          customtypes.StateRoots
 	stateRootsMultiValue                *MultiValueStateRoots
 	historicalRoots                     customtypes.HistoricalRoots
-	historicalSummaries                 []*ethpb.HistoricalSummary
 	eth1Data                            *ethpb.Eth1Data
 	eth1DataVotes                       []*ethpb.Eth1Data
 	eth1DepositIndex                    uint64
@@ -55,8 +54,11 @@ type BeaconState struct {
 	latestExecutionPayloadHeader        *enginev1.ExecutionPayloadHeader
 	latestExecutionPayloadHeaderCapella *enginev1.ExecutionPayloadHeaderCapella
 	latestExecutionPayloadHeaderDeneb   *enginev1.ExecutionPayloadHeaderDeneb
-	nextWithdrawalIndex                 uint64
-	nextWithdrawalValidatorIndex        primitives.ValidatorIndex
+
+	// Capella fields
+	nextWithdrawalIndex          uint64
+	nextWithdrawalValidatorIndex primitives.ValidatorIndex
+	historicalSummaries          []*ethpb.HistoricalSummary
 
 	// Electra fields
 	depositRequestsStartIndex     uint64
@@ -90,7 +92,6 @@ type beaconStateMarshalable struct {
 	BlockRoots                          customtypes.BlockRoots                  `json:"block_roots" yaml:"block_roots"`
 	StateRoots                          customtypes.StateRoots                  `json:"state_roots" yaml:"state_roots"`
 	HistoricalRoots                     customtypes.HistoricalRoots             `json:"historical_roots" yaml:"historical_roots"`
-	HistoricalSummaries                 []*ethpb.HistoricalSummary              `json:"historical_summaries" yaml:"historical_summaries"`
 	Eth1Data                            *ethpb.Eth1Data                         `json:"eth_1_data" yaml:"eth_1_data"`
 	Eth1DataVotes                       []*ethpb.Eth1Data                       `json:"eth_1_data_votes" yaml:"eth_1_data_votes"`
 	Eth1DepositIndex                    uint64                                  `json:"eth_1_deposit_index" yaml:"eth_1_deposit_index"`
@@ -114,6 +115,7 @@ type beaconStateMarshalable struct {
 	LatestExecutionPayloadHeaderDeneb   *enginev1.ExecutionPayloadHeaderDeneb   `json:"latest_execution_payload_header_deneb" yaml:"latest_execution_payload_header_deneb"`
 	NextWithdrawalIndex                 uint64                                  `json:"next_withdrawal_index" yaml:"next_withdrawal_index"`
 	NextWithdrawalValidatorIndex        primitives.ValidatorIndex               `json:"next_withdrawal_validator_index" yaml:"next_withdrawal_validator_index"`
+	HistoricalSummaries                 []*ethpb.HistoricalSummary              `json:"historical_summaries" yaml:"historical_summaries"`
 	DepositRequestsStartIndex           uint64                                  `json:"deposit_requests_start_index" yaml:"deposit_requests_start_index"`
 	DepositBalanceToConsume             primitives.Gwei                         `json:"deposit_balance_to_consume" yaml:"deposit_balance_to_consume"`
 	ExitBalanceToConsume                primitives.Gwei                         `json:"exit_balance_to_consume" yaml:"exit_balance_to_consume"`
@@ -159,7 +161,6 @@ func (b *BeaconState) MarshalJSON() ([]byte, error) {
 		BlockRoots:                          bRoots,
 		StateRoots:                          sRoots,
 		HistoricalRoots:                     b.historicalRoots,
-		HistoricalSummaries:                 b.historicalSummaries,
 		Eth1Data:                            b.eth1Data,
 		Eth1DataVotes:                       b.eth1DataVotes,
 		Eth1DepositIndex:                    b.eth1DepositIndex,
@@ -183,6 +184,7 @@ func (b *BeaconState) MarshalJSON() ([]byte, error) {
 		LatestExecutionPayloadHeaderDeneb:   b.latestExecutionPayloadHeaderDeneb,
 		NextWithdrawalIndex:                 b.nextWithdrawalIndex,
 		NextWithdrawalValidatorIndex:        b.nextWithdrawalValidatorIndex,
+		HistoricalSummaries:                 b.historicalSummaries,
 		DepositRequestsStartIndex:           b.depositRequestsStartIndex,
 		DepositBalanceToConsume:             b.depositBalanceToConsume,
 		ExitBalanceToConsume:                b.exitBalanceToConsume,

--- a/beacon-chain/state/state-native/setters_consolidation.go
+++ b/beacon-chain/state/state-native/setters_consolidation.go
@@ -1,6 +1,7 @@
 package state_native
 
 import (
+	"errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native/types"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"

--- a/beacon-chain/state/state-native/setters_consolidation.go
+++ b/beacon-chain/state/state-native/setters_consolidation.go
@@ -2,6 +2,7 @@ package state_native
 
 import (
 	"errors"
+
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native/types"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"

--- a/beacon-chain/state/state-native/setters_consolidation.go
+++ b/beacon-chain/state/state-native/setters_consolidation.go
@@ -15,6 +15,9 @@ func (b *BeaconState) AppendPendingConsolidation(val *ethpb.PendingConsolidation
 	if b.version < version.Electra {
 		return errNotSupported("AppendPendingConsolidation", b.version)
 	}
+	if val == nil {
+		return errors.New("cannot append nil pending consolidation")
+	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 

--- a/beacon-chain/state/state-native/setters_deposits.go
+++ b/beacon-chain/state/state-native/setters_deposits.go
@@ -1,6 +1,7 @@
 package state_native
 
 import (
+	"errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native/types"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"

--- a/beacon-chain/state/state-native/setters_deposits.go
+++ b/beacon-chain/state/state-native/setters_deposits.go
@@ -2,6 +2,7 @@ package state_native
 
 import (
 	"errors"
+
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native/types"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"

--- a/beacon-chain/state/state-native/setters_deposits.go
+++ b/beacon-chain/state/state-native/setters_deposits.go
@@ -15,6 +15,9 @@ func (b *BeaconState) AppendPendingDeposit(pd *ethpb.PendingDeposit) error {
 	if b.version < version.Electra {
 		return errNotSupported("AppendPendingDeposit", b.version)
 	}
+	if pd == nil {
+		return errors.New("cannot append nil pending deposit")
+	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 

--- a/beacon-chain/state/state-native/setters_withdrawal.go
+++ b/beacon-chain/state/state-native/setters_withdrawal.go
@@ -64,10 +64,10 @@ func (b *BeaconState) AppendPendingPartialWithdrawal(ppw *eth.PendingPartialWith
 	return nil
 }
 
-// DequeuePartialWithdrawals removes the partial withdrawals from the beginning of the partial withdrawals list.
-func (b *BeaconState) DequeuePartialWithdrawals(n uint64) error {
+// DequeuePendingPartialWithdrawals removes the partial withdrawals from the beginning of the partial withdrawals list.
+func (b *BeaconState) DequeuePendingPartialWithdrawals(n uint64) error {
 	if b.version < version.Electra {
-		return errNotSupported("DequeuePartialWithdrawals", b.version)
+		return errNotSupported("DequeuePendingPartialWithdrawals", b.version)
 	}
 
 	if n > uint64(len(b.pendingPartialWithdrawals)) {

--- a/beacon-chain/state/state-native/setters_withdrawal_test.go
+++ b/beacon-chain/state/state-native/setters_withdrawal_test.go
@@ -68,7 +68,7 @@ func TestDequeuePendingWithdrawals(t *testing.T) {
 	num, err := s.NumPendingPartialWithdrawals()
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), num)
-	require.NoError(t, s.DequeuePartialWithdrawals(2))
+	require.NoError(t, s.DequeuePendingPartialWithdrawals(2))
 	num, err = s.NumPendingPartialWithdrawals()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), num)
@@ -77,13 +77,13 @@ func TestDequeuePendingWithdrawals(t *testing.T) {
 	num, err = s.NumPendingPartialWithdrawals()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), num)
-	require.ErrorContains(t, "cannot dequeue more withdrawals than are in the queue", s.DequeuePartialWithdrawals(2))
+	require.ErrorContains(t, "cannot dequeue more withdrawals than are in the queue", s.DequeuePendingPartialWithdrawals(2))
 
 	// Removing all pending partial withdrawals should be OK.
 	num, err = s.NumPendingPartialWithdrawals()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), num)
-	require.NoError(t, s.DequeuePartialWithdrawals(1))
+	require.NoError(t, s.DequeuePendingPartialWithdrawals(1))
 	num, err = s.Copy().NumPendingPartialWithdrawals()
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), num)
@@ -91,7 +91,7 @@ func TestDequeuePendingWithdrawals(t *testing.T) {
 	s, err = InitializeFromProtoDeneb(&eth.BeaconStateDeneb{})
 	require.NoError(t, err)
 
-	require.ErrorContains(t, "is not supported", s.DequeuePartialWithdrawals(0))
+	require.ErrorContains(t, "is not supported", s.DequeuePendingPartialWithdrawals(0))
 }
 
 func TestAppendPendingWithdrawals(t *testing.T) {

--- a/beacon-chain/state/state-native/spec_parameters.go
+++ b/beacon-chain/state/state-native/spec_parameters.go
@@ -14,7 +14,7 @@ func (b *BeaconState) ProportionalSlashingMultiplier() (uint64, error) {
 	case version.Phase0:
 		return params.BeaconConfig().ProportionalSlashingMultiplier, nil
 	}
-	return 0, errNotSupported("ProportionalSlashingMultiplier()", b.version)
+	return 0, errNotSupported("ProportionalSlashingMultiplier", b.version)
 }
 
 func (b *BeaconState) InactivityPenaltyQuotient() (uint64, error) {
@@ -26,5 +26,5 @@ func (b *BeaconState) InactivityPenaltyQuotient() (uint64, error) {
 	case version.Phase0:
 		return params.BeaconConfig().InactivityPenaltyQuotient, nil
 	}
-	return 0, errNotSupported("InactivityPenaltyQuotient()", b.version)
+	return 0, errNotSupported("InactivityPenaltyQuotient", b.version)
 }

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -96,10 +96,10 @@ var denebFields = append(
 
 var electraFields = append(
 	altairFields,
+	types.LatestExecutionPayloadHeaderDeneb,
 	types.NextWithdrawalIndex,
 	types.NextWithdrawalValidatorIndex,
 	types.HistoricalSummaries,
-	types.LatestExecutionPayloadHeaderDeneb,
 	types.DepositRequestsStartIndex,
 	types.DepositBalanceToConsume,
 	types.ExitBalanceToConsume,


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

* To mimic `AppendPendingPartialWithdrawal`, add a nil check for the value.
* Remove unused `ProcessSyncAggregate` alias.
* Move `historicalSummaries` that is in the "wrong" spot.
* Move `PendingDeposit.Amount` that is in the "wrong" spot.
* Rename `DequeuePartialWithdrawals` to `DequeuePendingPartialWithdrawals`.
* Remove parentheses from `errNotSupported` argument.
* In `state_trie.electraFields`, move `LatestExecutionPayloadHeaderDeneb`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
