### PR TITLE
Peer das sync empty requests

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -668,27 +668,14 @@ func buildBwbSlices(wrappedBwbsMissingColumns *bwbsMissingColumns, batchsize int
 
 	previousBlockSlot := firstROBlock.Block().Slot()
 	previousStartIndex := 0
+	previousStartBlockSlot := previousBlockSlot
+	batchSizeSlot := primitives.Slot(batchsize)
 
 	const offset = 1
 
 	result := make([]bwbSlice, 0, 1)
 	for currentIndexWithoutOffest, bwb := range bwbs[offset:] {
 		currentIndex := currentIndexWithoutOffest + offset
-
-		// Check if the batch size is reached.
-		if currentIndex-previousStartIndex == batchsize {
-			// Append the slice to the result.
-			slice := bwbSlice{
-				start:       previousStartIndex,
-				end:         currentIndex - 1,
-				dataColumns: previousMissingDataColumns,
-			}
-
-			result = append(result, slice)
-
-			previousStartIndex = currentIndex
-			continue
-		}
 
 		// Extract the ROBlock from the blockWithROBlob.
 		currentROBlock := bwb.Block
@@ -730,8 +717,10 @@ func buildBwbSlices(wrappedBwbsMissingColumns *bwbsMissingColumns, batchsize int
 		// Compute if the missing data columns differ.
 		missingDataColumnsDiffer := uint64MapDiffer(previousMissingDataColumns, missingDataColumns)
 
-		// Check if there is a gap or if the missing data columns differ.
-		if missingDataColumnsDiffer {
+		// Compute if the batch size is reached.
+		batchSizeReached := currentBlockSlot-previousStartBlockSlot >= batchSizeSlot
+
+		if missingDataColumnsDiffer || batchSizeReached {
 			// Append the slice to the result.
 			slice := bwbSlice{
 				start:       previousStartIndex,
@@ -742,6 +731,7 @@ func buildBwbSlices(wrappedBwbsMissingColumns *bwbsMissingColumns, batchsize int
 			result = append(result, slice)
 
 			previousStartIndex = currentIndex
+			previousStartBlockSlot = currentBlockSlot
 			previousMissingDataColumns = missingDataColumns
 		}
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -686,8 +686,8 @@ func buildBwbSlices(wrappedBwbsMissingColumns *bwbsMissingColumns, batchsize int
 		// Extract the slot from the block.
 		currentBlockSlot := currentBlock.Slot()
 
-		if currentBlockSlot < previousBlockSlot {
-			return nil, errors.New("blocks are not sorted by slot")
+		if currentBlockSlot <= previousBlockSlot {
+			return nil, errors.Errorf("blocks are not strictly sorted by slot. Previous block slot: %d, current block slot: %d", previousBlockSlot, currentBlockSlot)
 		}
 
 		// Extract KZG commitments count from the current block body
@@ -874,6 +874,9 @@ func computeMissingDataColumnsCount(missingColumnsByRoot map[[fieldparams.RootLe
 	return count
 }
 
+// fetchBwbSliceFromPeers requests data columns by range to relevant peers, then mutates
+// - `wrappedBwbsMissingColumns.bwbs` by adding the fetched data columns,
+// - `wrappedBwbsMissingColumns.missingColumnsByRoot` by removing the fetched data columns.
 func (f *blocksFetcher) fetchBwbSliceFromPeers(
 	ctx context.Context,
 	identifier int,
@@ -937,7 +940,6 @@ func (f *blocksFetcher) fetchBwbSliceFromPeers(
 		slices.Sort[[]uint64](dataColumnsToFetch)
 
 		// Build the request.
-
 		request := &p2ppb.DataColumnSidecarsByRangeRequest{
 			StartSlot: startSlot,
 			Count:     blockCount,
@@ -1183,8 +1185,8 @@ func (f *blocksFetcher) waitForPeersForDataColumns(
 	return dataColumnsByAdmissiblePeer, nil
 }
 
-// processDataColumns mutates `bwbs` argument by adding the data column,
-// and mutates `missingColumnsByRoot` by removing the data column if the
+// processDataColumns mutates `wrappedBwbsMissingColumns.bwbs` argument by adding the data column,
+// and mutates `wrappedBwbsMissingColumns.missingColumnsByRoot` by removing the data column if the
 // data column passes all the check.
 func (f *blocksFetcher) processDataColumns(
 	wrappedBwbsMissingColumns *bwbsMissingColumns,
@@ -1273,8 +1275,8 @@ func (f *blocksFetcher) processDataColumns(
 }
 
 // fetchDataColumnsFromPeer sends `request` to `peer`, then mutates:
-// - `bwbs` by adding the fetched data columns,
-// - `missingColumnsByRoot` by removing the fetched data columns.
+// - `wrappedBwbsMissingColumns.bwbs` by adding the fetched data columns,
+// - `wrappedBwbsMissingColumns.missingColumnsByRoot` by removing the fetched data columns.
 func (f *blocksFetcher) fetchDataColumnFromPeer(
 	ctx context.Context,
 	identifier int,

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -1672,9 +1672,10 @@ func TestBuildBwbSlices(t *testing.T) {
 			},
 		},
 		{
-			name:      "eight items - columns break, limiting batch size",
+			name:      "eleven items - columns break, limiting batch size",
 			batchSize: 3,
 			missingColumnsWithCommitments: []*missingColumnsWithCommitment{
+				{areCommitments: true, missingColumns: map[uint64]bool{1: true, 3: true, 5: true}},
 				{areCommitments: true, missingColumns: map[uint64]bool{1: true, 3: true, 5: true}},
 				{areCommitments: true, missingColumns: map[uint64]bool{1: true, 3: true, 5: true}},
 				{areCommitments: true, missingColumns: map[uint64]bool{1: true, 3: true}},
@@ -1687,11 +1688,11 @@ func TestBuildBwbSlices(t *testing.T) {
 				{areCommitments: true, missingColumns: map[uint64]bool{}},
 			},
 			bwbSlices: []bwbSlice{
-				{start: 0, end: 1, dataColumns: map[uint64]bool{1: true, 3: true, 5: true}},
-				{start: 2, end: 4, dataColumns: map[uint64]bool{1: true, 3: true}},
-				{start: 5, end: 5, dataColumns: map[uint64]bool{1: true, 3: true}},
-				{start: 6, end: 8, dataColumns: map[uint64]bool{}},
-				{start: 9, end: 9, dataColumns: map[uint64]bool{}},
+				{start: 0, end: 2, dataColumns: map[uint64]bool{1: true, 3: true, 5: true}},
+				{start: 3, end: 5, dataColumns: map[uint64]bool{1: true, 3: true}},
+				{start: 6, end: 6, dataColumns: map[uint64]bool{1: true, 3: true}},
+				{start: 7, end: 9, dataColumns: map[uint64]bool{}},
+				{start: 10, end: 10, dataColumns: map[uint64]bool{}},
 			},
 		},
 	}

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -213,9 +213,10 @@ func validateDataColumnsByRootRequest(colIdents types.DataColumnSidecarsByRootRe
 
 func DataColumnsRPCMinValidSlot(current primitives.Slot) (primitives.Slot, error) {
 	// Avoid overflow if we're running on a config where deneb is set to far future epoch.
-	if params.BeaconConfig().DenebForkEpoch == math.MaxUint64 || !coreTime.PeerDASIsActive(current) {
+	if !coreTime.PeerDASIsActive(current) {
 		return primitives.Slot(math.MaxUint64), nil
 	}
+
 	minReqEpochs := params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest
 	currEpoch := slots.ToEpoch(current)
 	minStart := params.BeaconConfig().FuluForkEpoch


### PR DESCRIPTION
**Please read commit by commit**

Fix edge case where initial sync was blocked because of a bug in the `buildBwbSlices` function when, at the same time, we reach the batch limit **and** the set of missing columns is changing.

The first commit adds a new (failing) test case.
The second commit modifies the `buildBwbSlices` to comply with the newsly introduced test case.
The other commits are cosmetics.