### PR TITLE
Raise http body limit for fetching genesis state on Holesky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Diverse log improvements and comment additions.
 - P2P: Avoid infinite loop when looking for peers in small networks.
 - Fixed another rollback bug due to a context deadline.
+- Fix checkpoint sync bug on holesky. [pr](https://github.com/prysmaticlabs/prysm/pull/14689)
 
 
 ### Security

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	MaxBodySize    int64 = 1 << 23 // 8MB default, WithMaxBodySize can override
-	MaxErrBodySize int64 = 1 << 17 // 128KB
+	MaxBodySize      int64 = 1 << 23 // 8MB default, WithMaxBodySize can override
+	MaxBodySizeState int64 = 1 << 29 // 512MB
+	MaxErrBodySize   int64 = 1 << 17 // 128KB
 )
 
 // Client is a wrapper object around the HTTP client.

--- a/beacon-chain/sync/checkpoint/api.go
+++ b/beacon-chain/sync/checkpoint/api.go
@@ -10,8 +10,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 )
 
-const stateSizeLimit int64 = 1 << 29 // 512MB
-
 // APIInitializer manages initializing the beacon node using checkpoint sync, retrieving the checkpoint state and root
 // from the remote beacon node api.
 type APIInitializer struct {
@@ -21,7 +19,7 @@ type APIInitializer struct {
 // NewAPIInitializer creates an APIInitializer, handling the set up of a beacon node api client
 // using the provided host string.
 func NewAPIInitializer(beaconNodeHost string) (*APIInitializer, error) {
-	c, err := beacon.NewClient(beaconNodeHost, client.WithMaxBodySize(stateSizeLimit))
+	c, err := beacon.NewClient(beaconNodeHost, client.WithMaxBodySize(client.MaxBodySizeState))
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse beacon node url or hostname - %s", beaconNodeHost)
 	}

--- a/beacon-chain/sync/genesis/BUILD.bazel
+++ b/beacon-chain/sync/genesis/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/sync/genesis",
     visibility = ["//visibility:public"],
     deps = [
+        "//api/client:go_default_library",
         "//api/client/beacon:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//crypto/hash:go_default_library",

--- a/beacon-chain/sync/genesis/api.go
+++ b/beacon-chain/sync/genesis/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/api/client"
 	"github.com/prysmaticlabs/prysm/v5/api/client/beacon"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/db"
 )
@@ -17,7 +18,7 @@ type APIInitializer struct {
 // NewAPIInitializer creates an APIInitializer, handling the set up of a beacon node api client
 // using the provided host string.
 func NewAPIInitializer(beaconNodeHost string) (*APIInitializer, error) {
-	c, err := beacon.NewClient(beaconNodeHost)
+	c, err := beacon.NewClient(beaconNodeHost, client.WithMaxBodySize(client.MaxBodySizeState))
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse beacon node url or hostname - %s", beaconNodeHost)
 	}

--- a/cmd/prysmctl/checkpointsync/download.go
+++ b/cmd/prysmctl/checkpointsync/download.go
@@ -42,13 +42,11 @@ var downloadCmd = &cli.Command{
 	},
 }
 
-const stateSizeLimit int64 = 1 << 29 // 512MB to accommodate future state growth
-
 func cliActionDownload(_ *cli.Context) error {
 	ctx := context.Background()
 	f := downloadFlags
 
-	opts := []client.ClientOpt{client.WithTimeout(f.Timeout), client.WithMaxBodySize(stateSizeLimit)}
+	opts := []client.ClientOpt{client.WithTimeout(f.Timeout), client.WithMaxBodySize(client.MaxBodySizeState)}
 	client, err := beacon.NewClient(downloadFlags.BeaconNodeHost, opts...)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This fixes a bug where checkpoint sync could not be started against holesky when downloading the genesis state from the checkpoint origin server. This issue was unique to holesky where the genesis state is much larger than the default 8MB limit.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
