### PR TITLE
Update earliest exit epoch for upgrade to electra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Updated light client protobufs. [PR](https://github.com/prysmaticlabs/prysm/pull/14650)
 - Added `Eth-Consensus-Version` header to `ListAttestationsV2` and `GetAggregateAttestationV2` endpoints.
 - Updated light client consensus types. [PR](https://github.com/prysmaticlabs/prysm/pull/14652)
+- Update earliest exit epoch for upgrade to electra
 
 ### Deprecated
 

--- a/beacon-chain/core/electra/upgrade.go
+++ b/beacon-chain/core/electra/upgrade.go
@@ -187,7 +187,7 @@ func UpgradeToElectra(beaconState state.BeaconState) (state.BeaconState, error) 
 	}
 
 	// [New in Electra:EIP7251]
-	earliestExitEpoch := time.CurrentEpoch(beaconState)
+	earliestExitEpoch := helpers.ActivationExitEpoch(time.CurrentEpoch(beaconState))
 	preActivationIndices := make([]primitives.ValidatorIndex, 0)
 	compoundWithdrawalIndices := make([]primitives.ValidatorIndex, 0)
 	if err = beaconState.ReadFromEveryValidator(func(index int, val state.ReadOnlyValidator) error {

--- a/beacon-chain/core/electra/upgrade_test.go
+++ b/beacon-chain/core/electra/upgrade_test.go
@@ -159,7 +159,7 @@ func TestUpgradeToElectra(t *testing.T) {
 
 	eee, err := mSt.EarliestExitEpoch()
 	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(1), eee)
+	require.Equal(t, helpers.ActivationExitEpoch(primitives.Epoch(1)), eee)
 
 	cbtc, err := mSt.ConsolidationBalanceToConsume()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR addresses an edge case which is correct `earliest_exit_epoch` value when the greatest validator exit epoch in the state is less than the current epoch

Reference: https://github.com/ethereum/consensus-specs/pull/4001