### PR TITLE
version pin unclog release

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,6 +18,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
         with:
           repo: OffchainLabs/unclog
+          version: "tags/v0.1.3"
           file: "unclog"
 
       - name: Get new changelog files

--- a/changelog/kasey_unclog-v0-1-3.md
+++ b/changelog/kasey_unclog-v0-1-3.md
@@ -1,0 +1,2 @@
+### Changed
+- Version pinning unclog after making some ux improvements.


### PR DESCRIPTION

**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**

Currently the `unclog` changelog management action always uses the latest release from the `OffchainLabs/unclog`. Given that a bad release could wedge prysm's ability to merge PRs it seems like a good idea to version pin.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
