### PR TITLE
Update setters_misc.go

### DIFF
--- a/beacon-chain/state/state-native/setters_misc.go
+++ b/beacon-chain/state/state-native/setters_misc.go
@@ -38,7 +38,7 @@ import (
 const (
 	// This specifies the limit till which we process all dirty indices for a certain field.
 	// If we have more dirty indices than the threshold, then we rebuild the whole trie. This
-	// comes due to the fact that O(alogn) > O(n) beyond a certain value of a.
+	// comes due to the fact that O(along) > O(n) beyond a certain value of a.
 	indicesLimit = 8000
 )
 


### PR DESCRIPTION
Fixed a typo in a comment within setters_misc.go: Changed "along" to "alog n" to correctly reflect the intended mathematical notation.