### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+repos:
+  # First run code formatters
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline
+        exclude_types: ["proto"]
+      - id: mixed-line-ending # ensures that a file doesn't contain a mix of LF and CRLF
+      - id: no-commit-to-branch # Protect specific branches (default: main/master) from direct checkins
+
+  - repo: local
+    hooks:
+      - id: gci
+        name: goimports
+        entry: bash -c 'command -v gci >/dev/null 2>&1 || go install github.com/daixiang0/gci@latest; gci write --skip-generated -s standard -s default "$@"' --
+        language: golang
+        files: \.go$
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.4.0
+    hooks:
+      - id: go-fmt
+        args: [ -w, -s ] # simplify code and write result to (source) file instead of stdout
+      - id: go-mod-tidy
+        files: go.mod
+
+  # Fix bazel build files
+  - repo: local
+    hooks:
+      - id: gazelle
+        name: bazel-fix
+        entry: .pre-commit/fixbazel.sh
+        language: system

--- a/.pre-commit/fixbazel.sh
+++ b/.pre-commit/fixbazel.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bazel run //:gazelle -- fix


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
Enables [pre-commit](https://pre-commit.com/) git hooks that will run certain commands before each commit.

**Other notes for review**
To enable this feature, first we need to install pre-commit cli:
```sh
pip install pre-commit
```

Then install pre-commit hooks for prysm repo:
```sh
cd /PATH/TO/PRYSM
pre-commit install
```

The above commands are only run once while installing. After this, these git hooks will run everytime you commit.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
