### PR TITLE
Use `GetBlockAttestationV2` at handler

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -601,7 +601,7 @@ func (s *Service) beaconEndpoints(
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
 			},
-			handler: server.GetBlockAttestations,
+			handler: server.GetBlockAttestationsV2,
 			methods: []string{http.MethodGet},
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

I'm not sure for the exact context, but `GetBlockAttestationsV2` was well implemented in #14478 but never used in the actual handler. This PR addresses the missing one.
It seems that adding an entry to CHANGELOG is not needed, so I skipped it.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
