### PR TITLE
switch to unclog latest release instead of run artifact

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,12 +15,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download unclog binary
-        uses: actions/download-artifact@v4
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: OffchainLabs/unclog
-          name: unclog
-          run-id: 12679708867
+          repo: OffchainLabs/unclog
+          file: "unclog"
 
       - name: Get new changelog files
         id: new-changelog-files

--- a/changelog/kasey_stabilize-unclog.md
+++ b/changelog/kasey_stabilize-unclog.md
@@ -1,0 +1,13 @@
+### Changed
+
+- Updated geth to 1.14~. [[PR]](https://github.com/prysmaticlabs/prysm/pull/14351)
+- E2e tests start from bellatrix. [[PR]](https://github.com/prysmaticlabs/prysm/pull/14351)
+
+### Removed
+
+- Remove `/memsize/` pprof endpoint as it will no longer be supported in go 1.23. [[PR]](https://github.com/prysmaticlabs/prysm/pull/14351)
+
+### Ignored
+
+- switches unclog from using a flaky github artifact to using a stable release asset.
+- Adds changelog entries that were missing from the branch switching prysm over to unclog.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The current workflow uses a hardcoded run-id to download the unclog binary as an artifact from the unclog repository. This is fragile because this artifact will be cleared 90 days after it is built, so we'll need to continually update the run-id to the latest cron job run in the unclog repo. I have removed the cron job on the unclog repo and set it up to automatically produce a release whenever a release tag is pushed. This branch switches the workflow to instead use the latest release artifact built by that process.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
