### PR TITLE
Add peer format on flags & Refactor parsing address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Updated the `beacon-chain/monitor` package to Electra. [PR](https://github.com/prysmaticlabs/prysm/pull/14562)
 - Added ListAttestationsV2 endpoint.
 - Add ability to rollback node's internal state during processing.
+- Add acceptable address types for static peers. [PR](https://github.com/prysmaticlabs/prysm/pull/14615)
 
 ### Changed
 
@@ -43,6 +44,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Changed the signature of `ProcessPayload`.
 - Only Build the Protobuf state once during serialization.
 - Capella blocks are execution.
+- Refactor parsing generic address for p2p.
 
 ### Deprecated
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -674,7 +674,7 @@ func (b *BeaconNode) registerP2P(cliCtx *cli.Context) error {
 	svc, err := p2p.NewService(b.ctx, &p2p.Config{
 		NoDiscovery:          cliCtx.Bool(cmd.NoDiscovery.Name),
 		StaticPeers:          slice.SplitCommaSeparated(cliCtx.StringSlice(cmd.StaticPeers.Name)),
-		Discv5BootStrapAddrs: p2p.ParseBootStrapAddrs(bootstrapNodeAddrs),
+		Discv5BootStrapAddrs: bootstrapNodeAddrs,
 		RelayNodeAddr:        cliCtx.String(cmd.RelayNode.Name),
 		DataDir:              dataDir,
 		LocalIP:              cliCtx.String(cmd.P2PIP.Name),

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -538,7 +538,7 @@ func (s *Service) wantedPeerDials() int {
 }
 
 // ParseGenericAddrs parses a list of generic addresses into a list of peer.AddrInfo.
-// The generic addresses can be either 1) enode strings , 2) multiaddresses, or 3) enr strings.
+// The generic addresses can be either 1) enode strings, 2) multiaddresses, or 3) enr strings.
 func ParseGenericAddrs(addrs []string) ([]peer.AddrInfo, error) {
 	var allAddrs []ma.Multiaddr
 	enodeString, multiAddrString := classifyAddrs(addrs)

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -560,20 +560,12 @@ func ParseGenericAddrs(addrs []string) ([]peer.AddrInfo, error) {
 		}
 		allAddrs = append(allAddrs, nodeAddrs...)
 	}
-	
+
 	addrInfos, err := peer.AddrInfosFromP2pAddrs(allAddrs...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not derive addr info from multiaddress")
 	}
 	return addrInfos, nil
-}
-
-func ParseBootStrapAddrs(addrs []string) (discv5Nodes []string) {
-	discv5Nodes, _ = classifyAddrs(addrs)
-	if len(discv5Nodes) == 0 {
-		log.Warn("No bootstrap addresses supplied")
-	}
-	return discv5Nodes
 }
 
 // classifyAddrs tries to parse the given address and classify them into enode and multiaddr strings.

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"time"
 
@@ -150,31 +149,17 @@ func (s *Service) pubsubOptions() []pubsub.Option {
 	}
 
 	if len(s.cfg.StaticPeers) > 0 {
-		directPeersAddrInfos, err := parsePeersEnr(s.cfg.StaticPeers)
+		peerInfos, err := ParseGenericAddrs(s.cfg.StaticPeers)
 		if err != nil {
 			log.WithError(err).Error("Could not add direct peer option")
 			return psOpts
 		}
-		psOpts = append(psOpts, pubsub.WithDirectPeers(directPeersAddrInfos))
+		if len(peerInfos) > 0 {
+			psOpts = append(psOpts, pubsub.WithDirectPeers(peerInfos))
+		}	
 	}
 
 	return psOpts
-}
-
-// parsePeersEnr takes a list of raw ENRs and converts them into a list of AddrInfos.
-func parsePeersEnr(peers []string) ([]peer.AddrInfo, error) {
-	addrs, err := PeersFromStringAddrs(peers)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot convert peers raw ENRs into multiaddresses: %w", err)
-	}
-	if len(addrs) == 0 {
-		return nil, fmt.Errorf("Converting peers raw ENRs into multiaddresses resulted in an empty list")
-	}
-	directAddrInfos, err := peer.AddrInfosFromP2pAddrs(addrs...)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot convert peers multiaddresses into AddrInfos: %w", err)
-	}
-	return directAddrInfos, nil
 }
 
 // creates a custom gossipsub parameter set.

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -156,7 +156,7 @@ func (s *Service) pubsubOptions() []pubsub.Option {
 		}
 		if len(peerInfos) > 0 {
 			psOpts = append(psOpts, pubsub.WithDirectPeers(peerInfos))
-		}	
+		}
 	}
 
 	return psOpts

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -215,14 +215,14 @@ func (s *Service) Start() {
 	s.started = true
 
 	if len(s.cfg.StaticPeers) > 0 {
-		addrs, err := PeersFromStringAddrs(s.cfg.StaticPeers)
+		addrInfos, err := ParseGenericAddrs(s.cfg.StaticPeers)
 		if err != nil {
-			log.WithError(err).Error("could not convert ENR to multiaddr")
+			log.WithError(err).Error("Could not convert raw peer addresses to address infos")
 		}
 		// Set trusted peers for those that are provided as static addresses.
-		pids := peerIdsFromMultiAddrs(addrs)
+		pids := peerIdsFromAddrInfos(addrInfos)
 		s.peers.SetTrustedPeers(pids)
-		s.connectWithAllTrustedPeers(addrs)
+		s.connectWithAllTrustedPeers(addrInfos)
 	}
 	// Initialize metadata according to the
 	// current epoch.
@@ -421,12 +421,7 @@ func (s *Service) awaitStateInitialized() {
 	}
 }
 
-func (s *Service) connectWithAllTrustedPeers(multiAddrs []multiaddr.Multiaddr) {
-	addrInfos, err := peer.AddrInfosFromP2pAddrs(multiAddrs...)
-	if err != nil {
-		log.WithError(err).Error("Could not convert to peer address info's from multiaddresses")
-		return
-	}
+func (s *Service) connectWithAllTrustedPeers(addrInfos []peer.AddrInfo) {
 	for _, info := range addrInfos {
 		// add peer into peer status
 		s.peers.Add(nil, info.ID, info.Addrs[0], network.DirUnknown)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -96,17 +96,17 @@ var (
 	// StaticPeers specifies a set of peers to connect to explicitly, accepting following format of addresses:
 	// enode, multiaddr, enr.
 	StaticPeers = &cli.StringSliceFlag{
-		Name:  "peer",
+		Name: "peer",
 		Usage: "Connect with this peer, this flag may be used multiple times. " +
-				"This peer is recognized as a trusted peer." +
-				"Accepts enode, multiaddr, and enr formats.",
+			"This peer is recognized as a trusted peer." +
+			"Accepts enode, multiaddr, and enr formats.",
 	}
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
 	BootstrapNode = &cli.StringSliceFlag{
-		Name:  "bootstrap-node",
+		Name: "bootstrap-node",
 		Usage: "The enr/enode address of bootstrap node. Beacon node will connect for peer discovery via DHT. " +
-				"Multiple nodes can be passed by using the flag multiple times but not comma-separated. " +
-				"You can also pass YAML files containing multiple nodes.",
+			"Multiple nodes can be passed by using the flag multiple times but not comma-separated. " +
+			"You can also pass YAML files containing multiple nodes.",
 		Value: cli.NewStringSlice(params.BeaconNetworkConfig().BootstrapNodes...),
 	}
 	// RelayNode tells the beacon node which relay node to connect to.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -93,15 +93,20 @@ var (
 		Name:  "no-discovery",
 		Usage: "Enable only local network p2p and do not connect to cloud bootstrap nodes",
 	}
-	// StaticPeers specifies a set of peers to connect to explicitly.
+	// StaticPeers specifies a set of peers to connect to explicitly, accepting following format of addresses:
+	// enode, multiaddr, enr.
 	StaticPeers = &cli.StringSliceFlag{
 		Name:  "peer",
-		Usage: "Connect with this peer, this flag may be used multiple times. This peer is recognized as a trusted peer.",
+		Usage: "Connect with this peer, this flag may be used multiple times. " +
+				"This peer is recognized as a trusted peer." +
+				"Accepts enode, multiaddr, and enr formats.",
 	}
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
 	BootstrapNode = &cli.StringSliceFlag{
 		Name:  "bootstrap-node",
-		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT.  Multiple nodes can be passed by using the flag multiple times but not comma-separated. You can also pass YAML files containing multiple nodes.",
+		Usage: "The enr/enode address of bootstrap node. Beacon node will connect for peer discovery via DHT. " +
+				"Multiple nodes can be passed by using the flag multiple times but not comma-separated. " +
+				"You can also pass YAML files containing multiple nodes.",
 		Value: cli.NewStringSlice(params.BeaconNetworkConfig().BootstrapNodes...),
 	}
 	// RelayNode tells the beacon node which relay node to connect to.

--- a/cmd/prysmctl/p2p/peers.go
+++ b/cmd/prysmctl/p2p/peers.go
@@ -3,18 +3,13 @@ package p2p
 import (
 	"context"
 
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
 )
 
-func (c *client) connectToPeers(ctx context.Context, peerMultiaddrs ...string) error {
-	peers, err := p2p.PeersFromStringAddrs(peerMultiaddrs)
+func (c *client) connectToPeers(ctx context.Context, rawPeerAddrs ...string) error {
+	addrInfos, err := p2p.ParseGenericAddrs(rawPeerAddrs)
 	if err != nil {
 		return err
-	}
-	addrInfos, err := peer.AddrInfosFromP2pAddrs(peers...)
-	if err != nil {
-		panic(err)
 	}
 	for _, info := range addrInfos {
 		if info.ID == c.host.ID() {


### PR DESCRIPTION
**What type of PR is this?**

Feature & Refactor

**What does this PR do? Why is it needed?**

- CLI users will be aware of which type for p2p addresses, especially for `--peer` and `--bootstrap-node` flags. 
- There are some redundancies in parsing and converting p2p addresses. (e.g. `parsePeersEnr`, `PeersFromStringAddrs`, `connectWithAllTrustedPeers`, `connectWithAllPeers`...) I refactored those util functions for more readability.

**Which issues(s) does this PR fix?**

Fixes #14166 & #14606 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
