### PR TITLE
Return an error when attempting to invalidate the finalized checkpoint

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync.go
@@ -23,6 +23,9 @@ func (s *Store) setOptimisticToInvalid(ctx context.Context, root, parentRoot, la
 		if node == nil {
 			return invalidRoots, errors.Wrap(ErrNilNode, "could not set node to invalid")
 		}
+		if node.parent == nil {
+			return invalidRoots, errors.New("attempting to set the root node to invalid")
+		}
 		if node.parent.root != parentRoot {
 			return invalidRoots, errInvalidParentRoot
 		}

--- a/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync_test.go
@@ -385,6 +385,13 @@ func TestSetOptimisticToInvalid_ForkAtMerge_bis(t *testing.T) {
 	require.DeepEqual(t, roots, [][32]byte{{'b'}, {'c'}, {'d'}, {'e'}})
 }
 
+func TestSetOptimisticToInvalid_InvalidRoot(t *testing.T) {
+	ctx := context.Background()
+	f := setup(1, 1)
+	_, err := f.SetOptimisticToInvalid(ctx, [32]byte{}, [32]byte{}, [32]byte{})
+	require.ErrorContains(t, "attempting to set the root node to invalid", err)
+}
+
 func TestSetOptimisticToValid(t *testing.T) {
 	f := setup(1, 1)
 	op, err := f.IsOptimistic([32]byte{})


### PR DESCRIPTION
return an error instead of panicking if the finalized checkpoint is being marked as invalid. 

(h/t @nalepae for finding this)