### PR TITLE
Fix eventstream electra atts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fix panic in validator REST mode when checking status after removing all keys
 - Fix panic on attestation interface since we call data before validation
 - corrects nil check on some interface attestation types
+- temporary solution to handling electra attesation and attester_slashing events. [pr](14655)
 
 
 ### Security

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -451,14 +451,20 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 			return jsonMarshalReader(eventName, att)
 		}, nil
 	case *operation.UnAggregatedAttReceivedData:
-		att, ok := v.Attestation.(*eth.Attestation)
-		if !ok {
+		switch att := v.Attestation.(type) {
+		case *eth.Attestation:
+			return func() io.Reader {
+				att := structs.AttFromConsensus(att)
+				return jsonMarshalReader(eventName, att)
+			}, nil
+		case *eth.AttestationElectra:
+			return func() io.Reader {
+				att := structs.AttElectraFromConsensus(att)
+				return jsonMarshalReader(eventName, att)
+			}, nil
+		default:
 			return nil, errors.Wrapf(errUnhandledEventData, "Unexpected type %T for the .Attestation field of UnAggregatedAttReceivedData", v.Attestation)
 		}
-		return func() io.Reader {
-			att := structs.AttFromConsensus(att)
-			return jsonMarshalReader(eventName, att)
-		}, nil
 	case *operation.ExitReceivedData:
 		return func() io.Reader {
 			return jsonMarshalReader(eventName, structs.SignedExitFromConsensus(v.Exit))


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR updates the event stream api to support electra `attestation` and `attester_slashing` messages. The approach taken is to marshal these values as they would be represented elsewhere in the beacon api, without any special treatment around distinguishing the different schema of events that could be streamed in the same client session. This is unlikely to be the correct way to marshal these events when the [beacon API spec discussion on this topic](https://github.com/ethereum/beacon-APIs/pull/459) resolves, but in the meantime this approach should be backwards-compatible with the [attestantio/go-eth2-client](https://github.com/attestantio/go-eth2-client) stream client used by tools like xatu and ethereum-metrics-exporter, assuming these tools are not using the new `committee_bits` field.


**Other notes for review**


This works because the electra attestation is almost the same as pre-electra, only adding `committee_bits` to the outer container (outside the signed container). So unmarshaling the electra json into a pre-electra struct should work, except it will drop the unknown `committee_bits` field on the floor.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
