### PR TITLE
move credential helpers to ReadOnlyValidator methods

### DIFF
--- a/beacon-chain/core/electra/effective_balance_updates.go
+++ b/beacon-chain/core/electra/effective_balance_updates.go
@@ -39,7 +39,7 @@ func ProcessEffectiveBalanceUpdates(st state.BeaconState) error {
 
 	// Update effective balances with hysteresis.
 	validatorFunc := func(idx int, val state.ReadOnlyValidator) (newVal *ethpb.Validator, err error) {
-		if val == nil {
+		if val.IsNil() {
 			return nil, fmt.Errorf("validator %d is nil in state", idx)
 		}
 		if idx >= len(bals) {

--- a/beacon-chain/core/electra/effective_balance_updates.go
+++ b/beacon-chain/core/electra/effective_balance_updates.go
@@ -3,7 +3,6 @@ package electra
 import (
 	"fmt"
 
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
@@ -49,7 +48,7 @@ func ProcessEffectiveBalanceUpdates(st state.BeaconState) error {
 		balance := bals[idx]
 
 		effectiveBalanceLimit := params.BeaconConfig().MinActivationBalance
-		if helpers.HasCompoundingWithdrawalCredential(val) {
+		if val.HasCompoundingWithdrawalCredentials() {
 			effectiveBalanceLimit = params.BeaconConfig().MaxEffectiveBalanceElectra
 		}
 

--- a/beacon-chain/core/electra/effective_balance_updates_test.go
+++ b/beacon-chain/core/electra/effective_balance_updates_test.go
@@ -77,7 +77,7 @@ func TestProcessEffectiveBalnceUpdates(t *testing.T) {
 					Validators: []*eth.Validator{
 						{
 							EffectiveBalance:      params.BeaconConfig().MinActivationBalance / 2,
-							WithdrawalCredentials: nil,
+							WithdrawalCredentials: make([]byte, 32),
 						},
 					},
 					Balances: []uint64{

--- a/beacon-chain/core/electra/upgrade.go
+++ b/beacon-chain/core/electra/upgrade.go
@@ -194,7 +194,7 @@ func UpgradeToElectra(beaconState state.BeaconState) (state.BeaconState, error) 
 		if val.ActivationEpoch() == params.BeaconConfig().FarFutureEpoch {
 			preActivationIndices = append(preActivationIndices, primitives.ValidatorIndex(index))
 		}
-		if helpers.HasCompoundingWithdrawalCredential(val) {
+		if val.HasCompoundingWithdrawalCredentials() {
 			compoundWithdrawalIndices = append(compoundWithdrawalIndices, primitives.ValidatorIndex(index))
 		}
 		return nil

--- a/beacon-chain/core/electra/withdrawals.go
+++ b/beacon-chain/core/electra/withdrawals.go
@@ -116,7 +116,7 @@ func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []
 			return nil, err
 		}
 		// Verify withdrawal credentials
-		hasCorrectCredential := helpers.HasExecutionWithdrawalCredentials(validator)
+		hasCorrectCredential := validator.HasExecutionWithdrawalCredentials()
 		wc := validator.GetWithdrawalCredentials()
 		isCorrectSourceAddress := bytes.Equal(wc[12:], wr.SourceAddress)
 		if !hasCorrectCredential || !isCorrectSourceAddress {
@@ -165,7 +165,7 @@ func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []
 		hasExcessBalance := vBal > params.BeaconConfig().MinActivationBalance+pendingBalanceToWithdraw
 
 		// Only allow partial withdrawals with compounding withdrawal credentials
-		if helpers.HasCompoundingWithdrawalCredential(validator) && hasSufficientEffectiveBalance && hasExcessBalance {
+		if validator.HasCompoundingWithdrawalCredentials() && hasSufficientEffectiveBalance && hasExcessBalance {
 			// Spec definition:
 			//  to_withdraw = min(
 			//	  state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw,

--- a/beacon-chain/core/fulu/upgrade.go
+++ b/beacon-chain/core/fulu/upgrade.go
@@ -85,7 +85,7 @@ func UpgradeToFulu(beaconState state.BeaconState) (state.BeaconState, error) {
 		if val.ActivationEpoch() == params.BeaconConfig().FarFutureEpoch {
 			preActivationIndices = append(preActivationIndices, primitives.ValidatorIndex(index))
 		}
-		if helpers.HasCompoundingWithdrawalCredential(val) {
+		if val.HasCompoundingWithdrawalCredentials() {
 			compoundWithdrawalIndices = append(compoundWithdrawalIndices, primitives.ValidatorIndex(index))
 		}
 		return nil

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
-        "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//container/slice:go_default_library",
         "//container/trie:go_default_library",

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -919,10 +919,6 @@ func TestHasETH1WithdrawalCredentials(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, roV.HasETH1WithdrawalCredentials())
 	// No Withdrawal cred
-	v = &ethpb.Validator{}
-	roV, err = state_native.NewValidator(v)
-	require.NoError(t, err)
-	require.Equal(t, false, roV.HasETH1WithdrawalCredentials())
 }
 
 func TestHasCompoundingWithdrawalCredential(t *testing.T) {
@@ -937,7 +933,6 @@ func TestHasCompoundingWithdrawalCredential(t *testing.T) {
 		{"Does not have compounding withdrawal credential",
 			&ethpb.Validator{WithdrawalCredentials: bytesutil.PadTo([]byte{0x00}, 32)},
 			false},
-		{"Handles nil case", nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -963,7 +958,6 @@ func TestHasExecutionWithdrawalCredentials(t *testing.T) {
 		{"Does not have compounding withdrawal credential or eth1 withdrawal credential",
 			&ethpb.Validator{WithdrawalCredentials: bytesutil.PadTo([]byte{0x00}, 32)},
 			false},
-		{"Handles nil case", nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -910,13 +910,19 @@ func TestProposerIndexFromCheckpoint(t *testing.T) {
 func TestHasETH1WithdrawalCredentials(t *testing.T) {
 	creds := []byte{0xFA, 0xCC}
 	v := &ethpb.Validator{WithdrawalCredentials: creds}
-	require.Equal(t, false, helpers.HasETH1WithdrawalCredential(v))
+	roV, err := state_native.NewValidator(v)
+	require.NoError(t, err)
+	require.Equal(t, false, roV.HasETH1WithdrawalCredentials())
 	creds = []byte{params.BeaconConfig().ETH1AddressWithdrawalPrefixByte, 0xCC}
 	v = &ethpb.Validator{WithdrawalCredentials: creds}
-	require.Equal(t, true, helpers.HasETH1WithdrawalCredential(v))
+	roV, err = state_native.NewValidator(v)
+	require.NoError(t, err)
+	require.Equal(t, true, roV.HasETH1WithdrawalCredentials())
 	// No Withdrawal cred
 	v = &ethpb.Validator{}
-	require.Equal(t, false, helpers.HasETH1WithdrawalCredential(v))
+	roV, err = state_native.NewValidator(v)
+	require.NoError(t, err)
+	require.Equal(t, false, roV.HasETH1WithdrawalCredentials())
 }
 
 func TestHasCompoundingWithdrawalCredential(t *testing.T) {
@@ -935,7 +941,9 @@ func TestHasCompoundingWithdrawalCredential(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, helpers.HasCompoundingWithdrawalCredential(tt.validator))
+			roV, err := state_native.NewValidator(tt.validator)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, roV.HasCompoundingWithdrawalCredentials())
 		})
 	}
 }
@@ -959,7 +967,9 @@ func TestHasExecutionWithdrawalCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, helpers.HasExecutionWithdrawalCredentials(tt.validator))
+			roV, err := state_native.NewValidator(tt.validator)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, roV.HasExecutionWithdrawalCredentials())
 		})
 	}
 }

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -461,7 +461,7 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 				defer testSync.cleanup()
 
 				st := tc.getState()
-				v := &eth.Validator{ExitEpoch: math.MaxUint64, EffectiveBalance: params.BeaconConfig().MinActivationBalance}
+				v := &eth.Validator{ExitEpoch: math.MaxUint64, EffectiveBalance: params.BeaconConfig().MinActivationBalance, WithdrawalCredentials: make([]byte, 32)}
 				require.NoError(t, st.SetValidators([]*eth.Validator{v}))
 				currentSlot := primitives.Slot(0)
 				// to avoid slot processing

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -119,6 +119,9 @@ type ReadOnlyValidator interface {
 	Copy() *ethpb.Validator
 	Slashed() bool
 	IsNil() bool
+	HasETH1WithdrawalCredentials() bool
+	HasCompoundingWithdrawalCredentials() bool
+	HasExecutionWithdrawalCredentials() bool
 }
 
 // ReadOnlyValidators defines a struct which only has read access to validators methods.

--- a/beacon-chain/state/state-native/readonly_validator.go
+++ b/beacon-chain/state/state-native/readonly_validator.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 )
@@ -86,6 +87,27 @@ func (v readOnlyValidator) Slashed() bool {
 // IsNil returns true if the validator is nil.
 func (v readOnlyValidator) IsNil() bool {
 	return v.validator == nil
+}
+
+// HasETH1WithdrawalCredentials returns true if the validator has an ETH1 withdrawal credentials.
+func (v readOnlyValidator) HasETH1WithdrawalCredentials() bool {
+	if v.IsNil() {
+		return false
+	}
+	return v.validator.WithdrawalCredentials[0] == params.BeaconConfig().ETH1AddressWithdrawalPrefixByte
+}
+
+// HasCompoundingWithdrawalCredentials returns true if the validator has a compounding withdrawal credentials.
+func (v readOnlyValidator) HasCompoundingWithdrawalCredentials() bool {
+	if v.IsNil() {
+		return false
+	}
+	return v.validator.WithdrawalCredentials[0] == params.BeaconConfig().CompoundingWithdrawalPrefixByte
+}
+
+// HasExecutionWithdrawalCredentials returns true if the validator has an execution withdrawal credentials.
+func (v readOnlyValidator) HasExecutionWithdrawalCredentials() bool {
+	return v.HasETH1WithdrawalCredentials() || v.HasCompoundingWithdrawalCredentials()
 }
 
 // Copy returns a new validator from the read only validator

--- a/changelog/potuz_credentials_as_methods.md
+++ b/changelog/potuz_credentials_as_methods.md
@@ -1,0 +1,2 @@
+### Changed
+- Remove helpers to check for execution/compounding withdrawal credentials and expose them as methods.


### PR DESCRIPTION
This PR removes the helpers `HasCompoundingWithdrawalCredential`, `HasETH1WithdrawalCredential` and `HasExecutionWithdrawalCredentials`  to exposed methods within the `ReadOnlyValidator` interface. 

It also fixes the naming to be coherent in number. 