### PR TITLE
Use `SingleAttestation` for Fulu in p2p attestation map

### DIFF
--- a/beacon-chain/p2p/types/object_mapping.go
+++ b/beacon-chain/p2p/types/object_mapping.go
@@ -123,7 +123,7 @@ func InitializeDataMaps() {
 			return &ethpb.SingleAttestation{}, nil
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().FuluForkVersion): func() (ethpb.Att, error) {
-			return &ethpb.AttestationElectra{}, nil
+			return &ethpb.SingleAttestation{}, nil
 		},
 	}
 

--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -292,7 +292,7 @@ func TestExtractDataType(t *testing.T) {
 				return wsb
 			}(),
 			wantMd:        wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
-			wantAtt:       &ethpb.AttestationElectra{},
+			wantAtt:       &ethpb.SingleAttestation{},
 			wantAggregate: &ethpb.SignedAggregateAttestationAndProofElectra{},
 			wantErr:       false,
 		},

--- a/changelog/radek_fulu-object-mapping.md
+++ b/changelog/radek_fulu-object-mapping.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use `SingleAttestation` for Fulu in p2p attestation map.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The attestation map that holds fork-->type mappings for our p2p code has the incorrect type for Fulu. It should be `SingleAttestation`, not `AttestationElectra`.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
