### PR TITLE
Simplify next Fork boilerplate creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Re-organize the content of the `*.proto` files (No functional change).
 - Updated Electra spec definition for `process_epoch`.
 - Update our `go-libp2p-pubsub` dependency.
+- Re-organize the content of files to ease the creation of a new fork boilerplate.
 
 ### Deprecated
 

--- a/api/server/structs/block.go
+++ b/api/server/structs/block.go
@@ -14,6 +14,10 @@ type SignedMessageJsoner interface {
 	SigString() string
 }
 
+// ----------------------------------------------------------------------------
+// Phase 0
+// ----------------------------------------------------------------------------
+
 type SignedBeaconBlock struct {
 	Message   *BeaconBlock `json:"message"`
 	Signature string       `json:"signature"`
@@ -47,6 +51,29 @@ type BeaconBlockBody struct {
 	Deposits          []*Deposit             `json:"deposits"`
 	VoluntaryExits    []*SignedVoluntaryExit `json:"voluntary_exits"`
 }
+
+type SignedBeaconBlockHeaderContainer struct {
+	Header    *SignedBeaconBlockHeader `json:"header"`
+	Root      string                   `json:"root"`
+	Canonical bool                     `json:"canonical"`
+}
+
+type SignedBeaconBlockHeader struct {
+	Message   *BeaconBlockHeader `json:"message"`
+	Signature string             `json:"signature"`
+}
+
+type BeaconBlockHeader struct {
+	Slot          string `json:"slot"`
+	ProposerIndex string `json:"proposer_index"`
+	ParentRoot    string `json:"parent_root"`
+	StateRoot     string `json:"state_root"`
+	BodyRoot      string `json:"body_root"`
+}
+
+// ----------------------------------------------------------------------------
+// Altair
+// ----------------------------------------------------------------------------
 
 type SignedBeaconBlockAltair struct {
 	Message   *BeaconBlockAltair `json:"message"`
@@ -82,6 +109,10 @@ type BeaconBlockBodyAltair struct {
 	VoluntaryExits    []*SignedVoluntaryExit `json:"voluntary_exits"`
 	SyncAggregate     *SyncAggregate         `json:"sync_aggregate"`
 }
+
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
 
 type SignedBeaconBlockBellatrix struct {
 	Message   *BeaconBlockBellatrix `json:"message"`
@@ -154,6 +185,44 @@ type BlindedBeaconBlockBodyBellatrix struct {
 	SyncAggregate          *SyncAggregate          `json:"sync_aggregate"`
 	ExecutionPayloadHeader *ExecutionPayloadHeader `json:"execution_payload_header"`
 }
+
+type ExecutionPayload struct {
+	ParentHash    string   `json:"parent_hash"`
+	FeeRecipient  string   `json:"fee_recipient"`
+	StateRoot     string   `json:"state_root"`
+	ReceiptsRoot  string   `json:"receipts_root"`
+	LogsBloom     string   `json:"logs_bloom"`
+	PrevRandao    string   `json:"prev_randao"`
+	BlockNumber   string   `json:"block_number"`
+	GasLimit      string   `json:"gas_limit"`
+	GasUsed       string   `json:"gas_used"`
+	Timestamp     string   `json:"timestamp"`
+	ExtraData     string   `json:"extra_data"`
+	BaseFeePerGas string   `json:"base_fee_per_gas"`
+	BlockHash     string   `json:"block_hash"`
+	Transactions  []string `json:"transactions"`
+}
+
+type ExecutionPayloadHeader struct {
+	ParentHash       string `json:"parent_hash"`
+	FeeRecipient     string `json:"fee_recipient"`
+	StateRoot        string `json:"state_root"`
+	ReceiptsRoot     string `json:"receipts_root"`
+	LogsBloom        string `json:"logs_bloom"`
+	PrevRandao       string `json:"prev_randao"`
+	BlockNumber      string `json:"block_number"`
+	GasLimit         string `json:"gas_limit"`
+	GasUsed          string `json:"gas_used"`
+	Timestamp        string `json:"timestamp"`
+	ExtraData        string `json:"extra_data"`
+	BaseFeePerGas    string `json:"base_fee_per_gas"`
+	BlockHash        string `json:"block_hash"`
+	TransactionsRoot string `json:"transactions_root"`
+}
+
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
 
 type SignedBeaconBlockCapella struct {
 	Message   *BeaconBlockCapella `json:"message"`
@@ -228,6 +297,46 @@ type BlindedBeaconBlockBodyCapella struct {
 	ExecutionPayloadHeader *ExecutionPayloadHeaderCapella `json:"execution_payload_header"`
 	BLSToExecutionChanges  []*SignedBLSToExecutionChange  `json:"bls_to_execution_changes"`
 }
+
+type ExecutionPayloadCapella struct {
+	ParentHash    string        `json:"parent_hash"`
+	FeeRecipient  string        `json:"fee_recipient"`
+	StateRoot     string        `json:"state_root"`
+	ReceiptsRoot  string        `json:"receipts_root"`
+	LogsBloom     string        `json:"logs_bloom"`
+	PrevRandao    string        `json:"prev_randao"`
+	BlockNumber   string        `json:"block_number"`
+	GasLimit      string        `json:"gas_limit"`
+	GasUsed       string        `json:"gas_used"`
+	Timestamp     string        `json:"timestamp"`
+	ExtraData     string        `json:"extra_data"`
+	BaseFeePerGas string        `json:"base_fee_per_gas"`
+	BlockHash     string        `json:"block_hash"`
+	Transactions  []string      `json:"transactions"`
+	Withdrawals   []*Withdrawal `json:"withdrawals"`
+}
+
+type ExecutionPayloadHeaderCapella struct {
+	ParentHash       string `json:"parent_hash"`
+	FeeRecipient     string `json:"fee_recipient"`
+	StateRoot        string `json:"state_root"`
+	ReceiptsRoot     string `json:"receipts_root"`
+	LogsBloom        string `json:"logs_bloom"`
+	PrevRandao       string `json:"prev_randao"`
+	BlockNumber      string `json:"block_number"`
+	GasLimit         string `json:"gas_limit"`
+	GasUsed          string `json:"gas_used"`
+	Timestamp        string `json:"timestamp"`
+	ExtraData        string `json:"extra_data"`
+	BaseFeePerGas    string `json:"base_fee_per_gas"`
+	BlockHash        string `json:"block_hash"`
+	TransactionsRoot string `json:"transactions_root"`
+	WithdrawalsRoot  string `json:"withdrawals_root"`
+}
+
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
 
 type SignedBeaconBlockContentsDeneb struct {
 	SignedBlock *SignedBeaconBlockDeneb `json:"signed_block"`
@@ -316,6 +425,50 @@ type BlindedBeaconBlockBodyDeneb struct {
 	BLSToExecutionChanges  []*SignedBLSToExecutionChange `json:"bls_to_execution_changes"`
 	BlobKzgCommitments     []string                      `json:"blob_kzg_commitments"`
 }
+
+type ExecutionPayloadDeneb struct {
+	ParentHash    string        `json:"parent_hash"`
+	FeeRecipient  string        `json:"fee_recipient"`
+	StateRoot     string        `json:"state_root"`
+	ReceiptsRoot  string        `json:"receipts_root"`
+	LogsBloom     string        `json:"logs_bloom"`
+	PrevRandao    string        `json:"prev_randao"`
+	BlockNumber   string        `json:"block_number"`
+	GasLimit      string        `json:"gas_limit"`
+	GasUsed       string        `json:"gas_used"`
+	Timestamp     string        `json:"timestamp"`
+	ExtraData     string        `json:"extra_data"`
+	BaseFeePerGas string        `json:"base_fee_per_gas"`
+	BlockHash     string        `json:"block_hash"`
+	Transactions  []string      `json:"transactions"`
+	Withdrawals   []*Withdrawal `json:"withdrawals"`
+	BlobGasUsed   string        `json:"blob_gas_used"`
+	ExcessBlobGas string        `json:"excess_blob_gas"`
+}
+
+type ExecutionPayloadHeaderDeneb struct {
+	ParentHash       string `json:"parent_hash"`
+	FeeRecipient     string `json:"fee_recipient"`
+	StateRoot        string `json:"state_root"`
+	ReceiptsRoot     string `json:"receipts_root"`
+	LogsBloom        string `json:"logs_bloom"`
+	PrevRandao       string `json:"prev_randao"`
+	BlockNumber      string `json:"block_number"`
+	GasLimit         string `json:"gas_limit"`
+	GasUsed          string `json:"gas_used"`
+	Timestamp        string `json:"timestamp"`
+	ExtraData        string `json:"extra_data"`
+	BaseFeePerGas    string `json:"base_fee_per_gas"`
+	BlockHash        string `json:"block_hash"`
+	TransactionsRoot string `json:"transactions_root"`
+	WithdrawalsRoot  string `json:"withdrawals_root"`
+	BlobGasUsed      string `json:"blob_gas_used"`
+	ExcessBlobGas    string `json:"excess_blob_gas"`
+}
+
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
 
 type SignedBeaconBlockContentsElectra struct {
 	SignedBlock *SignedBeaconBlockElectra `json:"signed_block"`
@@ -407,141 +560,13 @@ type BlindedBeaconBlockBodyElectra struct {
 	ExecutionRequests      *ExecutionRequests             `json:"execution_requests"`
 }
 
-type SignedBeaconBlockHeaderContainer struct {
-	Header    *SignedBeaconBlockHeader `json:"header"`
-	Root      string                   `json:"root"`
-	Canonical bool                     `json:"canonical"`
-}
+type (
+	ExecutionRequests struct {
+		Deposits       []*DepositRequest       `json:"deposits"`
+		Withdrawals    []*WithdrawalRequest    `json:"withdrawals"`
+		Consolidations []*ConsolidationRequest `json:"consolidations"`
+	}
 
-type SignedBeaconBlockHeader struct {
-	Message   *BeaconBlockHeader `json:"message"`
-	Signature string             `json:"signature"`
-}
-
-type BeaconBlockHeader struct {
-	Slot          string `json:"slot"`
-	ProposerIndex string `json:"proposer_index"`
-	ParentRoot    string `json:"parent_root"`
-	StateRoot     string `json:"state_root"`
-	BodyRoot      string `json:"body_root"`
-}
-
-type ExecutionPayload struct {
-	ParentHash    string   `json:"parent_hash"`
-	FeeRecipient  string   `json:"fee_recipient"`
-	StateRoot     string   `json:"state_root"`
-	ReceiptsRoot  string   `json:"receipts_root"`
-	LogsBloom     string   `json:"logs_bloom"`
-	PrevRandao    string   `json:"prev_randao"`
-	BlockNumber   string   `json:"block_number"`
-	GasLimit      string   `json:"gas_limit"`
-	GasUsed       string   `json:"gas_used"`
-	Timestamp     string   `json:"timestamp"`
-	ExtraData     string   `json:"extra_data"`
-	BaseFeePerGas string   `json:"base_fee_per_gas"`
-	BlockHash     string   `json:"block_hash"`
-	Transactions  []string `json:"transactions"`
-}
-
-type ExecutionPayloadHeader struct {
-	ParentHash       string `json:"parent_hash"`
-	FeeRecipient     string `json:"fee_recipient"`
-	StateRoot        string `json:"state_root"`
-	ReceiptsRoot     string `json:"receipts_root"`
-	LogsBloom        string `json:"logs_bloom"`
-	PrevRandao       string `json:"prev_randao"`
-	BlockNumber      string `json:"block_number"`
-	GasLimit         string `json:"gas_limit"`
-	GasUsed          string `json:"gas_used"`
-	Timestamp        string `json:"timestamp"`
-	ExtraData        string `json:"extra_data"`
-	BaseFeePerGas    string `json:"base_fee_per_gas"`
-	BlockHash        string `json:"block_hash"`
-	TransactionsRoot string `json:"transactions_root"`
-}
-
-type ExecutionPayloadCapella struct {
-	ParentHash    string        `json:"parent_hash"`
-	FeeRecipient  string        `json:"fee_recipient"`
-	StateRoot     string        `json:"state_root"`
-	ReceiptsRoot  string        `json:"receipts_root"`
-	LogsBloom     string        `json:"logs_bloom"`
-	PrevRandao    string        `json:"prev_randao"`
-	BlockNumber   string        `json:"block_number"`
-	GasLimit      string        `json:"gas_limit"`
-	GasUsed       string        `json:"gas_used"`
-	Timestamp     string        `json:"timestamp"`
-	ExtraData     string        `json:"extra_data"`
-	BaseFeePerGas string        `json:"base_fee_per_gas"`
-	BlockHash     string        `json:"block_hash"`
-	Transactions  []string      `json:"transactions"`
-	Withdrawals   []*Withdrawal `json:"withdrawals"`
-}
-
-type ExecutionPayloadHeaderCapella struct {
-	ParentHash       string `json:"parent_hash"`
-	FeeRecipient     string `json:"fee_recipient"`
-	StateRoot        string `json:"state_root"`
-	ReceiptsRoot     string `json:"receipts_root"`
-	LogsBloom        string `json:"logs_bloom"`
-	PrevRandao       string `json:"prev_randao"`
-	BlockNumber      string `json:"block_number"`
-	GasLimit         string `json:"gas_limit"`
-	GasUsed          string `json:"gas_used"`
-	Timestamp        string `json:"timestamp"`
-	ExtraData        string `json:"extra_data"`
-	BaseFeePerGas    string `json:"base_fee_per_gas"`
-	BlockHash        string `json:"block_hash"`
-	TransactionsRoot string `json:"transactions_root"`
-	WithdrawalsRoot  string `json:"withdrawals_root"`
-}
-
-type ExecutionPayloadDeneb struct {
-	ParentHash    string        `json:"parent_hash"`
-	FeeRecipient  string        `json:"fee_recipient"`
-	StateRoot     string        `json:"state_root"`
-	ReceiptsRoot  string        `json:"receipts_root"`
-	LogsBloom     string        `json:"logs_bloom"`
-	PrevRandao    string        `json:"prev_randao"`
-	BlockNumber   string        `json:"block_number"`
-	GasLimit      string        `json:"gas_limit"`
-	GasUsed       string        `json:"gas_used"`
-	Timestamp     string        `json:"timestamp"`
-	ExtraData     string        `json:"extra_data"`
-	BaseFeePerGas string        `json:"base_fee_per_gas"`
-	BlockHash     string        `json:"block_hash"`
-	Transactions  []string      `json:"transactions"`
-	Withdrawals   []*Withdrawal `json:"withdrawals"`
-	BlobGasUsed   string        `json:"blob_gas_used"`
-	ExcessBlobGas string        `json:"excess_blob_gas"`
-}
-
-type ExecutionPayloadElectra = ExecutionPayloadDeneb
-
-type ExecutionPayloadHeaderDeneb struct {
-	ParentHash       string `json:"parent_hash"`
-	FeeRecipient     string `json:"fee_recipient"`
-	StateRoot        string `json:"state_root"`
-	ReceiptsRoot     string `json:"receipts_root"`
-	LogsBloom        string `json:"logs_bloom"`
-	PrevRandao       string `json:"prev_randao"`
-	BlockNumber      string `json:"block_number"`
-	GasLimit         string `json:"gas_limit"`
-	GasUsed          string `json:"gas_used"`
-	Timestamp        string `json:"timestamp"`
-	ExtraData        string `json:"extra_data"`
-	BaseFeePerGas    string `json:"base_fee_per_gas"`
-	BlockHash        string `json:"block_hash"`
-	TransactionsRoot string `json:"transactions_root"`
-	WithdrawalsRoot  string `json:"withdrawals_root"`
-	BlobGasUsed      string `json:"blob_gas_used"`
-	ExcessBlobGas    string `json:"excess_blob_gas"`
-}
-
-type ExecutionPayloadHeaderElectra = ExecutionPayloadHeaderDeneb
-
-type ExecutionRequests struct {
-	Deposits       []*DepositRequest       `json:"deposits"`
-	Withdrawals    []*WithdrawalRequest    `json:"withdrawals"`
-	Consolidations []*ConsolidationRequest `json:"consolidations"`
-}
+	ExecutionPayloadElectra       = ExecutionPayloadDeneb
+	ExecutionPayloadHeaderElectra = ExecutionPayloadHeaderDeneb
+)

--- a/api/server/structs/conversions_lightclient.go
+++ b/api/server/structs/conversions_lightclient.go
@@ -176,9 +176,9 @@ func lightClientHeaderToJSON(header interfaces.LightClientHeader) (json.RawMessa
 		if err != nil {
 			return nil, err
 		}
-		ex, ok := exInterface.Proto().(*enginev1.ExecutionPayloadHeaderElectra)
+		ex, ok := exInterface.Proto().(*enginev1.ExecutionPayloadHeaderDeneb)
 		if !ok {
-			return nil, fmt.Errorf("execution data is not %T", &enginev1.ExecutionPayloadHeaderElectra{})
+			return nil, fmt.Errorf("execution data is not %T", &enginev1.ExecutionPayloadHeaderDeneb{})
 		}
 		execution, err := ExecutionPayloadHeaderElectraFromConsensus(ex)
 		if err != nil {

--- a/api/server/structs/conversions_state.go
+++ b/api/server/structs/conversions_state.go
@@ -11,6 +11,10 @@ import (
 
 var errPayloadHeaderNotFound = errors.New("expected payload header not found")
 
+// ----------------------------------------------------------------------------
+// Phase 0
+// ----------------------------------------------------------------------------
+
 func BeaconStateFromConsensus(st beaconState.BeaconState) (*BeaconState, error) {
 	srcBr := st.BlockRoots()
 	br := make([]string, len(srcBr))
@@ -96,6 +100,10 @@ func BeaconStateFromConsensus(st beaconState.BeaconState) (*BeaconState, error) 
 		FinalizedCheckpoint:         CheckpointFromConsensus(st.FinalizedCheckpoint()),
 	}, nil
 }
+
+// ----------------------------------------------------------------------------
+// Altair
+// ----------------------------------------------------------------------------
 
 func BeaconStateAltairFromConsensus(st beaconState.BeaconState) (*BeaconStateAltair, error) {
 	srcBr := st.BlockRoots()
@@ -201,6 +209,10 @@ func BeaconStateAltairFromConsensus(st beaconState.BeaconState) (*BeaconStateAlt
 		NextSyncCommittee:           SyncCommitteeFromConsensus(nextSc),
 	}, nil
 }
+
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
 
 func BeaconStateBellatrixFromConsensus(st beaconState.BeaconState) (*BeaconStateBellatrix, error) {
 	srcBr := st.BlockRoots()
@@ -319,6 +331,10 @@ func BeaconStateBellatrixFromConsensus(st beaconState.BeaconState) (*BeaconState
 		LatestExecutionPayloadHeader: payload,
 	}, nil
 }
+
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
 
 func BeaconStateCapellaFromConsensus(st beaconState.BeaconState) (*BeaconStateCapella, error) {
 	srcBr := st.BlockRoots()
@@ -457,6 +473,10 @@ func BeaconStateCapellaFromConsensus(st beaconState.BeaconState) (*BeaconStateCa
 	}, nil
 }
 
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
+
 func BeaconStateDenebFromConsensus(st beaconState.BeaconState) (*BeaconStateDeneb, error) {
 	srcBr := st.BlockRoots()
 	br := make([]string, len(srcBr))
@@ -593,6 +613,10 @@ func BeaconStateDenebFromConsensus(st beaconState.BeaconState) (*BeaconStateDene
 		HistoricalSummaries:          hs,
 	}, nil
 }
+
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
 
 func BeaconStateElectraFromConsensus(st beaconState.BeaconState) (*BeaconStateElectra, error) {
 	srcBr := st.BlockRoots()

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -421,7 +421,7 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 		return attr
 	}
 
-	log.WithField("version", st.Version()).Error("Could not get payload attribute due to unknown state version")
+	log.WithField("version", version.String(st.Version())).Error("Could not get payload attribute due to unknown state version")
 	return emptyAttri
 }
 

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -399,7 +399,6 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 			SuggestedFeeRecipient: val.FeeRecipient[:],
 			Withdrawals:           withdrawals,
 		})
-
 		if err != nil {
 			log.WithError(err).Error("Could not get payload attribute")
 			return emptyAttri

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -413,7 +413,6 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 			PrevRandao:            prevRando,
 			SuggestedFeeRecipient: val.FeeRecipient[:],
 		})
-
 		if err != nil {
 			log.WithError(err).Error("Could not get payload attribute")
 			return emptyAttri

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -362,57 +362,70 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 		return emptyAttri
 	}
 
-	var attr payloadattribute.Attributer
-	switch st.Version() {
-	case version.Deneb, version.Electra:
+	v := st.Version()
+
+	if v >= version.Deneb {
 		withdrawals, _, err := st.ExpectedWithdrawals()
 		if err != nil {
 			log.WithError(err).Error("Could not get expected withdrawals to get payload attribute")
 			return emptyAttri
 		}
-		attr, err = payloadattribute.New(&enginev1.PayloadAttributesV3{
+
+		attr, err := payloadattribute.New(&enginev1.PayloadAttributesV3{
 			Timestamp:             uint64(t.Unix()),
 			PrevRandao:            prevRando,
 			SuggestedFeeRecipient: val.FeeRecipient[:],
 			Withdrawals:           withdrawals,
 			ParentBeaconBlockRoot: headRoot,
 		})
+
 		if err != nil {
 			log.WithError(err).Error("Could not get payload attribute")
 			return emptyAttri
 		}
-	case version.Capella:
+
+		return attr
+	}
+
+	if v >= version.Capella {
 		withdrawals, _, err := st.ExpectedWithdrawals()
 		if err != nil {
 			log.WithError(err).Error("Could not get expected withdrawals to get payload attribute")
 			return emptyAttri
 		}
-		attr, err = payloadattribute.New(&enginev1.PayloadAttributesV2{
+
+		attr, err := payloadattribute.New(&enginev1.PayloadAttributesV2{
 			Timestamp:             uint64(t.Unix()),
 			PrevRandao:            prevRando,
 			SuggestedFeeRecipient: val.FeeRecipient[:],
 			Withdrawals:           withdrawals,
 		})
+
 		if err != nil {
 			log.WithError(err).Error("Could not get payload attribute")
 			return emptyAttri
 		}
-	case version.Bellatrix:
-		attr, err = payloadattribute.New(&enginev1.PayloadAttributes{
+
+		return attr
+	}
+
+	if v >= version.Bellatrix {
+		attr, err := payloadattribute.New(&enginev1.PayloadAttributes{
 			Timestamp:             uint64(t.Unix()),
 			PrevRandao:            prevRando,
 			SuggestedFeeRecipient: val.FeeRecipient[:],
 		})
+
 		if err != nil {
 			log.WithError(err).Error("Could not get payload attribute")
 			return emptyAttri
 		}
-	default:
-		log.WithField("version", st.Version()).Error("Could not get payload attribute due to unknown state version")
-		return emptyAttri
+
+		return attr
 	}
 
-	return attr
+	log.WithField("version", st.Version()).Error("Could not get payload attribute due to unknown state version")
+	return emptyAttri
 }
 
 // removeInvalidBlockAndState removes the invalid block, blob and its corresponding state from the cache and DB.

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -378,7 +378,6 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 			Withdrawals:           withdrawals,
 			ParentBeaconBlockRoot: headRoot,
 		})
-
 		if err != nil {
 			log.WithError(err).Error("Could not get payload attribute")
 			return emptyAttri

--- a/beacon-chain/core/blocks/genesis.go
+++ b/beacon-chain/core/blocks/genesis.go
@@ -198,7 +198,7 @@ func NewGenesisBlockForState(ctx context.Context, st state.BeaconState) (interfa
 						SyncCommitteeBits:      make([]byte, fieldparams.SyncCommitteeLength/8),
 						SyncCommitteeSignature: make([]byte, fieldparams.BLSSignatureLength),
 					},
-					ExecutionPayload: &enginev1.ExecutionPayloadElectra{
+					ExecutionPayload: &enginev1.ExecutionPayloadDeneb{
 						ParentHash:    make([]byte, 32),
 						FeeRecipient:  make([]byte, 20),
 						StateRoot:     make([]byte, 32),

--- a/beacon-chain/core/blocks/withdrawals_test.go
+++ b/beacon-chain/core/blocks/withdrawals_test.go
@@ -1152,7 +1152,7 @@ func TestProcessWithdrawals(t *testing.T) {
 						}
 						st, err = state_native.InitializeFromProtoUnsafeElectra(spb)
 						require.NoError(t, err)
-						p, err = consensusblocks.WrappedExecutionPayloadElectra(&enginev1.ExecutionPayloadElectra{Withdrawals: test.Args.Withdrawals})
+						p, err = consensusblocks.WrappedExecutionPayloadDeneb(&enginev1.ExecutionPayloadDeneb{Withdrawals: test.Args.Withdrawals})
 						require.NoError(t, err)
 					default:
 						t.Fatalf("Add a beacon state setup for version %s", version.String(fork))

--- a/beacon-chain/core/electra/upgrade.go
+++ b/beacon-chain/core/electra/upgrade.go
@@ -240,7 +240,7 @@ func UpgradeToElectra(beaconState state.BeaconState) (state.BeaconState, error) 
 		InactivityScores:            inactivityScores,
 		CurrentSyncCommittee:        currentSyncCommittee,
 		NextSyncCommittee:           nextSyncCommittee,
-		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderElectra{
+		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderDeneb{
 			ParentHash:       payloadHeader.ParentHash(),
 			FeeRecipient:     payloadHeader.FeeRecipient(),
 			StateRoot:        payloadHeader.StateRoot(),

--- a/beacon-chain/core/electra/upgrade_test.go
+++ b/beacon-chain/core/electra/upgrade_test.go
@@ -102,7 +102,7 @@ func TestUpgradeToElectra(t *testing.T) {
 
 	header, err := mSt.LatestExecutionPayloadHeader()
 	require.NoError(t, err)
-	protoHeader, ok := header.Proto().(*enginev1.ExecutionPayloadHeaderElectra)
+	protoHeader, ok := header.Proto().(*enginev1.ExecutionPayloadHeaderDeneb)
 	require.Equal(t, true, ok)
 	prevHeader, err := preForkState.LatestExecutionPayloadHeader()
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestUpgradeToElectra(t *testing.T) {
 
 	wdRoot, err := prevHeader.WithdrawalsRoot()
 	require.NoError(t, err)
-	wanted := &enginev1.ExecutionPayloadHeaderElectra{
+	wanted := &enginev1.ExecutionPayloadHeaderDeneb{
 		ParentHash:       prevHeader.ParentHash(),
 		FeeRecipient:     prevHeader.FeeRecipient(),
 		StateRoot:        prevHeader.StateRoot(),

--- a/beacon-chain/core/light-client/lightclient_test.go
+++ b/beacon-chain/core/light-client/lightclient_test.go
@@ -697,7 +697,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 			excessBlobGas, err := payload.ExcessBlobGas()
 			require.NoError(t, err)
 
-			executionHeader := &v11.ExecutionPayloadHeaderElectra{
+			executionHeader := &v11.ExecutionPayloadHeaderDeneb{
 				ParentHash:       payload.ParentHash(),
 				FeeRecipient:     payload.FeeRecipient(),
 				StateRoot:        payload.StateRoot(),
@@ -762,7 +762,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 			excessBlobGas, err := payload.ExcessBlobGas()
 			require.NoError(t, err)
 
-			executionHeader := &v11.ExecutionPayloadHeaderElectra{
+			executionHeader := &v11.ExecutionPayloadHeaderDeneb{
 				ParentHash:       payload.ParentHash(),
 				FeeRecipient:     payload.FeeRecipient(),
 				StateRoot:        payload.StateRoot(),

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -298,7 +298,7 @@ func ProcessSlotsCore(ctx context.Context, span trace.Span, state state.BeaconSt
 func ProcessEpoch(ctx context.Context, state state.BeaconState) (state.BeaconState, error) {
 	var err error
 	if time.CanProcessEpoch(state) {
-		if state.Version() == version.Electra {
+		if state.Version() >= version.Electra {
 			if err = electra.ProcessEpoch(ctx, state); err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("could not process %s epoch", version.String(state.Version())))
 			}
@@ -322,9 +322,11 @@ func UpgradeState(ctx context.Context, state state.BeaconState) (state.BeaconSta
 	defer span.End()
 
 	var err error
+
+	slot := state.Slot()
 	upgraded := false
 
-	if time.CanUpgradeToAltair(state.Slot()) {
+	if time.CanUpgradeToAltair(slot) {
 		state, err = altair.UpgradeToAltair(ctx, state)
 		if err != nil {
 			tracing.AnnotateError(span, err)
@@ -333,7 +335,7 @@ func UpgradeState(ctx context.Context, state state.BeaconState) (state.BeaconSta
 		upgraded = true
 	}
 
-	if time.CanUpgradeToBellatrix(state.Slot()) {
+	if time.CanUpgradeToBellatrix(slot) {
 		state, err = execution.UpgradeToBellatrix(state)
 		if err != nil {
 			tracing.AnnotateError(span, err)
@@ -342,7 +344,7 @@ func UpgradeState(ctx context.Context, state state.BeaconState) (state.BeaconSta
 		upgraded = true
 	}
 
-	if time.CanUpgradeToCapella(state.Slot()) {
+	if time.CanUpgradeToCapella(slot) {
 		state, err = capella.UpgradeToCapella(state)
 		if err != nil {
 			tracing.AnnotateError(span, err)
@@ -351,7 +353,7 @@ func UpgradeState(ctx context.Context, state state.BeaconState) (state.BeaconSta
 		upgraded = true
 	}
 
-	if time.CanUpgradeToDeneb(state.Slot()) {
+	if time.CanUpgradeToDeneb(slot) {
 		state, err = deneb.UpgradeToDeneb(state)
 		if err != nil {
 			tracing.AnnotateError(span, err)
@@ -360,7 +362,7 @@ func UpgradeState(ctx context.Context, state state.BeaconState) (state.BeaconSta
 		upgraded = true
 	}
 
-	if time.CanUpgradeToElectra(state.Slot()) {
+	if time.CanUpgradeToElectra(slot) {
 		state, err = electra.UpgradeToElectra(state)
 		if err != nil {
 			tracing.AnnotateError(span, err)
@@ -370,7 +372,7 @@ func UpgradeState(ctx context.Context, state state.BeaconState) (state.BeaconSta
 	}
 
 	if upgraded {
-		log.Debugf("upgraded state to %s", version.String(state.Version()))
+		log.WithField("version", version.String(state.Version())).Debug("Upgraded state to")
 	}
 
 	return state, nil

--- a/beacon-chain/core/validators/slashing.go
+++ b/beacon-chain/core/validators/slashing.go
@@ -9,25 +9,35 @@ import (
 // SlashingParamsPerVersion returns the slashing parameters for the given state version.
 func SlashingParamsPerVersion(v int) (slashingQuotient, proposerRewardQuotient, whistleblowerRewardQuotient uint64, err error) {
 	cfg := params.BeaconConfig()
-	switch v {
-	case version.Phase0:
-		slashingQuotient = cfg.MinSlashingPenaltyQuotient
-		proposerRewardQuotient = cfg.ProposerRewardQuotient
-		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
-	case version.Altair:
-		slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
-		proposerRewardQuotient = cfg.ProposerRewardQuotient
-		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
-	case version.Bellatrix, version.Capella, version.Deneb:
-		slashingQuotient = cfg.MinSlashingPenaltyQuotientBellatrix
-		proposerRewardQuotient = cfg.ProposerRewardQuotient
-		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
-	case version.Electra:
+
+	if v >= version.Electra {
 		slashingQuotient = cfg.MinSlashingPenaltyQuotientElectra
 		proposerRewardQuotient = cfg.ProposerRewardQuotient
 		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotientElectra
-	default:
-		err = errors.New("unknown state version")
+		return
 	}
+
+	if v >= version.Bellatrix {
+		slashingQuotient = cfg.MinSlashingPenaltyQuotientBellatrix
+		proposerRewardQuotient = cfg.ProposerRewardQuotient
+		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
+		return
+	}
+
+	if v >= version.Altair {
+		slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
+		proposerRewardQuotient = cfg.ProposerRewardQuotient
+		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
+		return
+	}
+
+	if v >= version.Phase0 {
+		slashingQuotient = cfg.MinSlashingPenaltyQuotient
+		proposerRewardQuotient = cfg.ProposerRewardQuotient
+		whistleblowerRewardQuotient = cfg.WhistleBlowerRewardQuotient
+		return
+	}
+
+	err = errors.New("unknown state version")
 	return
 }

--- a/beacon-chain/core/validators/slashing.go
+++ b/beacon-chain/core/validators/slashing.go
@@ -38,6 +38,6 @@ func SlashingParamsPerVersion(v int) (slashingQuotient, proposerRewardQuotient, 
 		return
 	}
 
-	err = errors.New("unknown state version")
+	err = errors.Errorf("unknown state version %s", version.String(v))
 	return
 }

--- a/beacon-chain/db/kv/lightclient_test.go
+++ b/beacon-chain/db/kv/lightclient_test.go
@@ -122,7 +122,7 @@ func createUpdate(t *testing.T, v int) (interfaces.LightClientUpdate, error) {
 				StateRoot:     sampleRoot,
 				BodyRoot:      sampleRoot,
 			},
-			Execution: &enginev1.ExecutionPayloadHeaderElectra{
+			Execution: &enginev1.ExecutionPayloadHeaderDeneb{
 				ParentHash:       make([]byte, fieldparams.RootLength),
 				FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
 				StateRoot:        make([]byte, fieldparams.RootLength),

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -139,7 +139,7 @@ func TestState_CanSaveRetrieve(t *testing.T) {
 				st, err := util.NewBeaconStateElectra()
 				require.NoError(t, err)
 				require.NoError(t, st.SetSlot(100))
-				p, err := blocks.WrappedExecutionPayloadHeaderElectra(&enginev1.ExecutionPayloadHeaderElectra{
+				p, err := blocks.WrappedExecutionPayloadHeaderDeneb(&enginev1.ExecutionPayloadHeaderDeneb{
 					ParentHash:       make([]byte, 32),
 					FeeRecipient:     make([]byte, 20),
 					StateRoot:        make([]byte, 32),

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -631,43 +631,7 @@ func fullPayloadFromPayloadBody(
 		return nil, errors.New("execution block and header cannot be nil")
 	}
 
-	switch bVersion {
-	case version.Bellatrix:
-		return blocks.WrappedExecutionPayload(&pb.ExecutionPayload{
-			ParentHash:    header.ParentHash(),
-			FeeRecipient:  header.FeeRecipient(),
-			StateRoot:     header.StateRoot(),
-			ReceiptsRoot:  header.ReceiptsRoot(),
-			LogsBloom:     header.LogsBloom(),
-			PrevRandao:    header.PrevRandao(),
-			BlockNumber:   header.BlockNumber(),
-			GasLimit:      header.GasLimit(),
-			GasUsed:       header.GasUsed(),
-			Timestamp:     header.Timestamp(),
-			ExtraData:     header.ExtraData(),
-			BaseFeePerGas: header.BaseFeePerGas(),
-			BlockHash:     header.BlockHash(),
-			Transactions:  pb.RecastHexutilByteSlice(body.Transactions),
-		})
-	case version.Capella:
-		return blocks.WrappedExecutionPayloadCapella(&pb.ExecutionPayloadCapella{
-			ParentHash:    header.ParentHash(),
-			FeeRecipient:  header.FeeRecipient(),
-			StateRoot:     header.StateRoot(),
-			ReceiptsRoot:  header.ReceiptsRoot(),
-			LogsBloom:     header.LogsBloom(),
-			PrevRandao:    header.PrevRandao(),
-			BlockNumber:   header.BlockNumber(),
-			GasLimit:      header.GasLimit(),
-			GasUsed:       header.GasUsed(),
-			Timestamp:     header.Timestamp(),
-			ExtraData:     header.ExtraData(),
-			BaseFeePerGas: header.BaseFeePerGas(),
-			BlockHash:     header.BlockHash(),
-			Transactions:  pb.RecastHexutilByteSlice(body.Transactions),
-			Withdrawals:   body.Withdrawals,
-		}) // We can't get the block value and don't care about the block value for this instance
-	case version.Deneb, version.Electra:
+	if bVersion >= version.Deneb {
 		ebg, err := header.ExcessBlobGas()
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to extract ExcessBlobGas attribute from execution payload header")
@@ -696,9 +660,48 @@ func fullPayloadFromPayloadBody(
 				ExcessBlobGas: ebg,
 				BlobGasUsed:   bgu,
 			}) // We can't get the block value and don't care about the block value for this instance
-	default:
-		return nil, fmt.Errorf("unknown execution block version for payload %d", bVersion)
 	}
+
+	if bVersion >= version.Capella {
+		return blocks.WrappedExecutionPayloadCapella(&pb.ExecutionPayloadCapella{
+			ParentHash:    header.ParentHash(),
+			FeeRecipient:  header.FeeRecipient(),
+			StateRoot:     header.StateRoot(),
+			ReceiptsRoot:  header.ReceiptsRoot(),
+			LogsBloom:     header.LogsBloom(),
+			PrevRandao:    header.PrevRandao(),
+			BlockNumber:   header.BlockNumber(),
+			GasLimit:      header.GasLimit(),
+			GasUsed:       header.GasUsed(),
+			Timestamp:     header.Timestamp(),
+			ExtraData:     header.ExtraData(),
+			BaseFeePerGas: header.BaseFeePerGas(),
+			BlockHash:     header.BlockHash(),
+			Transactions:  pb.RecastHexutilByteSlice(body.Transactions),
+			Withdrawals:   body.Withdrawals,
+		}) // We can't get the block value and don't care about the block value for this instance
+	}
+
+	if bVersion >= version.Bellatrix {
+		return blocks.WrappedExecutionPayload(&pb.ExecutionPayload{
+			ParentHash:    header.ParentHash(),
+			FeeRecipient:  header.FeeRecipient(),
+			StateRoot:     header.StateRoot(),
+			ReceiptsRoot:  header.ReceiptsRoot(),
+			LogsBloom:     header.LogsBloom(),
+			PrevRandao:    header.PrevRandao(),
+			BlockNumber:   header.BlockNumber(),
+			GasLimit:      header.GasLimit(),
+			GasUsed:       header.GasUsed(),
+			Timestamp:     header.Timestamp(),
+			ExtraData:     header.ExtraData(),
+			BaseFeePerGas: header.BaseFeePerGas(),
+			BlockHash:     header.BlockHash(),
+			Transactions:  pb.RecastHexutilByteSlice(body.Transactions),
+		})
+	}
+
+	return nil, fmt.Errorf("unknown execution block version for payload %d", bVersion)
 }
 
 // Handles errors received from the RPC server according to the specification.
@@ -790,35 +793,7 @@ func tDStringToUint256(td string) (*uint256.Int, error) {
 }
 
 func EmptyExecutionPayload(v int) (proto.Message, error) {
-	switch v {
-	case version.Bellatrix:
-		return &pb.ExecutionPayload{
-			ParentHash:    make([]byte, fieldparams.RootLength),
-			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
-			StateRoot:     make([]byte, fieldparams.RootLength),
-			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
-			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
-			PrevRandao:    make([]byte, fieldparams.RootLength),
-			ExtraData:     make([]byte, 0),
-			BaseFeePerGas: make([]byte, fieldparams.RootLength),
-			BlockHash:     make([]byte, fieldparams.RootLength),
-			Transactions:  make([][]byte, 0),
-		}, nil
-	case version.Capella:
-		return &pb.ExecutionPayloadCapella{
-			ParentHash:    make([]byte, fieldparams.RootLength),
-			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
-			StateRoot:     make([]byte, fieldparams.RootLength),
-			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
-			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
-			PrevRandao:    make([]byte, fieldparams.RootLength),
-			ExtraData:     make([]byte, 0),
-			BaseFeePerGas: make([]byte, fieldparams.RootLength),
-			BlockHash:     make([]byte, fieldparams.RootLength),
-			Transactions:  make([][]byte, 0),
-			Withdrawals:   make([]*pb.Withdrawal, 0),
-		}, nil
-	case version.Deneb, version.Electra:
+	if v >= version.Deneb {
 		return &pb.ExecutionPayloadDeneb{
 			ParentHash:    make([]byte, fieldparams.RootLength),
 			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
@@ -832,15 +807,10 @@ func EmptyExecutionPayload(v int) (proto.Message, error) {
 			Transactions:  make([][]byte, 0),
 			Withdrawals:   make([]*pb.Withdrawal, 0),
 		}, nil
-	default:
-		return nil, errors.Wrapf(ErrUnsupportedVersion, "version=%s", version.String(v))
 	}
-}
 
-func EmptyExecutionPayloadHeader(v int) (proto.Message, error) {
-	switch v {
-	case version.Bellatrix:
-		return &pb.ExecutionPayloadHeader{
+	if v >= version.Capella {
+		return &pb.ExecutionPayloadCapella{
 			ParentHash:    make([]byte, fieldparams.RootLength),
 			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
 			StateRoot:     make([]byte, fieldparams.RootLength),
@@ -850,22 +820,31 @@ func EmptyExecutionPayloadHeader(v int) (proto.Message, error) {
 			ExtraData:     make([]byte, 0),
 			BaseFeePerGas: make([]byte, fieldparams.RootLength),
 			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  make([][]byte, 0),
+			Withdrawals:   make([]*pb.Withdrawal, 0),
 		}, nil
-	case version.Capella:
-		return &pb.ExecutionPayloadHeaderCapella{
-			ParentHash:       make([]byte, fieldparams.RootLength),
-			FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
-			StateRoot:        make([]byte, fieldparams.RootLength),
-			ReceiptsRoot:     make([]byte, fieldparams.RootLength),
-			LogsBloom:        make([]byte, fieldparams.LogsBloomLength),
-			PrevRandao:       make([]byte, fieldparams.RootLength),
-			ExtraData:        make([]byte, 0),
-			BaseFeePerGas:    make([]byte, fieldparams.RootLength),
-			BlockHash:        make([]byte, fieldparams.RootLength),
-			TransactionsRoot: make([]byte, fieldparams.RootLength),
-			WithdrawalsRoot:  make([]byte, fieldparams.RootLength),
+	}
+
+	if v >= version.Bellatrix {
+		return &pb.ExecutionPayload{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			ExtraData:     make([]byte, 0),
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  make([][]byte, 0),
 		}, nil
-	case version.Deneb, version.Electra:
+	}
+
+	return nil, errors.Wrapf(ErrUnsupportedVersion, "version=%s", version.String(v))
+}
+
+func EmptyExecutionPayloadHeader(v int) (proto.Message, error) {
+	if v >= version.Deneb {
 		return &pb.ExecutionPayloadHeaderDeneb{
 			ParentHash:       make([]byte, fieldparams.RootLength),
 			FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
@@ -879,9 +858,39 @@ func EmptyExecutionPayloadHeader(v int) (proto.Message, error) {
 			TransactionsRoot: make([]byte, fieldparams.RootLength),
 			WithdrawalsRoot:  make([]byte, fieldparams.RootLength),
 		}, nil
-	default:
-		return nil, errors.Wrapf(ErrUnsupportedVersion, "version=%s", version.String(v))
 	}
+
+	if v >= version.Capella {
+		return &pb.ExecutionPayloadHeaderCapella{
+			ParentHash:       make([]byte, fieldparams.RootLength),
+			FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:        make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:     make([]byte, fieldparams.RootLength),
+			LogsBloom:        make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:       make([]byte, fieldparams.RootLength),
+			ExtraData:        make([]byte, 0),
+			BaseFeePerGas:    make([]byte, fieldparams.RootLength),
+			BlockHash:        make([]byte, fieldparams.RootLength),
+			TransactionsRoot: make([]byte, fieldparams.RootLength),
+			WithdrawalsRoot:  make([]byte, fieldparams.RootLength),
+		}, nil
+	}
+
+	if v >= version.Bellatrix {
+		return &pb.ExecutionPayloadHeader{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			ExtraData:     make([]byte, 0),
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+		}, nil
+	}
+
+	return nil, errors.Wrapf(ErrUnsupportedVersion, "version=%s", version.String(v))
 }
 
 func toBlockNumArg(number *big.Int) string {

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -701,7 +701,7 @@ func fullPayloadFromPayloadBody(
 		})
 	}
 
-	return nil, fmt.Errorf("unknown execution block version for payload %d", bVersion)
+	return nil, fmt.Errorf("unknown execution block version for payload %s", version.String(bVersion))
 }
 
 // Handles errors received from the RPC server according to the specification.

--- a/beacon-chain/execution/payload_body_test.go
+++ b/beacon-chain/execution/payload_body_test.go
@@ -17,14 +17,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
 
-type versioner struct {
-	version int
-}
-
-func (v versioner) Version() int {
-	return v.version
-}
-
 func payloadToBody(t *testing.T, ed interfaces.ExecutionData) *pb.ExecutionPayloadBody {
 	body := &pb.ExecutionPayloadBody{}
 	txs, err := ed.Transactions()

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -236,7 +236,7 @@ func (c *AttCaches) AggregatedAttestationsBySlotIndexElectra(
 	c.aggregatedAttLock.RLock()
 	defer c.aggregatedAttLock.RUnlock()
 	for _, as := range c.aggregatedAtt {
-		if as[0].Version() == version.Electra && slot == as[0].GetData().Slot && as[0].CommitteeBitsVal().BitAt(uint64(committeeIndex)) {
+		if as[0].Version() >= version.Electra && slot == as[0].GetData().Slot && as[0].CommitteeBitsVal().BitAt(uint64(committeeIndex)) {
 			for _, a := range as {
 				att, ok := a.(*ethpb.AttestationElectra)
 				// This will never fail in practice because we asserted the version

--- a/beacon-chain/operations/attestations/kv/unaggregated.go
+++ b/beacon-chain/operations/attestations/kv/unaggregated.go
@@ -115,7 +115,7 @@ func (c *AttCaches) UnaggregatedAttestationsBySlotIndexElectra(
 
 	unAggregatedAtts := c.unAggregatedAtt
 	for _, a := range unAggregatedAtts {
-		if a.Version() == version.Electra && slot == a.GetData().Slot && a.CommitteeBitsVal().BitAt(uint64(committeeIndex)) {
+		if a.Version() >= version.Electra && slot == a.GetData().Slot && a.CommitteeBitsVal().BitAt(uint64(committeeIndex)) {
 			att, ok := a.(*ethpb.AttestationElectra)
 			// This will never fail in practice because we asserted the version
 			if ok {

--- a/beacon-chain/p2p/types/object_mapping.go
+++ b/beacon-chain/p2p/types/object_mapping.go
@@ -67,7 +67,7 @@ func InitializeDataMaps() {
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().ElectraForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
-				&ethpb.SignedBeaconBlockElectra{Block: &ethpb.BeaconBlockElectra{Body: &ethpb.BeaconBlockBodyElectra{ExecutionPayload: &enginev1.ExecutionPayloadElectra{}}}},
+				&ethpb.SignedBeaconBlockElectra{Block: &ethpb.BeaconBlockElectra{Body: &ethpb.BeaconBlockBodyElectra{ExecutionPayload: &enginev1.ExecutionPayloadDeneb{}}}},
 			)
 		},
 	}

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -1821,7 +1821,7 @@ func createUpdate(t *testing.T, v int) (interfaces.LightClientUpdate, error) {
 				StateRoot:     sampleRoot,
 				BodyRoot:      sampleRoot,
 			},
-			Execution: &enginev1.ExecutionPayloadHeaderElectra{
+			Execution: &enginev1.ExecutionPayloadHeaderDeneb{
 				ParentHash:       make([]byte, fieldparams.RootLength),
 				FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
 				StateRoot:        make([]byte, fieldparams.RootLength),

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
@@ -26,34 +26,44 @@ func (vs *Server) constructGenericBeaconBlock(sBlk interfaces.SignedBeaconBlock,
 	bidStr := primitives.WeiToBigInt(winningBid).String()
 
 	switch sBlk.Version() {
-	case version.Electra:
-		return vs.constructElectraBlock(blockProto, isBlinded, bidStr, blobsBundle), nil
-	case version.Deneb:
-		return vs.constructDenebBlock(blockProto, isBlinded, bidStr, blobsBundle), nil
-	case version.Capella:
-		return vs.constructCapellaBlock(blockProto, isBlinded, bidStr), nil
-	case version.Bellatrix:
-		return vs.constructBellatrixBlock(blockProto, isBlinded, bidStr), nil
-	case version.Altair:
-		return vs.constructAltairBlock(blockProto), nil
 	case version.Phase0:
 		return vs.constructPhase0Block(blockProto), nil
+	case version.Altair:
+		return vs.constructAltairBlock(blockProto), nil
+	case version.Bellatrix:
+		return vs.constructBellatrixBlock(blockProto, isBlinded, bidStr), nil
+	case version.Capella:
+		return vs.constructCapellaBlock(blockProto, isBlinded, bidStr), nil
+	case version.Deneb:
+		return vs.constructDenebBlock(blockProto, isBlinded, bidStr, blobsBundle), nil
+	case version.Electra:
+		return vs.constructElectraBlock(blockProto, isBlinded, bidStr, blobsBundle), nil
 	default:
 		return nil, fmt.Errorf("unknown block version: %d", sBlk.Version())
 	}
 }
 
 // Helper functions for constructing blocks for each version
-func (vs *Server) constructElectraBlock(blockProto proto.Message, isBlinded bool, payloadValue string, bundle *enginev1.BlobsBundle) *ethpb.GenericBeaconBlock {
+func (vs *Server) constructPhase0Block(pb proto.Message) *ethpb.GenericBeaconBlock {
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Phase0{Phase0: pb.(*ethpb.BeaconBlock)}}
+}
+
+func (vs *Server) constructAltairBlock(pb proto.Message) *ethpb.GenericBeaconBlock {
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Altair{Altair: pb.(*ethpb.BeaconBlockAltair)}}
+}
+
+func (vs *Server) constructBellatrixBlock(pb proto.Message, isBlinded bool, payloadValue string) *ethpb.GenericBeaconBlock {
 	if isBlinded {
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedElectra{BlindedElectra: blockProto.(*ethpb.BlindedBeaconBlockElectra)}, IsBlinded: true, PayloadValue: payloadValue}
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedBellatrix{BlindedBellatrix: pb.(*ethpb.BlindedBeaconBlockBellatrix)}, IsBlinded: true, PayloadValue: payloadValue}
 	}
-	electraContents := &ethpb.BeaconBlockContentsElectra{Block: blockProto.(*ethpb.BeaconBlockElectra)}
-	if bundle != nil {
-		electraContents.KzgProofs = bundle.Proofs
-		electraContents.Blobs = bundle.Blobs
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Bellatrix{Bellatrix: pb.(*ethpb.BeaconBlockBellatrix)}, IsBlinded: false, PayloadValue: payloadValue}
+}
+
+func (vs *Server) constructCapellaBlock(pb proto.Message, isBlinded bool, payloadValue string) *ethpb.GenericBeaconBlock {
+	if isBlinded {
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedCapella{BlindedCapella: pb.(*ethpb.BlindedBeaconBlockCapella)}, IsBlinded: true, PayloadValue: payloadValue}
 	}
-	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Electra{Electra: electraContents}, IsBlinded: false, PayloadValue: payloadValue}
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Capella{Capella: pb.(*ethpb.BeaconBlockCapella)}, IsBlinded: false, PayloadValue: payloadValue}
 }
 
 func (vs *Server) constructDenebBlock(blockProto proto.Message, isBlinded bool, payloadValue string, bundle *enginev1.BlobsBundle) *ethpb.GenericBeaconBlock {
@@ -68,24 +78,14 @@ func (vs *Server) constructDenebBlock(blockProto proto.Message, isBlinded bool, 
 	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Deneb{Deneb: denebContents}, IsBlinded: false, PayloadValue: payloadValue}
 }
 
-func (vs *Server) constructCapellaBlock(pb proto.Message, isBlinded bool, payloadValue string) *ethpb.GenericBeaconBlock {
+func (vs *Server) constructElectraBlock(blockProto proto.Message, isBlinded bool, payloadValue string, bundle *enginev1.BlobsBundle) *ethpb.GenericBeaconBlock {
 	if isBlinded {
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedCapella{BlindedCapella: pb.(*ethpb.BlindedBeaconBlockCapella)}, IsBlinded: true, PayloadValue: payloadValue}
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedElectra{BlindedElectra: blockProto.(*ethpb.BlindedBeaconBlockElectra)}, IsBlinded: true, PayloadValue: payloadValue}
 	}
-	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Capella{Capella: pb.(*ethpb.BeaconBlockCapella)}, IsBlinded: false, PayloadValue: payloadValue}
-}
-
-func (vs *Server) constructBellatrixBlock(pb proto.Message, isBlinded bool, payloadValue string) *ethpb.GenericBeaconBlock {
-	if isBlinded {
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedBellatrix{BlindedBellatrix: pb.(*ethpb.BlindedBeaconBlockBellatrix)}, IsBlinded: true, PayloadValue: payloadValue}
+	electraContents := &ethpb.BeaconBlockContentsElectra{Block: blockProto.(*ethpb.BeaconBlockElectra)}
+	if bundle != nil {
+		electraContents.KzgProofs = bundle.Proofs
+		electraContents.Blobs = bundle.Blobs
 	}
-	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Bellatrix{Bellatrix: pb.(*ethpb.BeaconBlockBellatrix)}, IsBlinded: false, PayloadValue: payloadValue}
-}
-
-func (vs *Server) constructAltairBlock(pb proto.Message) *ethpb.GenericBeaconBlock {
-	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Altair{Altair: pb.(*ethpb.BeaconBlockAltair)}}
-}
-
-func (vs *Server) constructPhase0Block(pb proto.Message) *ethpb.GenericBeaconBlock {
-	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Phase0{Phase0: pb.(*ethpb.BeaconBlock)}}
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Electra{Electra: electraContents}, IsBlinded: false, PayloadValue: payloadValue}
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -617,7 +617,7 @@ func TestServer_GetBeaconBlock_Electra(t *testing.T) {
 				Graffiti:      genesis.Block.Body.Graffiti,
 				Eth1Data:      genesis.Block.Body.Eth1Data,
 				SyncAggregate: &ethpb.SyncAggregate{SyncCommitteeBits: scBits[:], SyncCommitteeSignature: make([]byte, 96)},
-				ExecutionPayload: &enginev1.ExecutionPayloadElectra{
+				ExecutionPayload: &enginev1.ExecutionPayloadDeneb{
 					ParentHash:    make([]byte, fieldparams.RootLength),
 					FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
 					StateRoot:     make([]byte, fieldparams.RootLength),
@@ -646,7 +646,7 @@ func TestServer_GetBeaconBlock_Electra(t *testing.T) {
 	require.NoError(t, err)
 	timeStamp, err := slots.ToTime(beaconState.GenesisTime(), electraSlot+1)
 	require.NoError(t, err)
-	payload := &enginev1.ExecutionPayloadElectra{
+	payload := &enginev1.ExecutionPayloadDeneb{
 		Timestamp:     uint64(timeStamp.Unix()),
 		ParentHash:    make([]byte, fieldparams.RootLength),
 		FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),

--- a/beacon-chain/state/state-native/getters_payload_header.go
+++ b/beacon-chain/state/state-native/getters_payload_header.go
@@ -17,14 +17,17 @@ func (b *BeaconState) LatestExecutionPayloadHeader() (interfaces.ExecutionData, 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	switch b.version {
-	case version.Bellatrix:
-		return blocks.WrappedExecutionPayloadHeader(b.latestExecutionPayloadHeader.Copy())
-	case version.Capella:
-		return blocks.WrappedExecutionPayloadHeaderCapella(b.latestExecutionPayloadHeaderCapella.Copy())
-	case version.Deneb, version.Electra:
+	if b.version >= version.Deneb {
 		return blocks.WrappedExecutionPayloadHeaderDeneb(b.latestExecutionPayloadHeaderDeneb.Copy())
-	default:
-		return nil, fmt.Errorf("unsupported version (%s) for latest execution payload header", version.String(b.version))
 	}
+
+	if b.version >= version.Capella {
+		return blocks.WrappedExecutionPayloadHeaderCapella(b.latestExecutionPayloadHeaderCapella.Copy())
+	}
+
+	if b.version >= version.Bellatrix {
+		return blocks.WrappedExecutionPayloadHeader(b.latestExecutionPayloadHeader.Copy())
+	}
+
+	return nil, fmt.Errorf("unsupported version (%s) for latest execution payload header", version.String(b.version))
 }

--- a/beacon-chain/state/state-native/setters_payload_header_test.go
+++ b/beacon-chain/state/state-native/setters_payload_header_test.go
@@ -35,7 +35,7 @@ func TestSetLatestExecutionPayloadHeader(t *testing.T) {
 		}(),
 		func() interfaces.ExecutionData {
 			e := util.NewBeaconBlockElectra().Block.Body.ExecutionPayload
-			ee, err := blocks.WrappedExecutionPayloadElectra(e)
+			ee, err := blocks.WrappedExecutionPayloadDeneb(e)
 			require.NoError(t, err)
 			return ee
 		}(),

--- a/beacon-chain/state/state-native/spec_parameters.go
+++ b/beacon-chain/state/state-native/spec_parameters.go
@@ -10,7 +10,7 @@ func (b *BeaconState) ProportionalSlashingMultiplier() (uint64, error) {
 		return params.BeaconConfig().ProportionalSlashingMultiplierBellatrix, nil
 	}
 
-	if b.version == version.Altair {
+	if b.version >= version.Altair {
 		return params.BeaconConfig().ProportionalSlashingMultiplierAltair, nil
 	}
 

--- a/beacon-chain/state/state-native/spec_parameters.go
+++ b/beacon-chain/state/state-native/spec_parameters.go
@@ -30,7 +30,7 @@ func (b *BeaconState) InactivityPenaltyQuotient() (uint64, error) {
 		return params.BeaconConfig().InactivityPenaltyQuotientAltair, nil
 	}
 
-	if b.version == version.Phase0 {
+	if b.version >= version.Phase0 {
 		return params.BeaconConfig().InactivityPenaltyQuotient, nil
 	}
 

--- a/beacon-chain/state/state-native/spec_parameters.go
+++ b/beacon-chain/state/state-native/spec_parameters.go
@@ -6,25 +6,33 @@ import (
 )
 
 func (b *BeaconState) ProportionalSlashingMultiplier() (uint64, error) {
-	switch b.version {
-	case version.Bellatrix, version.Capella, version.Deneb, version.Electra:
+	if b.version >= version.Bellatrix {
 		return params.BeaconConfig().ProportionalSlashingMultiplierBellatrix, nil
-	case version.Altair:
+	}
+
+	if b.version == version.Altair {
 		return params.BeaconConfig().ProportionalSlashingMultiplierAltair, nil
-	case version.Phase0:
+	}
+
+	if b.version == version.Phase0 {
 		return params.BeaconConfig().ProportionalSlashingMultiplier, nil
 	}
+
 	return 0, errNotSupported("ProportionalSlashingMultiplier", b.version)
 }
 
 func (b *BeaconState) InactivityPenaltyQuotient() (uint64, error) {
-	switch b.version {
-	case version.Bellatrix, version.Capella, version.Deneb, version.Electra:
+	if b.version >= version.Bellatrix {
 		return params.BeaconConfig().InactivityPenaltyQuotientBellatrix, nil
-	case version.Altair:
+	}
+
+	if b.version == version.Altair {
 		return params.BeaconConfig().InactivityPenaltyQuotientAltair, nil
-	case version.Phase0:
+	}
+
+	if b.version == version.Phase0 {
 		return params.BeaconConfig().InactivityPenaltyQuotient, nil
 	}
+
 	return 0, errNotSupported("InactivityPenaltyQuotient", b.version)
 }

--- a/beacon-chain/state/state-native/spec_parameters.go
+++ b/beacon-chain/state/state-native/spec_parameters.go
@@ -26,7 +26,7 @@ func (b *BeaconState) InactivityPenaltyQuotient() (uint64, error) {
 		return params.BeaconConfig().InactivityPenaltyQuotientBellatrix, nil
 	}
 
-	if b.version == version.Altair {
+	if b.version >= version.Altair {
 		return params.BeaconConfig().InactivityPenaltyQuotientAltair, nil
 	}
 

--- a/beacon-chain/state/state-native/spec_parameters.go
+++ b/beacon-chain/state/state-native/spec_parameters.go
@@ -14,7 +14,7 @@ func (b *BeaconState) ProportionalSlashingMultiplier() (uint64, error) {
 		return params.BeaconConfig().ProportionalSlashingMultiplierAltair, nil
 	}
 
-	if b.version == version.Phase0 {
+	if b.version >= version.Phase0 {
 		return params.BeaconConfig().ProportionalSlashingMultiplier, nil
 	}
 

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -25,90 +25,88 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var phase0Fields = []types.FieldIndex{
-	types.GenesisTime,
-	types.GenesisValidatorsRoot,
-	types.Slot,
-	types.Fork,
-	types.LatestBlockHeader,
-	types.BlockRoots,
-	types.StateRoots,
-	types.HistoricalRoots,
-	types.Eth1Data,
-	types.Eth1DataVotes,
-	types.Eth1DepositIndex,
-	types.Validators,
-	types.Balances,
-	types.RandaoMixes,
-	types.Slashings,
-	types.PreviousEpochAttestations,
-	types.CurrentEpochAttestations,
-	types.JustificationBits,
-	types.PreviousJustifiedCheckpoint,
-	types.CurrentJustifiedCheckpoint,
-	types.FinalizedCheckpoint,
-}
+var (
+	phase0Fields = []types.FieldIndex{
+		types.GenesisTime,
+		types.GenesisValidatorsRoot,
+		types.Slot,
+		types.Fork,
+		types.LatestBlockHeader,
+		types.BlockRoots,
+		types.StateRoots,
+		types.HistoricalRoots,
+		types.Eth1Data,
+		types.Eth1DataVotes,
+		types.Eth1DepositIndex,
+		types.Validators,
+		types.Balances,
+		types.RandaoMixes,
+		types.Slashings,
+		types.PreviousEpochAttestations,
+		types.CurrentEpochAttestations,
+		types.JustificationBits,
+		types.PreviousJustifiedCheckpoint,
+		types.CurrentJustifiedCheckpoint,
+		types.FinalizedCheckpoint,
+	}
 
-var altairFields = []types.FieldIndex{
-	types.GenesisTime,
-	types.GenesisValidatorsRoot,
-	types.Slot,
-	types.Fork,
-	types.LatestBlockHeader,
-	types.BlockRoots,
-	types.StateRoots,
-	types.HistoricalRoots,
-	types.Eth1Data,
-	types.Eth1DataVotes,
-	types.Eth1DepositIndex,
-	types.Validators,
-	types.Balances,
-	types.RandaoMixes,
-	types.Slashings,
-	types.PreviousEpochParticipationBits,
-	types.CurrentEpochParticipationBits,
-	types.JustificationBits,
-	types.PreviousJustifiedCheckpoint,
-	types.CurrentJustifiedCheckpoint,
-	types.FinalizedCheckpoint,
-	types.InactivityScores,
-	types.CurrentSyncCommittee,
-	types.NextSyncCommittee,
-}
+	altairFields = []types.FieldIndex{
+		types.GenesisTime,
+		types.GenesisValidatorsRoot,
+		types.Slot,
+		types.Fork,
+		types.LatestBlockHeader,
+		types.BlockRoots,
+		types.StateRoots,
+		types.HistoricalRoots,
+		types.Eth1Data,
+		types.Eth1DataVotes,
+		types.Eth1DepositIndex,
+		types.Validators,
+		types.Balances,
+		types.RandaoMixes,
+		types.Slashings,
+		types.PreviousEpochParticipationBits,
+		types.CurrentEpochParticipationBits,
+		types.JustificationBits,
+		types.PreviousJustifiedCheckpoint,
+		types.CurrentJustifiedCheckpoint,
+		types.FinalizedCheckpoint,
+		types.InactivityScores,
+		types.CurrentSyncCommittee,
+		types.NextSyncCommittee,
+	}
 
-var bellatrixFields = append(altairFields, types.LatestExecutionPayloadHeader)
+	bellatrixFields = append(altairFields, types.LatestExecutionPayloadHeader)
 
-var capellaFields = append(
-	altairFields,
-	types.LatestExecutionPayloadHeaderCapella,
-	types.NextWithdrawalIndex,
-	types.NextWithdrawalValidatorIndex,
-	types.HistoricalSummaries,
-)
+	capellaFields = append(
+		altairFields,
+		types.LatestExecutionPayloadHeaderCapella,
+		types.NextWithdrawalIndex,
+		types.NextWithdrawalValidatorIndex,
+		types.HistoricalSummaries,
+	)
 
-var denebFields = append(
-	altairFields,
-	types.LatestExecutionPayloadHeaderDeneb,
-	types.NextWithdrawalIndex,
-	types.NextWithdrawalValidatorIndex,
-	types.HistoricalSummaries,
-)
+	denebFields = append(
+		altairFields,
+		types.LatestExecutionPayloadHeaderDeneb,
+		types.NextWithdrawalIndex,
+		types.NextWithdrawalValidatorIndex,
+		types.HistoricalSummaries,
+	)
 
-var electraFields = append(
-	altairFields,
-	types.LatestExecutionPayloadHeaderDeneb,
-	types.NextWithdrawalIndex,
-	types.NextWithdrawalValidatorIndex,
-	types.HistoricalSummaries,
-	types.DepositRequestsStartIndex,
-	types.DepositBalanceToConsume,
-	types.ExitBalanceToConsume,
-	types.EarliestExitEpoch,
-	types.ConsolidationBalanceToConsume,
-	types.EarliestConsolidationEpoch,
-	types.PendingDeposits,
-	types.PendingPartialWithdrawals,
-	types.PendingConsolidations,
+	electraFields = append(
+		denebFields,
+		types.DepositRequestsStartIndex,
+		types.DepositBalanceToConsume,
+		types.ExitBalanceToConsume,
+		types.EarliestExitEpoch,
+		types.ConsolidationBalanceToConsume,
+		types.EarliestConsolidationEpoch,
+		types.PendingDeposits,
+		types.PendingPartialWithdrawals,
+		types.PendingConsolidations,
+	)
 )
 
 const (

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -38,34 +38,22 @@ type rpcHandler func(context.Context, interface{}, libp2pcore.Stream) error
 
 // rpcHandlerByTopicFromFork returns the RPC handlers for a given fork index.
 func (s *Service) rpcHandlerByTopicFromFork(forkIndex int) (map[string]rpcHandler, error) {
-	switch forkIndex {
-	// PhaseO: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#messages
-	case version.Phase0:
+	// Electra: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/p2p-interface.md#messages
+	if forkIndex >= version.Electra {
 		return map[string]rpcHandler{
-			p2p.RPCStatusTopicV1:        s.statusRPCHandler,
-			p2p.RPCGoodByeTopicV1:       s.goodbyeRPCHandler,
-			p2p.RPCBlocksByRangeTopicV1: s.beaconBlocksByRangeRPCHandler,
-			p2p.RPCBlocksByRootTopicV1:  s.beaconBlocksRootRPCHandler,
-			p2p.RPCPingTopicV1:          s.pingHandler,
-			p2p.RPCMetaDataTopicV1:      s.metaDataHandler,
+			p2p.RPCStatusTopicV1:              s.statusRPCHandler,
+			p2p.RPCGoodByeTopicV1:             s.goodbyeRPCHandler,
+			p2p.RPCBlocksByRangeTopicV2:       s.beaconBlocksByRangeRPCHandler,
+			p2p.RPCBlocksByRootTopicV2:        s.beaconBlocksRootRPCHandler,
+			p2p.RPCPingTopicV1:                s.pingHandler,
+			p2p.RPCMetaDataTopicV2:            s.metaDataHandler,
+			p2p.RPCBlobSidecarsByRootTopicV2:  s.blobSidecarByRootRPCHandler,   // Modified in Electra
+			p2p.RPCBlobSidecarsByRangeTopicV2: s.blobSidecarsByRangeRPCHandler, // Modified in Electra
 		}, nil
-
-	// Altair: https://github.com/ethereum/consensus-specs/tree/dev/specs/altair#messages
-	// Bellatrix: https://github.com/ethereum/consensus-specs/tree/dev/specs/bellatrix#messages
-	// Capella: https://github.com/ethereum/consensus-specs/tree/dev/specs/capella#messages
-	case version.Altair, version.Bellatrix, version.Capella:
-		return map[string]rpcHandler{
-			p2p.RPCStatusTopicV1:        s.statusRPCHandler,
-			p2p.RPCGoodByeTopicV1:       s.goodbyeRPCHandler,
-			p2p.RPCBlocksByRangeTopicV2: s.beaconBlocksByRangeRPCHandler, // Modified in Altair
-			p2p.RPCBlocksByRootTopicV2:  s.beaconBlocksRootRPCHandler,    // Modified in Altair
-			p2p.RPCPingTopicV1:          s.pingHandler,
-			p2p.RPCMetaDataTopicV2:      s.metaDataHandler, // Modified in Altair
-		}, nil
+	}
 
 	// Deneb: https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/p2p-interface.md#messages
-	// Electra: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/p2p-interface.md#messages
-	case version.Deneb:
+	if forkIndex >= version.Deneb {
 		return map[string]rpcHandler{
 			p2p.RPCStatusTopicV1:              s.statusRPCHandler,
 			p2p.RPCGoodByeTopicV1:             s.goodbyeRPCHandler,
@@ -76,20 +64,35 @@ func (s *Service) rpcHandlerByTopicFromFork(forkIndex int) (map[string]rpcHandle
 			p2p.RPCBlobSidecarsByRootTopicV1:  s.blobSidecarByRootRPCHandler,   // Added in Deneb
 			p2p.RPCBlobSidecarsByRangeTopicV1: s.blobSidecarsByRangeRPCHandler, // Added in Deneb
 		}, nil
-	case version.Electra:
-		return map[string]rpcHandler{
-			p2p.RPCStatusTopicV1:              s.statusRPCHandler,
-			p2p.RPCGoodByeTopicV1:             s.goodbyeRPCHandler,
-			p2p.RPCBlocksByRangeTopicV2:       s.beaconBlocksByRangeRPCHandler,
-			p2p.RPCBlocksByRootTopicV2:        s.beaconBlocksRootRPCHandler,
-			p2p.RPCPingTopicV1:                s.pingHandler,
-			p2p.RPCMetaDataTopicV2:            s.metaDataHandler,
-			p2p.RPCBlobSidecarsByRootTopicV2:  s.blobSidecarByRootRPCHandler,   // Added in Electra
-			p2p.RPCBlobSidecarsByRangeTopicV2: s.blobSidecarsByRangeRPCHandler, // Added in Electra
-		}, nil
-	default:
-		return nil, errors.Errorf("RPC handler not found for fork index %d", forkIndex)
 	}
+
+	// Capella: https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/p2p-interface.md#messages
+	// Bellatrix: https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/p2p-interface.md#messages
+	// Altair: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/p2p-interface.md#messages
+	if forkIndex >= version.Altair {
+		return map[string]rpcHandler{
+			p2p.RPCStatusTopicV1:        s.statusRPCHandler,
+			p2p.RPCGoodByeTopicV1:       s.goodbyeRPCHandler,
+			p2p.RPCBlocksByRangeTopicV2: s.beaconBlocksByRangeRPCHandler, // Modified in Altair
+			p2p.RPCBlocksByRootTopicV2:  s.beaconBlocksRootRPCHandler,    // Modified in Altair
+			p2p.RPCPingTopicV1:          s.pingHandler,
+			p2p.RPCMetaDataTopicV2:      s.metaDataHandler, // Modified in Altair
+		}, nil
+	}
+
+	// PhaseO: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#messages
+	if forkIndex >= version.Phase0 {
+		return map[string]rpcHandler{
+			p2p.RPCStatusTopicV1:        s.statusRPCHandler,
+			p2p.RPCGoodByeTopicV1:       s.goodbyeRPCHandler,
+			p2p.RPCBlocksByRangeTopicV1: s.beaconBlocksByRangeRPCHandler,
+			p2p.RPCBlocksByRootTopicV1:  s.beaconBlocksRootRPCHandler,
+			p2p.RPCPingTopicV1:          s.pingHandler,
+			p2p.RPCMetaDataTopicV1:      s.metaDataHandler,
+		}, nil
+	}
+
+	return nil, errors.Errorf("RPC handler not found for fork index %d", forkIndex)
 }
 
 // rpcHandlerByTopic returns the RPC handlers for a given epoch.

--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -864,8 +864,6 @@ func WrappedExecutionPayloadHeaderDeneb(p *enginev1.ExecutionPayloadHeaderDeneb)
 	return w, nil
 }
 
-var WrappedExecutionPayloadHeaderElectra = WrappedExecutionPayloadHeaderDeneb
-
 // IsNil checks if the underlying data is nil.
 func (e executionPayloadHeaderDeneb) IsNil() bool {
 	return e.p == nil
@@ -1023,8 +1021,6 @@ func WrappedExecutionPayloadDeneb(p *enginev1.ExecutionPayloadDeneb) (interfaces
 	}
 	return w, nil
 }
-
-var WrappedExecutionPayloadElectra = WrappedExecutionPayloadDeneb
 
 // IsNil checks if the underlying data is nil.
 func (e executionPayloadDeneb) IsNil() bool {

--- a/consensus-types/blocks/factory.go
+++ b/consensus-types/blocks/factory.go
@@ -472,7 +472,7 @@ func BuildSignedBeaconBlockFromExecutionPayload(blk interfaces.ReadOnlySignedBea
 			Signature: sig[:],
 		}
 	case version.Electra:
-		p, ok := payload.(*enginev1.ExecutionPayloadElectra)
+		p, ok := payload.(*enginev1.ExecutionPayloadDeneb)
 		if !ok {
 			return nil, errors.New("payload not of Electra type")
 		}

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -153,7 +153,7 @@ func (b *SignedBeaconBlock) ToBlinded() (interfaces.ReadOnlySignedBeaconBlock, e
 	}
 
 	if b.version >= version.Electra {
-		p, ok := payload.Proto().(*enginev1.ExecutionPayloadElectra)
+		p, ok := payload.Proto().(*enginev1.ExecutionPayloadDeneb)
 		if !ok {
 			return nil, fmt.Errorf("%T is not an execution payload header of Deneb version", p)
 		}
@@ -1103,14 +1103,15 @@ func (b *BeaconBlockBody) BLSToExecutionChanges() ([]*eth.SignedBLSToExecutionCh
 
 // BlobKzgCommitments returns the blob kzg commitments in the block.
 func (b *BeaconBlockBody) BlobKzgCommitments() ([][]byte, error) {
-	switch b.version {
-	case version.Phase0, version.Altair, version.Bellatrix, version.Capella:
-		return nil, consensus_types.ErrNotSupported("BlobKzgCommitments", b.version)
-	case version.Deneb, version.Electra:
+	if b.version >= version.Deneb {
 		return b.blobKzgCommitments, nil
-	default:
-		return nil, errIncorrectBlockVersion
 	}
+
+	if b.version >= version.Phase0 {
+		return nil, consensus_types.ErrNotSupported("BlobKzgCommitments", b.version)
+	}
+
+	return nil, errIncorrectBlockVersion
 }
 
 // ExecutionRequests returns the execution requests

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -613,7 +613,7 @@ func hydrateBeaconBlockBodyElectra() *eth.BeaconBlockBodyElectra {
 			SyncCommitteeBits:      make([]byte, fieldparams.SyncAggregateSyncCommitteeBytesLength),
 			SyncCommitteeSignature: make([]byte, fieldparams.BLSSignatureLength),
 		},
-		ExecutionPayload: &pb.ExecutionPayloadElectra{
+		ExecutionPayload: &pb.ExecutionPayloadDeneb{
 			ParentHash:    make([]byte, fieldparams.RootLength),
 			FeeRecipient:  make([]byte, 20),
 			StateRoot:     make([]byte, fieldparams.RootLength),

--- a/consensus-types/blocks/proto.go
+++ b/consensus-types/blocks/proto.go
@@ -510,10 +510,10 @@ func (b *BeaconBlockBody) Proto() (proto.Message, error) {
 		}, nil
 	case version.Electra:
 		if b.IsBlinded() {
-			var ph *enginev1.ExecutionPayloadHeaderElectra
+			var ph *enginev1.ExecutionPayloadHeaderDeneb
 			var ok bool
 			if b.executionPayloadHeader != nil {
-				ph, ok = b.executionPayloadHeader.Proto().(*enginev1.ExecutionPayloadHeaderElectra)
+				ph, ok = b.executionPayloadHeader.Proto().(*enginev1.ExecutionPayloadHeaderDeneb)
 				if !ok {
 					return nil, errPayloadHeaderWrongType
 				}
@@ -534,10 +534,10 @@ func (b *BeaconBlockBody) Proto() (proto.Message, error) {
 				ExecutionRequests:      b.executionRequests,
 			}, nil
 		}
-		var p *enginev1.ExecutionPayloadElectra
+		var p *enginev1.ExecutionPayloadDeneb
 		var ok bool
 		if b.executionPayload != nil {
-			p, ok = b.executionPayload.Proto().(*enginev1.ExecutionPayloadElectra)
+			p, ok = b.executionPayload.Proto().(*enginev1.ExecutionPayloadDeneb)
 			if !ok {
 				return nil, errPayloadWrongType
 			}
@@ -563,6 +563,10 @@ func (b *BeaconBlockBody) Proto() (proto.Message, error) {
 	}
 }
 
+// ----------------------------------------------------------------------------
+// Phase 0
+// ----------------------------------------------------------------------------
+
 func initSignedBlockFromProtoPhase0(pb *eth.SignedBeaconBlock) (*SignedBeaconBlock, error) {
 	if pb == nil {
 		return nil, errNilBlock
@@ -574,159 +578,6 @@ func initSignedBlockFromProtoPhase0(pb *eth.SignedBeaconBlock) (*SignedBeaconBlo
 	}
 	b := &SignedBeaconBlock{
 		version:   version.Phase0,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initSignedBlockFromProtoAltair(pb *eth.SignedBeaconBlockAltair) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlockFromProtoAltair(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Altair,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initSignedBlockFromProtoBellatrix(pb *eth.SignedBeaconBlockBellatrix) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlockFromProtoBellatrix(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Bellatrix,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initSignedBlockFromProtoCapella(pb *eth.SignedBeaconBlockCapella) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlockFromProtoCapella(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Capella,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initSignedBlockFromProtoDeneb(pb *eth.SignedBeaconBlockDeneb) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlockFromProtoDeneb(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Deneb,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initSignedBlockFromProtoElectra(pb *eth.SignedBeaconBlockElectra) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlockFromProtoElectra(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Electra,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initBlindedSignedBlockFromProtoBellatrix(pb *eth.SignedBlindedBeaconBlockBellatrix) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlindedBlockFromProtoBellatrix(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Bellatrix,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initBlindedSignedBlockFromProtoCapella(pb *eth.SignedBlindedBeaconBlockCapella) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlindedBlockFromProtoCapella(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Capella,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initBlindedSignedBlockFromProtoDeneb(pb *eth.SignedBlindedBeaconBlockDeneb) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlindedBlockFromProtoDeneb(pb.Message)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Deneb,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initBlindedSignedBlockFromProtoElectra(pb *eth.SignedBlindedBeaconBlockElectra) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlindedBlockFromProtoElectra(pb.Message)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Electra,
 		block:     block,
 		signature: bytesutil.ToBytes96(pb.Signature),
 	}
@@ -753,6 +604,46 @@ func initBlockFromProtoPhase0(pb *eth.BeaconBlock) (*BeaconBlock, error) {
 	return b, nil
 }
 
+func initBlockBodyFromProtoPhase0(pb *eth.BeaconBlockBody) (*BeaconBlockBody, error) {
+	if pb == nil {
+		return nil, errNilBlockBody
+	}
+
+	b := &BeaconBlockBody{
+		version:           version.Phase0,
+		randaoReveal:      bytesutil.ToBytes96(pb.RandaoReveal),
+		eth1Data:          pb.Eth1Data,
+		graffiti:          bytesutil.ToBytes32(pb.Graffiti),
+		proposerSlashings: pb.ProposerSlashings,
+		attesterSlashings: pb.AttesterSlashings,
+		attestations:      pb.Attestations,
+		deposits:          pb.Deposits,
+		voluntaryExits:    pb.VoluntaryExits,
+	}
+	return b, nil
+}
+
+// ----------------------------------------------------------------------------
+// Altair
+// ----------------------------------------------------------------------------
+
+func initSignedBlockFromProtoAltair(pb *eth.SignedBeaconBlockAltair) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlockFromProtoAltair(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Altair,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
 func initBlockFromProtoAltair(pb *eth.BeaconBlockAltair) (*BeaconBlock, error) {
 	if pb == nil {
 		return nil, errNilBlock
@@ -769,6 +660,64 @@ func initBlockFromProtoAltair(pb *eth.BeaconBlockAltair) (*BeaconBlock, error) {
 		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
 		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
 		body:          body,
+	}
+	return b, nil
+}
+
+func initBlockBodyFromProtoAltair(pb *eth.BeaconBlockBodyAltair) (*BeaconBlockBody, error) {
+	if pb == nil {
+		return nil, errNilBlockBody
+	}
+
+	b := &BeaconBlockBody{
+		version:           version.Altair,
+		randaoReveal:      bytesutil.ToBytes96(pb.RandaoReveal),
+		eth1Data:          pb.Eth1Data,
+		graffiti:          bytesutil.ToBytes32(pb.Graffiti),
+		proposerSlashings: pb.ProposerSlashings,
+		attesterSlashings: pb.AttesterSlashings,
+		attestations:      pb.Attestations,
+		deposits:          pb.Deposits,
+		voluntaryExits:    pb.VoluntaryExits,
+		syncAggregate:     pb.SyncAggregate,
+	}
+	return b, nil
+}
+
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
+
+func initSignedBlockFromProtoBellatrix(pb *eth.SignedBeaconBlockBellatrix) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlockFromProtoBellatrix(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Bellatrix,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlindedSignedBlockFromProtoBellatrix(pb *eth.SignedBlindedBeaconBlockBellatrix) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlindedBlockFromProtoBellatrix(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Bellatrix,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
 	}
 	return b, nil
 }
@@ -809,165 +758,6 @@ func initBlindedBlockFromProtoBellatrix(pb *eth.BlindedBeaconBlockBellatrix) (*B
 		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
 		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
 		body:          body,
-	}
-	return b, nil
-}
-
-func initBlockFromProtoCapella(pb *eth.BeaconBlockCapella) (*BeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	body, err := initBlockBodyFromProtoCapella(pb.Body)
-	if err != nil {
-		return nil, err
-	}
-	b := &BeaconBlock{
-		version:       version.Capella,
-		slot:          pb.Slot,
-		proposerIndex: pb.ProposerIndex,
-		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
-		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
-		body:          body,
-	}
-	return b, nil
-}
-
-func initBlockFromProtoDeneb(pb *eth.BeaconBlockDeneb) (*BeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	body, err := initBlockBodyFromProtoDeneb(pb.Body)
-	if err != nil {
-		return nil, err
-	}
-	b := &BeaconBlock{
-		version:       version.Deneb,
-		slot:          pb.Slot,
-		proposerIndex: pb.ProposerIndex,
-		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
-		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
-		body:          body,
-	}
-	return b, nil
-}
-
-func initBlockFromProtoElectra(pb *eth.BeaconBlockElectra) (*BeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	body, err := initBlockBodyFromProtoElectra(pb.Body)
-	if err != nil {
-		return nil, err
-	}
-	b := &BeaconBlock{
-		version:       version.Electra,
-		slot:          pb.Slot,
-		proposerIndex: pb.ProposerIndex,
-		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
-		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
-		body:          body,
-	}
-	return b, nil
-}
-
-func initBlindedBlockFromProtoCapella(pb *eth.BlindedBeaconBlockCapella) (*BeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	body, err := initBlindedBlockBodyFromProtoCapella(pb.Body)
-	if err != nil {
-		return nil, err
-	}
-	b := &BeaconBlock{
-		version:       version.Capella,
-		slot:          pb.Slot,
-		proposerIndex: pb.ProposerIndex,
-		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
-		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
-		body:          body,
-	}
-	return b, nil
-}
-
-func initBlindedBlockFromProtoDeneb(pb *eth.BlindedBeaconBlockDeneb) (*BeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	body, err := initBlindedBlockBodyFromProtoDeneb(pb.Body)
-	if err != nil {
-		return nil, err
-	}
-	b := &BeaconBlock{
-		version:       version.Deneb,
-		slot:          pb.Slot,
-		proposerIndex: pb.ProposerIndex,
-		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
-		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
-		body:          body,
-	}
-	return b, nil
-}
-
-func initBlindedBlockFromProtoElectra(pb *eth.BlindedBeaconBlockElectra) (*BeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	body, err := initBlindedBlockBodyFromProtoElectra(pb.Body)
-	if err != nil {
-		return nil, err
-	}
-	b := &BeaconBlock{
-		version:       version.Electra,
-		slot:          pb.Slot,
-		proposerIndex: pb.ProposerIndex,
-		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
-		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
-		body:          body,
-	}
-	return b, nil
-}
-
-func initBlockBodyFromProtoPhase0(pb *eth.BeaconBlockBody) (*BeaconBlockBody, error) {
-	if pb == nil {
-		return nil, errNilBlockBody
-	}
-
-	b := &BeaconBlockBody{
-		version:           version.Phase0,
-		randaoReveal:      bytesutil.ToBytes96(pb.RandaoReveal),
-		eth1Data:          pb.Eth1Data,
-		graffiti:          bytesutil.ToBytes32(pb.Graffiti),
-		proposerSlashings: pb.ProposerSlashings,
-		attesterSlashings: pb.AttesterSlashings,
-		attestations:      pb.Attestations,
-		deposits:          pb.Deposits,
-		voluntaryExits:    pb.VoluntaryExits,
-	}
-	return b, nil
-}
-
-func initBlockBodyFromProtoAltair(pb *eth.BeaconBlockBodyAltair) (*BeaconBlockBody, error) {
-	if pb == nil {
-		return nil, errNilBlockBody
-	}
-
-	b := &BeaconBlockBody{
-		version:           version.Altair,
-		randaoReveal:      bytesutil.ToBytes96(pb.RandaoReveal),
-		eth1Data:          pb.Eth1Data,
-		graffiti:          bytesutil.ToBytes32(pb.Graffiti),
-		proposerSlashings: pb.ProposerSlashings,
-		attesterSlashings: pb.AttesterSlashings,
-		attestations:      pb.Attestations,
-		deposits:          pb.Deposits,
-		voluntaryExits:    pb.VoluntaryExits,
-		syncAggregate:     pb.SyncAggregate,
 	}
 	return b, nil
 }
@@ -1024,6 +814,84 @@ func initBlindedBlockBodyFromProtoBellatrix(pb *eth.BlindedBeaconBlockBodyBellat
 	return b, nil
 }
 
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
+
+func initSignedBlockFromProtoCapella(pb *eth.SignedBeaconBlockCapella) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlockFromProtoCapella(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Capella,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlindedSignedBlockFromProtoCapella(pb *eth.SignedBlindedBeaconBlockCapella) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlindedBlockFromProtoCapella(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Capella,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlockFromProtoCapella(pb *eth.BeaconBlockCapella) (*BeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	body, err := initBlockBodyFromProtoCapella(pb.Body)
+	if err != nil {
+		return nil, err
+	}
+	b := &BeaconBlock{
+		version:       version.Capella,
+		slot:          pb.Slot,
+		proposerIndex: pb.ProposerIndex,
+		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
+		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
+		body:          body,
+	}
+	return b, nil
+}
+
+func initBlindedBlockFromProtoCapella(pb *eth.BlindedBeaconBlockCapella) (*BeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	body, err := initBlindedBlockBodyFromProtoCapella(pb.Body)
+	if err != nil {
+		return nil, err
+	}
+	b := &BeaconBlock{
+		version:       version.Capella,
+		slot:          pb.Slot,
+		proposerIndex: pb.ProposerIndex,
+		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
+		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
+		body:          body,
+	}
+	return b, nil
+}
+
 func initBlockBodyFromProtoCapella(pb *eth.BeaconBlockBodyCapella) (*BeaconBlockBody, error) {
 	if pb == nil {
 		return nil, errNilBlockBody
@@ -1074,6 +942,84 @@ func initBlindedBlockBodyFromProtoCapella(pb *eth.BlindedBeaconBlockBodyCapella)
 		syncAggregate:          pb.SyncAggregate,
 		executionPayloadHeader: ph,
 		blsToExecutionChanges:  pb.BlsToExecutionChanges,
+	}
+	return b, nil
+}
+
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
+
+func initSignedBlockFromProtoDeneb(pb *eth.SignedBeaconBlockDeneb) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlockFromProtoDeneb(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Deneb,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlindedSignedBlockFromProtoDeneb(pb *eth.SignedBlindedBeaconBlockDeneb) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlindedBlockFromProtoDeneb(pb.Message)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Deneb,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlockFromProtoDeneb(pb *eth.BeaconBlockDeneb) (*BeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	body, err := initBlockBodyFromProtoDeneb(pb.Body)
+	if err != nil {
+		return nil, err
+	}
+	b := &BeaconBlock{
+		version:       version.Deneb,
+		slot:          pb.Slot,
+		proposerIndex: pb.ProposerIndex,
+		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
+		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
+		body:          body,
+	}
+	return b, nil
+}
+
+func initBlindedBlockFromProtoDeneb(pb *eth.BlindedBeaconBlockDeneb) (*BeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	body, err := initBlindedBlockBodyFromProtoDeneb(pb.Body)
+	if err != nil {
+		return nil, err
+	}
+	b := &BeaconBlock{
+		version:       version.Deneb,
+		slot:          pb.Slot,
+		proposerIndex: pb.ProposerIndex,
+		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
+		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
+		body:          body,
 	}
 	return b, nil
 }
@@ -1134,12 +1080,90 @@ func initBlindedBlockBodyFromProtoDeneb(pb *eth.BlindedBeaconBlockBodyDeneb) (*B
 	return b, nil
 }
 
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
+
+func initSignedBlockFromProtoElectra(pb *eth.SignedBeaconBlockElectra) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlockFromProtoElectra(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Electra,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlindedSignedBlockFromProtoElectra(pb *eth.SignedBlindedBeaconBlockElectra) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlindedBlockFromProtoElectra(pb.Message)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Electra,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlockFromProtoElectra(pb *eth.BeaconBlockElectra) (*BeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	body, err := initBlockBodyFromProtoElectra(pb.Body)
+	if err != nil {
+		return nil, err
+	}
+	b := &BeaconBlock{
+		version:       version.Electra,
+		slot:          pb.Slot,
+		proposerIndex: pb.ProposerIndex,
+		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
+		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
+		body:          body,
+	}
+	return b, nil
+}
+
+func initBlindedBlockFromProtoElectra(pb *eth.BlindedBeaconBlockElectra) (*BeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	body, err := initBlindedBlockBodyFromProtoElectra(pb.Body)
+	if err != nil {
+		return nil, err
+	}
+	b := &BeaconBlock{
+		version:       version.Electra,
+		slot:          pb.Slot,
+		proposerIndex: pb.ProposerIndex,
+		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
+		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
+		body:          body,
+	}
+	return b, nil
+}
+
 func initBlockBodyFromProtoElectra(pb *eth.BeaconBlockBodyElectra) (*BeaconBlockBody, error) {
 	if pb == nil {
 		return nil, errNilBlockBody
 	}
 
-	p, err := WrappedExecutionPayloadElectra(pb.ExecutionPayload)
+	p, err := WrappedExecutionPayloadDeneb(pb.ExecutionPayload)
 	// We allow the payload to be nil
 	if err != nil && !errors.Is(err, consensus_types.ErrNilObjectWrapped) {
 		return nil, err
@@ -1172,7 +1196,7 @@ func initBlindedBlockBodyFromProtoElectra(pb *eth.BlindedBeaconBlockBodyElectra)
 		return nil, errNilBlockBody
 	}
 
-	ph, err := WrappedExecutionPayloadHeaderElectra(pb.ExecutionPayloadHeader)
+	ph, err := WrappedExecutionPayloadHeaderDeneb(pb.ExecutionPayloadHeader)
 	// We allow the payload to be nil
 	if err != nil && !errors.Is(err, consensus_types.ErrNilObjectWrapped) {
 		return nil, err

--- a/encoding/ssz/detect/configfork_test.go
+++ b/encoding/ssz/detect/configfork_test.go
@@ -563,6 +563,10 @@ func TestUnmarshalBlindedBlock(t *testing.T) {
 	}
 }
 
+// ----------------------------------------------------------------------------
+// Phase 0
+// ----------------------------------------------------------------------------
+
 func signedTestBlockGenesis(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlock()
 	b.Block.Slot = slot
@@ -571,6 +575,10 @@ func signedTestBlockGenesis(t *testing.T, slot primitives.Slot) interfaces.ReadO
 	return s
 }
 
+// ----------------------------------------------------------------------------
+// Altair
+// ----------------------------------------------------------------------------
+
 func signedTestBlockAltair(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlockAltair()
 	b.Block.Slot = slot
@@ -578,6 +586,10 @@ func signedTestBlockAltair(t *testing.T, slot primitives.Slot) interfaces.ReadOn
 	require.NoError(t, err)
 	return s
 }
+
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
 
 func signedTestBlockBellatrix(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlockBellatrix()
@@ -595,6 +607,10 @@ func signedTestBlindedBlockBellatrix(t *testing.T, slot primitives.Slot) interfa
 	return s
 }
 
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
+
 func signedTestBlockCapella(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlockCapella()
 	b.Block.Slot = slot
@@ -611,16 +627,12 @@ func signedTestBlindedBlockCapella(t *testing.T, slot primitives.Slot) interface
 	return s
 }
 
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
+
 func signedTestBlockDeneb(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlockDeneb()
-	b.Block.Slot = slot
-	s, err := blocks.NewSignedBeaconBlock(b)
-	require.NoError(t, err)
-	return s
-}
-
-func signedTestBlockElectra(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
-	b := util.NewBeaconBlockElectra()
 	b.Block.Slot = slot
 	s, err := blocks.NewSignedBeaconBlock(b)
 	require.NoError(t, err)
@@ -630,6 +642,18 @@ func signedTestBlockElectra(t *testing.T, slot primitives.Slot) interfaces.ReadO
 func signedTestBlindedBlockDeneb(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBlindedBeaconBlockDeneb()
 	b.Message.Slot = slot
+	s, err := blocks.NewSignedBeaconBlock(b)
+	require.NoError(t, err)
+	return s
+}
+
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
+
+func signedTestBlockElectra(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
+	b := util.NewBeaconBlockElectra()
+	b.Block.Slot = slot
 	s, err := blocks.NewSignedBeaconBlock(b)
 	require.NoError(t, err)
 	return s

--- a/proto/engine/v1/electra.go
+++ b/proto/engine/v1/electra.go
@@ -8,9 +8,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 )
 
-type ExecutionPayloadElectra = ExecutionPayloadDeneb
-type ExecutionPayloadHeaderElectra = ExecutionPayloadHeaderDeneb
-
 var (
 	drExample = &DepositRequest{}
 	drSize    = drExample.SizeSSZ()

--- a/proto/prysm/v1alpha1/beacon_block.go
+++ b/proto/prysm/v1alpha1/beacon_block.go
@@ -5,6 +5,10 @@ import (
 	enginev1 "github.com/prysmaticlabs/prysm/v5/proto/engine/v1"
 )
 
+// ----------------------------------------------------------------------------
+// Phase 0
+// ----------------------------------------------------------------------------
+
 // Copy --
 func (sigBlock *SignedBeaconBlock) Copy() *SignedBeaconBlock {
 	if sigBlock == nil {
@@ -44,443 +48,6 @@ func (body *BeaconBlockBody) Copy() *BeaconBlockBody {
 		Attestations:      CopySlice(body.Attestations),
 		Deposits:          CopySlice(body.Deposits),
 		VoluntaryExits:    CopySlice(body.VoluntaryExits),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBeaconBlockAltair) Copy() *SignedBeaconBlockAltair {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBeaconBlockAltair{
-		Block:     sigBlock.Block.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BeaconBlockAltair) Copy() *BeaconBlockAltair {
-	if block == nil {
-		return nil
-	}
-	return &BeaconBlockAltair{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BeaconBlockBodyAltair) Copy() *BeaconBlockBodyAltair {
-	if body == nil {
-		return nil
-	}
-	return &BeaconBlockBodyAltair{
-		RandaoReveal:      bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:          body.Eth1Data.Copy(),
-		Graffiti:          bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings: CopySlice(body.ProposerSlashings),
-		AttesterSlashings: CopySlice(body.AttesterSlashings),
-		Attestations:      CopySlice(body.Attestations),
-		Deposits:          CopySlice(body.Deposits),
-		VoluntaryExits:    CopySlice(body.VoluntaryExits),
-		SyncAggregate:     body.SyncAggregate.Copy(),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBeaconBlockBellatrix) Copy() *SignedBeaconBlockBellatrix {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBeaconBlockBellatrix{
-		Block:     sigBlock.Block.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BeaconBlockBellatrix) Copy() *BeaconBlockBellatrix {
-	if block == nil {
-		return nil
-	}
-	return &BeaconBlockBellatrix{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BeaconBlockBodyBellatrix) Copy() *BeaconBlockBodyBellatrix {
-	if body == nil {
-		return nil
-	}
-	return &BeaconBlockBodyBellatrix{
-		RandaoReveal:      bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:          body.Eth1Data.Copy(),
-		Graffiti:          bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings: CopySlice(body.ProposerSlashings),
-		AttesterSlashings: CopySlice(body.AttesterSlashings),
-		Attestations:      CopySlice(body.Attestations),
-		Deposits:          CopySlice(body.Deposits),
-		VoluntaryExits:    CopySlice(body.VoluntaryExits),
-		SyncAggregate:     body.SyncAggregate.Copy(),
-		ExecutionPayload:  body.ExecutionPayload.Copy(),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBeaconBlockCapella) Copy() *SignedBeaconBlockCapella {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBeaconBlockCapella{
-		Block:     sigBlock.Block.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BeaconBlockCapella) Copy() *BeaconBlockCapella {
-	if block == nil {
-		return nil
-	}
-	return &BeaconBlockCapella{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BeaconBlockBodyCapella) Copy() *BeaconBlockBodyCapella {
-	if body == nil {
-		return nil
-	}
-	return &BeaconBlockBodyCapella{
-		RandaoReveal:          bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:              body.Eth1Data.Copy(),
-		Graffiti:              bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings:     CopySlice(body.ProposerSlashings),
-		AttesterSlashings:     CopySlice(body.AttesterSlashings),
-		Attestations:          CopySlice(body.Attestations),
-		Deposits:              CopySlice(body.Deposits),
-		VoluntaryExits:        CopySlice(body.VoluntaryExits),
-		SyncAggregate:         body.SyncAggregate.Copy(),
-		ExecutionPayload:      body.ExecutionPayload.Copy(),
-		BlsToExecutionChanges: CopySlice(body.BlsToExecutionChanges),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBlindedBeaconBlockCapella) Copy() *SignedBlindedBeaconBlockCapella {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBlindedBeaconBlockCapella{
-		Block:     sigBlock.Block.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BlindedBeaconBlockCapella) Copy() *BlindedBeaconBlockCapella {
-	if block == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockCapella{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BlindedBeaconBlockBodyCapella) Copy() *BlindedBeaconBlockBodyCapella {
-	if body == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockBodyCapella{
-		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:               body.Eth1Data.Copy(),
-		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings:      CopySlice(body.ProposerSlashings),
-		AttesterSlashings:      CopySlice(body.AttesterSlashings),
-		Attestations:           CopySlice(body.Attestations),
-		Deposits:               CopySlice(body.Deposits),
-		VoluntaryExits:         CopySlice(body.VoluntaryExits),
-		SyncAggregate:          body.SyncAggregate.Copy(),
-		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
-		BlsToExecutionChanges:  CopySlice(body.BlsToExecutionChanges),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBlindedBeaconBlockDeneb) Copy() *SignedBlindedBeaconBlockDeneb {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBlindedBeaconBlockDeneb{
-		Message:   sigBlock.Message.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BlindedBeaconBlockDeneb) Copy() *BlindedBeaconBlockDeneb {
-	if block == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockDeneb{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BlindedBeaconBlockBodyDeneb) Copy() *BlindedBeaconBlockBodyDeneb {
-	if body == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockBodyDeneb{
-		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:               body.Eth1Data.Copy(),
-		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings:      CopySlice(body.ProposerSlashings),
-		AttesterSlashings:      CopySlice(body.AttesterSlashings),
-		Attestations:           CopySlice(body.Attestations),
-		Deposits:               CopySlice(body.Deposits),
-		VoluntaryExits:         CopySlice(body.VoluntaryExits),
-		SyncAggregate:          body.SyncAggregate.Copy(),
-		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
-		BlsToExecutionChanges:  CopySlice(body.BlsToExecutionChanges),
-		BlobKzgCommitments:     CopyBlobKZGs(body.BlobKzgCommitments),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBlindedBeaconBlockElectra) Copy() *SignedBlindedBeaconBlockElectra {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBlindedBeaconBlockElectra{
-		Message:   sigBlock.Message.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BlindedBeaconBlockElectra) Copy() *BlindedBeaconBlockElectra {
-	if block == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockElectra{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BlindedBeaconBlockBodyElectra) Copy() *BlindedBeaconBlockBodyElectra {
-	if body == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockBodyElectra{
-		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:               body.Eth1Data.Copy(),
-		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings:      CopySlice(body.ProposerSlashings),
-		AttesterSlashings:      CopySlice(body.AttesterSlashings),
-		Attestations:           CopySlice(body.Attestations),
-		Deposits:               CopySlice(body.Deposits),
-		VoluntaryExits:         CopySlice(body.VoluntaryExits),
-		SyncAggregate:          body.SyncAggregate.Copy(),
-		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
-		BlsToExecutionChanges:  CopySlice(body.BlsToExecutionChanges),
-		BlobKzgCommitments:     CopyBlobKZGs(body.BlobKzgCommitments),
-		ExecutionRequests:      CopyExecutionRequests(body.ExecutionRequests),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBlindedBeaconBlockBellatrix) Copy() *SignedBlindedBeaconBlockBellatrix {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBlindedBeaconBlockBellatrix{
-		Block:     sigBlock.Block.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BlindedBeaconBlockBellatrix) Copy() *BlindedBeaconBlockBellatrix {
-	if block == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockBellatrix{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BlindedBeaconBlockBodyBellatrix) Copy() *BlindedBeaconBlockBodyBellatrix {
-	if body == nil {
-		return nil
-	}
-	return &BlindedBeaconBlockBodyBellatrix{
-		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:               body.Eth1Data.Copy(),
-		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings:      CopySlice(body.ProposerSlashings),
-		AttesterSlashings:      CopySlice(body.AttesterSlashings),
-		Attestations:           CopySlice(body.Attestations),
-		Deposits:               CopySlice(body.Deposits),
-		VoluntaryExits:         CopySlice(body.VoluntaryExits),
-		SyncAggregate:          body.SyncAggregate.Copy(),
-		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
-	}
-}
-
-// CopyBlobKZGs copies the provided blob kzgs object.
-func CopyBlobKZGs(b [][]byte) [][]byte {
-	return bytesutil.SafeCopy2dBytes(b)
-}
-
-// CopyExecutionRequests copies the provided execution requests.
-func CopyExecutionRequests(e *enginev1.ExecutionRequests) *enginev1.ExecutionRequests {
-	if e == nil {
-		return nil
-	}
-	dr := make([]*enginev1.DepositRequest, len(e.Deposits))
-	for i, d := range e.Deposits {
-		dr[i] = d.Copy()
-	}
-	wr := make([]*enginev1.WithdrawalRequest, len(e.Withdrawals))
-	for i, w := range e.Withdrawals {
-		wr[i] = w.Copy()
-	}
-	cr := make([]*enginev1.ConsolidationRequest, len(e.Consolidations))
-	for i, c := range e.Consolidations {
-		cr[i] = c.Copy()
-	}
-
-	return &enginev1.ExecutionRequests{
-		Deposits:       dr,
-		Withdrawals:    wr,
-		Consolidations: cr,
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBeaconBlockDeneb) Copy() *SignedBeaconBlockDeneb {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBeaconBlockDeneb{
-		Block:     sigBlock.Block.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BeaconBlockDeneb) Copy() *BeaconBlockDeneb {
-	if block == nil {
-		return nil
-	}
-	return &BeaconBlockDeneb{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BeaconBlockBodyDeneb) Copy() *BeaconBlockBodyDeneb {
-	if body == nil {
-		return nil
-	}
-	return &BeaconBlockBodyDeneb{
-		RandaoReveal:          bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:              body.Eth1Data.Copy(),
-		Graffiti:              bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings:     CopySlice(body.ProposerSlashings),
-		AttesterSlashings:     CopySlice(body.AttesterSlashings),
-		Attestations:          CopySlice(body.Attestations),
-		Deposits:              CopySlice(body.Deposits),
-		VoluntaryExits:        CopySlice(body.VoluntaryExits),
-		SyncAggregate:         body.SyncAggregate.Copy(),
-		ExecutionPayload:      body.ExecutionPayload.Copy(),
-		BlsToExecutionChanges: CopySlice(body.BlsToExecutionChanges),
-		BlobKzgCommitments:    CopyBlobKZGs(body.BlobKzgCommitments),
-	}
-}
-
-// Copy --
-func (sigBlock *SignedBeaconBlockElectra) Copy() *SignedBeaconBlockElectra {
-	if sigBlock == nil {
-		return nil
-	}
-	return &SignedBeaconBlockElectra{
-		Block:     sigBlock.Block.Copy(),
-		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
-	}
-}
-
-// Copy --
-func (block *BeaconBlockElectra) Copy() *BeaconBlockElectra {
-	if block == nil {
-		return nil
-	}
-	return &BeaconBlockElectra{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
-		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
-		Body:          block.Body.Copy(),
-	}
-}
-
-// Copy --
-func (body *BeaconBlockBodyElectra) Copy() *BeaconBlockBodyElectra {
-	if body == nil {
-		return nil
-	}
-	return &BeaconBlockBodyElectra{
-		RandaoReveal:          bytesutil.SafeCopyBytes(body.RandaoReveal),
-		Eth1Data:              body.Eth1Data.Copy(),
-		Graffiti:              bytesutil.SafeCopyBytes(body.Graffiti),
-		ProposerSlashings:     CopySlice(body.ProposerSlashings),
-		AttesterSlashings:     CopySlice(body.AttesterSlashings),
-		Attestations:          CopySlice(body.Attestations),
-		Deposits:              CopySlice(body.Deposits),
-		VoluntaryExits:        CopySlice(body.VoluntaryExits),
-		SyncAggregate:         body.SyncAggregate.Copy(),
-		ExecutionPayload:      body.ExecutionPayload.Copy(),
-		BlsToExecutionChanges: CopySlice(body.BlsToExecutionChanges),
-		BlobKzgCommitments:    CopyBlobKZGs(body.BlobKzgCommitments),
-		ExecutionRequests:     CopyExecutionRequests(body.ExecutionRequests),
 	}
 }
 
@@ -581,6 +148,53 @@ func (exit *VoluntaryExit) Copy() *VoluntaryExit {
 	}
 }
 
+// ----------------------------------------------------------------------------
+// Altair
+// ----------------------------------------------------------------------------
+
+// Copy --
+func (sigBlock *SignedBeaconBlockAltair) Copy() *SignedBeaconBlockAltair {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBeaconBlockAltair{
+		Block:     sigBlock.Block.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BeaconBlockAltair) Copy() *BeaconBlockAltair {
+	if block == nil {
+		return nil
+	}
+	return &BeaconBlockAltair{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BeaconBlockBodyAltair) Copy() *BeaconBlockBodyAltair {
+	if body == nil {
+		return nil
+	}
+	return &BeaconBlockBodyAltair{
+		RandaoReveal:      bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:          body.Eth1Data.Copy(),
+		Graffiti:          bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings: CopySlice(body.ProposerSlashings),
+		AttesterSlashings: CopySlice(body.AttesterSlashings),
+		Attestations:      CopySlice(body.Attestations),
+		Deposits:          CopySlice(body.Deposits),
+		VoluntaryExits:    CopySlice(body.VoluntaryExits),
+		SyncAggregate:     body.SyncAggregate.Copy(),
+	}
+}
+
 // Copy --
 func (a *SyncAggregate) Copy() *SyncAggregate {
 	if a == nil {
@@ -589,6 +203,203 @@ func (a *SyncAggregate) Copy() *SyncAggregate {
 	return &SyncAggregate{
 		SyncCommitteeBits:      bytesutil.SafeCopyBytes(a.SyncCommitteeBits),
 		SyncCommitteeSignature: bytesutil.SafeCopyBytes(a.SyncCommitteeSignature),
+	}
+}
+
+// Copy --
+func (summary *HistoricalSummary) Copy() *HistoricalSummary {
+	if summary == nil {
+		return nil
+	}
+	return &HistoricalSummary{
+		BlockSummaryRoot: bytesutil.SafeCopyBytes(summary.BlockSummaryRoot),
+		StateSummaryRoot: bytesutil.SafeCopyBytes(summary.StateSummaryRoot),
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
+
+// Copy --
+func (sigBlock *SignedBeaconBlockBellatrix) Copy() *SignedBeaconBlockBellatrix {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBeaconBlockBellatrix{
+		Block:     sigBlock.Block.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BeaconBlockBellatrix) Copy() *BeaconBlockBellatrix {
+	if block == nil {
+		return nil
+	}
+	return &BeaconBlockBellatrix{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BeaconBlockBodyBellatrix) Copy() *BeaconBlockBodyBellatrix {
+	if body == nil {
+		return nil
+	}
+	return &BeaconBlockBodyBellatrix{
+		RandaoReveal:      bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:          body.Eth1Data.Copy(),
+		Graffiti:          bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings: CopySlice(body.ProposerSlashings),
+		AttesterSlashings: CopySlice(body.AttesterSlashings),
+		Attestations:      CopySlice(body.Attestations),
+		Deposits:          CopySlice(body.Deposits),
+		VoluntaryExits:    CopySlice(body.VoluntaryExits),
+		SyncAggregate:     body.SyncAggregate.Copy(),
+		ExecutionPayload:  body.ExecutionPayload.Copy(),
+	}
+}
+
+// Copy --
+func (sigBlock *SignedBlindedBeaconBlockBellatrix) Copy() *SignedBlindedBeaconBlockBellatrix {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBlindedBeaconBlockBellatrix{
+		Block:     sigBlock.Block.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BlindedBeaconBlockBellatrix) Copy() *BlindedBeaconBlockBellatrix {
+	if block == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockBellatrix{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BlindedBeaconBlockBodyBellatrix) Copy() *BlindedBeaconBlockBodyBellatrix {
+	if body == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockBodyBellatrix{
+		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:               body.Eth1Data.Copy(),
+		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings:      CopySlice(body.ProposerSlashings),
+		AttesterSlashings:      CopySlice(body.AttesterSlashings),
+		Attestations:           CopySlice(body.Attestations),
+		Deposits:               CopySlice(body.Deposits),
+		VoluntaryExits:         CopySlice(body.VoluntaryExits),
+		SyncAggregate:          body.SyncAggregate.Copy(),
+		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
+
+// Copy --
+func (sigBlock *SignedBeaconBlockCapella) Copy() *SignedBeaconBlockCapella {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBeaconBlockCapella{
+		Block:     sigBlock.Block.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BeaconBlockCapella) Copy() *BeaconBlockCapella {
+	if block == nil {
+		return nil
+	}
+	return &BeaconBlockCapella{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BeaconBlockBodyCapella) Copy() *BeaconBlockBodyCapella {
+	if body == nil {
+		return nil
+	}
+	return &BeaconBlockBodyCapella{
+		RandaoReveal:          bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:              body.Eth1Data.Copy(),
+		Graffiti:              bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings:     CopySlice(body.ProposerSlashings),
+		AttesterSlashings:     CopySlice(body.AttesterSlashings),
+		Attestations:          CopySlice(body.Attestations),
+		Deposits:              CopySlice(body.Deposits),
+		VoluntaryExits:        CopySlice(body.VoluntaryExits),
+		SyncAggregate:         body.SyncAggregate.Copy(),
+		ExecutionPayload:      body.ExecutionPayload.Copy(),
+		BlsToExecutionChanges: CopySlice(body.BlsToExecutionChanges),
+	}
+}
+
+// Copy --
+func (sigBlock *SignedBlindedBeaconBlockCapella) Copy() *SignedBlindedBeaconBlockCapella {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBlindedBeaconBlockCapella{
+		Block:     sigBlock.Block.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BlindedBeaconBlockCapella) Copy() *BlindedBeaconBlockCapella {
+	if block == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockCapella{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BlindedBeaconBlockBodyCapella) Copy() *BlindedBeaconBlockBodyCapella {
+	if body == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockBodyCapella{
+		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:               body.Eth1Data.Copy(),
+		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings:      CopySlice(body.ProposerSlashings),
+		AttesterSlashings:      CopySlice(body.AttesterSlashings),
+		Attestations:           CopySlice(body.Attestations),
+		Deposits:               CopySlice(body.Deposits),
+		VoluntaryExits:         CopySlice(body.VoluntaryExits),
+		SyncAggregate:          body.SyncAggregate.Copy(),
+		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
+		BlsToExecutionChanges:  CopySlice(body.BlsToExecutionChanges),
 	}
 }
 
@@ -615,13 +426,226 @@ func (change *BLSToExecutionChange) Copy() *BLSToExecutionChange {
 	}
 }
 
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
+
 // Copy --
-func (summary *HistoricalSummary) Copy() *HistoricalSummary {
-	if summary == nil {
+func (sigBlock *SignedBlindedBeaconBlockDeneb) Copy() *SignedBlindedBeaconBlockDeneb {
+	if sigBlock == nil {
 		return nil
 	}
-	return &HistoricalSummary{
-		BlockSummaryRoot: bytesutil.SafeCopyBytes(summary.BlockSummaryRoot),
-		StateSummaryRoot: bytesutil.SafeCopyBytes(summary.StateSummaryRoot),
+	return &SignedBlindedBeaconBlockDeneb{
+		Message:   sigBlock.Message.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BlindedBeaconBlockDeneb) Copy() *BlindedBeaconBlockDeneb {
+	if block == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockDeneb{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BlindedBeaconBlockBodyDeneb) Copy() *BlindedBeaconBlockBodyDeneb {
+	if body == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockBodyDeneb{
+		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:               body.Eth1Data.Copy(),
+		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings:      CopySlice(body.ProposerSlashings),
+		AttesterSlashings:      CopySlice(body.AttesterSlashings),
+		Attestations:           CopySlice(body.Attestations),
+		Deposits:               CopySlice(body.Deposits),
+		VoluntaryExits:         CopySlice(body.VoluntaryExits),
+		SyncAggregate:          body.SyncAggregate.Copy(),
+		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
+		BlsToExecutionChanges:  CopySlice(body.BlsToExecutionChanges),
+		BlobKzgCommitments:     CopyBlobKZGs(body.BlobKzgCommitments),
+	}
+}
+
+// Copy --
+func (sigBlock *SignedBeaconBlockDeneb) Copy() *SignedBeaconBlockDeneb {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBeaconBlockDeneb{
+		Block:     sigBlock.Block.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BeaconBlockDeneb) Copy() *BeaconBlockDeneb {
+	if block == nil {
+		return nil
+	}
+	return &BeaconBlockDeneb{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BeaconBlockBodyDeneb) Copy() *BeaconBlockBodyDeneb {
+	if body == nil {
+		return nil
+	}
+	return &BeaconBlockBodyDeneb{
+		RandaoReveal:          bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:              body.Eth1Data.Copy(),
+		Graffiti:              bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings:     CopySlice(body.ProposerSlashings),
+		AttesterSlashings:     CopySlice(body.AttesterSlashings),
+		Attestations:          CopySlice(body.Attestations),
+		Deposits:              CopySlice(body.Deposits),
+		VoluntaryExits:        CopySlice(body.VoluntaryExits),
+		SyncAggregate:         body.SyncAggregate.Copy(),
+		ExecutionPayload:      body.ExecutionPayload.Copy(),
+		BlsToExecutionChanges: CopySlice(body.BlsToExecutionChanges),
+		BlobKzgCommitments:    CopyBlobKZGs(body.BlobKzgCommitments),
+	}
+}
+
+// CopyBlobKZGs copies the provided blob kzgs object.
+func CopyBlobKZGs(b [][]byte) [][]byte {
+	return bytesutil.SafeCopy2dBytes(b)
+}
+
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
+
+// Copy --
+func (sigBlock *SignedBlindedBeaconBlockElectra) Copy() *SignedBlindedBeaconBlockElectra {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBlindedBeaconBlockElectra{
+		Message:   sigBlock.Message.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BlindedBeaconBlockElectra) Copy() *BlindedBeaconBlockElectra {
+	if block == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockElectra{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BlindedBeaconBlockBodyElectra) Copy() *BlindedBeaconBlockBodyElectra {
+	if body == nil {
+		return nil
+	}
+	return &BlindedBeaconBlockBodyElectra{
+		RandaoReveal:           bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:               body.Eth1Data.Copy(),
+		Graffiti:               bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings:      CopySlice(body.ProposerSlashings),
+		AttesterSlashings:      CopySlice(body.AttesterSlashings),
+		Attestations:           CopySlice(body.Attestations),
+		Deposits:               CopySlice(body.Deposits),
+		VoluntaryExits:         CopySlice(body.VoluntaryExits),
+		SyncAggregate:          body.SyncAggregate.Copy(),
+		ExecutionPayloadHeader: body.ExecutionPayloadHeader.Copy(),
+		BlsToExecutionChanges:  CopySlice(body.BlsToExecutionChanges),
+		BlobKzgCommitments:     CopyBlobKZGs(body.BlobKzgCommitments),
+		ExecutionRequests:      CopyExecutionRequests(body.ExecutionRequests),
+	}
+}
+
+// Copy --
+func (sigBlock *SignedBeaconBlockElectra) Copy() *SignedBeaconBlockElectra {
+	if sigBlock == nil {
+		return nil
+	}
+	return &SignedBeaconBlockElectra{
+		Block:     sigBlock.Block.Copy(),
+		Signature: bytesutil.SafeCopyBytes(sigBlock.Signature),
+	}
+}
+
+// Copy --
+func (block *BeaconBlockElectra) Copy() *BeaconBlockElectra {
+	if block == nil {
+		return nil
+	}
+	return &BeaconBlockElectra{
+		Slot:          block.Slot,
+		ProposerIndex: block.ProposerIndex,
+		ParentRoot:    bytesutil.SafeCopyBytes(block.ParentRoot),
+		StateRoot:     bytesutil.SafeCopyBytes(block.StateRoot),
+		Body:          block.Body.Copy(),
+	}
+}
+
+// Copy --
+func (body *BeaconBlockBodyElectra) Copy() *BeaconBlockBodyElectra {
+	if body == nil {
+		return nil
+	}
+	return &BeaconBlockBodyElectra{
+		RandaoReveal:          bytesutil.SafeCopyBytes(body.RandaoReveal),
+		Eth1Data:              body.Eth1Data.Copy(),
+		Graffiti:              bytesutil.SafeCopyBytes(body.Graffiti),
+		ProposerSlashings:     CopySlice(body.ProposerSlashings),
+		AttesterSlashings:     CopySlice(body.AttesterSlashings),
+		Attestations:          CopySlice(body.Attestations),
+		Deposits:              CopySlice(body.Deposits),
+		VoluntaryExits:        CopySlice(body.VoluntaryExits),
+		SyncAggregate:         body.SyncAggregate.Copy(),
+		ExecutionPayload:      body.ExecutionPayload.Copy(),
+		BlsToExecutionChanges: CopySlice(body.BlsToExecutionChanges),
+		BlobKzgCommitments:    CopyBlobKZGs(body.BlobKzgCommitments),
+		ExecutionRequests:     CopyExecutionRequests(body.ExecutionRequests),
+	}
+}
+
+// CopyExecutionRequests copies the provided execution requests.
+func CopyExecutionRequests(e *enginev1.ExecutionRequests) *enginev1.ExecutionRequests {
+	if e == nil {
+		return nil
+	}
+	dr := make([]*enginev1.DepositRequest, len(e.Deposits))
+	for i, d := range e.Deposits {
+		dr[i] = d.Copy()
+	}
+	wr := make([]*enginev1.WithdrawalRequest, len(e.Withdrawals))
+	for i, w := range e.Withdrawals {
+		wr[i] = w.Copy()
+	}
+	cr := make([]*enginev1.ConsolidationRequest, len(e.Consolidations))
+	for i, c := range e.Consolidations {
+		cr[i] = c.Copy()
+	}
+
+	return &enginev1.ExecutionRequests{
+		Deposits:       dr,
+		Withdrawals:    wr,
+		Consolidations: cr,
 	}
 }

--- a/proto/prysm/v1alpha1/beacon_state.proto
+++ b/proto/prysm/v1alpha1/beacon_state.proto
@@ -381,6 +381,10 @@ message BeaconStateDeneb {
   repeated HistoricalSummary historical_summaries = 11003 [(ethereum.eth.ext.ssz_max) = "16777216"];
 }
 
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
+
 message BeaconStateElectra {
   // Versioning [1001-2000]
   uint64 genesis_time = 1001;

--- a/runtime/interop/BUILD.bazel
+++ b/runtime/interop/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
-        "//consensus-types/interfaces:go_default_library",
         "//container/trie:go_default_library",
         "//crypto/bls:go_default_library",
         "//crypto/hash:go_default_library",

--- a/runtime/interop/premine-state.go
+++ b/runtime/interop/premine-state.go
@@ -13,7 +13,6 @@ import (
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
-	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/container/trie"
 	"github.com/prysmaticlabs/prysm/v5/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
@@ -543,7 +542,7 @@ func (s *PremineGenesisConfig) setLatestBlockHeader(g state.BeaconState) error {
 				SyncCommitteeBits:      make([]byte, fieldparams.SyncCommitteeLength/8),
 				SyncCommitteeSignature: make([]byte, fieldparams.BLSSignatureLength),
 			},
-			ExecutionPayload: &enginev1.ExecutionPayloadElectra{
+			ExecutionPayload: &enginev1.ExecutionPayloadDeneb{
 				ParentHash:    make([]byte, 32),
 				FeeRecipient:  make([]byte, 20),
 				StateRoot:     make([]byte, 32),
@@ -581,74 +580,9 @@ func (s *PremineGenesisConfig) setLatestBlockHeader(g state.BeaconState) error {
 }
 
 func (s *PremineGenesisConfig) setExecutionPayload(g state.BeaconState) error {
-	if s.Version < version.Bellatrix {
-		return nil
-	}
-
 	gb := s.GB
 
-	var ed interfaces.ExecutionData
-	switch s.Version {
-	case version.Bellatrix:
-		payload := &enginev1.ExecutionPayload{
-			ParentHash:    gb.ParentHash().Bytes(),
-			FeeRecipient:  gb.Coinbase().Bytes(),
-			StateRoot:     gb.Root().Bytes(),
-			ReceiptsRoot:  gb.ReceiptHash().Bytes(),
-			LogsBloom:     gb.Bloom().Bytes(),
-			PrevRandao:    params.BeaconConfig().ZeroHash[:],
-			BlockNumber:   gb.NumberU64(),
-			GasLimit:      gb.GasLimit(),
-			GasUsed:       gb.GasUsed(),
-			Timestamp:     gb.Time(),
-			ExtraData:     gb.Extra()[:32],
-			BaseFeePerGas: bytesutil.PadTo(bytesutil.ReverseByteOrder(gb.BaseFee().Bytes()), fieldparams.RootLength),
-			BlockHash:     gb.Hash().Bytes(),
-			Transactions:  make([][]byte, 0),
-		}
-		wep, err := blocks.WrappedExecutionPayload(payload)
-		if err != nil {
-			return err
-		}
-		eph, err := blocks.PayloadToHeader(wep)
-		if err != nil {
-			return err
-		}
-		ed, err = blocks.WrappedExecutionPayloadHeader(eph)
-		if err != nil {
-			return err
-		}
-	case version.Capella:
-		payload := &enginev1.ExecutionPayloadCapella{
-			ParentHash:    gb.ParentHash().Bytes(),
-			FeeRecipient:  gb.Coinbase().Bytes(),
-			StateRoot:     gb.Root().Bytes(),
-			ReceiptsRoot:  gb.ReceiptHash().Bytes(),
-			LogsBloom:     gb.Bloom().Bytes(),
-			PrevRandao:    params.BeaconConfig().ZeroHash[:],
-			BlockNumber:   gb.NumberU64(),
-			GasLimit:      gb.GasLimit(),
-			GasUsed:       gb.GasUsed(),
-			Timestamp:     gb.Time(),
-			ExtraData:     gb.Extra()[:32],
-			BaseFeePerGas: bytesutil.PadTo(bytesutil.ReverseByteOrder(gb.BaseFee().Bytes()), fieldparams.RootLength),
-			BlockHash:     gb.Hash().Bytes(),
-			Transactions:  make([][]byte, 0),
-			Withdrawals:   make([]*enginev1.Withdrawal, 0),
-		}
-		wep, err := blocks.WrappedExecutionPayloadCapella(payload)
-		if err != nil {
-			return err
-		}
-		eph, err := blocks.PayloadToHeaderCapella(wep)
-		if err != nil {
-			return err
-		}
-		ed, err = blocks.WrappedExecutionPayloadHeaderCapella(eph)
-		if err != nil {
-			return err
-		}
-	case version.Deneb:
+	if s.Version >= version.Deneb {
 		payload := &enginev1.ExecutionPayloadDeneb{
 			ParentHash:    gb.ParentHash().Bytes(),
 			FeeRecipient:  gb.Coinbase().Bytes(),
@@ -668,20 +602,27 @@ func (s *PremineGenesisConfig) setExecutionPayload(g state.BeaconState) error {
 			ExcessBlobGas: unwrapUint64Ptr(gb.ExcessBlobGas()),
 			BlobGasUsed:   unwrapUint64Ptr(gb.BlobGasUsed()),
 		}
+
 		wep, err := blocks.WrappedExecutionPayloadDeneb(payload)
 		if err != nil {
 			return err
 		}
+
 		eph, err := blocks.PayloadToHeaderDeneb(wep)
 		if err != nil {
 			return err
 		}
-		ed, err = blocks.WrappedExecutionPayloadHeaderDeneb(eph)
+
+		ed, err := blocks.WrappedExecutionPayloadHeaderDeneb(eph)
 		if err != nil {
 			return err
 		}
-	case version.Electra:
-		payload := &enginev1.ExecutionPayloadElectra{
+
+		return g.SetLatestExecutionPayloadHeader(ed)
+	}
+
+	if s.Version >= version.Capella {
+		payload := &enginev1.ExecutionPayloadCapella{
 			ParentHash:    gb.ParentHash().Bytes(),
 			FeeRecipient:  gb.Coinbase().Bytes(),
 			StateRoot:     gb.Root().Bytes(),
@@ -697,25 +638,67 @@ func (s *PremineGenesisConfig) setExecutionPayload(g state.BeaconState) error {
 			BlockHash:     gb.Hash().Bytes(),
 			Transactions:  make([][]byte, 0),
 			Withdrawals:   make([]*enginev1.Withdrawal, 0),
-			ExcessBlobGas: *gb.ExcessBlobGas(),
-			BlobGasUsed:   *gb.BlobGasUsed(),
 		}
-		wep, err := blocks.WrappedExecutionPayloadElectra(payload)
+
+		wep, err := blocks.WrappedExecutionPayloadCapella(payload)
 		if err != nil {
 			return err
 		}
-		eph, err := blocks.PayloadToHeaderElectra(wep)
+
+		eph, err := blocks.PayloadToHeaderCapella(wep)
 		if err != nil {
 			return err
 		}
-		ed, err = blocks.WrappedExecutionPayloadHeaderElectra(eph)
+
+		ed, err := blocks.WrappedExecutionPayloadHeaderCapella(eph)
 		if err != nil {
 			return err
 		}
-	default:
-		return errUnsupportedVersion
+
+		return g.SetLatestExecutionPayloadHeader(ed)
 	}
-	return g.SetLatestExecutionPayloadHeader(ed)
+
+	if s.Version >= version.Bellatrix {
+		payload := &enginev1.ExecutionPayload{
+			ParentHash:    gb.ParentHash().Bytes(),
+			FeeRecipient:  gb.Coinbase().Bytes(),
+			StateRoot:     gb.Root().Bytes(),
+			ReceiptsRoot:  gb.ReceiptHash().Bytes(),
+			LogsBloom:     gb.Bloom().Bytes(),
+			PrevRandao:    params.BeaconConfig().ZeroHash[:],
+			BlockNumber:   gb.NumberU64(),
+			GasLimit:      gb.GasLimit(),
+			GasUsed:       gb.GasUsed(),
+			Timestamp:     gb.Time(),
+			ExtraData:     gb.Extra()[:32],
+			BaseFeePerGas: bytesutil.PadTo(bytesutil.ReverseByteOrder(gb.BaseFee().Bytes()), fieldparams.RootLength),
+			BlockHash:     gb.Hash().Bytes(),
+			Transactions:  make([][]byte, 0),
+		}
+
+		wep, err := blocks.WrappedExecutionPayload(payload)
+		if err != nil {
+			return err
+		}
+
+		eph, err := blocks.PayloadToHeader(wep)
+		if err != nil {
+			return err
+		}
+
+		ed, err := blocks.WrappedExecutionPayloadHeader(eph)
+		if err != nil {
+			return err
+		}
+
+		return g.SetLatestExecutionPayloadHeader(ed)
+	}
+
+	if s.Version >= version.Phase0 {
+		return nil
+	}
+
+	return errUnsupportedVersion
 }
 
 func unwrapUint64Ptr(u *uint64) uint64 {

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -192,150 +192,6 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 	}
 }
 
-func unmarshalPhase0State(t *testing.T, raw []byte) state.BeaconState {
-	base := &ethpb.BeaconState{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoPhase0(base)
-	require.NoError(t, err)
-	return st
-}
-
-func unmarshalPhase0Block(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.BeaconBlock{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalSignedPhase0Block(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.SignedBeaconBlock{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(base)
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalAltairState(t *testing.T, raw []byte) state.BeaconState {
-	base := &ethpb.BeaconStateAltair{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoAltair(base)
-	require.NoError(t, err)
-	return st
-}
-
-func unmarshalAltairBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.BeaconBlockAltair{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockAltair{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalSignedAltairBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.SignedBeaconBlockAltair{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(base)
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalBellatrixState(t *testing.T, raw []byte) state.BeaconState {
-	base := &ethpb.BeaconStateBellatrix{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoBellatrix(base)
-	require.NoError(t, err)
-	return st
-}
-
-func unmarshalBellatrixBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.BeaconBlockBellatrix{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalSignedBellatrixBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.SignedBeaconBlockBellatrix{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(base)
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalCapellaState(t *testing.T, raw []byte) state.BeaconState {
-	base := &ethpb.BeaconStateCapella{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoCapella(base)
-	require.NoError(t, err)
-	return st
-}
-
-func unmarshalCapellaBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.BeaconBlockCapella{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockCapella{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalSignedCapellaBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
-	base := &ethpb.SignedBeaconBlockCapella{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(base)
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalDenebState(t *testing.T, raw []byte) state.BeaconState {
-	base := &ethpb.BeaconStateDeneb{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoDeneb(base)
-	require.NoError(t, err)
-	return st
-}
-
-func unmarshalDenebBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
-	base := &ethpb.BeaconBlockDeneb{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockDeneb{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalSignedDenebBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
-	base := &ethpb.SignedBeaconBlockDeneb{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(base)
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalElectraState(t *testing.T, raw []byte) state.BeaconState {
-	base := &ethpb.BeaconStateElectra{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoElectra(base)
-	require.NoError(t, err)
-	return st
-}
-
-func unmarshalElectraBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
-	base := &ethpb.BeaconBlockElectra{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockElectra{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
-	require.NoError(t, err)
-	return blk
-}
-
-func unmarshalSignedElectraBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
-	base := &ethpb.SignedBeaconBlockElectra{}
-	require.NoError(t, base.UnmarshalSSZ(raw))
-	blk, err := blocks.NewSignedBeaconBlock(base)
-	require.NoError(t, err)
-	return blk
-}
-
 func runBlobStep(t *testing.T,
 	step Step,
 	beaconBlock interfaces.ReadOnlySignedBeaconBlock,
@@ -453,4 +309,172 @@ func errAssertionForStep(step Step, expect error) func(t *testing.T, err error) 
 			t.Fatal(strings.Join(fmsg, ";"))
 		}
 	}
+}
+
+// ----------------------------------------------------------------------------
+// Phase 0
+// ----------------------------------------------------------------------------
+
+func unmarshalPhase0State(t *testing.T, raw []byte) state.BeaconState {
+	base := &ethpb.BeaconState{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	st, err := state_native.InitializeFromProtoPhase0(base)
+	require.NoError(t, err)
+	return st
+}
+
+func unmarshalPhase0Block(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.BeaconBlock{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+	require.NoError(t, err)
+	return blk
+}
+
+func unmarshalSignedPhase0Block(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.SignedBeaconBlock{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(base)
+	require.NoError(t, err)
+	return blk
+}
+
+// ----------------------------------------------------------------------------
+// Altair
+// ----------------------------------------------------------------------------
+
+func unmarshalAltairState(t *testing.T, raw []byte) state.BeaconState {
+	base := &ethpb.BeaconStateAltair{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	st, err := state_native.InitializeFromProtoAltair(base)
+	require.NoError(t, err)
+	return st
+}
+
+func unmarshalAltairBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.BeaconBlockAltair{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockAltair{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+	require.NoError(t, err)
+	return blk
+}
+
+func unmarshalSignedAltairBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.SignedBeaconBlockAltair{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(base)
+	require.NoError(t, err)
+	return blk
+}
+
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
+
+func unmarshalBellatrixState(t *testing.T, raw []byte) state.BeaconState {
+	base := &ethpb.BeaconStateBellatrix{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	st, err := state_native.InitializeFromProtoBellatrix(base)
+	require.NoError(t, err)
+	return st
+}
+
+func unmarshalBellatrixBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.BeaconBlockBellatrix{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+	require.NoError(t, err)
+	return blk
+}
+
+func unmarshalSignedBellatrixBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.SignedBeaconBlockBellatrix{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(base)
+	require.NoError(t, err)
+	return blk
+}
+
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
+
+func unmarshalCapellaState(t *testing.T, raw []byte) state.BeaconState {
+	base := &ethpb.BeaconStateCapella{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	st, err := state_native.InitializeFromProtoCapella(base)
+	require.NoError(t, err)
+	return st
+}
+
+func unmarshalCapellaBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.BeaconBlockCapella{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockCapella{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+	require.NoError(t, err)
+	return blk
+}
+
+func unmarshalSignedCapellaBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
+	base := &ethpb.SignedBeaconBlockCapella{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(base)
+	require.NoError(t, err)
+	return blk
+}
+
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
+
+func unmarshalDenebState(t *testing.T, raw []byte) state.BeaconState {
+	base := &ethpb.BeaconStateDeneb{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	st, err := state_native.InitializeFromProtoDeneb(base)
+	require.NoError(t, err)
+	return st
+}
+
+func unmarshalDenebBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+	base := &ethpb.BeaconBlockDeneb{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockDeneb{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+	require.NoError(t, err)
+	return blk
+}
+
+func unmarshalSignedDenebBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+	base := &ethpb.SignedBeaconBlockDeneb{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(base)
+	require.NoError(t, err)
+	return blk
+}
+
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
+
+func unmarshalElectraState(t *testing.T, raw []byte) state.BeaconState {
+	base := &ethpb.BeaconStateElectra{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	st, err := state_native.InitializeFromProtoElectra(base)
+	require.NoError(t, err)
+	return st
+}
+
+func unmarshalElectraBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+	base := &ethpb.BeaconBlockElectra{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockElectra{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+	require.NoError(t, err)
+	return blk
+}
+
+func unmarshalSignedElectraBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+	base := &ethpb.SignedBeaconBlockElectra{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(base)
+	require.NoError(t, err)
+	return blk
 }

--- a/testing/spectest/shared/electra/operations/withdrawals.go
+++ b/testing/spectest/shared/electra/operations/withdrawals.go
@@ -13,7 +13,7 @@ import (
 )
 
 func blockWithWithdrawals(ssz []byte) (interfaces.SignedBeaconBlock, error) {
-	e := &enginev1.ExecutionPayloadElectra{}
+	e := &enginev1.ExecutionPayloadDeneb{}
 	if err := e.UnmarshalSSZ(ssz); err != nil {
 		return nil, err
 	}

--- a/testing/spectest/shared/electra/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/electra/ssz_static/ssz_static.go
@@ -37,9 +37,9 @@ func UnmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (i
 	var obj interface{}
 	switch folderName {
 	case "ExecutionPayload":
-		obj = &enginev1.ExecutionPayloadElectra{}
+		obj = &enginev1.ExecutionPayloadDeneb{}
 	case "ExecutionPayloadHeader":
-		obj = &enginev1.ExecutionPayloadHeaderElectra{}
+		obj = &enginev1.ExecutionPayloadHeaderDeneb{}
 	case "Attestation":
 		obj = &ethpb.AttestationElectra{}
 	case "AttestationData":

--- a/testing/util/block.go
+++ b/testing/util/block.go
@@ -64,6 +64,10 @@ func DefaultBlockGenConfig() *BlockGenConfig {
 	}
 }
 
+// ----------------------------------------------------------------------------
+// Phase 0
+// ----------------------------------------------------------------------------
+
 // NewBeaconBlock creates a beacon block with minimum marshalable fields.
 func NewBeaconBlock() *ethpb.SignedBeaconBlock {
 	return &ethpb.SignedBeaconBlock{
@@ -497,41 +501,6 @@ func randValIndex(bState state.BeaconState) (primitives.ValidatorIndex, error) {
 	return primitives.ValidatorIndex(rand.NewGenerator().Uint64() % activeCount), nil
 }
 
-func generateWithdrawals(
-	bState state.BeaconState,
-	privs []bls.SecretKey,
-	numWithdrawals uint64,
-) ([]*enginev1.Withdrawal, error) {
-	withdrawalRequests := make([]*enginev1.Withdrawal, numWithdrawals)
-	for i := uint64(0); i < numWithdrawals; i++ {
-		valIndex, err := randValIndex(bState)
-		if err != nil {
-			return nil, err
-		}
-		amount := uint64(10000)
-		bal, err := bState.BalanceAtIndex(valIndex)
-		if err != nil {
-			return nil, err
-		}
-		amounts := []uint64{
-			amount, // some smaller amount
-			bal,    // the entire balance
-		}
-		// Get a random index
-		nBig, err := rd.Int(rd.Reader, big.NewInt(int64(len(amounts))))
-		if err != nil {
-			return nil, err
-		}
-		randomIndex := nBig.Uint64()
-		withdrawalRequests[i] = &enginev1.Withdrawal{
-			ValidatorIndex: valIndex,
-			Address:        make([]byte, common.AddressLength),
-			Amount:         amounts[randomIndex],
-		}
-	}
-	return withdrawalRequests, nil
-}
-
 // HydrateSignedBeaconHeader hydrates a signed beacon block header with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
 func HydrateSignedBeaconHeader(h *ethpb.SignedBeaconBlockHeader) *ethpb.SignedBeaconBlockHeader {
@@ -654,6 +623,17 @@ func HydrateV1BeaconBlockBody(b *v1.BeaconBlockBody) *v1.BeaconBlockBody {
 	return b
 }
 
+func SaveBlock(tb assertions.AssertionTestingTB, ctx context.Context, db iface.NoHeadAccessDatabase, b interface{}) interfaces.SignedBeaconBlock {
+	wsb, err := blocks.NewSignedBeaconBlock(b)
+	require.NoError(tb, err)
+	require.NoError(tb, db.SaveBlock(ctx, wsb))
+	return wsb
+}
+
+// ----------------------------------------------------------------------------
+// Altair
+// ----------------------------------------------------------------------------
+
 // HydrateSignedBeaconBlockAltair hydrates a signed beacon block with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
 func HydrateSignedBeaconBlockAltair(b *ethpb.SignedBeaconBlockAltair) *ethpb.SignedBeaconBlockAltair {
@@ -706,6 +686,10 @@ func HydrateBeaconBlockBodyAltair(b *ethpb.BeaconBlockBodyAltair) *ethpb.BeaconB
 	}
 	return b
 }
+
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
 
 // HydrateSignedBeaconBlockBellatrix hydrates a signed beacon block with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
@@ -840,6 +824,10 @@ func HydrateBlindedBeaconBlockBodyBellatrix(b *ethpb.BlindedBeaconBlockBodyBella
 	}
 	return b
 }
+
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
 
 // HydrateSignedBeaconBlockCapella hydrates a signed beacon block with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
@@ -977,12 +965,9 @@ func HydrateBlindedBeaconBlockBodyCapella(b *ethpb.BlindedBeaconBlockBodyCapella
 	return b
 }
 
-func SaveBlock(tb assertions.AssertionTestingTB, ctx context.Context, db iface.NoHeadAccessDatabase, b interface{}) interfaces.SignedBeaconBlock {
-	wsb, err := blocks.NewSignedBeaconBlock(b)
-	require.NoError(tb, err)
-	require.NoError(tb, db.SaveBlock(ctx, wsb))
-	return wsb
-}
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
 
 // HydrateSignedBeaconBlockDeneb hydrates a signed beacon block with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
@@ -997,30 +982,10 @@ func HydrateSignedBeaconBlockDeneb(b *ethpb.SignedBeaconBlockDeneb) *ethpb.Signe
 	return b
 }
 
-// HydrateSignedBeaconBlockElectra hydrates a signed beacon block with correct field length sizes
-// to comply with fssz marshalling and unmarshalling rules.
-func HydrateSignedBeaconBlockElectra(b *ethpb.SignedBeaconBlockElectra) *ethpb.SignedBeaconBlockElectra {
-	if b == nil {
-		b = &ethpb.SignedBeaconBlockElectra{}
-	}
-	if b.Signature == nil {
-		b.Signature = make([]byte, fieldparams.BLSSignatureLength)
-	}
-	b.Block = HydrateBeaconBlockElectra(b.Block)
-	return b
-}
-
 // HydrateSignedBeaconBlockContentsDeneb hydrates a signed beacon block with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
 func HydrateSignedBeaconBlockContentsDeneb(b *ethpb.SignedBeaconBlockContentsDeneb) *ethpb.SignedBeaconBlockContentsDeneb {
 	b.Block = HydrateSignedBeaconBlockDeneb(b.Block)
-	return b
-}
-
-// HydrateSignedBeaconBlockContentsElectra hydrates a signed beacon block with correct field length sizes
-// to comply with fssz marshalling and unmarshalling rules.
-func HydrateSignedBeaconBlockContentsElectra(b *ethpb.SignedBeaconBlockContentsElectra) *ethpb.SignedBeaconBlockContentsElectra {
-	b.Block = HydrateSignedBeaconBlockElectra(b.Block)
 	return b
 }
 
@@ -1037,22 +1002,6 @@ func HydrateBeaconBlockDeneb(b *ethpb.BeaconBlockDeneb) *ethpb.BeaconBlockDeneb 
 		b.StateRoot = make([]byte, fieldparams.RootLength)
 	}
 	b.Body = HydrateBeaconBlockBodyDeneb(b.Body)
-	return b
-}
-
-// HydrateBeaconBlockElectra hydrates a beacon block with correct field length sizes
-// to comply with fssz marshalling and unmarshalling rules.
-func HydrateBeaconBlockElectra(b *ethpb.BeaconBlockElectra) *ethpb.BeaconBlockElectra {
-	if b == nil {
-		b = &ethpb.BeaconBlockElectra{}
-	}
-	if b.ParentRoot == nil {
-		b.ParentRoot = make([]byte, fieldparams.RootLength)
-	}
-	if b.StateRoot == nil {
-		b.StateRoot = make([]byte, fieldparams.RootLength)
-	}
-	b.Body = HydrateBeaconBlockBodyElectra(b.Body)
 	return b
 }
 
@@ -1098,67 +1047,6 @@ func HydrateBeaconBlockBodyDeneb(b *ethpb.BeaconBlockBodyDeneb) *ethpb.BeaconBlo
 	return b
 }
 
-// HydrateBeaconBlockBodyElectra hydrates a beacon block body with correct field length sizes
-// to comply with fssz marshalling and unmarshalling rules.
-func HydrateBeaconBlockBodyElectra(b *ethpb.BeaconBlockBodyElectra) *ethpb.BeaconBlockBodyElectra {
-	if b == nil {
-		b = &ethpb.BeaconBlockBodyElectra{}
-	}
-	if b.RandaoReveal == nil {
-		b.RandaoReveal = make([]byte, fieldparams.BLSSignatureLength)
-	}
-	if b.Graffiti == nil {
-		b.Graffiti = make([]byte, fieldparams.RootLength)
-	}
-	if b.Eth1Data == nil {
-		b.Eth1Data = &ethpb.Eth1Data{
-			DepositRoot: make([]byte, fieldparams.RootLength),
-			BlockHash:   make([]byte, fieldparams.RootLength),
-		}
-	}
-	if b.SyncAggregate == nil {
-		b.SyncAggregate = &ethpb.SyncAggregate{
-			SyncCommitteeBits:      make([]byte, fieldparams.SyncAggregateSyncCommitteeBytesLength),
-			SyncCommitteeSignature: make([]byte, fieldparams.BLSSignatureLength),
-		}
-	}
-	if b.ExecutionPayload == nil {
-		b.ExecutionPayload = &enginev1.ExecutionPayloadElectra{
-			ParentHash:    make([]byte, fieldparams.RootLength),
-			FeeRecipient:  make([]byte, 20),
-			StateRoot:     make([]byte, fieldparams.RootLength),
-			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
-			LogsBloom:     make([]byte, 256),
-			PrevRandao:    make([]byte, fieldparams.RootLength),
-			ExtraData:     make([]byte, 0),
-			BaseFeePerGas: make([]byte, fieldparams.RootLength),
-			BlockHash:     make([]byte, fieldparams.RootLength),
-			Transactions:  make([][]byte, 0),
-			Withdrawals:   make([]*enginev1.Withdrawal, 0),
-		}
-	}
-	b.ExecutionRequests = HydrateExecutionRequests(b.ExecutionRequests)
-	return b
-}
-
-// HydrateExecutionRequests fills the execution requests with the correct field
-// lengths
-func HydrateExecutionRequests(e *enginev1.ExecutionRequests) *enginev1.ExecutionRequests {
-	if e == nil {
-		e = &enginev1.ExecutionRequests{}
-	}
-	if e.Deposits == nil {
-		e.Deposits = make([]*enginev1.DepositRequest, 0)
-	}
-	if e.Withdrawals == nil {
-		e.Withdrawals = make([]*enginev1.WithdrawalRequest, 0)
-	}
-	if e.Consolidations == nil {
-		e.Consolidations = make([]*enginev1.ConsolidationRequest, 0)
-	}
-	return e
-}
-
 // HydrateSignedBlindedBeaconBlockDeneb hydrates a signed blinded beacon block with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
 func HydrateSignedBlindedBeaconBlockDeneb(b *ethpb.SignedBlindedBeaconBlockDeneb) *ethpb.SignedBlindedBeaconBlockDeneb {
@@ -1166,48 +1054,6 @@ func HydrateSignedBlindedBeaconBlockDeneb(b *ethpb.SignedBlindedBeaconBlockDeneb
 		b.Signature = make([]byte, fieldparams.BLSSignatureLength)
 	}
 	b.Message = HydrateBlindedBeaconBlockDeneb(b.Message)
-	return b
-}
-
-// HydrateSignedBlindedBeaconBlockElectra hydrates a signed blinded beacon block with correct field length sizes
-// to comply with fssz marshalling and unmarshalling rules.
-func HydrateSignedBlindedBeaconBlockElectra(b *ethpb.SignedBlindedBeaconBlockElectra) *ethpb.SignedBlindedBeaconBlockElectra {
-	if b.Signature == nil {
-		b.Signature = make([]byte, fieldparams.BLSSignatureLength)
-	}
-	b.Message = HydrateBlindedBeaconBlockElectra(b.Message)
-	return b
-}
-
-// HydrateBlindedBeaconBlockDeneb hydrates a blinded beacon block with correct field length sizes
-// to comply with fssz marshalling and unmarshalling rules.
-func HydrateBlindedBeaconBlockDeneb(b *ethpb.BlindedBeaconBlockDeneb) *ethpb.BlindedBeaconBlockDeneb {
-	if b == nil {
-		b = &ethpb.BlindedBeaconBlockDeneb{}
-	}
-	if b.ParentRoot == nil {
-		b.ParentRoot = make([]byte, fieldparams.RootLength)
-	}
-	if b.StateRoot == nil {
-		b.StateRoot = make([]byte, fieldparams.RootLength)
-	}
-	b.Body = HydrateBlindedBeaconBlockBodyDeneb(b.Body)
-	return b
-}
-
-// HydrateBlindedBeaconBlockElectra hydrates a blinded beacon block with correct field length sizes
-// to comply with fssz marshalling and unmarshalling rules.
-func HydrateBlindedBeaconBlockElectra(b *ethpb.BlindedBeaconBlockElectra) *ethpb.BlindedBeaconBlockElectra {
-	if b == nil {
-		b = &ethpb.BlindedBeaconBlockElectra{}
-	}
-	if b.ParentRoot == nil {
-		b.ParentRoot = make([]byte, fieldparams.RootLength)
-	}
-	if b.StateRoot == nil {
-		b.StateRoot = make([]byte, fieldparams.RootLength)
-	}
-	b.Body = HydrateBlindedBeaconBlockBodyElectra(b.Body)
 	return b
 }
 
@@ -1253,6 +1099,149 @@ func HydrateBlindedBeaconBlockBodyDeneb(b *ethpb.BlindedBeaconBlockBodyDeneb) *e
 	return b
 }
 
+// HydrateBlindedBeaconBlockDeneb hydrates a blinded beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateBlindedBeaconBlockDeneb(b *ethpb.BlindedBeaconBlockDeneb) *ethpb.BlindedBeaconBlockDeneb {
+	if b == nil {
+		b = &ethpb.BlindedBeaconBlockDeneb{}
+	}
+	if b.ParentRoot == nil {
+		b.ParentRoot = make([]byte, fieldparams.RootLength)
+	}
+	if b.StateRoot == nil {
+		b.StateRoot = make([]byte, fieldparams.RootLength)
+	}
+	b.Body = HydrateBlindedBeaconBlockBodyDeneb(b.Body)
+	return b
+}
+
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
+
+// HydrateSignedBeaconBlockElectra hydrates a signed beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateSignedBeaconBlockElectra(b *ethpb.SignedBeaconBlockElectra) *ethpb.SignedBeaconBlockElectra {
+	if b == nil {
+		b = &ethpb.SignedBeaconBlockElectra{}
+	}
+	if b.Signature == nil {
+		b.Signature = make([]byte, fieldparams.BLSSignatureLength)
+	}
+	b.Block = HydrateBeaconBlockElectra(b.Block)
+	return b
+}
+
+// HydrateSignedBeaconBlockContentsElectra hydrates a signed beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateSignedBeaconBlockContentsElectra(b *ethpb.SignedBeaconBlockContentsElectra) *ethpb.SignedBeaconBlockContentsElectra {
+	b.Block = HydrateSignedBeaconBlockElectra(b.Block)
+	return b
+}
+
+// HydrateBeaconBlockElectra hydrates a beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateBeaconBlockElectra(b *ethpb.BeaconBlockElectra) *ethpb.BeaconBlockElectra {
+	if b == nil {
+		b = &ethpb.BeaconBlockElectra{}
+	}
+	if b.ParentRoot == nil {
+		b.ParentRoot = make([]byte, fieldparams.RootLength)
+	}
+	if b.StateRoot == nil {
+		b.StateRoot = make([]byte, fieldparams.RootLength)
+	}
+	b.Body = HydrateBeaconBlockBodyElectra(b.Body)
+	return b
+}
+
+// HydrateBeaconBlockBodyElectra hydrates a beacon block body with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateBeaconBlockBodyElectra(b *ethpb.BeaconBlockBodyElectra) *ethpb.BeaconBlockBodyElectra {
+	if b == nil {
+		b = &ethpb.BeaconBlockBodyElectra{}
+	}
+	if b.RandaoReveal == nil {
+		b.RandaoReveal = make([]byte, fieldparams.BLSSignatureLength)
+	}
+	if b.Graffiti == nil {
+		b.Graffiti = make([]byte, fieldparams.RootLength)
+	}
+	if b.Eth1Data == nil {
+		b.Eth1Data = &ethpb.Eth1Data{
+			DepositRoot: make([]byte, fieldparams.RootLength),
+			BlockHash:   make([]byte, fieldparams.RootLength),
+		}
+	}
+	if b.SyncAggregate == nil {
+		b.SyncAggregate = &ethpb.SyncAggregate{
+			SyncCommitteeBits:      make([]byte, fieldparams.SyncAggregateSyncCommitteeBytesLength),
+			SyncCommitteeSignature: make([]byte, fieldparams.BLSSignatureLength),
+		}
+	}
+	if b.ExecutionPayload == nil {
+		b.ExecutionPayload = &enginev1.ExecutionPayloadDeneb{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, 20),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, 256),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			ExtraData:     make([]byte, 0),
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  make([][]byte, 0),
+			Withdrawals:   make([]*enginev1.Withdrawal, 0),
+		}
+	}
+	b.ExecutionRequests = HydrateExecutionRequests(b.ExecutionRequests)
+	return b
+}
+
+// HydrateExecutionRequests fills the execution requests with the correct field
+// lengths
+func HydrateExecutionRequests(e *enginev1.ExecutionRequests) *enginev1.ExecutionRequests {
+	if e == nil {
+		e = &enginev1.ExecutionRequests{}
+	}
+	if e.Deposits == nil {
+		e.Deposits = make([]*enginev1.DepositRequest, 0)
+	}
+	if e.Withdrawals == nil {
+		e.Withdrawals = make([]*enginev1.WithdrawalRequest, 0)
+	}
+	if e.Consolidations == nil {
+		e.Consolidations = make([]*enginev1.ConsolidationRequest, 0)
+	}
+	return e
+}
+
+// HydrateSignedBlindedBeaconBlockElectra hydrates a signed blinded beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateSignedBlindedBeaconBlockElectra(b *ethpb.SignedBlindedBeaconBlockElectra) *ethpb.SignedBlindedBeaconBlockElectra {
+	if b.Signature == nil {
+		b.Signature = make([]byte, fieldparams.BLSSignatureLength)
+	}
+	b.Message = HydrateBlindedBeaconBlockElectra(b.Message)
+	return b
+}
+
+// HydrateBlindedBeaconBlockElectra hydrates a blinded beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateBlindedBeaconBlockElectra(b *ethpb.BlindedBeaconBlockElectra) *ethpb.BlindedBeaconBlockElectra {
+	if b == nil {
+		b = &ethpb.BlindedBeaconBlockElectra{}
+	}
+	if b.ParentRoot == nil {
+		b.ParentRoot = make([]byte, fieldparams.RootLength)
+	}
+	if b.StateRoot == nil {
+		b.StateRoot = make([]byte, fieldparams.RootLength)
+	}
+	b.Body = HydrateBlindedBeaconBlockBodyElectra(b.Body)
+	return b
+}
+
 // HydrateBlindedBeaconBlockBodyElectra hydrates a blinded beacon block body with correct field length sizes
 // to comply with fssz marshalling and unmarshalling rules.
 func HydrateBlindedBeaconBlockBodyElectra(b *ethpb.BlindedBeaconBlockBodyElectra) *ethpb.BlindedBeaconBlockBodyElectra {
@@ -1278,7 +1267,7 @@ func HydrateBlindedBeaconBlockBodyElectra(b *ethpb.BlindedBeaconBlockBodyElectra
 		}
 	}
 	if b.ExecutionPayloadHeader == nil {
-		b.ExecutionPayloadHeader = &enginev1.ExecutionPayloadHeaderElectra{
+		b.ExecutionPayloadHeader = &enginev1.ExecutionPayloadHeaderDeneb{
 			ParentHash:       make([]byte, 32),
 			FeeRecipient:     make([]byte, 20),
 			StateRoot:        make([]byte, fieldparams.RootLength),
@@ -1294,4 +1283,39 @@ func HydrateBlindedBeaconBlockBodyElectra(b *ethpb.BlindedBeaconBlockBodyElectra
 	}
 	b.ExecutionRequests = HydrateExecutionRequests(b.ExecutionRequests)
 	return b
+}
+
+func generateWithdrawals(
+	bState state.BeaconState,
+	privs []bls.SecretKey,
+	numWithdrawals uint64,
+) ([]*enginev1.Withdrawal, error) {
+	withdrawalRequests := make([]*enginev1.Withdrawal, numWithdrawals)
+	for i := uint64(0); i < numWithdrawals; i++ {
+		valIndex, err := randValIndex(bState)
+		if err != nil {
+			return nil, err
+		}
+		amount := uint64(10000)
+		bal, err := bState.BalanceAtIndex(valIndex)
+		if err != nil {
+			return nil, err
+		}
+		amounts := []uint64{
+			amount, // some smaller amount
+			bal,    // the entire balance
+		}
+		// Get a random index
+		nBig, err := rd.Int(rd.Reader, big.NewInt(int64(len(amounts))))
+		if err != nil {
+			return nil, err
+		}
+		randomIndex := nBig.Uint64()
+		withdrawalRequests[i] = &enginev1.Withdrawal{
+			ValidatorIndex: valIndex,
+			Address:        make([]byte, common.AddressLength),
+			Amount:         amounts[randomIndex],
+		}
+	}
+	return withdrawalRequests, nil
 }

--- a/testing/util/electra.go
+++ b/testing/util/electra.go
@@ -47,7 +47,7 @@ type electraBlockGenerator struct {
 	sk       bls.SecretKey
 	proposer primitives.ValidatorIndex
 	valRoot  []byte
-	payload  *enginev1.ExecutionPayloadElectra
+	payload  *enginev1.ExecutionPayloadDeneb
 }
 
 func WithElectraProposerSigning(idx primitives.ValidatorIndex, sk bls.SecretKey, valRoot []byte) ElectraBlockGeneratorOption {
@@ -59,7 +59,7 @@ func WithElectraProposerSigning(idx primitives.ValidatorIndex, sk bls.SecretKey,
 	}
 }
 
-func WithElectraPayload(p *enginev1.ExecutionPayloadElectra) ElectraBlockGeneratorOption {
+func WithElectraPayload(p *enginev1.ExecutionPayloadDeneb) ElectraBlockGeneratorOption {
 	return func(g *electraBlockGenerator) {
 		g.payload = p
 	}
@@ -96,7 +96,7 @@ func GenerateTestElectraBlockWithSidecar(t *testing.T, parent [32]byte, slot pri
 		logsBloom := bytesutil.PadTo([]byte("logs"), fieldparams.LogsBloomLength)
 		receiptsRoot := bytesutil.PadTo([]byte("receiptsRoot"), fieldparams.RootLength)
 		parentHash := bytesutil.PadTo([]byte("parentHash"), fieldparams.RootLength)
-		g.payload = &enginev1.ExecutionPayloadElectra{
+		g.payload = &enginev1.ExecutionPayloadDeneb{
 			ParentHash:    parentHash,
 			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
 			StateRoot:     stateRoot,

--- a/testing/util/electra_block.go
+++ b/testing/util/electra_block.go
@@ -172,7 +172,7 @@ func GenerateFullBlockElectra(
 		return nil, err
 	}
 	blockHash := indexToHash(uint64(slot))
-	newExecutionPayloadElectra := &v1.ExecutionPayloadElectra{
+	newExecutionPayloadElectra := &v1.ExecutionPayloadDeneb{
 		ParentHash:    parentExecution.BlockHash(),
 		FeeRecipient:  make([]byte, 20),
 		StateRoot:     params.BeaconConfig().ZeroHash[:],

--- a/testing/util/electra_state.go
+++ b/testing/util/electra_state.go
@@ -96,7 +96,7 @@ func emptyGenesisStateElectra() (state.BeaconState, error) {
 		Eth1DataVotes:    []*ethpb.Eth1Data{},
 		Eth1DepositIndex: 0,
 
-		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderElectra{},
+		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderDeneb{},
 
 		DepositBalanceToConsume:       primitives.Gwei(0),
 		ExitBalanceToConsume:          primitives.Gwei(0),
@@ -226,7 +226,7 @@ func buildGenesisBeaconStateElectra(genesisTime uint64, preState state.BeaconSta
 			SyncCommitteeBits:      scBits[:],
 			SyncCommitteeSignature: make([]byte, 96),
 		},
-		ExecutionPayload: &enginev1.ExecutionPayloadElectra{
+		ExecutionPayload: &enginev1.ExecutionPayloadDeneb{
 			ParentHash:    make([]byte, 32),
 			FeeRecipient:  make([]byte, 20),
 			StateRoot:     make([]byte, 32),
@@ -273,7 +273,7 @@ func buildGenesisBeaconStateElectra(genesisTime uint64, preState state.BeaconSta
 		AggregatePubkey: aggregated.Marshal(),
 	}
 
-	st.LatestExecutionPayloadHeader = &enginev1.ExecutionPayloadHeaderElectra{
+	st.LatestExecutionPayloadHeader = &enginev1.ExecutionPayloadHeaderDeneb{
 		ParentHash:       make([]byte, 32),
 		FeeRecipient:     make([]byte, 20),
 		StateRoot:        make([]byte, 32),

--- a/testing/util/merge.go
+++ b/testing/util/merge.go
@@ -4,6 +4,10 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 )
 
+// ----------------------------------------------------------------------------
+// Bellatrix
+// ----------------------------------------------------------------------------
+
 // NewBeaconBlockBellatrix creates a beacon block with minimum marshalable fields.
 func NewBeaconBlockBellatrix() *ethpb.SignedBeaconBlockBellatrix {
 	return HydrateSignedBeaconBlockBellatrix(&ethpb.SignedBeaconBlockBellatrix{})
@@ -13,6 +17,10 @@ func NewBeaconBlockBellatrix() *ethpb.SignedBeaconBlockBellatrix {
 func NewBlindedBeaconBlockBellatrix() *ethpb.SignedBlindedBeaconBlockBellatrix {
 	return HydrateSignedBlindedBeaconBlockBellatrix(&ethpb.SignedBlindedBeaconBlockBellatrix{})
 }
+
+// ----------------------------------------------------------------------------
+// Capella
+// ----------------------------------------------------------------------------
 
 // NewBeaconBlockCapella creates a beacon block with minimum marshalable fields.
 func NewBeaconBlockCapella() *ethpb.SignedBeaconBlockCapella {
@@ -24,14 +32,13 @@ func NewBlindedBeaconBlockCapella() *ethpb.SignedBlindedBeaconBlockCapella {
 	return HydrateSignedBlindedBeaconBlockCapella(&ethpb.SignedBlindedBeaconBlockCapella{})
 }
 
+// ----------------------------------------------------------------------------
+// Deneb
+// ----------------------------------------------------------------------------
+
 // NewBeaconBlockDeneb creates a beacon block with minimum marshalable fields.
 func NewBeaconBlockDeneb() *ethpb.SignedBeaconBlockDeneb {
 	return HydrateSignedBeaconBlockDeneb(&ethpb.SignedBeaconBlockDeneb{})
-}
-
-// NewBeaconBlockElectra creates a beacon block with minimum marshalable fields.
-func NewBeaconBlockElectra() *ethpb.SignedBeaconBlockElectra {
-	return HydrateSignedBeaconBlockElectra(&ethpb.SignedBeaconBlockElectra{})
 }
 
 // NewBeaconBlockContentsDeneb creates a beacon block with minimum marshalable fields.
@@ -42,6 +49,15 @@ func NewBeaconBlockContentsDeneb() *ethpb.SignedBeaconBlockContentsDeneb {
 // NewBlindedBeaconBlockDeneb creates a blinded beacon block with minimum marshalable fields.
 func NewBlindedBeaconBlockDeneb() *ethpb.SignedBlindedBeaconBlockDeneb {
 	return HydrateSignedBlindedBeaconBlockDeneb(&ethpb.SignedBlindedBeaconBlockDeneb{})
+}
+
+// ----------------------------------------------------------------------------
+// Electra
+// ----------------------------------------------------------------------------
+
+// NewBeaconBlockElectra creates a beacon block with minimum marshalable fields.
+func NewBeaconBlockElectra() *ethpb.SignedBeaconBlockElectra {
+	return HydrateSignedBeaconBlockElectra(&ethpb.SignedBeaconBlockElectra{})
 }
 
 // NewBeaconBlockContentsElectra creates a beacon block with minimum marshalable fields.

--- a/testing/util/state.go
+++ b/testing/util/state.go
@@ -424,7 +424,7 @@ func NewBeaconStateElectra(options ...func(state *ethpb.BeaconStateElectra) erro
 			Pubkeys:         pubkeys,
 			AggregatePubkey: make([]byte, 48),
 		},
-		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderElectra{
+		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderDeneb{
 			ParentHash:       make([]byte, 32),
 			FeeRecipient:     make([]byte, 20),
 			StateRoot:        make([]byte, 32),


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR aims to simplify the creation of the boilerplate for a new fork.

It uses
```go
if version.<fork> > ... {
   ...
}
```
instead of
```go
switch v {
case version.<fork>:
   ...
}
```

when possible.

The rationale is we assume, from fork `<n>` to fork `<n+1>`, that changing items are less numerous than remaining ones.
Using the `>` approach instead of the `switch/case` one lets the developer not to add the new fork version as a specific case when not needed.

This PR re-organises when possible functions by fork.
When adding the boilerplate for a new fork is needed, only the tail of the file needs to be modified.

Some types (example: `enginev1.ExecutionPayloadHeaderElectra`) where aliased to the same type from previous forks (example: `enginev1.ExecutionPayloadHeaderDeneb`). This usage is quite exceptional in the codebase. In the vast majority of the code base, when a fork use a struct defined in a previous fork, then this struct is directly used.
Aliased types are removed to keep the codebase consistent.

**Other notes for review**
This PR does not bring any functional change.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
