### PR TITLE
`startDB`: Add log when checkpoint sync.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,6 +431,7 @@ block profit. If you want to preserve the existing behavior, set --local-block-v
 - Set default LocalBlockValueBoost to 10
 - Add bid value metrics
 - REST VC metrics
+- `startDB`: Add log when checkpoint sync.
 
 ### Changed
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -557,6 +557,7 @@ func (b *BeaconNode) startDB(cliCtx *cli.Context, depositAddress string) error {
 	}
 
 	if b.CheckpointInitializer != nil {
+		log.Info("Checkpoint sync - Downloading origin state and block")
 		if err := b.CheckpointInitializer.Initialize(b.ctx, d); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
When starting a node with checkpoint sync (especially on Holesky on a low bandwidth connection), nothing at all is happening in beacon node logs. The user may think the node is in a deadlock.

This PR just adds a log warning the user something is downloading (and possibly can take some time).
**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.

```
[2024-12-04 10:32:21]  INFO execution: Finished reading JWT secret from /Users/manu/OffchainLabs/ethereum/jwt.hex
[2024-12-04 10:32:21]  INFO flags: Running on the Holesky Beacon Chain Testnet
[2024-12-04 10:32:21]  WARN node: In order to receive transaction fees from proposing blocks, you must provide flag --suggested-fee-recipient with a valid ethereum address when starting your beacon node. Please see our documentation for more information on this requirement (https://docs.prylabs.network/docs/execution-node/fee-recipient).
[2024-12-04 10:32:21]  INFO node: Checking DB databasePath=/Users/manu/Library/Eth2/beaconchaindata
[2024-12-04 10:32:21]  INFO db: Opening Bolt DB path=/Users/manu/Library/Eth2/beaconchaindata/beaconchain.db
[2024-12-04 10:32:35]  INFO node: Checkpoint sync - Downloading origin state and block
[2024-12-04 10:32:45]  INFO beacon: Detected supported config in remote finalized state fork=deneb name=holesky
...
```