### PR TITLE
Set payload env downstream subscriber

### DIFF
--- a/beacon-chain/sync/execution_payload_envelope.go
+++ b/beacon-chain/sync/execution_payload_envelope.go
@@ -69,6 +69,9 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 		return pubsub.ValidationReject, err
 	}
 	s.payloadEnvelopeCache.Store(root, struct{}{})
+
+	msg.ValidatorData = signedEnvelope
+
 	return pubsub.ValidationAccept, nil
 }
 


### PR DESCRIPTION
this ensures `executionPayloadEnvelopeSubscriber` gets the payload envelope