### PR TITLE
warn that --enable-historical-state-representation is up for deprecation

### DIFF
--- a/changelog/kasey_warn-hist-state-rep.md
+++ b/changelog/kasey_warn-hist-state-rep.md
@@ -1,0 +1,2 @@
+### Added
+- WARN log message on node startup advising of the upcoming deprecation of the --enable-historical-state-representation feature flag.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -166,6 +166,7 @@ func applyHoleskyFeatureFlags(ctx *cli.Context) {
 // ConfigureBeaconChain sets the global config based
 // on what flags are enabled for the beacon-chain client.
 func ConfigureBeaconChain(ctx *cli.Context) error {
+	warnDeprecationUpcoming(ctx)
 	complainOnDeprecatedFlags(ctx)
 	cfg := &Flags{}
 	if ctx.Bool(devModeFlag.Name) {
@@ -332,6 +333,22 @@ func complainOnDeprecatedFlags(ctx *cli.Context) {
 	for _, f := range deprecatedFlags {
 		if ctx.IsSet(f.Names()[0]) {
 			log.Errorf("%s is deprecated and has no effect. Do not use this flag, it will be deleted soon.", f.Names()[0])
+		}
+	}
+}
+
+var upcomingDeprecationExtra = map[string]string{
+	enableHistoricalSpaceRepresentation.Name: "The node needs to be resynced after flag removal.",
+}
+
+func warnDeprecationUpcoming(ctx *cli.Context) {
+	for _, f := range upcomingDeprecation {
+		if ctx.IsSet(f.Names()[0]) {
+			extra := "Please remove this flag from your configuration."
+			if special, ok := upcomingDeprecationExtra[f.Names()[0]]; ok {
+				extra += " " + special
+			}
+			log.Warnf("--%s is pending deprecation and will be removed in the next release. %s", f.Names()[0], extra)
 		}
 	}
 }

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -120,6 +120,10 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableQuic,
 }
 
+var upcomingDeprecation = []cli.Flag{
+	enableHistoricalSpaceRepresentation,
+}
+
 // deprecatedBeaconFlags contains flags that are still used by other components
 // and therefore cannot be added to deprecatedFlags
 var deprecatedBeaconFlags = []cli.Flag{

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -205,7 +205,7 @@ var E2EValidatorFlags = []string{
 }
 
 // BeaconChainFlags contains a list of all the feature flags that apply to the beacon-chain client.
-var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []cli.Flag{
+var BeaconChainFlags = combinedFlags([]cli.Flag{
 	devModeFlag,
 	disableExperimentalState,
 	writeSSZStateTransitionsFlag,
@@ -218,7 +218,6 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	disablePeerScorer,
 	disableBroadcastSlashingFlag,
 	enableSlasherFlag,
-	enableHistoricalSpaceRepresentation,
 	disableStakinContractCheck,
 	SaveFullExecutionPayloads,
 	enableStartupOptimistic,
@@ -236,7 +235,18 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	DisableCommitteeAwarePacking,
 	EnableDiscoveryReboot,
 	enableExperimentalAttestationPool,
-}...)...)
+}, deprecatedBeaconFlags, deprecatedFlags, upcomingDeprecation)
+
+func combinedFlags(flags ...[]cli.Flag) []cli.Flag {
+	if len(flags) == 0 {
+		return []cli.Flag{}
+	}
+	collected := flags[0]
+	for _, f := range flags[1:] {
+		collected = append(collected, f...)
+	}
+	return collected
+}
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.
 var E2EBeaconChainFlags = []string{


### PR DESCRIPTION
**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**

logs the following warning if `--enable-historical-state-representation`
```
WARN flags: --enable-historical-state-representation is pending deprecation and will be removed in the next release. This node will need to be resynced once the flag is removed.
```
This is needed because we have decided to deprecate this feature and want to notify users ahead of time, because removing the feature code will render their state database unusable.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
