### PR TITLE
Typo Update README.md

### DIFF
--- a/config/features/README.md
+++ b/config/features/README.md
@@ -27,7 +27,7 @@ Examples of when not to use a feature flag:
 ## How to use a feature flag?
 
 Once it has been decided that you should use a feature flag. Follow these steps to safely
-releasing your feature. In general, try to create a single PR for each step of this process.
+release your feature. In general, try to create a single PR for each step of this process.
 
 1. Add your feature flag to `shared/featureconfig/flags.go`, use the flag to toggle a boolean in the
 feature config in shared/featureconfig/config.go. It is a good idea to use the `enable` prefix for

--- a/config/features/README.md
+++ b/config/features/README.md
@@ -26,7 +26,7 @@ Examples of when not to use a feature flag:
 
 ## How to use a feature flag?
 
-Once it has been decided that you should use a feature flag. Follow these steps to safely
+Once it has been decided that you should use a feature flag, follow these steps to safely
 release your feature. In general, try to create a single PR for each step of this process.
 
 1. Add your feature flag to `shared/featureconfig/flags.go`, use the flag to toggle a boolean in the


### PR DESCRIPTION
### Description:

This pull request fixes a small typo in the documentation. 

**Issue:**

In the section "How to use a feature flag?", the sentence:

> "Once it has been decided that you should use a feature flag. Follow these steps to safely releasing your feature."

contains an error where **"releasing"** should be in the infinitive form **"release"**.

**Fix:**

The corrected sentence now reads:

> "Once it has been decided that you should use a feature flag, follow these steps to safely release your feature."

**Importance:**

This correction is important for maintaining grammatical accuracy and clarity in the documentation. The use of the correct verb form ("release" instead of "releasing") ensures that the sentence follows standard English usage, which makes the instructions clearer for readers and avoids confusion.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
