### PR TITLE
Fix kzg commitment inclusion proof depth minimal value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Added check to prevent nil pointer deference or out of bounds array access when validating the BLSToExecutionChange on an impossibly nil validator.
 - EIP-7691: Ensure new blobs subnets are subscribed on epoch in advance.
+- Fix kzg commitment inclusion proof depth minimal value.
 
 ### Security
 

--- a/config/fieldparams/minimal.go
+++ b/config/fieldparams/minimal.go
@@ -31,7 +31,7 @@ const (
 	BlobLength                            = 131072            // BlobLength defines the byte length of a blob.
 	BlobSize                              = 131072            // defined to match blob.size in bazel ssz codegen
 	BlobSidecarSize                       = 131928            // defined to match blob sidecar size in bazel ssz codegen
-	KzgCommitmentInclusionProofDepth      = 17                // Merkle proof depth for blob_kzg_commitments list item
+	KzgCommitmentInclusionProofDepth      = 10                // Merkle proof depth for blob_kzg_commitments list item
 	ExecutionBranchDepth                  = 4                 // ExecutionBranchDepth defines the number of leaves in a merkle proof of the execution payload header.
 	SyncCommitteeBranchDepth              = 5                 // SyncCommitteeBranchDepth defines the number of leaves in a merkle proof of a sync committee.
 	SyncCommitteeBranchDepthElectra       = 6                 // SyncCommitteeBranchDepthElectra defines the number of leaves in a merkle proof of a sync committee.


### PR DESCRIPTION
H/t to @lucassaldanha for noting that the minimal value for the KZG inclusion proof is 10, not 17.  
Reference: [https://github.com/ethereum/consensus-specs/blob/dev/presets/minimal/deneb.yaml](https://github.com/ethereum/consensus-specs/blob/dev/presets/minimal/deneb.yaml)