### PR TITLE
nil checks on ToConsensus() functions

### DIFF
--- a/api/server/structs/BUILD.bazel
+++ b/api/server/structs/BUILD.bazel
@@ -52,5 +52,6 @@ go_test(
     deps = [
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/api/server/structs/BUILD.bazel
+++ b/api/server/structs/BUILD.bazel
@@ -52,6 +52,5 @@ go_test(
     deps = [
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -106,11 +106,11 @@ func SignedBLSChangeFromConsensus(ch *eth.SignedBLSToExecutionChange) *SignedBLS
 
 func SignedBLSChangesToConsensus(src []*SignedBLSToExecutionChange) ([]*eth.SignedBLSToExecutionChange, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "SignedBLSToExecutionChanges")
 	}
 	err := slice.VerifyMaxLength(src, 16)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "SignedBLSToExecutionChanges")
 	}
 	changes := make([]*eth.SignedBLSToExecutionChange, len(src))
 	for i, ch := range src {
@@ -163,7 +163,7 @@ func ForkFromConsensus(f *eth.Fork) *Fork {
 
 func (s *SignedValidatorRegistration) ToConsensus() (*eth.SignedValidatorRegistrationV1, error) {
 	if s.Message == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Message")
 	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
@@ -222,7 +222,7 @@ func SignedValidatorRegistrationFromConsensus(vr *eth.SignedValidatorRegistratio
 
 func (s *SignedContributionAndProof) ToConsensus() (*eth.SignedContributionAndProof, error) {
 	if s.Message == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Message")
 	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
@@ -249,7 +249,7 @@ func SignedContributionAndProofFromConsensus(c *eth.SignedContributionAndProof) 
 
 func (c *ContributionAndProof) ToConsensus() (*eth.ContributionAndProof, error) {
 	if c.Contribution == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Contribution")
 	}
 	contribution, err := c.Contribution.ToConsensus()
 	if err != nil {
@@ -323,7 +323,7 @@ func SyncCommitteeContributionFromConsensus(c *eth.SyncCommitteeContribution) *S
 
 func (s *SignedAggregateAttestationAndProof) ToConsensus() (*eth.SignedAggregateAttestationAndProof, error) {
 	if s.Message == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Message")
 	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
@@ -346,7 +346,7 @@ func (a *AggregateAttestationAndProof) ToConsensus() (*eth.AggregateAttestationA
 		return nil, server.NewDecodeError(err, "AggregatorIndex")
 	}
 	if a.Aggregate == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Aggregate")
 	}
 	agg, err := a.Aggregate.ToConsensus()
 	if err != nil {
@@ -365,7 +365,7 @@ func (a *AggregateAttestationAndProof) ToConsensus() (*eth.AggregateAttestationA
 
 func (s *SignedAggregateAttestationAndProofElectra) ToConsensus() (*eth.SignedAggregateAttestationAndProofElectra, error) {
 	if s.Message == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Message")
 	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
@@ -388,7 +388,7 @@ func (a *AggregateAttestationAndProofElectra) ToConsensus() (*eth.AggregateAttes
 		return nil, server.NewDecodeError(err, "AggregatorIndex")
 	}
 	if a.Aggregate == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Aggregate")
 	}
 	agg, err := a.Aggregate.ToConsensus()
 	if err != nil {
@@ -411,7 +411,7 @@ func (a *Attestation) ToConsensus() (*eth.Attestation, error) {
 		return nil, server.NewDecodeError(err, "AggregationBits")
 	}
 	if a.Data == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Data")
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -443,7 +443,7 @@ func (a *AttestationElectra) ToConsensus() (*eth.AttestationElectra, error) {
 		return nil, server.NewDecodeError(err, "AggregationBits")
 	}
 	if a.Data == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Data")
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -485,7 +485,7 @@ func (a *SingleAttestation) ToConsensus() (*eth.SingleAttestation, error) {
 		return nil, server.NewDecodeError(err, "AttesterIndex")
 	}
 	if a.Data == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Data")
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -527,14 +527,14 @@ func (a *AttestationData) ToConsensus() (*eth.AttestationData, error) {
 		return nil, server.NewDecodeError(err, "BeaconBlockRoot")
 	}
 	if a.Source == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Source")
 	}
 	source, err := a.Source.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Source")
 	}
 	if a.Target == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Target")
 	}
 	target, err := a.Target.ToConsensus()
 	if err != nil {
@@ -636,7 +636,7 @@ func (b *BeaconCommitteeSubscription) ToConsensus() (*validator.BeaconCommitteeS
 
 func (e *SignedVoluntaryExit) ToConsensus() (*eth.SignedVoluntaryExit, error) {
 	if e.Message == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Message")
 	}
 	exit, err := e.Message.ToConsensus()
 	if err != nil {
@@ -749,14 +749,14 @@ func Eth1DataFromConsensus(e1d *eth.Eth1Data) *Eth1Data {
 
 func (s *ProposerSlashing) ToConsensus() (*eth.ProposerSlashing, error) {
 	if s.SignedHeader1 == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "SignedHeader1")
 	}
 	h1, err := s.SignedHeader1.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "SignedHeader1")
 	}
 	if s.SignedHeader2 == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "SignedHeader2")
 	}
 	h2, err := s.SignedHeader2.ToConsensus()
 	if err != nil {
@@ -771,14 +771,14 @@ func (s *ProposerSlashing) ToConsensus() (*eth.ProposerSlashing, error) {
 
 func (s *AttesterSlashing) ToConsensus() (*eth.AttesterSlashing, error) {
 	if s.Attestation1 == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Attestation1")
 	}
 	att1, err := s.Attestation1.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Attestation1")
 	}
 	if s.Attestation2 == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Attestation2")
 	}
 	att2, err := s.Attestation2.ToConsensus()
 	if err != nil {
@@ -789,14 +789,14 @@ func (s *AttesterSlashing) ToConsensus() (*eth.AttesterSlashing, error) {
 
 func (s *AttesterSlashingElectra) ToConsensus() (*eth.AttesterSlashingElectra, error) {
 	if s.Attestation1 == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Attestation1")
 	}
 	att1, err := s.Attestation1.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Attestation1")
 	}
 	if s.Attestation2 == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Attestation2")
 	}
 	att2, err := s.Attestation2.ToConsensus()
 	if err != nil {
@@ -819,7 +819,7 @@ func (a *IndexedAttestation) ToConsensus() (*eth.IndexedAttestation, error) {
 		}
 	}
 	if a.Data == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Data")
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -854,7 +854,7 @@ func (a *IndexedAttestationElectra) ToConsensus() (*eth.IndexedAttestationElectr
 		}
 	}
 	if a.Data == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Data")
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -1011,11 +1011,11 @@ func (d *DepositRequest) ToConsensus() (*enginev1.DepositRequest, error) {
 
 func ProposerSlashingsToConsensus(src []*ProposerSlashing) ([]*eth.ProposerSlashing, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "ProposerSlashings")
 	}
 	err := slice.VerifyMaxLength(src, 16)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "ProposerSlashings")
 	}
 	proposerSlashings := make([]*eth.ProposerSlashing, len(src))
 	for i, s := range src {
@@ -1144,11 +1144,11 @@ func ProposerSlashingFromConsensus(src *eth.ProposerSlashing) *ProposerSlashing 
 
 func AttesterSlashingsToConsensus(src []*AttesterSlashing) ([]*eth.AttesterSlashing, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "AttesterSlashings")
 	}
 	err := slice.VerifyMaxLength(src, 2)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "AttesterSlashings")
 	}
 
 	attesterSlashings := make([]*eth.AttesterSlashing, len(src))
@@ -1156,11 +1156,20 @@ func AttesterSlashingsToConsensus(src []*AttesterSlashing) ([]*eth.AttesterSlash
 		if s == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
 		}
-		if s.Attestation1 == nil || s.Attestation1.Data == nil {
+		if s.Attestation1 == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation1", i))
 		}
-		if s.Attestation2 == nil || s.Attestation2.Data == nil {
+
+		if s.Attestation1.Data == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation1.Data", i))
+		}
+
+		if s.Attestation2 == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation2", i))
+		}
+
+		if s.Attestation2.Data == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation2.Data", i))
 		}
 
 		a1Sig, err := bytesutil.DecodeHexWithLength(s.Attestation1.Signature, fieldparams.BLSSignatureLength)
@@ -1277,11 +1286,11 @@ func AttesterSlashingFromConsensus(src *eth.AttesterSlashing) *AttesterSlashing 
 
 func AttesterSlashingsElectraToConsensus(src []*AttesterSlashingElectra) ([]*eth.AttesterSlashingElectra, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "AttesterSlashinElectras")
 	}
 	err := slice.VerifyMaxLength(src, fieldparams.MaxAttesterSlashingsElectra)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "AttesterSlashinElectras")
 	}
 
 	attesterSlashings := make([]*eth.AttesterSlashingElectra, len(src))
@@ -1289,11 +1298,21 @@ func AttesterSlashingsElectraToConsensus(src []*AttesterSlashingElectra) ([]*eth
 		if s == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
 		}
-		if s.Attestation1 == nil || s.Attestation1.Data == nil {
+
+		if s.Attestation1 == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation1", i))
 		}
-		if s.Attestation2 == nil || s.Attestation2.Data == nil {
+
+		if s.Attestation1.Data == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation1.Data", i))
+		}
+
+		if s.Attestation2 == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation2", i))
+		}
+
+		if s.Attestation2.Data == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation2.Data", i))
 		}
 
 		a1Sig, err := bytesutil.DecodeHexWithLength(s.Attestation1.Signature, fieldparams.BLSSignatureLength)
@@ -1409,11 +1428,11 @@ func AttesterSlashingElectraFromConsensus(src *eth.AttesterSlashingElectra) *Att
 
 func AttsToConsensus(src []*Attestation) ([]*eth.Attestation, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Attestations")
 	}
 	err := slice.VerifyMaxLength(src, 128)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "Attestations")
 	}
 
 	atts := make([]*eth.Attestation, len(src))
@@ -1439,11 +1458,11 @@ func AttsFromConsensus(src []*eth.Attestation) []*Attestation {
 
 func AttsElectraToConsensus(src []*AttestationElectra) ([]*eth.AttestationElectra, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "AttestationElectras")
 	}
 	err := slice.VerifyMaxLength(src, 8)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "AttestationElectras")
 	}
 
 	atts := make([]*eth.AttestationElectra, len(src))
@@ -1469,11 +1488,11 @@ func AttsElectraFromConsensus(src []*eth.AttestationElectra) []*AttestationElect
 
 func DepositsToConsensus(src []*Deposit) ([]*eth.Deposit, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Deposits")
 	}
 	err := slice.VerifyMaxLength(src, 16)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "Deposits")
 	}
 
 	deposits := make([]*eth.Deposit, len(src))
@@ -1545,11 +1564,11 @@ func DepositsFromConsensus(src []*eth.Deposit) []*Deposit {
 
 func SignedExitsToConsensus(src []*SignedVoluntaryExit) ([]*eth.SignedVoluntaryExit, error) {
 	if src == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "SignedVoluntaryExits")
 	}
 	err := slice.VerifyMaxLength(src, 16)
 	if err != nil {
-		return nil, err
+		return nil, server.NewDecodeError(err, "SignedVoluntaryExits")
 	}
 
 	exits := make([]*eth.SignedVoluntaryExit, len(src))

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -1290,7 +1290,7 @@ func AttesterSlashingsElectraToConsensus(src []*AttesterSlashingElectra) ([]*eth
 	}
 	err := slice.VerifyMaxLength(src, fieldparams.MaxAttesterSlashingsElectra)
 	if err != nil {
-		return nil, server.NewDecodeError(err, "AttesterSlashinElectras")
+		return nil, server.NewDecodeError(err, "AttesterSlashingsElectra")
 	}
 
 	attesterSlashings := make([]*eth.AttesterSlashingElectra, len(src))

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -1458,7 +1458,7 @@ func AttsFromConsensus(src []*eth.Attestation) []*Attestation {
 
 func AttsElectraToConsensus(src []*AttestationElectra) ([]*eth.AttestationElectra, error) {
 	if src == nil {
-		return nil, server.NewDecodeError(errNilValue, "AttestationElectras")
+		return nil, server.NewDecodeError(errNilValue, "AttestationsElectra")
 	}
 	err := slice.VerifyMaxLength(src, 8)
 	if err != nil {

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -1462,7 +1462,7 @@ func AttsElectraToConsensus(src []*AttestationElectra) ([]*eth.AttestationElectr
 	}
 	err := slice.VerifyMaxLength(src, 8)
 	if err != nil {
-		return nil, server.NewDecodeError(err, "AttestationElectras")
+		return nil, server.NewDecodeError(err, "AttestationsElectra")
 	}
 
 	atts := make([]*eth.AttestationElectra, len(src))

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -52,6 +52,9 @@ func HistoricalSummaryFromConsensus(s *eth.HistoricalSummary) *HistoricalSummary
 }
 
 func (s *SignedBLSToExecutionChange) ToConsensus() (*eth.SignedBLSToExecutionChange, error) {
+	if s.Message == nil {
+		return nil, errNilValue
+	}
 	change, err := s.Message.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Message")
@@ -111,6 +114,9 @@ func SignedBLSChangesToConsensus(src []*SignedBLSToExecutionChange) ([]*eth.Sign
 	}
 	changes := make([]*eth.SignedBLSToExecutionChange, len(src))
 	for i, ch := range src {
+		if ch == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
+		}
 		changes[i], err = ch.ToConsensus()
 		if err != nil {
 			return nil, server.NewDecodeError(err, fmt.Sprintf("[%d]", i))
@@ -156,6 +162,9 @@ func ForkFromConsensus(f *eth.Fork) *Fork {
 }
 
 func (s *SignedValidatorRegistration) ToConsensus() (*eth.SignedValidatorRegistrationV1, error) {
+	if s.Message == nil {
+		return nil, errNilValue
+	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Message")
@@ -212,6 +221,9 @@ func SignedValidatorRegistrationFromConsensus(vr *eth.SignedValidatorRegistratio
 }
 
 func (s *SignedContributionAndProof) ToConsensus() (*eth.SignedContributionAndProof, error) {
+	if s.Message == nil {
+		return nil, errNilValue
+	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Message")
@@ -236,6 +248,9 @@ func SignedContributionAndProofFromConsensus(c *eth.SignedContributionAndProof) 
 }
 
 func (c *ContributionAndProof) ToConsensus() (*eth.ContributionAndProof, error) {
+	if c.Contribution == nil {
+		return nil, errNilValue
+	}
 	contribution, err := c.Contribution.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Contribution")
@@ -307,6 +322,9 @@ func SyncCommitteeContributionFromConsensus(c *eth.SyncCommitteeContribution) *S
 }
 
 func (s *SignedAggregateAttestationAndProof) ToConsensus() (*eth.SignedAggregateAttestationAndProof, error) {
+	if s.Message == nil {
+		return nil, errNilValue
+	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Message")
@@ -327,6 +345,9 @@ func (a *AggregateAttestationAndProof) ToConsensus() (*eth.AggregateAttestationA
 	if err != nil {
 		return nil, server.NewDecodeError(err, "AggregatorIndex")
 	}
+	if a.Aggregate == nil {
+		return nil, errNilValue
+	}
 	agg, err := a.Aggregate.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Aggregate")
@@ -343,6 +364,9 @@ func (a *AggregateAttestationAndProof) ToConsensus() (*eth.AggregateAttestationA
 }
 
 func (s *SignedAggregateAttestationAndProofElectra) ToConsensus() (*eth.SignedAggregateAttestationAndProofElectra, error) {
+	if s.Message == nil {
+		return nil, errNilValue
+	}
 	msg, err := s.Message.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Message")
@@ -363,6 +387,9 @@ func (a *AggregateAttestationAndProofElectra) ToConsensus() (*eth.AggregateAttes
 	if err != nil {
 		return nil, server.NewDecodeError(err, "AggregatorIndex")
 	}
+	if a.Aggregate == nil {
+		return nil, errNilValue
+	}
 	agg, err := a.Aggregate.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Aggregate")
@@ -382,6 +409,9 @@ func (a *Attestation) ToConsensus() (*eth.Attestation, error) {
 	aggBits, err := hexutil.Decode(a.AggregationBits)
 	if err != nil {
 		return nil, server.NewDecodeError(err, "AggregationBits")
+	}
+	if a.Data == nil {
+		return nil, errNilValue
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -411,6 +441,9 @@ func (a *AttestationElectra) ToConsensus() (*eth.AttestationElectra, error) {
 	aggBits, err := hexutil.Decode(a.AggregationBits)
 	if err != nil {
 		return nil, server.NewDecodeError(err, "AggregationBits")
+	}
+	if a.Data == nil {
+		return nil, errNilValue
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -451,6 +484,9 @@ func (a *SingleAttestation) ToConsensus() (*eth.SingleAttestation, error) {
 	if err != nil {
 		return nil, server.NewDecodeError(err, "AttesterIndex")
 	}
+	if a.Data == nil {
+		return nil, errNilValue
+	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Data")
@@ -490,9 +526,15 @@ func (a *AttestationData) ToConsensus() (*eth.AttestationData, error) {
 	if err != nil {
 		return nil, server.NewDecodeError(err, "BeaconBlockRoot")
 	}
+	if a.Source == nil {
+		return nil, errNilValue
+	}
 	source, err := a.Source.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Source")
+	}
+	if a.Target == nil {
+		return nil, errNilValue
 	}
 	target, err := a.Target.ToConsensus()
 	if err != nil {
@@ -593,15 +635,17 @@ func (b *BeaconCommitteeSubscription) ToConsensus() (*validator.BeaconCommitteeS
 }
 
 func (e *SignedVoluntaryExit) ToConsensus() (*eth.SignedVoluntaryExit, error) {
-	sig, err := bytesutil.DecodeHexWithLength(e.Signature, fieldparams.BLSSignatureLength)
-	if err != nil {
-		return nil, server.NewDecodeError(err, "Signature")
+	if e.Message == nil {
+		return nil, errNilValue
 	}
 	exit, err := e.Message.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Message")
 	}
-
+	sig, err := bytesutil.DecodeHexWithLength(e.Signature, fieldparams.BLSSignatureLength)
+	if err != nil {
+		return nil, server.NewDecodeError(err, "Signature")
+	}
 	return &eth.SignedVoluntaryExit{
 		Exit:      exit,
 		Signature: sig,
@@ -704,9 +748,15 @@ func Eth1DataFromConsensus(e1d *eth.Eth1Data) *Eth1Data {
 }
 
 func (s *ProposerSlashing) ToConsensus() (*eth.ProposerSlashing, error) {
+	if s.SignedHeader1 == nil {
+		return nil, errNilValue
+	}
 	h1, err := s.SignedHeader1.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "SignedHeader1")
+	}
+	if s.SignedHeader2 == nil {
+		return nil, errNilValue
 	}
 	h2, err := s.SignedHeader2.ToConsensus()
 	if err != nil {
@@ -720,9 +770,15 @@ func (s *ProposerSlashing) ToConsensus() (*eth.ProposerSlashing, error) {
 }
 
 func (s *AttesterSlashing) ToConsensus() (*eth.AttesterSlashing, error) {
+	if s.Attestation1 == nil {
+		return nil, errNilValue
+	}
 	att1, err := s.Attestation1.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Attestation1")
+	}
+	if s.Attestation2 == nil {
+		return nil, errNilValue
 	}
 	att2, err := s.Attestation2.ToConsensus()
 	if err != nil {
@@ -732,9 +788,15 @@ func (s *AttesterSlashing) ToConsensus() (*eth.AttesterSlashing, error) {
 }
 
 func (s *AttesterSlashingElectra) ToConsensus() (*eth.AttesterSlashingElectra, error) {
+	if s.Attestation1 == nil {
+		return nil, errNilValue
+	}
 	att1, err := s.Attestation1.ToConsensus()
 	if err != nil {
 		return nil, server.NewDecodeError(err, "Attestation1")
+	}
+	if s.Attestation2 == nil {
+		return nil, errNilValue
 	}
 	att2, err := s.Attestation2.ToConsensus()
 	if err != nil {
@@ -755,6 +817,9 @@ func (a *IndexedAttestation) ToConsensus() (*eth.IndexedAttestation, error) {
 		if err != nil {
 			return nil, server.NewDecodeError(err, fmt.Sprintf("AttestingIndices[%d]", i))
 		}
+	}
+	if a.Data == nil {
+		return nil, errNilValue
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -787,6 +852,9 @@ func (a *IndexedAttestationElectra) ToConsensus() (*eth.IndexedAttestationElectr
 		if err != nil {
 			return nil, server.NewDecodeError(err, fmt.Sprintf("AttestingIndices[%d]", i))
 		}
+	}
+	if a.Data == nil {
+		return nil, errNilValue
 	}
 	data, err := a.Data.ToConsensus()
 	if err != nil {
@@ -1088,10 +1156,10 @@ func AttesterSlashingsToConsensus(src []*AttesterSlashing) ([]*eth.AttesterSlash
 		if s == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
 		}
-		if s.Attestation1 == nil {
+		if s.Attestation1 == nil || s.Attestation1.Data == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation1", i))
 		}
-		if s.Attestation2 == nil {
+		if s.Attestation2 == nil || s.Attestation2.Data == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation2", i))
 		}
 
@@ -1111,6 +1179,7 @@ func AttesterSlashingsToConsensus(src []*AttesterSlashing) ([]*eth.AttesterSlash
 			}
 			a1AttestingIndices[j] = attestingIndex
 		}
+
 		a1Data, err := s.Attestation1.Data.ToConsensus()
 		if err != nil {
 			return nil, server.NewDecodeError(err, fmt.Sprintf("[%d].Attestation1.Data", i))
@@ -1220,10 +1289,10 @@ func AttesterSlashingsElectraToConsensus(src []*AttesterSlashingElectra) ([]*eth
 		if s == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
 		}
-		if s.Attestation1 == nil {
+		if s.Attestation1 == nil || s.Attestation1.Data == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation1", i))
 		}
-		if s.Attestation2 == nil {
+		if s.Attestation2 == nil || s.Attestation2.Data == nil {
 			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d].Attestation2", i))
 		}
 
@@ -1349,6 +1418,9 @@ func AttsToConsensus(src []*Attestation) ([]*eth.Attestation, error) {
 
 	atts := make([]*eth.Attestation, len(src))
 	for i, a := range src {
+		if a == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
+		}
 		atts[i], err = a.ToConsensus()
 		if err != nil {
 			return nil, server.NewDecodeError(err, fmt.Sprintf("[%d]", i))
@@ -1376,6 +1448,9 @@ func AttsElectraToConsensus(src []*AttestationElectra) ([]*eth.AttestationElectr
 
 	atts := make([]*eth.AttestationElectra, len(src))
 	for i, a := range src {
+		if a == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
+		}
 		atts[i], err = a.ToConsensus()
 		if err != nil {
 			return nil, server.NewDecodeError(err, fmt.Sprintf("[%d]", i))
@@ -1479,6 +1554,9 @@ func SignedExitsToConsensus(src []*SignedVoluntaryExit) ([]*eth.SignedVoluntaryE
 
 	exits := make([]*eth.SignedVoluntaryExit, len(src))
 	for i, e := range src {
+		if e == nil {
+			return nil, server.NewDecodeError(errNilValue, fmt.Sprintf("[%d]", i))
+		}
 		exits[i], err = e.ToConsensus()
 		if err != nil {
 			return nil, server.NewDecodeError(err, fmt.Sprintf("[%d]", i))

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -1286,7 +1286,7 @@ func AttesterSlashingFromConsensus(src *eth.AttesterSlashing) *AttesterSlashing 
 
 func AttesterSlashingsElectraToConsensus(src []*AttesterSlashingElectra) ([]*eth.AttesterSlashingElectra, error) {
 	if src == nil {
-		return nil, server.NewDecodeError(errNilValue, "AttesterSlashinElectras")
+		return nil, server.NewDecodeError(errNilValue, "AttesterSlashingsElectra")
 	}
 	err := slice.VerifyMaxLength(src, fieldparams.MaxAttesterSlashingsElectra)
 	if err != nil {

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -53,7 +53,7 @@ func HistoricalSummaryFromConsensus(s *eth.HistoricalSummary) *HistoricalSummary
 
 func (s *SignedBLSToExecutionChange) ToConsensus() (*eth.SignedBLSToExecutionChange, error) {
 	if s.Message == nil {
-		return nil, errNilValue
+		return nil, server.NewDecodeError(errNilValue, "Message")
 	}
 	change, err := s.Message.ToConsensus()
 	if err != nil {

--- a/api/server/structs/conversions_test.go
+++ b/api/server/structs/conversions_test.go
@@ -5,6 +5,7 @@ import (
 
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDepositSnapshotFromConsensus(t *testing.T) {
@@ -23,4 +24,97 @@ func TestDepositSnapshotFromConsensus(t *testing.T) {
 	require.Equal(t, "12345", res.DepositCount)
 	require.Equal(t, "0x1234", res.ExecutionBlockHash)
 	require.Equal(t, "67890", res.ExecutionBlockHeight)
+}
+
+func TestSignedBLSToExecutionChange_ToConsensus(t *testing.T) {
+	s := &SignedBLSToExecutionChange{Message: nil, Signature: ""}
+	_, err := s.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestSignedValidatorRegistration_ToConsensus(t *testing.T) {
+	s := &SignedValidatorRegistration{Message: nil, Signature: ""}
+	_, err := s.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestSignedContributionAndProof_ToConsensus(t *testing.T) {
+	s := &SignedContributionAndProof{Message: nil, Signature: ""}
+	_, err := s.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestContributionAndProof_ToConsensus(t *testing.T) {
+	c := &ContributionAndProof{
+		Contribution:    nil,
+		AggregatorIndex: "invalid",
+		SelectionProof:  "",
+	}
+	_, err := c.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestSignedAggregateAttestationAndProof_ToConsensus(t *testing.T) {
+	s := &SignedAggregateAttestationAndProof{Message: nil, Signature: ""}
+	_, err := s.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestAggregateAttestationAndProof_ToConsensus(t *testing.T) {
+	a := &AggregateAttestationAndProof{
+		AggregatorIndex: "1",
+		Aggregate:       nil,
+		SelectionProof:  "",
+	}
+	_, err := a.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestAttestation_ToConsensus(t *testing.T) {
+	a := &Attestation{
+		AggregationBits: "0x10",
+		Data:            nil,
+		Signature:       "",
+	}
+	_, err := a.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestSingleAttestation_ToConsensus(t *testing.T) {
+	s := &SingleAttestation{
+		CommitteeIndex: "1",
+		AttesterIndex:  "1",
+		Data:           nil,
+		Signature:      "",
+	}
+	_, err := s.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestSignedVoluntaryExit_ToConsensus(t *testing.T) {
+	s := &SignedVoluntaryExit{Message: nil, Signature: ""}
+	_, err := s.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestProposerSlashing_ToConsensus(t *testing.T) {
+	p := &ProposerSlashing{SignedHeader1: nil, SignedHeader2: nil}
+	_, err := p.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestAttesterSlashing_ToConsensus(t *testing.T) {
+	a := &AttesterSlashing{Attestation1: nil, Attestation2: nil}
+	_, err := a.ToConsensus()
+	assert.Equal(t, errNilValue, err)
+}
+
+func TestIndexedAttestation_ToConsensus(t *testing.T) {
+	a := &IndexedAttestation{
+		AttestingIndices: []string{"1"},
+		Data:             nil,
+		Signature:        "invalid",
+	}
+	_, err := a.ToConsensus()
+	assert.Equal(t, errNilValue, err)
 }

--- a/api/server/structs/conversions_test.go
+++ b/api/server/structs/conversions_test.go
@@ -5,7 +5,6 @@ import (
 
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDepositSnapshotFromConsensus(t *testing.T) {
@@ -29,19 +28,19 @@ func TestDepositSnapshotFromConsensus(t *testing.T) {
 func TestSignedBLSToExecutionChange_ToConsensus(t *testing.T) {
 	s := &SignedBLSToExecutionChange{Message: nil, Signature: ""}
 	_, err := s.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestSignedValidatorRegistration_ToConsensus(t *testing.T) {
 	s := &SignedValidatorRegistration{Message: nil, Signature: ""}
 	_, err := s.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestSignedContributionAndProof_ToConsensus(t *testing.T) {
 	s := &SignedContributionAndProof{Message: nil, Signature: ""}
 	_, err := s.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestContributionAndProof_ToConsensus(t *testing.T) {
@@ -51,13 +50,13 @@ func TestContributionAndProof_ToConsensus(t *testing.T) {
 		SelectionProof:  "",
 	}
 	_, err := c.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestSignedAggregateAttestationAndProof_ToConsensus(t *testing.T) {
 	s := &SignedAggregateAttestationAndProof{Message: nil, Signature: ""}
 	_, err := s.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestAggregateAttestationAndProof_ToConsensus(t *testing.T) {
@@ -67,7 +66,7 @@ func TestAggregateAttestationAndProof_ToConsensus(t *testing.T) {
 		SelectionProof:  "",
 	}
 	_, err := a.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestAttestation_ToConsensus(t *testing.T) {
@@ -77,7 +76,7 @@ func TestAttestation_ToConsensus(t *testing.T) {
 		Signature:       "",
 	}
 	_, err := a.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestSingleAttestation_ToConsensus(t *testing.T) {
@@ -88,25 +87,25 @@ func TestSingleAttestation_ToConsensus(t *testing.T) {
 		Signature:      "",
 	}
 	_, err := s.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestSignedVoluntaryExit_ToConsensus(t *testing.T) {
 	s := &SignedVoluntaryExit{Message: nil, Signature: ""}
 	_, err := s.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestProposerSlashing_ToConsensus(t *testing.T) {
 	p := &ProposerSlashing{SignedHeader1: nil, SignedHeader2: nil}
 	_, err := p.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestAttesterSlashing_ToConsensus(t *testing.T) {
 	a := &AttesterSlashing{Attestation1: nil, Attestation2: nil}
 	_, err := a.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }
 
 func TestIndexedAttestation_ToConsensus(t *testing.T) {
@@ -116,5 +115,5 @@ func TestIndexedAttestation_ToConsensus(t *testing.T) {
 		Signature:        "invalid",
 	}
 	_, err := a.ToConsensus()
-	assert.Equal(t, errNilValue, err)
+	require.ErrorContains(t, errNilValue.Error(), err)
 }

--- a/changelog/james-prysm_nil-check-to-consensus.md
+++ b/changelog/james-prysm_nil-check-to-consensus.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- add more nil checks on ToConsensus functions for added safety


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**
ToConsensus functions convert json representations to the consensus object, this conversion should validate the json for lengths and should try to check for nils or other unsafe data.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
