### PR TITLE
Fix grammatical issues in documentation

### DIFF
--- a/config/features/README.md
+++ b/config/features/README.md
@@ -27,7 +27,7 @@ Examples of when not to use a feature flag:
 ## How to use a feature flag?
 
 Once it has been decided that you should use a feature flag. Follow these steps to safely
-releasing your feature. In general, try to create a single PR for each step of this process.
+release your feature. In general, try to create a single PR for each step of this process.
 
 1. Add your feature flag to `shared/featureconfig/flags.go`, use the flag to toggle a boolean in the
 feature config in shared/featureconfig/config.go. It is a good idea to use the `enable` prefix for

--- a/config/fieldparams/mainnet.go
+++ b/config/fieldparams/mainnet.go
@@ -26,11 +26,11 @@ const (
 	SyncCommitteeAggregationBytesLength   = 16                // SyncCommitteeAggregationBytesLength defines the length of sync committee aggregate bytes.
 	SyncAggregateSyncCommitteeBytesLength = 64                // SyncAggregateSyncCommitteeBytesLength defines the length of sync committee bytes in a sync aggregate.
 	MaxWithdrawalsPerPayload              = 16                // MaxWithdrawalsPerPayloadLength defines the maximum number of withdrawals that can be included in a payload.
-	MaxBlobCommitmentsPerBlock            = 4096              // MaxBlobCommitmentsPerBlock defines the theoretical limit of blobs can be included in a block.
+	MaxBlobCommitmentsPerBlock            = 4096              // MaxBlobCommitmentsPerBlock defines the theoretical limit of blobs that can be included in a block.
 	LogMaxBlobCommitments                 = 12                // Log_2 of MaxBlobCommitmentsPerBlock
 	BlobLength                            = 131072            // BlobLength defines the byte length of a blob.
-	BlobSize                              = 131072            // defined to match blob.size in bazel ssz codegen
-	BlobSidecarSize                       = 131928            // defined to match blob sidecar size in bazel ssz codegen
+	BlobSize                              = 131072            // Defined to match blob.size in bazel ssz codegen
+	BlobSidecarSize                       = 131928            // Defined to match blob sidecar size in bazel ssz codegen
 	KzgCommitmentInclusionProofDepth      = 17                // Merkle proof depth for blob_kzg_commitments list item
 	ExecutionBranchDepth                  = 4                 // ExecutionBranchDepth defines the number of leaves in a merkle proof of the execution payload header.
 	SyncCommitteeBranchDepth              = 5                 // SyncCommitteeBranchDepth defines the number of leaves in a merkle proof of a sync committee.


### PR DESCRIPTION
Fix grammatical issues in documentation

Changes:

config/features/README.md:
- releasing your feature
+ release your feature

Reason: Using correct infinitive form after "to"

config/fieldparams/mainnet.go:
- MaxBlobCommitmentsPerBlock defines the theoretical limit of blobs can be included in a block.
+ MaxBlobCommitmentsPerBlock defines the theoretical limit of blobs that can be included in a block.
- defined to match blob.size in bazel ssz codegen
+ Defined to match blob.size in bazel ssz codegen

Reason: Added missing "that" and capitalized comment for consistency

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
