### PR TITLE
Move deposit request nil check for all

### DIFF
--- a/beacon-chain/core/electra/deposits.go
+++ b/beacon-chain/core/electra/deposits.go
@@ -587,10 +587,10 @@ func processDepositRequest(beaconState state.BeaconState, request *enginev1.Depo
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get deposit requests start index")
 	}
+	if request == nil {
+		return nil, errors.New("nil deposit request")
+	}
 	if requestsStartIndex == params.BeaconConfig().UnsetDepositRequestsStartIndex {
-		if request == nil {
-			return nil, errors.New("nil deposit request")
-		}
 		if err := beaconState.SetDepositRequestsStartIndex(request.Index); err != nil {
 			return nil, errors.Wrap(err, "could not set deposit requests start index")
 		}

--- a/beacon-chain/core/electra/deposits_test.go
+++ b/beacon-chain/core/electra/deposits_test.go
@@ -333,6 +333,7 @@ func TestProcessDepositRequests(t *testing.T) {
 	st, _ := util.DeterministicGenesisStateElectra(t, 1)
 	sk, err := bls.RandKey()
 	require.NoError(t, err)
+	require.NoError(t, st.SetDepositRequestsStartIndex(1))
 
 	t.Run("empty requests continues", func(t *testing.T) {
 		newSt, err := electra.ProcessDepositRequests(context.Background(), st, []*enginev1.DepositRequest{})

--- a/changelog/tt_deposit_req_nil_check.md
+++ b/changelog/tt_deposit_req_nil_check.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move deposit request nil check to apply all


### PR DESCRIPTION
Deposit request nil check was only applied under `requestsStartIndex == params.BeaconConfig().UnsetDepositRequestsStartIndex`, but it should be applied under all conditions. Moving it outside the if condition