### PR TITLE
Fix the potentially inconsistent issue.

### DIFF
--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -915,13 +915,12 @@ func (c *capabilityCache) save(cs []string) {
 	c.capabilitiesLock.Lock()
 	defer c.capabilitiesLock.Unlock()
 
-	if c.capabilities == nil {
-		c.capabilities = make(map[string]interface{})
+	capabilities := make(map[string]interface{})
+	for _, capability := range cs {
+		capabilities[capability] = struct{}{}
 	}
 
-	for _, capability := range cs {
-		c.capabilities[capability] = struct{}{}
-	}
+	c.capabilities = capabilities
 }
 
 func (c *capabilityCache) has(capability string) bool {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Improvements

**What does this PR do? Why is it needed?**
If the endpoint parameter of the execution layer specifies a domain name, for example: --execution-endpoint=http://execution-domain:8551, and the execution layer clients corresponding to the domain name include Geth and Reth, then when Reth client is accessed first and the list of capabilities obtained contains `engine_getBlobsV1`. However, when the connection is reconnected to Geth client, `engine_getBlobsV1` is not removed from `capabilityCache`, which may lead to unexpected results.

* Geth Engine API Capabilities: https://github.com/ethereum/go-ethereum/blob/08e6bdb550712503873fb2a138b30132cc36c481/eth/catalyst/api.go#L84
* Reth Engine API Capabilities: https://github.com/paradigmxyz/reth/blob/890f082453490828258dbb9d84e131f55f65cb25/crates/rpc/rpc-engine-api/src/capabilities.rs#L4

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
