### PR TITLE
Allow Protobuf State To Be Created Without Copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Updated the `beacon-chain/monitor` package to Electra. [PR](https://github.com/prysmaticlabs/prysm/pull/14562)
 - Added ListAttestationsV2 endpoint.
 - Add ability to rollback node's internal state during processing.
+- Add ability to access the validator registry without copying it for the experimental state.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Updated the `beacon-chain/monitor` package to Electra. [PR](https://github.com/prysmaticlabs/prysm/pull/14562)
 - Added ListAttestationsV2 endpoint.
 - Add ability to rollback node's internal state during processing.
-- Add ability to access the validator registry without copying it for the experimental state.
+- Change how unsafe protobuf state is created to prevent unnecessary copies.
 
 ### Changed
 

--- a/beacon-chain/state/state-native/getters_state.go
+++ b/beacon-chain/state/state-native/getters_state.go
@@ -22,12 +22,16 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 	rm := b.randaoMixesVal().Slice()
 	var vals []*ethpb.Validator
 	var bals []uint64
+	var inactivityScores []uint64
+
 	if features.Get().EnableExperimentalState {
-		vals = b.unsafeValidatorsVal()
-		bals = b.balancesVal()
+		bals = b.balancesMultiValue.Value(b)
+		inactivityScores = b.inactivityScoresMultiValue.Value(b)
+		vals = b.validatorsMultiValue.Value(b)
 	} else {
-		vals = b.validators
 		bals = b.balances
+		inactivityScores = b.inactivityScores
+		vals = b.validators
 	}
 
 	switch b.version {
@@ -78,7 +82,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 			PreviousJustifiedCheckpoint: b.previousJustifiedCheckpoint,
 			CurrentJustifiedCheckpoint:  b.currentJustifiedCheckpoint,
 			FinalizedCheckpoint:         b.finalizedCheckpoint,
-			InactivityScores:            b.inactivityScoresVal(),
+			InactivityScores:            inactivityScores,
 			CurrentSyncCommittee:        b.currentSyncCommittee,
 			NextSyncCommittee:           b.nextSyncCommittee,
 		}
@@ -105,7 +109,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 			PreviousJustifiedCheckpoint:  b.previousJustifiedCheckpoint,
 			CurrentJustifiedCheckpoint:   b.currentJustifiedCheckpoint,
 			FinalizedCheckpoint:          b.finalizedCheckpoint,
-			InactivityScores:             b.inactivityScoresVal(),
+			InactivityScores:             inactivityScores,
 			CurrentSyncCommittee:         b.currentSyncCommittee,
 			NextSyncCommittee:            b.nextSyncCommittee,
 			LatestExecutionPayloadHeader: b.latestExecutionPayloadHeader,
@@ -133,7 +137,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 			PreviousJustifiedCheckpoint:  b.previousJustifiedCheckpoint,
 			CurrentJustifiedCheckpoint:   b.currentJustifiedCheckpoint,
 			FinalizedCheckpoint:          b.finalizedCheckpoint,
-			InactivityScores:             b.inactivityScoresVal(),
+			InactivityScores:             inactivityScores,
 			CurrentSyncCommittee:         b.currentSyncCommittee,
 			NextSyncCommittee:            b.nextSyncCommittee,
 			LatestExecutionPayloadHeader: b.latestExecutionPayloadHeaderCapella,
@@ -164,7 +168,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 			PreviousJustifiedCheckpoint:  b.previousJustifiedCheckpoint,
 			CurrentJustifiedCheckpoint:   b.currentJustifiedCheckpoint,
 			FinalizedCheckpoint:          b.finalizedCheckpoint,
-			InactivityScores:             b.inactivityScoresVal(),
+			InactivityScores:             inactivityScores,
 			CurrentSyncCommittee:         b.currentSyncCommittee,
 			NextSyncCommittee:            b.nextSyncCommittee,
 			LatestExecutionPayloadHeader: b.latestExecutionPayloadHeaderDeneb,
@@ -195,7 +199,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 			PreviousJustifiedCheckpoint:   b.previousJustifiedCheckpoint,
 			CurrentJustifiedCheckpoint:    b.currentJustifiedCheckpoint,
 			FinalizedCheckpoint:           b.finalizedCheckpoint,
-			InactivityScores:              b.inactivityScoresVal(),
+			InactivityScores:              inactivityScores,
 			CurrentSyncCommittee:          b.currentSyncCommittee,
 			NextSyncCommittee:             b.nextSyncCommittee,
 			LatestExecutionPayloadHeader:  b.latestExecutionPayloadHeaderDeneb,

--- a/beacon-chain/state/state-native/getters_state.go
+++ b/beacon-chain/state/state-native/getters_state.go
@@ -25,9 +25,15 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 	var inactivityScores []uint64
 
 	if features.Get().EnableExperimentalState {
-		bals = b.balancesMultiValue.Value(b)
-		inactivityScores = b.inactivityScoresMultiValue.Value(b)
-		vals = b.validatorsMultiValue.Value(b)
+		if b.balancesMultiValue != nil {
+			bals = b.balancesMultiValue.Value(b)
+		}
+		if b.inactivityScoresMultiValue != nil {
+			inactivityScores = b.inactivityScoresMultiValue.Value(b)
+		}
+		if b.validatorsMultiValue != nil {
+			vals = b.validatorsMultiValue.Value(b)
+		}
 	} else {
 		bals = b.balances
 		inactivityScores = b.inactivityScores

--- a/beacon-chain/state/state-native/getters_state.go
+++ b/beacon-chain/state/state-native/getters_state.go
@@ -23,7 +23,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 	var vals []*ethpb.Validator
 	var bals []uint64
 	if features.Get().EnableExperimentalState {
-		vals = b.validatorsVal()
+		vals = b.unsafeValidatorsVal()
 		bals = b.balancesVal()
 	} else {
 		vals = b.validators

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -30,6 +30,24 @@ func (b *BeaconState) ValidatorsReadOnly() []state.ReadOnlyValidator {
 	return b.validatorsReadOnlyVal()
 }
 
+// This returns the validator registry without copying it. The caller
+// must ensure it is not modified and only read from.
+func (b *BeaconState) unsafeValidatorsVal() []*ethpb.Validator {
+	var v []*ethpb.Validator
+	if features.Get().EnableExperimentalState {
+		if b.validatorsMultiValue == nil {
+			return nil
+		}
+		v = b.validatorsMultiValue.Value(b)
+	} else {
+		if b.validators == nil {
+			return nil
+		}
+		v = b.validators
+	}
+	return v
+}
+
 func (b *BeaconState) validatorsVal() []*ethpb.Validator {
 	var v []*ethpb.Validator
 	if features.Get().EnableExperimentalState {

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -30,24 +30,6 @@ func (b *BeaconState) ValidatorsReadOnly() []state.ReadOnlyValidator {
 	return b.validatorsReadOnlyVal()
 }
 
-// This returns the validator registry without copying it. The caller
-// must ensure it is not modified and only read from.
-func (b *BeaconState) unsafeValidatorsVal() []*ethpb.Validator {
-	var v []*ethpb.Validator
-	if features.Get().EnableExperimentalState {
-		if b.validatorsMultiValue == nil {
-			return nil
-		}
-		v = b.validatorsMultiValue.Value(b)
-	} else {
-		if b.validators == nil {
-			return nil
-		}
-		v = b.validators
-	}
-	return v
-}
-
 func (b *BeaconState) validatorsVal() []*ethpb.Validator {
 	var v []*ethpb.Validator
 	if features.Get().EnableExperimentalState {


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

For the experimental state, when building out the protobuf state we end up copying the whole validator registry just to serialize it. Doing this has lead much longer state write transaction times, this PR fixes this by not copying the whole registry. This is as it is understood by the caller that we are accessing the internal state data (without copying). This behaviour maintains parity as it was done previously. 

We do the same for balances and inactivity scores fields.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
