### PR TITLE
Fix batch deposit processing by retrieving validators from state

### DIFF
--- a/changelog/tt_fix_pending_deposits.md
+++ b/changelog/tt_fix_pending_deposits.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prysmctl generate genesis state: fix truncation of ExtraData to 32 bytes to satisfy SSZ marshaling

--- a/changelog/tt_fix_pending_deposits.md
+++ b/changelog/tt_fix_pending_deposits.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Prysmctl generate genesis state: fix truncation of ExtraData to 32 bytes to satisfy SSZ marshaling
+- Fix batch process new pending deposits by getting validators from state


### PR DESCRIPTION
This PR ensures that a pending deposit can create a new validator even if an invalid deposit exists before a valid one under the same public key. It checks the state directly instead of the cache.