### PR TITLE
Remove kzg proof check for blob reconstructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Removed finalized validator index cache, no longer needed.
 - Removed validator queue position log on key reload and wait for activation.
 - Removed outdated spectest exclusions for EIP-6110.
+- Removed kzg proof check from blob reconstructor.
 
 ### Fixed
 

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -623,13 +623,7 @@ func (s *Service) ReconstructBlobSidecars(ctx context.Context, block interfaces.
 			continue
 		}
 
-		// Verify the sidecar KZG proof
 		v := s.blobVerifier(roBlob, verification.ELMemPoolRequirements)
-		if err := v.SidecarKzgProofVerified(); err != nil {
-			log.WithError(err).WithField("index", i).Error("failed to verify KZG proof for sidecar")
-			continue
-		}
-
 		verifiedBlob, err := v.VerifiedROBlob()
 		if err != nil {
 			log.WithError(err).WithField("index", i).Error("failed to verify RO blob")

--- a/beacon-chain/verification/blob.go
+++ b/beacon-chain/verification/blob.go
@@ -67,9 +67,11 @@ var InitsyncBlobSidecarRequirements = requirementList(GossipBlobSidecarRequireme
 	RequireSidecarProposerExpected,
 )
 
-// ELMemPoolRequirements is a list of verification requirements to be used when importing blobs and proof from
-// execution layer mempool. Only the KZG proof verification is required.
-var ELMemPoolRequirements = []Requirement{RequireSidecarKzgProofVerified}
+// ELMemPoolRequirements defines the verification requirements for importing blobs and proofs
+// from the execution layer's mempool. Currently, no requirements are enforced because it is
+// assumed that blobs and proofs from the execution layer are correctly formatted,
+// given the trusted relationship between the consensus layer and execution layer.
+var ELMemPoolRequirements []Requirement
 
 // BackfillBlobSidecarRequirements is the same as InitsyncBlobSidecarRequirements.
 var BackfillBlobSidecarRequirements = requirementList(InitsyncBlobSidecarRequirements).excluding()


### PR DESCRIPTION
Remove the KZG proof check for the blob reconstructor. The CL gets blobs and proofs from the EL, assuming a trusted relationship. Verification of the KZG proof is likely unnecessary, and in some cases, it takes more than 20ms. Removing it is safe, as the tradeoff is no longer worth it