### PR TITLE
Fix validator can specify gas limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Fix segmentation fault in E2E when light-client feature flag is enabled. [PR](https://github.com/prysmaticlabs/prysm/pull/14699)
 - Fix `searchForPeers` infinite loop in small networks.
 - Fix slashing pool behavior to enforce MaxAttesterSlashings limit in Electra version.
+- Fix validator gas limit usage through flag and file.
 
 ### Security
 

--- a/config/proposer/loader/BUILD.bazel
+++ b/config/proposer/loader/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
         "//config/proposer:go_default_library",
         "//consensus-types/validator:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//proto/prysm/v1alpha1/validator-client:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//validator/db/iface:go_default_library",

--- a/config/proposer/loader/loader.go
+++ b/config/proposer/loader/loader.go
@@ -265,6 +265,9 @@ func (psl *settingsLoader) processProposerSettings(loadedSettings, dbSettings *v
 	// process any overrides for proposer config
 	for _, option := range newSettings.ProposerConfig {
 		if option != nil {
+			if loadedSettings != nil && option.Builder != nil {
+				gasLimitOnly = &option.Builder.GasLimit
+			}
 			option.Builder = processBuilderConfig(option.Builder, builderConfig, gasLimitOnly)
 		}
 	}


### PR DESCRIPTION
fixes #14721

This PR updates the `processProposerSettings` function to ensure that the gas limit is overridden correctly. If a loaded setting (from a file) is not nil, it takes priority over both the config and the flag

### Testing
We verified the implementation using the following scenarios:

| Config | Flag | File | Result |
|--------|------|------|--------|
| 30M    | N/A  | N/A  | 30M    |
| 30M    | N/A  | 32M  | 32M    |
| 31M    | 31M  | N/A  | 31M    |
| 30M    | 31M  | 32M  | 32M    |

All tests passed as expected, confirming the intended behavior
