### PR TITLE
Add 'beacon' prefix to 'data_column_sidecar_computation' metric

### DIFF
--- a/beacon-chain/core/peerdas/metrics.go
+++ b/beacon-chain/core/peerdas/metrics.go
@@ -7,7 +7,7 @@ import (
 
 var dataColumnComputationTime = promauto.NewHistogram(
 	prometheus.HistogramOpts{
-		Name:    "data_column_sidecar_computation_milliseconds",
+		Name:    "beacon_data_column_sidecar_computation_milliseconds",
 		Help:    "Captures the time taken to compute data column sidecars from blobs.",
 		Buckets: []float64{100, 250, 500, 750, 1000, 1500, 2000, 4000, 8000, 12000, 16000},
 	},


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR renames PeerDAS metric `data_column_sidecar_computation_milliseconds` into `beacon_data_column_sidecar_computation_milliseconds` align with the [PeerDAS metrics specs](https://github.com/ethereum/beacon-metrics/pull/14)
**Which issues(s) does this PR fix?**

Fixes (partially) #14129

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
