### PR TITLE
Validator REST api: adding in check for empty keys changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fix keymanager API so that get keys returns an empty response instead of a 500 error when using an unsupported keystore.
 - Small log imporvement, removing some redundant or duplicate logs
 - EIP7521 - Fixes withdrawal bug by accounting for pending partial withdrawals and deducting already withdrawn amounts from the sweep balance. [PR](https://github.com/prysmaticlabs/prysm/pull/14578)
+- Fix panic in validator REST mode when updating status to all keys removed
 
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Small log imporvement, removing some redundant or duplicate logs
 - EIP7521 - Fixes withdrawal bug by accounting for pending partial withdrawals and deducting already withdrawn amounts from the sweep balance. [PR](https://github.com/prysmaticlabs/prysm/pull/14578)
 - unskip electra merkle spec test
-- Fix panic in validator REST mode when updating status to all keys removed
+- Fix panic in validator REST mode when checking status after removing all keys
 
 ### Security
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/status.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/status.go
@@ -287,6 +287,9 @@ func (vs *Server) validatorStatus(
 		Status:          ethpb.ValidatorStatus_UNKNOWN_STATUS,
 		ActivationEpoch: params.BeaconConfig().FarFutureEpoch,
 	}
+	if len(pubKey) == 0 {
+		return resp, nonExistentIndex
+	}
 	vStatus, idx, err := statusForPubKey(headState, pubKey)
 	if err != nil && !errors.Is(err, errPubkeyDoesNotExist) {
 		tracing.AnnotateError(span, err)

--- a/validator/client/beacon-api/status.go
+++ b/validator/client/beacon-api/status.go
@@ -52,7 +52,7 @@ func (c *beaconApiValidatorClient) validatorsStatusResponse(ctx context.Context,
 ) {
 	// if no parameters are provided we should just return an empty response
 	if len(inPubKeys) == 0 && len(inIndexes) == 0 {
-		return make([][]byte, 0), make([]primitives.ValidatorIndex, 0), make([]*ethpb.ValidatorStatusResponse, 0), nil
+		return [][]byte{}, []primitives.ValidatorIndex{}, []*ethpb.ValidatorStatusResponse{}, nil
 	}
 	// Represents the target set of keys
 	stringTargetPubKeysToPubKeys := make(map[string][]byte, len(inPubKeys))

--- a/validator/client/beacon-api/status.go
+++ b/validator/client/beacon-api/status.go
@@ -50,6 +50,10 @@ func (c *beaconApiValidatorClient) validatorsStatusResponse(ctx context.Context,
 	[]*ethpb.ValidatorStatusResponse,
 	error,
 ) {
+	// if no parameters are provided we should just return an empty response
+	if len(inPubKeys) == 0 && len(inIndexes) == 0 {
+		return make([][]byte, 0), make([]primitives.ValidatorIndex, 0), make([]*ethpb.ValidatorStatusResponse, 0), nil
+	}
 	// Represents the target set of keys
 	stringTargetPubKeysToPubKeys := make(map[string][]byte, len(inPubKeys))
 	stringTargetPubKeys := make([]string, len(inPubKeys))
@@ -78,6 +82,7 @@ func (c *beaconApiValidatorClient) validatorsStatusResponse(ctx context.Context,
 		return nil, nil, nil, errors.Wrap(err, "failed to get state validators")
 	}
 
+	// TODO: we should remove this API call
 	validatorsCountResponse, err := c.prysmChainClient.ValidatorCount(ctx, "head", nil)
 	if err != nil && !errors.Is(err, iface.ErrNotSupported) {
 		return nil, nil, nil, errors.Wrap(err, "failed to get total validator count")

--- a/validator/client/beacon-api/status_test.go
+++ b/validator/client/beacon-api/status_test.go
@@ -215,32 +215,23 @@ func TestMultipleValidatorStatus_Nominal(t *testing.T) {
 	assert.DeepEqual(t, &expectedValidatorStatusResponse, actualValidatorStatusResponse)
 }
 
-func TestMultipleValidatorStatus_Error(t *testing.T) {
+func TestMultipleValidatorStatus_No_Keys(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	ctx := context.Background()
 	stateValidatorsProvider := mock.NewMockStateValidatorsProvider(ctrl)
 
-	stateValidatorsProvider.EXPECT().StateValidators(
-		gomock.Any(),
-		gomock.Any(),
-		[]primitives.ValidatorIndex{},
-		nil,
-	).Return(
-		&structs.GetValidatorsResponse{},
-		errors.New("a specific error"),
-	).Times(1)
-
 	validatorClient := beaconApiValidatorClient{stateValidatorsProvider: stateValidatorsProvider}
 
-	_, err := validatorClient.MultipleValidatorStatus(
+	resp, err := validatorClient.MultipleValidatorStatus(
 		ctx,
 		&ethpb.MultipleValidatorStatusRequest{
 			PublicKeys: [][]byte{},
 		},
 	)
-	require.ErrorContains(t, "failed to get validators status response", err)
+	require.NoError(t, err)
+	require.DeepEqual(t, &ethpb.MultipleValidatorStatusResponse{}, resp)
 }
 
 func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) {

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1224,6 +1224,10 @@ func (v *validator) filterAndCacheActiveKeys(ctx context.Context, pubkeys [][fie
 
 // updateValidatorStatusCache updates the validator statuses cache, a map of keys currently used by the validator client
 func (v *validator) updateValidatorStatusCache(ctx context.Context, pubkeys [][fieldparams.BLSPubkeyLength]byte) error {
+	if len(pubkeys) == 0 {
+		v.pubkeyToStatus = make(map[[fieldparams.BLSPubkeyLength]byte]*validatorStatus, 0)
+		return nil
+	}
 	statusRequestKeys := make([][]byte, 0)
 	for _, k := range pubkeys {
 		statusRequestKeys = append(statusRequestKeys, k[:])

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -2899,4 +2899,9 @@ func TestUpdateValidatorStatusCache(t *testing.T) {
 		require.Equal(t, mockResponse.Statuses[i], status.status)
 		require.Equal(t, mockResponse.Indices[i], status.index)
 	}
+
+	err = v.updateValidatorStatusCache(ctx, nil)
+	assert.NoError(t, err)
+	// make sure the value is 0
+	assert.Equal(t, 0, len(v.pubkeyToStatus))
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

validator REST mode did not handle cases where the validator checks for validator status after removing all keys. This PR handles the panic presented when the endpoint is called but no keys are provided.

**Which issues(s) does this PR fix?**

Fixes #14636

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
