### PR TITLE
Correct log message Update config.go **docs**

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -48,7 +48,7 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	}
 	if ctx.IsSet(RPCMaxPageSizeFlag.Name) {
 		cfg.MaxRPCPageSize = ctx.Int(RPCMaxPageSizeFlag.Name)
-		log.Warnf("Starting beacon chain with max RPC page size of %d", cfg.MaxRPCPageSize)
+		log.Warnf("Configured beacon chain with max RPC page size of %d", cfg.MaxRPCPageSize)
 	}
 	Init(cfg)
 	return nil


### PR DESCRIPTION
**Description:**  
This pull request addresses a minor but important issue in the log message generated by the `ConfigureBeaconChain` function.  

### Issue  
The original log message reads:  

```go
log.Warnf("Starting beacon chain with max RPC page size of %d", cfg.MaxRPCPageSize)
```

This phrasing is inconsistent with the context and style of the project. The configuration of the beacon chain is already complete at this stage, so the verb "Starting" does not accurately describe the operation.  

### Fix  
The updated log message is as follows:  

```go
log.Warnf("Configured beacon chain with max RPC page size of %d", cfg.MaxRPCPageSize)
```

This change ensures the message better reflects the actual state and purpose of the log entry.  

### Importance of the Fix  
- **Consistency:** Aligns the log message with project terminology and other log entries, enhancing clarity and professionalism.  
- **Clarity:** More accurately describes the operation, reducing potential confusion for developers and maintainers when reviewing logs.  
- **Debugging Efficiency:** Clear and precise log messages make it easier to understand the system's behavior during runtime.  


**What type of PR is this?**

Documentation

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
