### PR TITLE
Prysmctl: generate genesis state with correct extra data

### DIFF
--- a/changelog/tt_fix_generate_genesis.md
+++ b/changelog/tt_fix_generate_genesis.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prysmctl generate genesis state: fix truncation of ExtraData to 32 bytes to satisfy SSZ marshaling

--- a/runtime/interop/premine-state.go
+++ b/runtime/interop/premine-state.go
@@ -621,6 +621,10 @@ func (s *PremineGenesisConfig) setLatestBlockHeader(g state.BeaconState) error {
 
 func (s *PremineGenesisConfig) setExecutionPayload(g state.BeaconState) error {
 	gb := s.GB
+	extraData := gb.Extra()
+	if len(extraData) > 32 {
+		extraData = extraData[:32]
+	}
 
 	if s.Version >= version.Deneb {
 		payload := &enginev1.ExecutionPayloadDeneb{
@@ -634,7 +638,7 @@ func (s *PremineGenesisConfig) setExecutionPayload(g state.BeaconState) error {
 			GasLimit:      gb.GasLimit(),
 			GasUsed:       gb.GasUsed(),
 			Timestamp:     gb.Time(),
-			ExtraData:     gb.Extra(),
+			ExtraData:     extraData,
 			BaseFeePerGas: bytesutil.PadTo(bytesutil.ReverseByteOrder(gb.BaseFee().Bytes()), fieldparams.RootLength),
 			BlockHash:     gb.Hash().Bytes(),
 			Transactions:  make([][]byte, 0),
@@ -673,7 +677,7 @@ func (s *PremineGenesisConfig) setExecutionPayload(g state.BeaconState) error {
 			GasLimit:      gb.GasLimit(),
 			GasUsed:       gb.GasUsed(),
 			Timestamp:     gb.Time(),
-			ExtraData:     gb.Extra(),
+			ExtraData:     extraData,
 			BaseFeePerGas: bytesutil.PadTo(bytesutil.ReverseByteOrder(gb.BaseFee().Bytes()), fieldparams.RootLength),
 			BlockHash:     gb.Hash().Bytes(),
 			Transactions:  make([][]byte, 0),
@@ -709,7 +713,7 @@ func (s *PremineGenesisConfig) setExecutionPayload(g state.BeaconState) error {
 			GasLimit:      gb.GasLimit(),
 			GasUsed:       gb.GasUsed(),
 			Timestamp:     gb.Time(),
-			ExtraData:     gb.Extra(),
+			ExtraData:     extraData,
 			BaseFeePerGas: bytesutil.PadTo(bytesutil.ReverseByteOrder(gb.BaseFee().Bytes()), fieldparams.RootLength),
 			BlockHash:     gb.Hash().Bytes(),
 			Transactions:  make([][]byte, 0),


### PR DESCRIPTION
h/t to @yahgwai for the report

`Extradata` specified in the execution layer's genesis JSON can be arbitrary in length. However, when used to generate an execution header for the beacon state, we made a deliberate choice to truncate it to 32 bytes instead of leaving it empty. This behavior has been in place since #11809.

#14351 removed the extra data truncation, causing genesis state generation to fail as follows:
```
INFO[0000] Specified a chain config file: /Users/t/go/src/github.com/prysmaticlabs/prysm/config.yml  prefix=genesis
INFO[0000] No genesis time specified, defaulting to now()  prefix=genesis
INFO[0000] Delaying genesis 1736981389 by 15 seconds     prefix=genesis
INFO[0000] Genesis is now 1736981404                     prefix=genesis
INFO[0000] Setting fork geth times                       cancun=1736981404 prefix=genesis shanghai=1736981404
118
FATA[0000] Could not generate beacon chain genesis state  error="--.ExtraData (bytes array does not have the correct length): expected 32 and 118 found" prefix=genesis
```

This PR reverts the changes related to extra data truncation.