### PR TITLE
Epbs payload

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "defragment.go",
         "error.go",
         "execution_engine.go",
+        "execution_engine_epbs.go",
         "forkchoice_update_execution.go",
         "head.go",
         "head_sync_committee_info.go",

--- a/beacon-chain/blockchain/execution_engine_epbs.go
+++ b/beacon-chain/blockchain/execution_engine_epbs.go
@@ -1,0 +1,62 @@
+package blockchain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/execution"
+	"github.com/prysmaticlabs/prysm/v5/config/features"
+	payloadattribute "github.com/prysmaticlabs/prysm/v5/consensus-types/payload-attribute"
+	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
+	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
+	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
+	"github.com/sirupsen/logrus"
+)
+
+// notifyForkchoiceUpdate signals execution engine the fork choice updates. Execution engine should:
+// 1. Re-organizes the execution payload chain and corresponding state to make head_block_hash the head.
+// 2. Applies finality to the execution state: it irreversibly persists the chain of all execution payloads and corresponding state, up to and including finalized_block_hash.
+func (s *Service) notifyForkchoiceUpdateEPBS(ctx context.Context, blockhash [32]byte, attributes payloadattribute.Attributer) (*enginev1.PayloadIDBytes, error) {
+	ctx, span := trace.StartSpan(ctx, "blockChain.notifyForkchoiceUpdateEPBS")
+	defer span.End()
+
+	finalizedHash := s.cfg.ForkChoiceStore.FinalizedPayloadBlockHash()
+	justifiedHash := s.cfg.ForkChoiceStore.UnrealizedJustifiedPayloadBlockHash()
+	fcs := &enginev1.ForkchoiceState{
+		HeadBlockHash:      blockhash[:],
+		SafeBlockHash:      justifiedHash[:],
+		FinalizedBlockHash: finalizedHash[:],
+	}
+	if attributes == nil {
+		attributes = payloadattribute.EmptyWithVersion(version.Electra)
+	}
+	payloadID, lastValidHash, err := s.cfg.ExecutionEngineCaller.ForkchoiceUpdated(ctx, fcs, attributes)
+	if err != nil {
+		switch {
+		case errors.Is(err, execution.ErrAcceptedSyncingPayloadStatus):
+			forkchoiceUpdatedOptimisticNodeCount.Inc()
+			log.WithFields(logrus.Fields{
+				"headPayloadBlockHash":      fmt.Sprintf("%#x", bytesutil.Trunc(blockhash[:])),
+				"finalizedPayloadBlockHash": fmt.Sprintf("%#x", bytesutil.Trunc(finalizedHash[:])),
+			}).Info("Called fork choice updated with optimistic block")
+			return payloadID, nil
+		case errors.Is(err, execution.ErrInvalidPayloadStatus):
+			log.WithError(err).Info("forkchoice updated to invalid block")
+			return nil, invalidBlock{error: ErrInvalidPayload, root: [32]byte(lastValidHash)}
+		default:
+			log.WithError(err).Error(ErrUndefinedExecutionEngineError)
+			return nil, nil
+		}
+	}
+	forkchoiceUpdatedValidNodeCount.Inc()
+	// If the forkchoice update call has an attribute, update the payload ID cache.
+	hasAttr := attributes != nil && !attributes.IsEmpty()
+	if hasAttr && payloadID == nil && !features.Get().PrepareAllPayloads {
+		log.WithFields(logrus.Fields{
+			"blockHash": fmt.Sprintf("%#x", blockhash[:]),
+		}).Error("Received nil payload ID on VALID engine response")
+	}
+	return payloadID, nil
+}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -491,7 +491,6 @@ func (s *Service) runLateBlockTasks() {
 				ticker.Done()
 				attThreshold := params.BeaconConfig().SecondsPerSlot / 4
 				ticker = slots.NewSlotTickerWithOffset(s.genesisTime, time.Duration(attThreshold)*time.Second, params.BeaconConfig().SecondsPerSlot)
-				time.Sleep(1 * time.Second)
 			}
 			s.lateBlockTasks(s.ctx)
 		case <-s.ctx.Done():

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -483,9 +483,16 @@ func (s *Service) runLateBlockTasks() {
 
 	attThreshold := params.BeaconConfig().SecondsPerSlot / 3
 	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, time.Duration(attThreshold)*time.Second, params.BeaconConfig().SecondsPerSlot)
+	epbs := params.BeaconConfig().EPBSForkEpoch
 	for {
 		select {
-		case <-ticker.C():
+		case slot := <-ticker.C():
+			if slots.ToEpoch(slot) == epbs && slot%32 == 0 {
+				ticker.Done()
+				attThreshold := params.BeaconConfig().SecondsPerSlot / 4
+				ticker = slots.NewSlotTickerWithOffset(s.genesisTime, time.Duration(attThreshold)*time.Second, params.BeaconConfig().SecondsPerSlot)
+				time.Sleep(1 * time.Second)
+			}
 			s.lateBlockTasks(s.ctx)
 		case <-s.ctx.Done():
 			log.Debug("Context closed, exiting routine")
@@ -656,24 +663,36 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		return
 	}
 
-	s.headLock.RLock()
-	headBlock, err := s.headBlock()
-	if err != nil {
+	if headState.Version() >= version.EPBS {
+		bh, err := headState.LatestBlockHash()
+		if err != nil {
+			log.WithError(err).Debug("could not perform late block tasks: failed to retrieve latest block hash")
+			return
+		}
+		_, err = s.notifyForkchoiceUpdateEPBS(ctx, [32]byte(bh), attribute)
+		if err != nil {
+			log.WithError(err).Debug("could not perform late block tasks: failed to update forkchoice with engine")
+		}
+	} else {
+		s.headLock.RLock()
+		headBlock, err := s.headBlock()
+		if err != nil {
+			s.headLock.RUnlock()
+			log.WithError(err).Debug("could not perform late block tasks: failed to retrieve head block")
+			return
+		}
 		s.headLock.RUnlock()
-		log.WithError(err).Debug("could not perform late block tasks: failed to retrieve head block")
-		return
-	}
-	s.headLock.RUnlock()
 
-	fcuArgs := &fcuConfig{
-		headState:  headState,
-		headRoot:   headRoot,
-		headBlock:  headBlock,
-		attributes: attribute,
-	}
-	_, err = s.notifyForkchoiceUpdate(ctx, fcuArgs)
-	if err != nil {
-		log.WithError(err).Debug("could not perform late block tasks: failed to update forkchoice with engine")
+		fcuArgs := &fcuConfig{
+			headState:  headState,
+			headRoot:   headRoot,
+			headBlock:  headBlock,
+			attributes: attribute,
+		}
+		_, err = s.notifyForkchoiceUpdate(ctx, fcuArgs)
+		if err != nil {
+			log.WithError(err).Debug("could not perform late block tasks: failed to update forkchoice with engine")
+		}
 	}
 }
 

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -109,6 +109,15 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 			}).Info("Forkchoice updated with payload attributes for proposal")
 			s.cfg.PayloadIDCache.Set(envelope.Slot()+1, root, pid)
 		}
+		headBlk, err := s.HeadBlock(ctx)
+		if err != nil {
+			log.WithError(err).Error("could not get head block")
+			return nil
+		}
+		if err := s.saveHead(ctx, root, headBlk, preState); err != nil {
+			log.WithError(err).Error("could not save new head")
+			return nil
+		}
 	}
 	timeWithoutDaWait := time.Since(receivedTime) - daWaitedTime
 	executionEngineProcessingTime.Observe(float64(timeWithoutDaWait.Milliseconds()))

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -39,7 +40,6 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
-	var postState state.BeaconState
 	eg.Go(func() error {
 		if err := epbs.ValidatePayloadStateTransition(ctx, preState, envelope); err != nil {
 			return errors.Wrap(err, "failed to validate consensus state transition function")
@@ -59,8 +59,6 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 	if err := eg.Wait(); err != nil {
 		return err
 	}
-	_ = isValidPayload
-	_ = postState
 	daStartTime := time.Now()
 	// TODO: Add DA check
 	daWaitedTime := time.Since(daStartTime)
@@ -70,6 +68,47 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 	}
 	if err := s.insertPayloadEnvelope(envelope); err != nil {
 		return errors.Wrap(err, "could not insert payload to forkchoice")
+	}
+	if isValidPayload {
+		s.ForkChoicer().Lock()
+		if err := s.ForkChoicer().SetOptimisticToValid(ctx, root); err != nil {
+			s.ForkChoicer().Unlock()
+			return errors.Wrap(err, "could not set optimistic payload to valid")
+		}
+		s.ForkChoicer().Unlock()
+	}
+
+	headRoot, err := s.HeadRoot(ctx)
+	if err != nil {
+		log.WithError(err).Error("could not get headroot to compute attributes")
+		return nil
+	}
+	if bytes.Equal(headRoot, root[:]) {
+		attr := s.getPayloadAttribute(ctx, preState, envelope.Slot()+1, headRoot)
+		execution, err := envelope.Execution()
+		if err != nil {
+			log.WithError(err).Error("could not get execution data")
+			return nil
+		}
+		blockHash := [32]byte(execution.BlockHash())
+		payloadID, err := s.notifyForkchoiceUpdateEPBS(ctx, blockHash, attr)
+		if err != nil {
+			if IsInvalidBlock(err) {
+				// TODO handle the lvh here
+				return err
+			}
+			return nil
+		}
+		if attr != nil && !attr.IsEmpty() && payloadID != nil {
+			var pid [8]byte
+			copy(pid[:], payloadID[:])
+			log.WithFields(logrus.Fields{
+				"blockRoot": fmt.Sprintf("%#x", bytesutil.Trunc(headRoot)),
+				"headSlot":  envelope.Slot(),
+				"payloadID": fmt.Sprintf("%#x", bytesutil.Trunc(payloadID[:])),
+			}).Info("Forkchoice updated with payload attributes for proposal")
+			s.cfg.PayloadIDCache.Set(envelope.Slot()+1, root, pid)
+		}
 	}
 	timeWithoutDaWait := time.Since(receivedTime) - daWaitedTime
 	executionEngineProcessingTime.Observe(float64(timeWithoutDaWait.Milliseconds()))

--- a/beacon-chain/core/blocks/payload.go
+++ b/beacon-chain/core/blocks/payload.go
@@ -58,6 +58,9 @@ func IsMergeTransitionComplete(st state.BeaconState) (bool, error) {
 //
 //	return block.body.execution_payload != ExecutionPayload()
 func IsExecutionBlock(body interfaces.ReadOnlyBeaconBlockBody) (bool, error) {
+	if body.Version() >= version.Capella {
+		return true, nil
+	}
 	if body == nil {
 		return false, errors.New("nil block body")
 	}

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -233,7 +233,7 @@ func (s *Service) ForkchoiceUpdated(
 		if err != nil {
 			return nil, nil, handleRPCError(err)
 		}
-	case version.Deneb, version.Electra:
+	case version.Deneb, version.Electra, version.EPBS:
 		a, err := attrs.PbV3()
 		if err != nil {
 			return nil, nil, err

--- a/consensus-types/payload-attribute/types.go
+++ b/consensus-types/payload-attribute/types.go
@@ -42,9 +42,14 @@ func New(i interface{}) (Attributer, error) {
 }
 
 // EmptyWithVersion returns an empty payload attribute with the given version.
-func EmptyWithVersion(version int) Attributer {
+func EmptyWithVersion(ver int) Attributer {
+	if ver == version.EPBS {
+		return &data{
+			version: version.Electra,
+		}
+	}
 	return &data{
-		version: version,
+		version: ver,
 	}
 }
 


### PR DESCRIPTION
This deals with sending FCU on the ePBS paths

- Removes calls from process CL blocks
- Adds a call after processing the payload
- Adds calls on reorgs by attestations
- Adds a call on late block tasks
- Also recreates the ticker for late block tasks to happen at 3 seconds instead of 4. 

Still broken by stategen (that needs to recover the right head state empty/full) and possibly the NSC
