### PR TITLE
feat(validator): Extend slashable attestation check to Electra fork

### DIFF
--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -134,6 +134,21 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot primitives.Slot,
 			tracing.AnnotateError(span, err)
 			return
 		}
+	} else if electraAtt, ok := indexedAtt.(*ethpb.IndexedAttestationElectra); ok {
+		// Convert Electra attestation to phase0 format for slashing protection check
+		phase0Format := &ethpb.IndexedAttestation{
+			AttestingIndices: electraAtt.AttestingIndices,
+			Data:            electraAtt.Data,
+			Signature:       electraAtt.Signature,
+		}
+		if err := v.db.SlashableAttestationCheck(ctx, phase0Format, pubKey, signingRoot, v.emitAccountMetrics, ValidatorAttestFailVec); err != nil {
+			log.WithError(err).Error("Failed attestation slashing protection check")
+			log.WithFields(
+				attestationLogFields(pubKey, indexedAtt),
+			).Debug("Attempted slashable attestation details")
+			tracing.AnnotateError(span, err)
+			return
+		}
 	}
 
 	var aggregationBitfield bitfield.Bitlist


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR extends the slashable attestation check to support the Electra fork. Currently, the slashing protection check is only implemented for phase0 attestations, but with the introduction of the Electra fork, we need to ensure the same level of protection is available for Electra attestations.

The changes:
1. Add type assertion for IndexedAttestationElectra
2. Convert Electra attestation to phase0 format for compatibility with existing slashing protection
3. Perform the same slashing protection check as for phase0

This ensures consistent slashing protection across both forks while maintaining compatibility with the existing protection system.

**Which issues(s) does this PR fix?**

Fixes TODO in validator/client/attest.go: "TODO: Extend to Electra"

**Other notes for review**

The implementation converts Electra attestations to phase0 format before performing the slashing check. This approach:
- Maintains backward compatibility
- Reuses existing, well-tested slashing protection logic
- Avoids code duplication
- Makes future maintenance easier

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.