### PR TITLE
`registerSubscribers`: Register blobs subnets correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Fixed
 
 - Added check to prevent nil pointer deference or out of bounds array access when validating the BLSToExecutionChange on an impossibly nil validator.
+- EIP-7691: Ensure new blobs subnets are subscribed on epoch in advance.
 
 ### Security
 


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
**Issue before this commit:**
The `currentSlot` in the `getSubnetsToSubscribe` is really set to the current slot.

So, even if the `registerSubscribers` function is called one epoch in advance, as done in `registerForUpcomingFork`, then `currentSlot` will still be - really - the current slot.

==> The new blobs subnets will be subscribed only at the start of the Electra fork, and not one epoch in advance.

**With this commit:**
The new blobs subnets will be effectively subscribed one epoch in advance.

In the following test, we have:
- Deneb: Epoch 0 (genesis)
- Electra: Epoch 2

At epoch 0 (Deneb), the BN registers to all the Deneb blob subnets: ✅
```
...
[2024-12-30 23:38:29]  INFO sync: Subscribed to topic=/eth2/d84e2ee0/blob_sidecar_0/ssz_snappy
[2024-12-30 23:38:29]  INFO sync: Subscribed to topic=/eth2/d84e2ee0/blob_sidecar_1/ssz_snappy
[2024-12-30 23:38:29]  INFO sync: Subscribed to topic=/eth2/d84e2ee0/blob_sidecar_2/ssz_snappy
[2024-12-30 23:38:29]  INFO sync: Subscribed to topic=/eth2/d84e2ee0/blob_sidecar_3/ssz_snappy
[2024-12-30 23:38:29]  INFO sync: Subscribed to topic=/eth2/d84e2ee0/blob_sidecar_4/ssz_snappy
[2024-12-30 23:38:29]  INFO sync: Subscribed to topic=/eth2/d84e2ee0/blob_sidecar_5/ssz_snappy
...
```

At epoch 1 (1 epoch before Electra), the BN registers to all the Electra blob subnets: ✅
```
...
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_0/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_1/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_2/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_3/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_4/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_5/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_6/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_7/ssz_snappy
[2024-12-30 23:40:37]  INFO sync: Subscribed to topic=/eth2/d11c2576/blob_sidecar_8/ssz_snappy
...
```

At epoch 2 (Electra), the BN unregisters from all the Deneb blob subnets: ✅
```
...
[2024-12-30 23:42:45]  INFO sync: Unsubscribed from topic=/eth2/d84e2ee0/blob_sidecar_0/ssz_snappy
[2024-12-30 23:42:45]  INFO sync: Unsubscribed from topic=/eth2/d84e2ee0/blob_sidecar_1/ssz_snappy
[2024-12-30 23:42:45]  INFO sync: Unsubscribed from topic=/eth2/d84e2ee0/blob_sidecar_2/ssz_snappy
[2024-12-30 23:42:45]  INFO sync: Unsubscribed from topic=/eth2/d84e2ee0/blob_sidecar_3/ssz_snappy
[2024-12-30 23:42:45]  INFO sync: Unsubscribed from topic=/eth2/d84e2ee0/blob_sidecar_4/ssz_snappy
[2024-12-30 23:42:45]  INFO sync: Unsubscribed from topic=/eth2/d84e2ee0/blob_sidecar_5/ssz_snappy
...
```

I also moved the `Subnets with this digest are no longer valid...` log from **WARNING** to **DEBUG**, since this log will always be displayed after a hard fork and is perfectly expected. So, no reason to keep it in **WARNING**.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.