### PR TITLE
Validate non zero bitfields for electra attestation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - corrects nil check on some interface attestation types
 - temporary solution to handling electra attesation and attester_slashing events. [pr](14655)
 - Diverse log improvements and comment additions.
+- Validate that each committee bitfield in an aggregate contains at least one non-zero bit
 
 
 ### Security

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations_test.go
@@ -765,6 +765,8 @@ func TestServer_ListIndexedAttestationsElectra(t *testing.T) {
 		cb := primitives.NewAttestationCommitteeBits()
 		cb.SetBitAt(0, true)
 		blockExample := util.NewBeaconBlockElectra()
+		ab := bitfield.NewBitlist(128 / uint64(params.BeaconConfig().SlotsPerEpoch))
+		ab.SetBitAt(0, true)
 		blockExample.Block.Body.Attestations = []*ethpb.AttestationElectra{
 			{
 				Signature: make([]byte, fieldparams.BLSSignatureLength),
@@ -778,7 +780,7 @@ func TestServer_ListIndexedAttestationsElectra(t *testing.T) {
 					},
 					Slot: i,
 				},
-				AggregationBits: bitfield.NewBitlist(128 / uint64(params.BeaconConfig().SlotsPerEpoch)),
+				AggregationBits: ab,
 				CommitteeBits:   cb,
 			},
 		}

--- a/proto/prysm/v1alpha1/attestation/attestation_utils.go
+++ b/proto/prysm/v1alpha1/attestation/attestation_utils.go
@@ -113,6 +113,9 @@ func AttestingIndices(att ethpb.Att, committees ...[]primitives.ValidatorIndex) 
 				committeeAttesters = append(committeeAttesters, uint64(vi))
 			}
 		}
+		if len(committeeAttesters) == 0 {
+			return nil, fmt.Errorf("no attesting indices found in committee %v", c)
+		}
 		attesters = append(attesters, committeeAttesters...)
 		committeeOffset += len(c)
 	}


### PR DESCRIPTION
This PR addresses a gap in the spec where an on-chain aggregate can include 63 committees with only a single non-zero bit, allowing ~4KB of uncompressed, wasteful data per aggregate to pass validation.

The proposed change introduces a validation rule requiring each attesting committee bitfield in the aggregate to have at least one non-zero bit, ensuring more efficient and meaningful data in on-chain aggregates.

Reference: https://github.com/ethereum/consensus-specs/pull/4002