### PR TITLE
Handle `AttesterSlashingElectra` everywhere in the codebase

### DIFF
--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/signing"
 	v "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/validators"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	state_native "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/testing/assert"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"github.com/prysmaticlabs/prysm/v5/testing/util"
@@ -105,439 +107,162 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 }
 
 func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
-	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
-	for _, vv := range beaconState.Validators() {
-		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
-	}
+	statePhase0, keysPhase0 := util.DeterministicGenesisState(t, 100)
+	stateAltair, keysAltair := util.DeterministicGenesisStateAltair(t, 100)
+	stateBellatrix, keysBellatrix := util.DeterministicGenesisStateBellatrix(t, 100)
+	stateCapella, keysCapella := util.DeterministicGenesisStateCapella(t, 100)
+	stateDeneb, keysDeneb := util.DeterministicGenesisStateDeneb(t, 100)
+	stateElectra, keysElectra := util.DeterministicGenesisStateElectra(t, 100)
 
-	att1 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+	att1Phase0 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
 		Data: &ethpb.AttestationData{
 			Source: &ethpb.Checkpoint{Epoch: 1},
 		},
 		AttestingIndices: []uint64{0, 1},
 	})
-	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 := privKeys[0].Sign(signingRoot[:])
-	sig1 := privKeys[1].Sign(signingRoot[:])
-	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att1.Signature = aggregateSig.Marshal()
-
-	att2 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+	att2Phase0 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
 		AttestingIndices: []uint64{0, 1},
 	})
-	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 = privKeys[0].Sign(signingRoot[:])
-	sig1 = privKeys[1].Sign(signingRoot[:])
-	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att2.Signature = aggregateSig.Marshal()
-
-	slashings := []*ethpb.AttesterSlashing{
-		{
-			Attestation_1: att1,
-			Attestation_2: att2,
-		},
-	}
-
-	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
-	require.NoError(t, beaconState.SetSlot(currentSlot))
-
-	b := util.NewBeaconBlock()
-	b.Block = &ethpb.BeaconBlock{
-		Body: &ethpb.BeaconBlockBody{
-			AttesterSlashings: slashings,
-		},
-	}
-
-	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
-	for i, s := range b.Block.Body.AttesterSlashings {
-		ss[i] = s
-	}
-	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
-	require.NoError(t, err)
-	newRegistry := newState.Validators()
-
-	// Given the intersection of slashable indices is [1], only validator
-	// at index 1 should be slashed and exited. We confirm this below.
-	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
-		t.Errorf(
-			`
-			Expected validator at index 1's exit epoch to match
-			%d, received %d instead
-			`,
-			beaconState.Validators()[1].ExitEpoch,
-			newRegistry[1].ExitEpoch,
-		)
-	}
-
-	require.Equal(t, uint64(31750000000), newState.Balances()[1])
-	require.Equal(t, uint64(32000000000), newState.Balances()[2])
-}
-
-func TestProcessAttesterSlashings_AppliesCorrectStatusAltair(t *testing.T) {
-	beaconState, privKeys := util.DeterministicGenesisStateAltair(t, 100)
-	for _, vv := range beaconState.Validators() {
-		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
-	}
-
-	att1 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+	att1Electra := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
 		Data: &ethpb.AttestationData{
 			Source: &ethpb.Checkpoint{Epoch: 1},
 		},
 		AttestingIndices: []uint64{0, 1},
 	})
-	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 := privKeys[0].Sign(signingRoot[:])
-	sig1 := privKeys[1].Sign(signingRoot[:])
-	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att1.Signature = aggregateSig.Marshal()
-
-	att2 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+	att2Electra := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
 		AttestingIndices: []uint64{0, 1},
 	})
-	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 = privKeys[0].Sign(signingRoot[:])
-	sig1 = privKeys[1].Sign(signingRoot[:])
-	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att2.Signature = aggregateSig.Marshal()
 
-	slashings := []*ethpb.AttesterSlashing{
+	slashingPhase0 := &ethpb.AttesterSlashing{
+		Attestation_1: att1Phase0,
+		Attestation_2: att2Phase0,
+	}
+	slashingElectra := &ethpb.AttesterSlashingElectra{
+		Attestation_1: att1Electra,
+		Attestation_2: att2Electra,
+	}
+
+	type testCase struct {
+		name           string
+		st             state.BeaconState
+		keys           []bls.SecretKey
+		att1           ethpb.IndexedAtt
+		att2           ethpb.IndexedAtt
+		slashing       ethpb.AttSlashing
+		slashedBalance uint64
+	}
+
+	testCases := []testCase{
 		{
-			Attestation_1: att1,
-			Attestation_2: att2,
+			name:           "phase0",
+			st:             statePhase0,
+			keys:           keysPhase0,
+			att1:           att1Phase0,
+			att2:           att2Phase0,
+			slashing:       slashingPhase0,
+			slashedBalance: 31750000000,
+		},
+		{
+			name:           "altair",
+			st:             stateAltair,
+			keys:           keysAltair,
+			att1:           att1Phase0,
+			att2:           att2Phase0,
+			slashing:       slashingPhase0,
+			slashedBalance: 31500000000,
+		},
+		{
+			name:           "bellatrix",
+			st:             stateBellatrix,
+			keys:           keysBellatrix,
+			att1:           att1Phase0,
+			att2:           att2Phase0,
+			slashing:       slashingPhase0,
+			slashedBalance: 31000000000,
+		},
+		{
+			name:           "capella",
+			st:             stateCapella,
+			keys:           keysCapella,
+			att1:           att1Phase0,
+			att2:           att2Phase0,
+			slashing:       slashingPhase0,
+			slashedBalance: 31000000000,
+		},
+		{
+			name:           "deneb",
+			st:             stateDeneb,
+			keys:           keysDeneb,
+			att1:           att1Phase0,
+			att2:           att2Phase0,
+			slashing:       slashingPhase0,
+			slashedBalance: 31000000000,
+		},
+		{
+			name:           "electra",
+			st:             stateElectra,
+			keys:           keysElectra,
+			att1:           att1Electra,
+			att2:           att2Electra,
+			slashing:       slashingElectra,
+			slashedBalance: 31992187500,
 		},
 	}
 
-	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
-	require.NoError(t, beaconState.SetSlot(currentSlot))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, vv := range tc.st.Validators() {
+				vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
+			}
 
-	b := util.NewBeaconBlock()
-	b.Block = &ethpb.BeaconBlock{
-		Body: &ethpb.BeaconBlockBody{
-			AttesterSlashings: slashings,
-		},
-	}
+			domain, err := signing.Domain(tc.st.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, tc.st.GenesisValidatorsRoot())
+			require.NoError(t, err)
+			signingRoot, err := signing.ComputeSigningRoot(tc.att1.GetData(), domain)
+			assert.NoError(t, err, "Could not get signing root of beacon block header")
+			sig0 := tc.keys[0].Sign(signingRoot[:])
+			sig1 := tc.keys[1].Sign(signingRoot[:])
+			aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
 
-	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
-	for i, s := range b.Block.Body.AttesterSlashings {
-		ss[i] = s
-	}
-	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
-	require.NoError(t, err)
-	newRegistry := newState.Validators()
+			if tc.att1.Version() >= version.Electra {
+				tc.att1.(*ethpb.IndexedAttestationElectra).Signature = aggregateSig.Marshal()
+			} else {
+				tc.att1.(*ethpb.IndexedAttestation).Signature = aggregateSig.Marshal()
+			}
 
-	// Given the intersection of slashable indices is [1], only validator
-	// at index 1 should be slashed and exited. We confirm this below.
-	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
-		t.Errorf(
-			`
+			signingRoot, err = signing.ComputeSigningRoot(tc.att2.GetData(), domain)
+			assert.NoError(t, err, "Could not get signing root of beacon block header")
+			sig0 = tc.keys[0].Sign(signingRoot[:])
+			sig1 = tc.keys[1].Sign(signingRoot[:])
+			aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+
+			if tc.att2.Version() >= version.Electra {
+				tc.att2.(*ethpb.IndexedAttestationElectra).Signature = aggregateSig.Marshal()
+			} else {
+				tc.att2.(*ethpb.IndexedAttestation).Signature = aggregateSig.Marshal()
+			}
+
+			currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
+			require.NoError(t, tc.st.SetSlot(currentSlot))
+
+			newState, err := blocks.ProcessAttesterSlashings(context.Background(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator)
+			require.NoError(t, err)
+			newRegistry := newState.Validators()
+
+			// Given the intersection of slashable indices is [1], only validator
+			// at index 1 should be slashed and exited. We confirm this below.
+			if newRegistry[1].ExitEpoch != tc.st.Validators()[1].ExitEpoch {
+				t.Errorf(
+					`
 			Expected validator at index 1's exit epoch to match
 			%d, received %d instead
 			`,
-			beaconState.Validators()[1].ExitEpoch,
-			newRegistry[1].ExitEpoch,
-		)
+					tc.st.Validators()[1].ExitEpoch,
+					newRegistry[1].ExitEpoch,
+				)
+			}
+
+			require.Equal(t, tc.slashedBalance, newState.Balances()[1])
+			require.Equal(t, uint64(32000000000), newState.Balances()[2])
+		})
 	}
-
-	require.Equal(t, uint64(31500000000), newState.Balances()[1])
-	require.Equal(t, uint64(32000000000), newState.Balances()[2])
-}
-
-func TestProcessAttesterSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
-	beaconState, privKeys := util.DeterministicGenesisStateBellatrix(t, 100)
-	for _, vv := range beaconState.Validators() {
-		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
-	}
-
-	att1 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{Epoch: 1},
-		},
-		AttestingIndices: []uint64{0, 1},
-	})
-	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 := privKeys[0].Sign(signingRoot[:])
-	sig1 := privKeys[1].Sign(signingRoot[:])
-	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att1.Signature = aggregateSig.Marshal()
-
-	att2 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-		AttestingIndices: []uint64{0, 1},
-	})
-	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 = privKeys[0].Sign(signingRoot[:])
-	sig1 = privKeys[1].Sign(signingRoot[:])
-	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att2.Signature = aggregateSig.Marshal()
-
-	slashings := []*ethpb.AttesterSlashing{
-		{
-			Attestation_1: att1,
-			Attestation_2: att2,
-		},
-	}
-
-	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
-	require.NoError(t, beaconState.SetSlot(currentSlot))
-
-	b := util.NewBeaconBlock()
-	b.Block = &ethpb.BeaconBlock{
-		Body: &ethpb.BeaconBlockBody{
-			AttesterSlashings: slashings,
-		},
-	}
-
-	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
-	for i, s := range b.Block.Body.AttesterSlashings {
-		ss[i] = s
-	}
-	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
-	require.NoError(t, err)
-	newRegistry := newState.Validators()
-
-	// Given the intersection of slashable indices is [1], only validator
-	// at index 1 should be slashed and exited. We confirm this below.
-	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
-		t.Errorf(
-			`
-			Expected validator at index 1's exit epoch to match
-			%d, received %d instead
-			`,
-			beaconState.Validators()[1].ExitEpoch,
-			newRegistry[1].ExitEpoch,
-		)
-	}
-
-	require.Equal(t, uint64(31000000000), newState.Balances()[1])
-	require.Equal(t, uint64(32000000000), newState.Balances()[2])
-}
-
-func TestProcessAttesterSlashings_AppliesCorrectStatusCapella(t *testing.T) {
-	beaconState, privKeys := util.DeterministicGenesisStateCapella(t, 100)
-	for _, vv := range beaconState.Validators() {
-		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
-	}
-
-	att1 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{Epoch: 1},
-		},
-		AttestingIndices: []uint64{0, 1},
-	})
-	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 := privKeys[0].Sign(signingRoot[:])
-	sig1 := privKeys[1].Sign(signingRoot[:])
-	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att1.Signature = aggregateSig.Marshal()
-
-	att2 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-		AttestingIndices: []uint64{0, 1},
-	})
-	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 = privKeys[0].Sign(signingRoot[:])
-	sig1 = privKeys[1].Sign(signingRoot[:])
-	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att2.Signature = aggregateSig.Marshal()
-
-	slashings := []*ethpb.AttesterSlashing{
-		{
-			Attestation_1: att1,
-			Attestation_2: att2,
-		},
-	}
-
-	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
-	require.NoError(t, beaconState.SetSlot(currentSlot))
-
-	b := util.NewBeaconBlock()
-	b.Block = &ethpb.BeaconBlock{
-		Body: &ethpb.BeaconBlockBody{
-			AttesterSlashings: slashings,
-		},
-	}
-
-	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
-	for i, s := range b.Block.Body.AttesterSlashings {
-		ss[i] = s
-	}
-	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
-	require.NoError(t, err)
-	newRegistry := newState.Validators()
-
-	// Given the intersection of slashable indices is [1], only validator
-	// at index 1 should be slashed and exited. We confirm this below.
-	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
-		t.Errorf(
-			`
-			Expected validator at index 1's exit epoch to match
-			%d, received %d instead
-			`,
-			beaconState.Validators()[1].ExitEpoch,
-			newRegistry[1].ExitEpoch,
-		)
-	}
-
-	require.Equal(t, uint64(31000000000), newState.Balances()[1])
-	require.Equal(t, uint64(32000000000), newState.Balances()[2])
-}
-
-func TestProcessAttesterSlashings_AppliesCorrectStatusDeneb(t *testing.T) {
-	beaconState, privKeys := util.DeterministicGenesisStateDeneb(t, 100)
-	for _, vv := range beaconState.Validators() {
-		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
-	}
-
-	att1 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{Epoch: 1},
-		},
-		AttestingIndices: []uint64{0, 1},
-	})
-	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 := privKeys[0].Sign(signingRoot[:])
-	sig1 := privKeys[1].Sign(signingRoot[:])
-	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att1.Signature = aggregateSig.Marshal()
-
-	att2 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
-		AttestingIndices: []uint64{0, 1},
-	})
-	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 = privKeys[0].Sign(signingRoot[:])
-	sig1 = privKeys[1].Sign(signingRoot[:])
-	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att2.Signature = aggregateSig.Marshal()
-
-	slashings := []*ethpb.AttesterSlashing{
-		{
-			Attestation_1: att1,
-			Attestation_2: att2,
-		},
-	}
-
-	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
-	require.NoError(t, beaconState.SetSlot(currentSlot))
-
-	b := util.NewBeaconBlock()
-	b.Block = &ethpb.BeaconBlock{
-		Body: &ethpb.BeaconBlockBody{
-			AttesterSlashings: slashings,
-		},
-	}
-
-	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
-	for i, s := range b.Block.Body.AttesterSlashings {
-		ss[i] = s
-	}
-	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
-	require.NoError(t, err)
-	newRegistry := newState.Validators()
-
-	// Given the intersection of slashable indices is [1], only validator
-	// at index 1 should be slashed and exited. We confirm this below.
-	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
-		t.Errorf(
-			`
-			Expected validator at index 1's exit epoch to match
-			%d, received %d instead
-			`,
-			beaconState.Validators()[1].ExitEpoch,
-			newRegistry[1].ExitEpoch,
-		)
-	}
-
-	require.Equal(t, uint64(31000000000), newState.Balances()[1])
-	require.Equal(t, uint64(32000000000), newState.Balances()[2])
-}
-
-func TestProcessAttesterSlashings_AppliesCorrectStatusElectra(t *testing.T) {
-	beaconState, privKeys := util.DeterministicGenesisStateElectra(t, 100)
-	for _, vv := range beaconState.Validators() {
-		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
-	}
-
-	att1 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{Epoch: 1},
-		},
-		AttestingIndices: []uint64{0, 1},
-	})
-	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
-	require.NoError(t, err)
-	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 := privKeys[0].Sign(signingRoot[:])
-	sig1 := privKeys[1].Sign(signingRoot[:])
-	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att1.Signature = aggregateSig.Marshal()
-
-	att2 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
-		AttestingIndices: []uint64{0, 1},
-	})
-	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
-	assert.NoError(t, err, "Could not get signing root of beacon block header")
-	sig0 = privKeys[0].Sign(signingRoot[:])
-	sig1 = privKeys[1].Sign(signingRoot[:])
-	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
-	att2.Signature = aggregateSig.Marshal()
-
-	slashings := []*ethpb.AttesterSlashingElectra{
-		{
-			Attestation_1: att1,
-			Attestation_2: att2,
-		},
-	}
-
-	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
-	require.NoError(t, beaconState.SetSlot(currentSlot))
-
-	b := util.NewBeaconBlockElectra()
-	b.Block = &ethpb.BeaconBlockElectra{
-		Body: &ethpb.BeaconBlockBodyElectra{
-			AttesterSlashings: slashings,
-		},
-	}
-
-	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
-	for i, s := range b.Block.Body.AttesterSlashings {
-		ss[i] = s
-	}
-	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
-	require.NoError(t, err)
-	newRegistry := newState.Validators()
-
-	// Given the intersection of slashable indices is [1], only validator
-	// at index 1 should be slashed and exited. We confirm this below.
-	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
-		t.Errorf(
-			`
-			Expected validator at index 1's exit epoch to match
-			%d, received %d instead
-			`,
-			beaconState.Validators()[1].ExitEpoch,
-			newRegistry[1].ExitEpoch,
-		)
-	}
-
-	require.Equal(t, uint64(31992187500), newState.Balances()[1])
-	require.Equal(t, uint64(32000000000), newState.Balances()[2])
 }

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -395,3 +395,149 @@ func TestProcessAttesterSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 	require.Equal(t, uint64(31000000000), newState.Balances()[1])
 	require.Equal(t, uint64(32000000000), newState.Balances()[2])
 }
+
+func TestProcessAttesterSlashings_AppliesCorrectStatusDeneb(t *testing.T) {
+	beaconState, privKeys := util.DeterministicGenesisStateDeneb(t, 100)
+	for _, vv := range beaconState.Validators() {
+		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
+	}
+
+	att1 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 1},
+		},
+		AttestingIndices: []uint64{0, 1},
+	})
+	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+	require.NoError(t, err)
+	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 := privKeys[0].Sign(signingRoot[:])
+	sig1 := privKeys[1].Sign(signingRoot[:])
+	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	att1.Signature = aggregateSig.Marshal()
+
+	att2 := util.HydrateIndexedAttestation(&ethpb.IndexedAttestation{
+		AttestingIndices: []uint64{0, 1},
+	})
+	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 = privKeys[0].Sign(signingRoot[:])
+	sig1 = privKeys[1].Sign(signingRoot[:])
+	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	att2.Signature = aggregateSig.Marshal()
+
+	slashings := []*ethpb.AttesterSlashing{
+		{
+			Attestation_1: att1,
+			Attestation_2: att2,
+		},
+	}
+
+	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
+	require.NoError(t, beaconState.SetSlot(currentSlot))
+
+	b := util.NewBeaconBlock()
+	b.Block = &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			AttesterSlashings: slashings,
+		},
+	}
+
+	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
+	for i, s := range b.Block.Body.AttesterSlashings {
+		ss[i] = s
+	}
+	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
+	require.NoError(t, err)
+	newRegistry := newState.Validators()
+
+	// Given the intersection of slashable indices is [1], only validator
+	// at index 1 should be slashed and exited. We confirm this below.
+	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
+		t.Errorf(
+			`
+			Expected validator at index 1's exit epoch to match
+			%d, received %d instead
+			`,
+			beaconState.Validators()[1].ExitEpoch,
+			newRegistry[1].ExitEpoch,
+		)
+	}
+
+	require.Equal(t, uint64(31000000000), newState.Balances()[1])
+	require.Equal(t, uint64(32000000000), newState.Balances()[2])
+}
+
+func TestProcessAttesterSlashings_AppliesCorrectStatusElectra(t *testing.T) {
+	beaconState, privKeys := util.DeterministicGenesisStateElectra(t, 100)
+	for _, vv := range beaconState.Validators() {
+		vv.WithdrawableEpoch = primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)
+	}
+
+	att1 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 1},
+		},
+		AttestingIndices: []uint64{0, 1},
+	})
+	domain, err := signing.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorsRoot())
+	require.NoError(t, err)
+	signingRoot, err := signing.ComputeSigningRoot(att1.Data, domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 := privKeys[0].Sign(signingRoot[:])
+	sig1 := privKeys[1].Sign(signingRoot[:])
+	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	att1.Signature = aggregateSig.Marshal()
+
+	att2 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
+		AttestingIndices: []uint64{0, 1},
+	})
+	signingRoot, err = signing.ComputeSigningRoot(att2.Data, domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 = privKeys[0].Sign(signingRoot[:])
+	sig1 = privKeys[1].Sign(signingRoot[:])
+	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	att2.Signature = aggregateSig.Marshal()
+
+	slashings := []*ethpb.AttesterSlashingElectra{
+		{
+			Attestation_1: att1,
+			Attestation_2: att2,
+		},
+	}
+
+	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
+	require.NoError(t, beaconState.SetSlot(currentSlot))
+
+	b := util.NewBeaconBlockElectra()
+	b.Block = &ethpb.BeaconBlockElectra{
+		Body: &ethpb.BeaconBlockBodyElectra{
+			AttesterSlashings: slashings,
+		},
+	}
+
+	ss := make([]ethpb.AttSlashing, len(b.Block.Body.AttesterSlashings))
+	for i, s := range b.Block.Body.AttesterSlashings {
+		ss[i] = s
+	}
+	newState, err := blocks.ProcessAttesterSlashings(context.Background(), beaconState, ss, v.SlashValidator)
+	require.NoError(t, err)
+	newRegistry := newState.Validators()
+
+	// Given the intersection of slashable indices is [1], only validator
+	// at index 1 should be slashed and exited. We confirm this below.
+	if newRegistry[1].ExitEpoch != beaconState.Validators()[1].ExitEpoch {
+		t.Errorf(
+			`
+			Expected validator at index 1's exit epoch to match
+			%d, received %d instead
+			`,
+			beaconState.Validators()[1].ExitEpoch,
+			newRegistry[1].ExitEpoch,
+		)
+	}
+
+	require.Equal(t, uint64(31992187500), newState.Balances()[1])
+	require.Equal(t, uint64(32000000000), newState.Balances()[2])
+}

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -403,11 +403,15 @@ func VerifyOperationLengths(_ context.Context, state state.BeaconState, b interf
 		)
 	}
 
-	if uint64(len(body.AttesterSlashings())) > params.BeaconConfig().MaxAttesterSlashings {
+	maxSlashings := params.BeaconConfig().MaxAttesterSlashings
+	if body.Version() >= version.Electra {
+		maxSlashings = params.BeaconConfig().MaxAttesterSlashingsElectra
+	}
+	if uint64(len(body.AttesterSlashings())) > maxSlashings {
 		return nil, fmt.Errorf(
 			"number of attester slashings (%d) in block body exceeds allowed threshold of %d",
 			len(body.AttesterSlashings()),
-			params.BeaconConfig().MaxAttesterSlashings,
+			maxSlashings,
 		)
 	}
 

--- a/beacon-chain/core/transition/transition_test.go
+++ b/beacon-chain/core/transition/transition_test.go
@@ -437,6 +437,25 @@ func TestProcessBlock_OverMaxAttesterSlashings(t *testing.T) {
 	assert.ErrorContains(t, want, err)
 }
 
+func TestProcessBlock_OverMaxAttesterSlashingsElectra(t *testing.T) {
+	maxSlashings := params.BeaconConfig().MaxAttesterSlashingsElectra
+	b := &ethpb.SignedBeaconBlockElectra{
+		Block: &ethpb.BeaconBlockElectra{
+			Body: &ethpb.BeaconBlockBodyElectra{
+				AttesterSlashings: make([]*ethpb.AttesterSlashingElectra, maxSlashings+1),
+			},
+		},
+	}
+	want := fmt.Sprintf("number of attester slashings (%d) in block body exceeds allowed threshold of %d",
+		len(b.Block.Body.AttesterSlashings), params.BeaconConfig().MaxAttesterSlashingsElectra)
+	s, err := state_native.InitializeFromProtoUnsafeElectra(&ethpb.BeaconStateElectra{})
+	require.NoError(t, err)
+	wsb, err := consensusblocks.NewSignedBeaconBlock(b)
+	require.NoError(t, err)
+	_, err = transition.VerifyOperationLengths(context.Background(), s, wsb.Block())
+	assert.ErrorContains(t, want, err)
+}
+
 func TestProcessBlock_OverMaxAttestations(t *testing.T) {
 	b := &ethpb.SignedBeaconBlock{
 		Block: &ethpb.BeaconBlock{

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -813,9 +813,9 @@ func unmarshalBlock(_ context.Context, enc []byte) (interfaces.ReadOnlySignedBea
 		if err := rawBlock.UnmarshalSSZ(enc[len(denebBlindKey):]); err != nil {
 			return nil, errors.Wrap(err, "could not unmarshal blinded Deneb block")
 		}
-	case hasElectraKey(enc):
+	case HasElectraKey(enc):
 		rawBlock = &ethpb.SignedBeaconBlockElectra{}
-		if err := rawBlock.UnmarshalSSZ(enc[len(electraKey):]); err != nil {
+		if err := rawBlock.UnmarshalSSZ(enc[len(ElectraKey):]); err != nil {
 			return nil, errors.Wrap(err, "could not unmarshal Electra block")
 		}
 	case hasElectraBlindKey(enc):
@@ -874,7 +874,7 @@ func keyForBlock(blk interfaces.ReadOnlySignedBeaconBlock) ([]byte, error) {
 		if blk.IsBlinded() {
 			return electraBlindKey, nil
 		}
-		return electraKey, nil
+		return ElectraKey, nil
 	}
 
 	if v >= version.Deneb {

--- a/beacon-chain/db/kv/key.go
+++ b/beacon-chain/db/kv/key.go
@@ -52,11 +52,12 @@ func hasDenebBlindKey(enc []byte) bool {
 	return bytes.Equal(enc[:len(denebBlindKey)], denebBlindKey)
 }
 
-func hasElectraKey(enc []byte) bool {
-	if len(electraKey) >= len(enc) {
+// HasElectraKey verifies if the encoding is Electra compatible.
+func HasElectraKey(enc []byte) bool {
+	if len(ElectraKey) >= len(enc) {
 		return false
 	}
-	return bytes.Equal(enc[:len(electraKey)], electraKey)
+	return bytes.Equal(enc[:len(ElectraKey)], ElectraKey)
 }
 
 func hasElectraBlindKey(enc []byte) bool {

--- a/beacon-chain/db/kv/lightclient.go
+++ b/beacon-chain/db/kv/lightclient.go
@@ -167,13 +167,13 @@ func decodeLightClientBootstrap(enc []byte) (interfaces.LightClientBootstrap, []
 		}
 		m = bootstrap
 		syncCommitteeHash = enc[len(denebKey) : len(denebKey)+32]
-	case hasElectraKey(enc):
+	case HasElectraKey(enc):
 		bootstrap := &ethpb.LightClientBootstrapElectra{}
-		if err := bootstrap.UnmarshalSSZ(enc[len(electraKey)+32:]); err != nil {
+		if err := bootstrap.UnmarshalSSZ(enc[len(ElectraKey)+32:]); err != nil {
 			return nil, nil, errors.Wrap(err, "could not unmarshal Electra light client bootstrap")
 		}
 		m = bootstrap
-		syncCommitteeHash = enc[len(electraKey) : len(electraKey)+32]
+		syncCommitteeHash = enc[len(ElectraKey) : len(ElectraKey)+32]
 	default:
 		return nil, nil, errors.New("decoding of saved light client bootstrap is unsupported")
 	}
@@ -277,9 +277,9 @@ func decodeLightClientUpdate(enc []byte) (interfaces.LightClientUpdate, error) {
 			return nil, errors.Wrap(err, "could not unmarshal Deneb light client update")
 		}
 		m = update
-	case hasElectraKey(enc):
+	case HasElectraKey(enc):
 		update := &ethpb.LightClientUpdateElectra{}
-		if err := update.UnmarshalSSZ(enc[len(electraKey):]); err != nil {
+		if err := update.UnmarshalSSZ(enc[len(ElectraKey):]); err != nil {
 			return nil, errors.Wrap(err, "could not unmarshal Electra light client update")
 		}
 		m = update
@@ -292,7 +292,7 @@ func decodeLightClientUpdate(enc []byte) (interfaces.LightClientUpdate, error) {
 func keyForLightClientUpdate(v int) ([]byte, error) {
 	switch v {
 	case version.Electra:
-		return electraKey, nil
+		return ElectraKey, nil
 	case version.Deneb:
 		return denebKey, nil
 	case version.Capella:

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -53,7 +53,7 @@ var (
 	saveBlindedBeaconBlocksKey = []byte("save-blinded-beacon-blocks")
 	denebKey                   = []byte("deneb")
 	denebBlindKey              = []byte("blind-deneb")
-	electraKey                 = []byte("electra")
+	ElectraKey                 = []byte("electra")
 	electraBlindKey            = []byte("blind-electra")
 	fuluKey                    = []byte("fulu")
 	fuluBlindKey               = []byte("blind-fulu")

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -357,7 +357,7 @@ func (s *Store) processElectra(ctx context.Context, pbState *ethpb.BeaconStateEl
 	if err != nil {
 		return err
 	}
-	encodedState := snappy.Encode(nil, append(electraKey, rawObj...))
+	encodedState := snappy.Encode(nil, append(ElectraKey, rawObj...))
 	if err := bucket.Put(rootHash, encodedState); err != nil {
 		return err
 	}
@@ -530,9 +530,9 @@ func (s *Store) unmarshalState(_ context.Context, enc []byte, validatorEntries [
 			protoState.Validators = validatorEntries
 		}
 		return statenative.InitializeFromProtoUnsafeFulu(protoState)
-	case hasElectraKey(enc):
+	case HasElectraKey(enc):
 		protoState := &ethpb.BeaconStateElectra{}
-		if err := protoState.UnmarshalSSZ(enc[len(electraKey):]); err != nil {
+		if err := protoState.UnmarshalSSZ(enc[len(ElectraKey):]); err != nil {
 			return nil, errors.Wrap(err, "failed to unmarshal encoding for Electra")
 		}
 		ok, err := s.isStateValidatorMigrationOver()
@@ -688,7 +688,7 @@ func marshalState(ctx context.Context, st state.ReadOnlyBeaconState) ([]byte, er
 		if err != nil {
 			return nil, err
 		}
-		return snappy.Encode(nil, append(electraKey, rawObj...)), nil
+		return snappy.Encode(nil, append(ElectraKey, rawObj...)), nil
 	case version.Fulu:
 		rState, ok := st.ToProtoUnsafe().(*ethpb.BeaconStateFulu)
 		if !ok {

--- a/beacon-chain/db/slasherkv/BUILD.bazel
+++ b/beacon-chain/db/slasherkv/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/db/iface:go_default_library",
+        "//beacon-chain/db/kv:go_default_library",
         "//beacon-chain/slasher/types:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
@@ -22,6 +23,7 @@ go_library(
         "//io/file:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
@@ -50,6 +52,7 @@ go_test(
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//runtime/version:go_default_library",
         "//testing/require:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_prysmaticlabs_fastssz//:go_default_library",

--- a/beacon-chain/db/slasherkv/pruning_test.go
+++ b/beacon-chain/db/slasherkv/pruning_test.go
@@ -8,6 +8,7 @@ import (
 	slashertypes "github.com/prysmaticlabs/prysm/v5/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 	logTest "github.com/sirupsen/logrus/hooks/test"
@@ -177,8 +178,8 @@ func TestStore_PruneAttestations_OK(t *testing.T) {
 				if i > 0 {
 					source = target - 1
 				}
-				att1 := createAttestationWrapper(source, target, []uint64{attester1}, []byte{0})
-				att2 := createAttestationWrapper(source, target, []uint64{attester2}, []byte{1})
+				att1 := createAttestationWrapper(version.Phase0, source, target, []uint64{attester1}, []byte{0})
+				att2 := createAttestationWrapper(version.Phase0, source, target, []uint64{attester2}, []byte{1})
 				attestations = append(attestations, att1, att2)
 			}
 		}

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -223,6 +223,39 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 			},
 		},
 		&feed.Event{
+			Type: operation.AttesterSlashingReceived,
+			Data: &operation.AttesterSlashingReceivedData{
+				AttesterSlashing: &eth.AttesterSlashingElectra{
+					Attestation_1: &eth.IndexedAttestationElectra{
+						AttestingIndices: []uint64{0, 1},
+						Data: &eth.AttestationData{
+							BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+							Source: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+							Target: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+						},
+						Signature: make([]byte, fieldparams.BLSSignatureLength),
+					},
+					Attestation_2: &eth.IndexedAttestationElectra{
+						AttestingIndices: []uint64{0, 1},
+						Data: &eth.AttestationData{
+							BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+							Source: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+							Target: &eth.Checkpoint{
+								Root: make([]byte, fieldparams.RootLength),
+							},
+						},
+						Signature: make([]byte, fieldparams.BLSSignatureLength),
+					},
+				},
+			},
+		},
+		&feed.Event{
 			Type: operation.ProposerSlashingReceived,
 			Data: &operation.ProposerSlashingReceivedData{
 				ProposerSlashing: &eth.ProposerSlashing{
@@ -544,7 +577,7 @@ func TestStuckReaderScenarios(t *testing.T) {
 
 func wedgedWriterTestCase(t *testing.T, queueDepth func([]*feed.Event) int) {
 	topics, events := operationEventsFixtures(t)
-	require.Equal(t, 8, len(events))
+	require.Equal(t, 9, len(events))
 
 	// set eventFeedDepth to a number lower than the events we intend to send to force the server to drop the reader.
 	stn := mockChain.NewEventFeedWrapper()

--- a/changelog/radek_eip-7549-slasher-pt1.md
+++ b/changelog/radek_eip-7549-slasher-pt1.md
@@ -1,3 +1,3 @@
 ### Added
 
-- Update slasher service to Electra
+- Update slasher service to Electra.

--- a/changelog/radek_eip-7549-slasher-pt2.md
+++ b/changelog/radek_eip-7549-slasher-pt2.md
@@ -1,0 +1,3 @@
+### Added
+
+- Handle `AttesterSlashingElectra` everywhere in the codebase.

--- a/config/params/configset_test.go
+++ b/config/params/configset_test.go
@@ -132,6 +132,7 @@ func compareConfigs(t *testing.T, expected, actual *BeaconChainConfig) {
 	require.DeepEqual(t, expected.ProportionalSlashingMultiplier, actual.ProportionalSlashingMultiplier)
 	require.DeepEqual(t, expected.MaxProposerSlashings, actual.MaxProposerSlashings)
 	require.DeepEqual(t, expected.MaxAttesterSlashings, actual.MaxAttesterSlashings)
+	require.DeepEqual(t, expected.MaxAttesterSlashingsElectra, actual.MaxAttesterSlashingsElectra)
 	require.DeepEqual(t, expected.MaxAttestations, actual.MaxAttestations)
 	require.DeepEqual(t, expected.MaxDeposits, actual.MaxDeposits)
 	require.DeepEqual(t, expected.MaxVoluntaryExits, actual.MaxVoluntaryExits)

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -135,6 +135,7 @@ func assertEqualConfigs(t *testing.T, name string, fields []string, expected, ac
 	// Max operations per block.
 	assert.Equal(t, expected.MaxProposerSlashings, actual.MaxProposerSlashings, "%s: MaxProposerSlashings", name)
 	assert.Equal(t, expected.MaxAttesterSlashings, actual.MaxAttesterSlashings, "%s: MaxAttesterSlashings", name)
+	assert.Equal(t, expected.MaxAttesterSlashingsElectra, actual.MaxAttesterSlashingsElectra, "%s: MaxAttesterSlashingsElectra", name)
 	assert.Equal(t, expected.MaxAttestations, actual.MaxAttestations, "%s: MaxAttestations", name)
 	assert.Equal(t, expected.MaxDeposits, actual.MaxDeposits, "%s: MaxDeposits", name)
 	assert.Equal(t, expected.MaxVoluntaryExits, actual.MaxVoluntaryExits, "%s: MaxVoluntaryExits", name)

--- a/config/params/testnet_config_test.go
+++ b/config/params/testnet_config_test.go
@@ -88,6 +88,7 @@ func compareConfigs(t *testing.T, expected, actual *params.BeaconChainConfig) {
 	require.DeepEqual(t, expected.ProportionalSlashingMultiplier, actual.ProportionalSlashingMultiplier)
 	require.DeepEqual(t, expected.MaxProposerSlashings, actual.MaxProposerSlashings)
 	require.DeepEqual(t, expected.MaxAttesterSlashings, actual.MaxAttesterSlashings)
+	require.DeepEqual(t, expected.MaxAttesterSlashingsElectra, actual.MaxAttesterSlashingsElectra)
 	require.DeepEqual(t, expected.MaxAttestations, actual.MaxAttestations)
 	require.DeepEqual(t, expected.MaxDeposits, actual.MaxDeposits)
 	require.DeepEqual(t, expected.MaxVoluntaryExits, actual.MaxVoluntaryExits)

--- a/testing/util/attestation.go
+++ b/testing/util/attestation.go
@@ -391,3 +391,16 @@ func HydrateIndexedAttestation(a *ethpb.IndexedAttestation) *ethpb.IndexedAttest
 	a.Data = HydrateAttestationData(a.Data)
 	return a
 }
+
+// HydrateIndexedAttestationElectra hydrates an indexed attestation with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateIndexedAttestationElectra(a *ethpb.IndexedAttestationElectra) *ethpb.IndexedAttestationElectra {
+	if a.Signature == nil {
+		a.Signature = make([]byte, 96)
+	}
+	if a.Data == nil {
+		a.Data = &ethpb.AttestationData{}
+	}
+	a.Data = HydrateAttestationData(a.Data)
+	return a
+}

--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -122,18 +122,14 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot primitives.Slot,
 		return
 	}
 
-	// TODO: Extend to Electra
-	phase0Att, ok := indexedAtt.(*ethpb.IndexedAttestation)
-	if ok {
-		// Send the attestation to the beacon node.
-		if err := v.db.SlashableAttestationCheck(ctx, phase0Att, pubKey, signingRoot, v.emitAccountMetrics, ValidatorAttestFailVec); err != nil {
-			log.WithError(err).Error("Failed attestation slashing protection check")
-			log.WithFields(
-				attestationLogFields(pubKey, indexedAtt),
-			).Debug("Attempted slashable attestation details")
-			tracing.AnnotateError(span, err)
-			return
-		}
+	// Send the attestation to the beacon node.
+	if err := v.db.SlashableAttestationCheck(ctx, indexedAtt, pubKey, signingRoot, v.emitAccountMetrics, ValidatorAttestFailVec); err != nil {
+		log.WithError(err).Error("Failed attestation slashing protection check")
+		log.WithFields(
+			attestationLogFields(pubKey, indexedAtt),
+		).Debug("Attempted slashable attestation details")
+		tracing.AnnotateError(span, err)
+		return
 	}
 
 	var aggregationBitfield bitfield.Bitlist


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Updates several pieces of the codebase for Electra slashing support:
- Tests cases in several packages
- Bug fix in `transition.go`, where the maximum number of slashings in a block was always the Phase0 config value
- Add electra key check for attestation encoding/decoding in SlasherDB
- Support for Electra slashings in Beacon API events
- Enable slashing protection check in the VC

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
