### PR TITLE
Add PeerDAS custody columns metric

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -336,7 +336,7 @@ func (bs *BlobStorage) SaveDataColumn(column blocks.VerifiedRODataColumn) error 
 		})
 	}
 
-	// TODO: Use new metrics for data columns
+	custodyColumnWrittenCounter.Inc()
 	blobsWrittenCounter.Inc()
 	blobSaveLatency.Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil

--- a/beacon-chain/db/filesystem/metrics.go
+++ b/beacon-chain/db/filesystem/metrics.go
@@ -33,4 +33,8 @@ var (
 		Name: "blob_disk_bytes",
 		Help: "Approximate number of bytes occupied by blobs in storage",
 	})
+	custodyColumnWrittenCounter = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_custody_columns_count_total",
+		Help: "Total count of columns in custody within the data availability boundary",
+	})
 )


### PR DESCRIPTION
**What type of PR is this?**

 Feature

**What does this PR do? Why is it needed?**
This PR adds gossip verification metrics align with the [PeerDAS metrics specs](https://github.com/ethereum/beacon-metrics/pull/14):
- `beacon_custody_columns_count_total`

**Which issues(s) does this PR fix?**

Fixes (partially) #14129

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
