### PR TITLE
Update `get_validator_from_deposit` to match spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ Updating to this release is recommended at your convenience.
 - Testing: added custom matcher for better push settings testing.
 - Registered `GetDepositSnapshot` Beacon API endpoint.
 - Fix rolling back of a block due to a context deadline.
+- Electra: base max effective balance on the validator's withdrawal credential in `get_validator_from_deposit`.
 
 ### Security
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

It appears that this function hasn't been updated recently & no longer matches the spec.

The old implementation does not base the max effective balance on provided withdrawal credentials. Meaning it's possible to set an effective balance greater than 32 ETH for regular (non-compounding) validators. I didn't look into whether or not this is actually possible, updating and moving on.

See: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-get_validator_from_deposit

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
