### PR TITLE
Improve blobs Beacon API endpoint

### DIFF
--- a/beacon-chain/rpc/lookup/BUILD.bazel
+++ b/beacon-chain/rpc/lookup/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -19,7 +19,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
-	log "github.com/sirupsen/logrus"
 )
 
 // BlockIdParseError represents an error scenario where a block ID could not be parsed.
@@ -194,10 +193,10 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 			}
 			ok, roots, err := p.BeaconDB.BlockRootsBySlot(ctx, primitives.Slot(slot))
 			if !ok {
-				return nil, &core.RpcError{Err: fmt.Errorf("block not found: no block roots at slot %d", slot), Reason: core.NotFound}
+				return nil, &core.RpcError{Err: fmt.Errorf("no block roots at slot %d", slot), Reason: core.NotFound}
 			}
 			if err != nil {
-				return nil, &core.RpcError{Err: errors.Wrap(err, "failed to get block roots by slot"), Reason: core.Internal}
+				return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to get block roots for slot %d", slot), Reason: core.Internal}
 			}
 			root = roots[0][:]
 			if len(roots) == 1 {
@@ -206,7 +205,7 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 			for _, blockRoot := range roots {
 				canonical, err := p.ChainInfoFetcher.IsCanonical(ctx, blockRoot)
 				if err != nil {
-					return nil, &core.RpcError{Err: errors.Wrap(err, "could not determine if block root is canonical"), Reason: core.Internal}
+					return nil, &core.RpcError{Err: errors.Wrapf(err, "could not determine if block %#x is canonical", blockRoot), Reason: core.Internal}
 				}
 				if canonical {
 					root = blockRoot[:]
@@ -215,45 +214,63 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 			}
 		}
 	}
+
 	if !p.BeaconDB.HasBlock(ctx, bytesutil.ToBytes32(root)) {
-		return nil, &core.RpcError{Err: errors.New("block not found"), Reason: core.NotFound}
+		return nil, &core.RpcError{Err: fmt.Errorf("block %#x not found in db", root), Reason: core.NotFound}
 	}
 	b, err := p.BeaconDB.Block(ctx, bytesutil.ToBytes32(root))
 	if err != nil {
-		return nil, &core.RpcError{Err: errors.Wrap(err, "failed to retrieve block from db"), Reason: core.Internal}
+		return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to retrieve block %#x from db", root), Reason: core.Internal}
 	}
-	// if block is not in the retention window  return 200 w/ empty list
+
+	// if block is not in the retention window, return 200 w/ empty list
 	if !p.BlobStorage.WithinRetentionPeriod(slots.ToEpoch(b.Block().Slot()), slots.ToEpoch(p.GenesisTimeFetcher.CurrentSlot())) {
 		return make([]*blocks.VerifiedROBlob, 0), nil
 	}
+
 	commitments, err := b.Block().Body().BlobKzgCommitments()
 	if err != nil {
-		return nil, &core.RpcError{Err: errors.Wrap(err, "failed to retrieve kzg commitments from block"), Reason: core.Internal}
+		return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to retrieve kzg commitments from block %#x", root), Reason: core.Internal}
 	}
 	// if there are no commitments return 200 w/ empty list
 	if len(commitments) == 0 {
 		return make([]*blocks.VerifiedROBlob, 0), nil
 	}
-	if len(indices) == 0 {
-		sum := p.BlobStorage.Summary(bytesutil.ToBytes32(root))
-		for i := range commitments {
-			if sum.HasIndex(uint64(i)) {
-				indices = append(indices, uint64(i))
+
+	m, err := p.BlobStorage.Indices(bytesutil.ToBytes32(root), b.Block().Slot())
+	if err != nil {
+		return nil, &core.RpcError{Err: fmt.Errorf("could not retrieve blob indices for block %#x", root), Reason: core.Internal}
+	}
+
+	indicesRequested := len(indices) > 0
+	for k, v := range m {
+		if v {
+			if k >= len(commitments) {
+				return nil, &core.RpcError{
+					Err:    fmt.Errorf("blob index %d is more than blob kzg commitment count %d for block %#x", k, len(commitments), root),
+					Reason: core.Internal,
+				}
+			}
+			if !indicesRequested {
+				indices = append(indices, uint64(k))
+			}
+		} else if indicesRequested {
+			for _, ix := range indices {
+				if uint64(k) == ix {
+					return nil, &core.RpcError{Err: fmt.Errorf("no blob at index %d found for block %#x", k, root), Reason: core.NotFound}
+				}
 			}
 		}
 	}
-	// returns empty slice if there are no indices
+
 	blobs := make([]*blocks.VerifiedROBlob, len(indices))
 	for i, index := range indices {
 		vblob, err := p.BlobStorage.Get(bytesutil.ToBytes32(root), index)
 		if err != nil {
-			log.WithFields(log.Fields{
-				"blockRoot": hexutil.Encode(root),
-				"blobIndex": index,
-			}).Error(errors.Wrapf(err, "could not retrieve blob for block root %#x at index %d", root, index))
 			return nil, &core.RpcError{Err: fmt.Errorf("could not retrieve blob for block root %#x at index %d", root, index), Reason: core.Internal}
 		}
 		blobs[i] = &vblob
 	}
+
 	return blobs, nil
 }

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -172,7 +172,7 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 	default:
 		if bytesutil.IsHex([]byte(id)) {
 			var err error
-			rootSlice, err = hexutil.Decode(id)
+			rootSlice, err = bytesutil.DecodeHexWithLength(id, fieldparams.RootLength)
 			if err != nil {
 				return nil, &core.RpcError{Err: NewBlockIdParseError(err), Reason: core.BadRequest}
 			}
@@ -217,12 +217,12 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 
 	root := bytesutil.ToBytes32(rootSlice)
 
-	if !p.BeaconDB.HasBlock(ctx, root) {
-		return nil, &core.RpcError{Err: fmt.Errorf("block %#x not found in db", rootSlice), Reason: core.NotFound}
-	}
 	b, err := p.BeaconDB.Block(ctx, root)
 	if err != nil {
 		return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to retrieve block %#x from db", rootSlice), Reason: core.Internal}
+	}
+	if b == nil {
+		return nil, &core.RpcError{Err: fmt.Errorf("block %#x not found in db", rootSlice), Reason: core.NotFound}
 	}
 
 	// if block is not in the retention window, return 200 w/ empty list

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -147,13 +147,13 @@ func (p *BeaconDbBlocker) Block(ctx context.Context, id []byte) (interfaces.Read
 //     we are technically not supposed to import a block to forkchoice unless we have the blobs, so the nuance here is if we can't find the file and we are inside the protocol-defined retention period, then it's actually a 500.
 //   - block exists, has commitments, outside retention period (greater of protocol- or user-specified) - ie just like block exists, no commitment
 func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64) ([]*blocks.VerifiedROBlob, *core.RpcError) {
-	var root []byte
+	var rootSlice []byte
 	switch id {
 	case "genesis":
 		return nil, &core.RpcError{Err: errors.New("blobs are not supported for Phase 0 fork"), Reason: core.BadRequest}
 	case "head":
 		var err error
-		root, err = p.ChainInfoFetcher.HeadRoot(ctx)
+		rootSlice, err = p.ChainInfoFetcher.HeadRoot(ctx)
 		if err != nil {
 			return nil, &core.RpcError{Err: errors.Wrapf(err, "could not retrieve head root"), Reason: core.Internal}
 		}
@@ -162,22 +162,22 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 		if fcp == nil {
 			return nil, &core.RpcError{Err: errors.New("received nil finalized checkpoint"), Reason: core.Internal}
 		}
-		root = fcp.Root
+		rootSlice = fcp.Root
 	case "justified":
 		jcp := p.ChainInfoFetcher.CurrentJustifiedCheckpt()
 		if jcp == nil {
 			return nil, &core.RpcError{Err: errors.New("received nil justified checkpoint"), Reason: core.Internal}
 		}
-		root = jcp.Root
+		rootSlice = jcp.Root
 	default:
 		if bytesutil.IsHex([]byte(id)) {
 			var err error
-			root, err = hexutil.Decode(id)
-			if len(root) != fieldparams.RootLength {
-				return nil, &core.RpcError{Err: fmt.Errorf("invalid block root of length %d", len(root)), Reason: core.BadRequest}
-			}
+			rootSlice, err = hexutil.Decode(id)
 			if err != nil {
 				return nil, &core.RpcError{Err: NewBlockIdParseError(err), Reason: core.BadRequest}
+			}
+			if len(rootSlice) != fieldparams.RootLength {
+				return nil, &core.RpcError{Err: fmt.Errorf("invalid block root of length %d", len(rootSlice)), Reason: core.BadRequest}
 			}
 		} else {
 			slot, err := strconv.ParseUint(id, 10, 64)
@@ -198,7 +198,7 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 			if err != nil {
 				return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to get block roots for slot %d", slot), Reason: core.Internal}
 			}
-			root = roots[0][:]
+			rootSlice = roots[0][:]
 			if len(roots) == 1 {
 				break
 			}
@@ -208,19 +208,21 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 					return nil, &core.RpcError{Err: errors.Wrapf(err, "could not determine if block %#x is canonical", blockRoot), Reason: core.Internal}
 				}
 				if canonical {
-					root = blockRoot[:]
+					rootSlice = blockRoot[:]
 					break
 				}
 			}
 		}
 	}
 
-	if !p.BeaconDB.HasBlock(ctx, bytesutil.ToBytes32(root)) {
-		return nil, &core.RpcError{Err: fmt.Errorf("block %#x not found in db", root), Reason: core.NotFound}
+	root := bytesutil.ToBytes32(rootSlice)
+
+	if !p.BeaconDB.HasBlock(ctx, root) {
+		return nil, &core.RpcError{Err: fmt.Errorf("block %#x not found in db", rootSlice), Reason: core.NotFound}
 	}
-	b, err := p.BeaconDB.Block(ctx, bytesutil.ToBytes32(root))
+	b, err := p.BeaconDB.Block(ctx, root)
 	if err != nil {
-		return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to retrieve block %#x from db", root), Reason: core.Internal}
+		return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to retrieve block %#x from db", rootSlice), Reason: core.Internal}
 	}
 
 	// if block is not in the retention window, return 200 w/ empty list
@@ -230,34 +232,33 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 
 	commitments, err := b.Block().Body().BlobKzgCommitments()
 	if err != nil {
-		return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to retrieve kzg commitments from block %#x", root), Reason: core.Internal}
+		return nil, &core.RpcError{Err: errors.Wrapf(err, "failed to retrieve kzg commitments from block %#x", rootSlice), Reason: core.Internal}
 	}
 	// if there are no commitments return 200 w/ empty list
 	if len(commitments) == 0 {
 		return make([]*blocks.VerifiedROBlob, 0), nil
 	}
 
-	m, err := p.BlobStorage.Indices(bytesutil.ToBytes32(root), b.Block().Slot())
-	if err != nil {
-		return nil, &core.RpcError{Err: fmt.Errorf("could not retrieve blob indices for block %#x", root), Reason: core.Internal}
-	}
+	sum := p.BlobStorage.Summary(root)
 
-	indicesRequested := len(indices) > 0
-	for k, v := range m {
-		if v {
-			if k >= len(commitments) {
+	if len(indices) == 0 {
+		for i := range commitments {
+			if sum.HasIndex(uint64(i)) {
+				indices = append(indices, uint64(i))
+			}
+		}
+	} else {
+		for _, ix := range indices {
+			if ix >= sum.MaxBlobsForEpoch() {
 				return nil, &core.RpcError{
-					Err:    fmt.Errorf("blob index %d is more than blob kzg commitment count %d for block %#x", k, len(commitments), root),
-					Reason: core.Internal,
+					Err:    fmt.Errorf("requested index %d is bigger than the maximum possible blob count %d", ix, sum.MaxBlobsForEpoch()),
+					Reason: core.BadRequest,
 				}
 			}
-			if !indicesRequested {
-				indices = append(indices, uint64(k))
-			}
-		} else if indicesRequested {
-			for _, ix := range indices {
-				if uint64(k) == ix {
-					return nil, &core.RpcError{Err: fmt.Errorf("no blob at index %d found for block %#x", k, root), Reason: core.NotFound}
+			if !sum.HasIndex(ix) {
+				return nil, &core.RpcError{
+					Err:    fmt.Errorf("requested index %d not found", ix),
+					Reason: core.NotFound,
 				}
 			}
 		}
@@ -265,9 +266,12 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 
 	blobs := make([]*blocks.VerifiedROBlob, len(indices))
 	for i, index := range indices {
-		vblob, err := p.BlobStorage.Get(bytesutil.ToBytes32(root), index)
+		vblob, err := p.BlobStorage.Get(root, index)
 		if err != nil {
-			return nil, &core.RpcError{Err: fmt.Errorf("could not retrieve blob for block root %#x at index %d", root, index), Reason: core.Internal}
+			return nil, &core.RpcError{
+				Err:    fmt.Errorf("could not retrieve blob for block root %#x at index %d", rootSlice, index),
+				Reason: core.Internal,
+			}
 		}
 		blobs[i] = &vblob
 	}

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -176,9 +176,6 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 			if err != nil {
 				return nil, &core.RpcError{Err: NewBlockIdParseError(err), Reason: core.BadRequest}
 			}
-			if len(rootSlice) != fieldparams.RootLength {
-				return nil, &core.RpcError{Err: fmt.Errorf("invalid block root of length %d", len(rootSlice)), Reason: core.BadRequest}
-			}
 		} else {
 			slot, err := strconv.ParseUint(id, 10, 64)
 			if err != nil {

--- a/beacon-chain/rpc/lookup/blocker_test.go
+++ b/beacon-chain/rpc/lookup/blocker_test.go
@@ -286,6 +286,20 @@ func TestGetBlob(t *testing.T) {
 		assert.DeepEqual(t, blobs[2].KzgCommitment, sidecar.KzgCommitment)
 		assert.DeepEqual(t, blobs[2].KzgProof, sidecar.KzgProof)
 	})
+	t.Run("no blob at index", func(t *testing.T) {
+		blocker := &BeaconDbBlocker{
+			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: bs,
+		}
+		noBlobIndex := uint64(len(blobs)) + 1
+		_, rpcErr := blocker.Blobs(ctx, "123", []uint64{0, noBlobIndex})
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, core.ErrorReason(core.NotFound), rpcErr.Reason)
+	})
 	t.Run("no blobs returns an empty array", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},

--- a/beacon-chain/rpc/lookup/blocker_test.go
+++ b/beacon-chain/rpc/lookup/blocker_test.go
@@ -3,6 +3,7 @@ package lookup
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"reflect"
 	"testing"
@@ -286,6 +287,19 @@ func TestGetBlob(t *testing.T) {
 		assert.DeepEqual(t, blobs[2].KzgCommitment, sidecar.KzgCommitment)
 		assert.DeepEqual(t, blobs[2].KzgProof, sidecar.KzgProof)
 	})
+	t.Run("no blobs returns an empty array", func(t *testing.T) {
+		blocker := &BeaconDbBlocker{
+			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			BeaconDB:    db,
+			BlobStorage: filesystem.NewEphemeralBlobStorage(t),
+		}
+		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "123", nil)
+		assert.Equal(t, rpcErr == nil, true)
+		require.Equal(t, 0, len(verifiedBlobs))
+	})
 	t.Run("no blob at index", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
@@ -300,17 +314,17 @@ func TestGetBlob(t *testing.T) {
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, core.ErrorReason(core.NotFound), rpcErr.Reason)
 	})
-	t.Run("no blobs returns an empty array", func(t *testing.T) {
+	t.Run("index too big", func(t *testing.T) {
 		blocker := &BeaconDbBlocker{
 			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
 			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
 				Genesis: time.Now(),
 			},
 			BeaconDB:    db,
-			BlobStorage: filesystem.NewEphemeralBlobStorage(t),
+			BlobStorage: bs,
 		}
-		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "123", nil)
-		assert.Equal(t, rpcErr == nil, true)
-		require.Equal(t, 0, len(verifiedBlobs))
+		_, rpcErr := blocker.Blobs(ctx, "123", []uint64{0, math.MaxUint})
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, core.ErrorReason(core.BadRequest), rpcErr.Reason)
 	})
 }

--- a/changelog/radek_blob-404.md
+++ b/changelog/radek_blob-404.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Return 404 instead of 500 from API when when a blob for a requested index is not found.
+
+### Ignored
+
+- Improve error messages and logs.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

- Currently we return an `500 InternalServerError` when a blob for a requested index is not found. It would be more useful to return a 404 instead, letting the user know that we don't have the blob, not that something went wrong when trying to fetch it.
- Additional information in some errors, such as block root or slot number

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
