### PR TITLE
adding in error for generic block check

### DIFF
--- a/changelog/james-prysm_handle-pbgeneric-error.md
+++ b/changelog/james-prysm_handle-pbgeneric-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix panic with type cast on pbgenericblock()

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -124,8 +124,12 @@ func (b *SignedBeaconBlock) PbGenericBlock() (*eth.GenericSignedBeaconBlock, err
 				Block: &eth.GenericSignedBeaconBlock_BlindedDeneb{BlindedDeneb: pb.(*eth.SignedBlindedBeaconBlockDeneb)},
 			}, nil
 		}
+		bc, ok := pb.(*eth.SignedBeaconBlockContentsDeneb)
+		if !ok {
+			return nil, fmt.Errorf("PbGenericBlock() only supports block content type but got %T", pb)
+		}
 		return &eth.GenericSignedBeaconBlock{
-			Block: &eth.GenericSignedBeaconBlock_Deneb{Deneb: pb.(*eth.SignedBeaconBlockContentsDeneb)},
+			Block: &eth.GenericSignedBeaconBlock_Deneb{Deneb: bc},
 		}, nil
 	case version.Electra:
 		if b.IsBlinded() {
@@ -133,8 +137,12 @@ func (b *SignedBeaconBlock) PbGenericBlock() (*eth.GenericSignedBeaconBlock, err
 				Block: &eth.GenericSignedBeaconBlock_BlindedElectra{BlindedElectra: pb.(*eth.SignedBlindedBeaconBlockElectra)},
 			}, nil
 		}
+		bc, ok := pb.(*eth.SignedBeaconBlockContentsElectra)
+		if !ok {
+			return nil, fmt.Errorf("PbGenericBlock() only supports block content type but got %T", pb)
+		}
 		return &eth.GenericSignedBeaconBlock{
-			Block: &eth.GenericSignedBeaconBlock_Electra{Electra: pb.(*eth.SignedBeaconBlockContentsElectra)},
+			Block: &eth.GenericSignedBeaconBlock_Electra{Electra: bc},
 		}, nil
 	case version.Fulu:
 		if b.IsBlinded() {
@@ -142,8 +150,12 @@ func (b *SignedBeaconBlock) PbGenericBlock() (*eth.GenericSignedBeaconBlock, err
 				Block: &eth.GenericSignedBeaconBlock_BlindedFulu{BlindedFulu: pb.(*eth.SignedBlindedBeaconBlockFulu)},
 			}, nil
 		}
+		bc, ok := pb.(*eth.SignedBeaconBlockContentsFulu)
+		if !ok {
+			return nil, fmt.Errorf("PbGenericBlock() only supports block content type but got %T", pb)
+		}
 		return &eth.GenericSignedBeaconBlock{
-			Block: &eth.GenericSignedBeaconBlock_Fulu{Fulu: pb.(*eth.SignedBeaconBlockContentsFulu)},
+			Block: &eth.GenericSignedBeaconBlock_Fulu{Fulu: bc},
 		}, nil
 	default:
 		return nil, errIncorrectBlockVersion

--- a/testing/util/block_test.go
+++ b/testing/util/block_test.go
@@ -322,3 +322,30 @@ func TestGenerateVoluntaryExits(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, coreBlock.VerifyExitAndSignature(val, beaconState, exit))
 }
+
+func Test_PostDenebPbGenericBlock_ErrorsForPlainBlock(t *testing.T) {
+	t.Run("Deneb block returns type error", func(t *testing.T) {
+		eb := NewBeaconBlockDeneb()
+		b, err := blocks.NewSignedBeaconBlock(eb)
+		require.NoError(t, err)
+
+		_, err = b.PbGenericBlock()
+		require.ErrorContains(t, "PbGenericBlock() only supports block content type but got", err)
+	})
+	t.Run("Electra block returns type error", func(t *testing.T) {
+		eb := NewBeaconBlockElectra()
+		b, err := blocks.NewSignedBeaconBlock(eb)
+		require.NoError(t, err)
+
+		_, err = b.PbGenericBlock()
+		require.ErrorContains(t, "PbGenericBlock() only supports block content type but got", err)
+	})
+	t.Run("Fulu block returns type error", func(t *testing.T) {
+		eb := NewBeaconBlockFulu()
+		b, err := blocks.NewSignedBeaconBlock(eb)
+		require.NoError(t, err)
+
+		_, err = b.PbGenericBlock()
+		require.ErrorContains(t, "PbGenericBlock() only supports block content type but got", err)
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

a user reported the tech debt we had since deneb around our pbgenericblock function which returns the generic block type based on the underlying block version. the issue is if we pass a signed deneb ( or greater) block instead of block contents we get a panic during the type conversion. the better way to handle this is to throw an error. This is still a bit of a tech debt item for us in its use but will at least prevent panics in the system.

**Which issues(s) does this PR fix?**

Fixes #14789

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
