### PR TITLE
Fix Typos and Improve Hyphenation Consistency in Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ You can explore our [Open Issues](https://github.com/prysmaticlabs/prysm/issues)
 
 **2. Fork the Prysm repo.**
 
-Sign in to your GitHub account or create a new account if you do not have one already. Then navigate your browser to https://github.com/prysmaticlabs/prysm/. In the upper right hand corner of the page, click “fork”. This will create a copy of the Prysm repo in your account.
+Sign in to your GitHub account or create a new account if you do not have one already. Then navigate your browser to https://github.com/prysmaticlabs/prysm/. In the upper right-hand corner of the page, click “fork”. This will create a copy of the Prysm repo in your account.
 
 **3. Create a local clone of Prysm.**
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -28,7 +28,7 @@ including complicated c++ dependencies.
 One key advantage of Bazel over vanilla `go build` is that Bazel automatically (re)builds generated
 pb.go files at build time when file changes are present in any protobuf definition file or after
 any updates to the protobuf compiler or other relevant dependencies. Vanilla go users should run
-the following scripts often to ensure their generated files are up to date. Furthermore, Prysm
+the following scripts often to ensure their generated files are up-to-date. Furthermore, Prysm
 generates SSZ marshal related code based on defined data structures. These generated files must
 also be updated and checked in as frequently.
 

--- a/config/features/README.md
+++ b/config/features/README.md
@@ -31,7 +31,7 @@ releasing your feature. In general, try to create a single PR for each step of t
 
 1. Add your feature flag to `shared/featureconfig/flags.go`, use the flag to toggle a boolean in the
 feature config in shared/featureconfig/config.go. It is a good idea to use the `enable` prefix for
-your flag since you're going to invert the flag in a later step. i.e you will use `disable` prefix
+your flag since you're going to invert the flag in a later step. i.e. you will use `disable` prefix
 later. For example, `--enable-my-feature`. Additionally, [create a feature flag tracking issue](https://github.com/prysmaticlabs/prysm/issues/new?template=feature_flag.md) 
 for your feature using the appropriate issue template.
 2. Use the feature throughout the application to enable your new functionality and be sure to write

--- a/config/features/README.md
+++ b/config/features/README.md
@@ -2,7 +2,7 @@
 
 Part of Prysm's feature development often involves use of feature flags which serve as a way to
 toggle new features as they are introduced. Using this methodology, you are assured that your
-feature can be safely tested in production with a fall back option if any regression were to occur.
+feature can be safely tested in production with a fall-back option if any regression were to occur.
 This reduces the likelihood of an emergency release or rollback of a given feature due to
 unforeseen issues.
 

--- a/config/features/README.md
+++ b/config/features/README.md
@@ -45,7 +45,7 @@ func someExistingMethod(ctx context.Context) error {
     // Otherwise continue with the existing code path.
 }
 ``` 
-3. Add the flag to the end to end tests. This set of flags can also be found in shared/featureconfig/flags.go. 
+3. Add the flag to the end-to-end tests. This set of flags can also be found in shared/featureconfig/flags.go. 
 4. Test the functionality locally and safely in production. Once you have enough confidence that
 your new function works and is safe to release then move onto the next step.
 5. Move your existing flag to the deprecated section of `shared/featureconfig/flags.go`. It is

--- a/tools/cross-toolchain/README.md
+++ b/tools/cross-toolchain/README.md
@@ -82,6 +82,6 @@ Use these values with `--config=<flag>`, multiple times if more than one value i
 
 There are a few caveats to each of these strategies.
 
-- Local runs require clang compiler and the appropriate cross compilers installed. These runs should only be considered for a power user or user with specific build requirements. See the Dockerfile setup scripts to understand what dependencies must be installed and where.
+- Local runs require clang compiler and the appropriate cross-compilers installed. These runs should only be considered for a power user or user with specific build requirements. See the Dockerfile setup scripts to understand what dependencies must be installed and where.
 - Docker sandbox is *slow*. Like really slow! The purpose of the docker sandbox is to test RBE builds without deploying a full RBE system. Each build action is executed in its own container. Given the large number of small targets in this project, the overhead of creating docker containers makes this strategy the slowest of all, but requires zero additional setup.
 - Remote Build Execution is by far the fastest, if you have a RBE backend available. This is another advanced use case which will require two config flags above as well as additional flags to specify the `--remote_executor`. Some of these flags are present in the project `.bazelrc` with example values, but commented out.

--- a/tools/cross-toolchain/README.md
+++ b/tools/cross-toolchain/README.md
@@ -2,7 +2,7 @@
 
 ## Toolchain suite
 
-This package declares a c++ toolchain suite with cross compilers for targeting five platforms:
+This package declares a c++ toolchain suite with cross-compilers for targeting five platforms:
 * linux_amd64
 * linux_arm64
 * osx_amd64

--- a/tools/pcli/README.md
+++ b/tools/pcli/README.md
@@ -29,7 +29,7 @@ This is a utility to help users perform Ethereum consensus specific commands.
 
 *State Transition Flags:*
    --block-path value              Path to block file(ssz)
-   --pre-state-patch value           Path to pre state file(ssz)
+   --pre-state-patch value           Path to pre-state file(ssz)
    --expected-post-state-path value  Path to expected post state file(ssz)
    --help, -h                     show help (default: false)
 


### PR DESCRIPTION
This pull request corrects typographical inconsistencies and enhances the use of hyphenation across various documentation files. The updates include:  
- Adding missing hyphens in compound adjectives like "right-hand" and "up-to-date."  
- Correcting the usage of expressions such as "fallback" and properly formatting "i.e."  
- Standardizing terminology such as "cross-compilers" and "pre-state."  

These changes aim to improve the readability and grammatical accuracy of the project's documentation.

## Type of PR  
**Documentation**

## Purpose  
To enhance clarity, maintain consistency, and align the documentation with grammatical best practices.

## Acknowledgements  
- [x] I have read the contributing guidelines.  
- [x] Updated the changelog if applicable.
