### PR TITLE
Set New Blob Limits For Electra

### DIFF
--- a/beacon-chain/core/electra/churn_test.go
+++ b/beacon-chain/core/electra/churn_test.go
@@ -177,9 +177,9 @@ func TestComputeConsolidationEpochAndUpdateChurn(t *testing.T) {
 				require.NoError(t, err)
 				return s
 			}(t),
-			consolidationBalance:                  helpers.ConsolidationChurnLimit(32000000000000000)+1,
+			consolidationBalance:                  helpers.ConsolidationChurnLimit(32000000000000000) + 1,
 			expectedEpoch:                         18, // Flows into another epoch.
-			expectedConsolidationBalanceToConsume: helpers.ConsolidationChurnLimit(32000000000000000)-1,
+			expectedConsolidationBalanceToConsume: helpers.ConsolidationChurnLimit(32000000000000000) - 1,
 		},
 	}
 

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -3,15 +3,13 @@ package kv
 import (
 	"context"
 	"fmt"
-	bolt "go.etcd.io/bbolt"
 	"testing"
 	"time"
-
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/db/filters"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
@@ -22,6 +20,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/testing/assert"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"github.com/prysmaticlabs/prysm/v5/testing/util"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/beacon-chain/sync/rpc_blob_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_range.go
@@ -144,9 +144,14 @@ func BlobRPCMinValidSlot(current primitives.Slot) (primitives.Slot, error) {
 	return slots.EpochStart(minStart)
 }
 
+// This function is used to derive what is the ideal block batch size we can serve
+// blobs to the remote peer for. We compute the current limit which is the maximum
+// blobs to be served to the peer every period. And then using the maximum blobs per
+// block determine the block batch size satisfying this limit.
 func blobBatchLimit(slot primitives.Slot) uint64 {
 	maxBlobsPerBlock := params.BeaconConfig().MaxBlobsPerBlock(slot)
-	return uint64(flags.Get().BlockBatchLimit / maxBlobsPerBlock)
+	maxPossibleBlobs := flags.Get().BlobBatchLimit * flags.Get().BlobBatchLimitBurstFactor
+	return uint64(maxPossibleBlobs / maxBlobsPerBlock)
 }
 
 func validateBlobsByRange(r *pb.BlobSidecarsByRangeRequest, current primitives.Slot) (rangeParams, error) {

--- a/beacon-chain/sync/sync_test.go
+++ b/beacon-chain/sync/sync_test.go
@@ -17,7 +17,7 @@ func TestMain(m *testing.M) {
 	flags.Init(&flags.GlobalFlags{
 		BlockBatchLimit:            64,
 		BlockBatchLimitBurstFactor: 10,
-		BlobBatchLimit:             8,
+		BlobBatchLimit:             32,
 		BlobBatchLimitBurstFactor:  2,
 	})
 	defer func() {

--- a/changelog/nisdas_increase_electra_limits.md
+++ b/changelog/nisdas_increase_electra_limits.md
@@ -1,0 +1,4 @@
+### Changed
+- Updated Blob-Batch-Limit to increase to 192 for electra.
+- Updated Blob-Batch-Limit-Burst-Factor to increase to 3. 
+- Changed the derived batch limit when serving blobs.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -196,13 +196,13 @@ var (
 	BlobBatchLimit = &cli.IntFlag{
 		Name:  "blob-batch-limit",
 		Usage: "The amount of blobs the local peer is bounded to request and respond to in a batch.",
-		Value: 64,
+		Value: 192,
 	}
 	// BlobBatchLimitBurstFactor specifies the factor by which blob batch size may increase.
 	BlobBatchLimitBurstFactor = &cli.IntFlag{
 		Name:  "blob-batch-limit-burst-factor",
 		Usage: "The factor by which blob batch limit may increase on burst.",
-		Value: 2,
+		Value: 3,
 	}
 	// DisableDebugRPCEndpoints disables the debug Beacon API namespace.
 	DisableDebugRPCEndpoints = &cli.BoolFlag{


### PR DESCRIPTION
**What type of PR is this?**

Networking Limit Change

**What does this PR do? Why is it needed?**

In Electra we have `EIP-7691` included which changes the blob target per block to 6 and the max to 9. With these parameters changing, Prysm nodes serving blobs to syncing nodes after Electra will need to serve more blobs  beyond the current rate limits per batch if blocks are consistently filled with the maximum amount of blob transactions. 

With the standard block batch size among clients being 64, the maximum amount of blobs a prysm node would have to serve per batch is 574. For that reason we have changed the `blob-batch-limit` and the `blob-burst-factor` to be able to satisfy this constraint. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
