### PR TITLE
Add PeerDAS kzg and inclusion proof verification metrics

### DIFF
--- a/beacon-chain/verification/metrics.go
+++ b/beacon-chain/verification/metrics.go
@@ -20,4 +20,18 @@ var (
 		},
 		[]string{"result"},
 	)
+	dataColumnSidecarInclusionProofVerificationHistogram = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "beacon_data_column_sidecar_inclusion_proof_verification_milliseconds",
+			Help:    "Captures the time taken to verify data column sidecar inclusion proof.",
+			Buckets: []float64{5, 10, 50, 100, 150, 250, 500, 1000, 2000},
+		},
+	)
+	dataColumnBatchKZGVerificationHistogram = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "beacon_kzg_verification_data_column_batch_milliseconds",
+			Help:    "Captures the time taken for batched data column kzg verification.",
+			Buckets: []float64{5, 10, 50, 100, 150, 250, 500, 1000, 2000},
+		},
+	)
 )


### PR DESCRIPTION
**What type of PR is this?**

 Feature


**What does this PR do? Why is it needed?**
This PR adds reconstruction metrics align with the [PeerDAS metrics specs](https://github.com/ethereum/beacon-metrics/pull/14):

- `beacon_data_column_sidecar_inclusion_proof_verification_milliseconds`
- `beacon_kzg_verification_data_column_batch_milliseconds`


**Which issues(s) does this PR fix?**

Fixes (partially) #14129

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
