### PR TITLE
Return early blob constructor if not deneb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Simplified `ExitedValidatorIndices`.
 - Simplified `EjectedValidatorIndices`.
 - `engine_newPayloadV4`,`engine_getPayloadV4` are changes due to new execution request serialization decisions, [PR](https://github.com/prysmaticlabs/prysm/pull/14580)
+- Return early for blob constructor during capella fork
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Simplified `ExitedValidatorIndices`.
 - Simplified `EjectedValidatorIndices`.
 - `engine_newPayloadV4`,`engine_getPayloadV4` are changes due to new execution request serialization decisions, [PR](https://github.com/prysmaticlabs/prysm/pull/14580)
-- Return early for blob constructor during capella fork
+- Return early for blob reconstructor during capella fork
 
 ### Deprecated
 

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/io/file"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 	"google.golang.org/protobuf/proto"
 )
@@ -62,6 +63,10 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 // This function reconstructs the blob sidecars from the EL using the block's KZG commitments,
 // broadcasts the reconstructed blobs over P2P, and saves them into the blob storage.
 func (s *Service) reconstructAndBroadcastBlobs(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock) {
+	if block.Version() < version.Deneb {
+		return
+	}
+
 	startTime, err := slots.ToTime(uint64(s.cfg.chain.GenesisTime().Unix()), block.Block().Slot())
 	if err != nil {
 		log.WithError(err).Error("Failed to convert slot to time")

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -194,3 +194,12 @@ func TestReconstructAndBroadcastBlobs(t *testing.T) {
 		})
 	}
 }
+
+func TestReconstructAndBroadcastBlobs_Capella(t *testing.T) {
+	b := util.NewBeaconBlockCapella()
+	sb, err := blocks.NewSignedBeaconBlock(b)
+	require.NoError(t, err)
+
+	s := Service{}
+	s.reconstructAndBroadcastBlobs(context.Background(), sb)
+}

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -194,4 +194,3 @@ func TestReconstructAndBroadcastBlobs(t *testing.T) {
 		})
 	}
 }
-

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -195,11 +195,3 @@ func TestReconstructAndBroadcastBlobs(t *testing.T) {
 	}
 }
 
-func TestReconstructAndBroadcastBlobs_Capella(t *testing.T) {
-	b := util.NewBeaconBlockCapella()
-	sb, err := blocks.NewSignedBeaconBlock(b)
-	require.NoError(t, err)
-
-	s := Service{}
-	s.reconstructAndBroadcastBlobs(context.Background(), sb)
-}


### PR DESCRIPTION
If the block is before Deneb, we don’t need to reconstruct the blob sidecar, and in this case, it’s reasonable to return early in the future instead of encountering errors down the line