### PR TITLE
Fix startup log for config file values

### DIFF
--- a/changelog/potuz_fix_forkmaps_log.md
+++ b/changelog/potuz_fix_forkmaps_log.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Fix the debug log with the config file values at startup.

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -65,6 +65,8 @@ func UnmarshalConfig(yamlFile []byte, conf *BeaconChainConfig) (*BeaconChainConf
 	}
 	// recompute SqrRootSlotsPerEpoch constant to handle non-standard values of SlotsPerEpoch
 	conf.SqrRootSlotsPerEpoch = primitives.Slot(math.IntegerSquareRoot(uint64(conf.SlotsPerEpoch)))
+	// Recompute the fork schedule
+	conf.InitializeForkSchedule()
 	log.Debugf("Config file values: %+v", conf)
 	return conf, nil
 }


### PR DESCRIPTION
when we load a config file, we call eventually UnmarshalConfig which first copies the mainnet config by calling MainnetConfig().Copy().

MainnetConfig() calls InitializeForkSchedule  which in turn calls to configForkSchedule(b) and configForkNames(b) so these maps are made from the default config and not from the config file. After that the unmarshaller finishes changing the config values, this will read the new fork versions and epochs from the config file, but not change the maps So the config file values printed at the end have bogus maps that do not corresponds to the config file. 

What worries me is that even if this is corrected later, this function UnmarshalConfig is returning a bogus config in inconsistent state.