### PR TITLE
Do not error on overflow when converting slashings

### DIFF
--- a/beacon-chain/operations/slashings/service_new.go
+++ b/beacon-chain/operations/slashings/service_new.go
@@ -50,7 +50,6 @@ func (p *PoolService) run() {
 
 	electraSlot, err := slots.EpochStart(params.BeaconConfig().ElectraForkEpoch)
 	if err != nil {
-		log.WithError(err).Error("Could not get Electra start slot")
 		return
 	}
 
@@ -64,7 +63,6 @@ func (p *PoolService) run() {
 
 	electraTime, err := slots.ToTime(uint64(p.clock.GenesisTime().Unix()), electraSlot)
 	if err != nil {
-		log.WithError(err).Error("Could not get Electra start time")
 		return
 	}
 

--- a/changelog/potuz_overflow_slashings.md
+++ b/changelog/potuz_overflow_slashings.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Don't error on overflow on the slashings converter. 


### PR DESCRIPTION
The overflow of  #14844 should not be treated as an error. 

