### PR TITLE
`nodeFilter`: Add `GossipBlobSidecarMessage` case.

### DIFF
--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -54,6 +54,8 @@ func (s *Service) nodeFilter(topic string, index uint64) (func(node *enode.Node)
 		return s.filterPeerForAttSubnet(index), nil
 	case strings.Contains(topic, GossipSyncCommitteeMessage):
 		return s.filterPeerForSyncSubnet(index), nil
+	case strings.Contains(topic, GossipBlobSidecarMessage):
+		return s.filterPeerForBlobSubnet(), nil
 	default:
 		return nil, errors.Errorf("no subnet exists for provided topic: %s", topic)
 	}
@@ -263,6 +265,14 @@ func (s *Service) filterPeerForSyncSubnet(index uint64) func(node *enode.Node) b
 			}
 		}
 		return indExists
+	}
+}
+
+// returns a method with filters peers specifically for a particular blob subnet.
+// All peers are supposed to be subscribed to all blob subnets.
+func (s *Service) filterPeerForBlobSubnet() func(_ *enode.Node) bool {
+	return func(_ *enode.Node) bool {
+		return true
 	}
 }
 

--- a/changelog/manu_blob_subnets_node_filter.md
+++ b/changelog/manu_blob_subnets_node_filter.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `nodeFilter`: Implement `filterPeerForBlobSubnet` to avoid error logs.


### PR DESCRIPTION

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this commit, this kind of logs were possible:

```
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_0/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_1/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_2/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_3/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_4/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_5/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_6/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_7/ssz_snappy
[2025-01-22 17:18:48]  DEBUG sync: Could not search for peers error=node filter: no subnet exists for provided topic: /eth2/d1f05cae/blob_sidecar_8/ssz_snappy
```

Note this bug has no real other impact than logging these errors: Since all nodes are subscribed to these subnets, as soon as some peers are found, there is no more issue.

**Why not using `s.subscribe` instead of `s.subscribeWithParameters`?**
Blobs subnets were before considered as static subnets. But since Electra, the number of subnets is a function of the epoch. So it's better to use `s.subscribeWithParameters` than 2 specific but almost identic functions in `s.subscribe`.

**Why `filterPeerForBlobSubnet` is the only one returning always `true`?**
Because blobs subnets are actually the only subnets which are both dynamic AND which have to be subscribed by all the nodes. So, `filterPeerForBlobSubnet` does not filter out any node.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
