### PR TITLE
Fix Typos in INTEROP.md and CHANGELOG.md 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2770,7 +2770,7 @@ notes [here](https://github.com/prysmaticlabs/prysm-web-ui/releases/tag/v1.0.0)
   Upstream go-ethereum is now used with familiar go.mod tooling.
 - Removed duplicate aggergation validation p2p pipelines.
 - Metrics calculation removed extra condition
-- Removed superflous errors from peer scoring parameters registration
+- Removed superfluous errors from peer scoring parameters registration
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1689,7 +1689,7 @@ notes [here](https://hackmd.io/TtyFurRJRKuklG3n8lMO9Q). This release is **strong
 Note: The released docker images are using the portable version of the blst cryptography library. The Prysm team will
 release docker images with the non-portable blst library as the default image. In the meantime, you can compile docker
 images with blst non-portable locally with the `--define=blst_modern=true` bazel flag, use the "-modern-" assets
-attached to releases, or set environment varaible USE_PRYSM_MODERN=true when using prysm.sh.
+attached to releases, or set environment variable USE_PRYSM_MODERN=true when using prysm.sh.
 
 ### Added
 

--- a/INTEROP.md
+++ b/INTEROP.md
@@ -74,7 +74,7 @@ bazel run //cmd/beacon-chain --config=minimal -- \
 This will start the system with 256 validators. The flags used can be explained as such:
 
 - `bazel run //cmd/beacon-chain --config=minimal` builds and runs the beacon node in minimal build configuration.
-- `--` is a flag divider to distingish between bazel flags and flags that should be passed to the application. All flags and arguments after this divider are passed to the beacon chain.
+- `--` is a flag divider to distinguish between bazel flags and flags that should be passed to the application. All flags and arguments after this divider are passed to the beacon chain.
 - `--minimal-config` tells the beacon node to use minimal network configuration. This is different from the compile time state configuration flag `--config=minimal` and both are required.
 - `--bootstrap-node=` disables the default bootstrap nodes. This prevents the client from attempting to peer with mainnet nodes.
 - `--datadir=/tmp/beacon-chain-minimal-devnet` sets the data directory in a temporary location. Change this to your preferred destination.


### PR DESCRIPTION

 

## Description  
This pull request fixes minor typographical errors in the documentation files `INTEROP.md` and `CHANGELOG.md`.  

## Details of Changes  
### CHANGELOG.md  
- Corrected "varaible" to "variable" (line 1689).  
- Fixed "superflous" to "superfluous" (line 2770).  

### INTEROP.md  
- Fixed "distingish" to "distinguish" (line 74).  

## Diff Summary  
- **Files changed:** 2  
- **Lines added:** 3  
- **Lines removed:** 3  

### Before  
- Incorrect terms: "varaible," "superflous," and "distingish."  

### After  
- Correct terms: "variable," "superfluous," and "distinguish."  

## Checklist  
- [x] Code changes adhere to the project's style guidelines.  
- [x] Documentation is updated appropriately.  
- [x] No new warnings introduced.  

## Reviewer Notes  
Please verify that all corrections align with the intended documentation meaning.  


