### PR TITLE
Add PeerDAS gossip verification metrics

### DIFF
--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -184,6 +184,25 @@ var (
 			Help: "Count the number of times blobs have been found in the database.",
 		},
 	)
+
+	// Data column sidecar validation, beacon metrics specs
+	dataColumnSidecarVerificationRequestsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_data_column_sidecar_processing_requests_total",
+		Help: "Count the number of data column sidecars submitted for verification",
+	})
+
+	dataColumnSidecarVerificationSuccessesCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_data_column_sidecar_processing_successes_total",
+		Help: "Count the number of data column sidecars verified for gossip",
+	})
+
+	dataColumnSidecarVerificationGossipHistogram = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "beacon_data_column_sidecar_gossip_verification_milliseconds",
+			Help:    "Captures the time taken to verify data column sidecars.",
+			Buckets: []float64{100, 250, 500, 750, 1000, 1500, 2000, 4000, 8000, 12000, 16000},
+		},
+	)
 )
 
 func (s *Service) updateMetrics() {


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR adds gossip verification metrics align with the [PeerDAS metrics specs](https://github.com/ethereum/beacon-metrics/pull/14):
- `beacon_data_column_sidecar_processing_requests_total`
- `beacon_data_column_sidecar_processing_successes_total`
- `beacon_data_column_sidecar_gossip_verification_milliseconds`

**Which issues(s) does this PR fix?**

Fixes (partially) #14129

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have made an appropriate entry to [CHANGELOG.md](https://github.com/prysmaticlabs/prysm/blob/develop/CHANGELOG.md).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
