### PR TITLE
Replace new `exampleIP` for `example.org`

### DIFF
--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -357,7 +357,7 @@ func TestHostIsResolved(t *testing.T) {
 	// As defined in RFC 2606 , example.org is a
 	// reserved example domain name.
 	exampleHost := "example.org"
-	exampleIP := "93.184.215.14"
+	exampleIP := "96.7.129.13"
 
 	s := &Service{
 		cfg: &Config{

--- a/changelog/syjn99_change-example-ip-address.md
+++ b/changelog/syjn99_change-example-ip-address.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Replace exampleIP to `96.7.129.13`


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR makes `TestHostIsResolved` happy by replacing IP for `example.org`. I'm not sure why its IP keeps changing every year.

```plaintext
❯ dig example.org @a.iana-servers.net

; <<>> DiG 9.10.6 <<>> example.org @a.iana-servers.net
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9079
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;example.org.			IN	A

;; ANSWER SECTION:
example.org.		300	IN	A	96.7.129.13

;; Query time: 137 msec
;; SERVER: 199.43.135.53#53(199.43.135.53)
;; WHEN: Wed Jan 15 13:59:47 KST 2025
;; MSG SIZE  rcvd: 56
```

**Other notes for review**

I've tested `dig` in various environment: local, an instance in New York, and changed DNS server for few times. All cases returned `96.7.129.13`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
