### PR TITLE
Add pectra testnet dates

### DIFF
--- a/changelog/tt_add_pectra_testnet_dates.md
+++ b/changelog/tt_add_pectra_testnet_dates.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add Pectra testnet dates. (Sepolia and Holesky)

--- a/config/params/testnet_holesky_config.go
+++ b/config/params/testnet_holesky_config.go
@@ -39,8 +39,8 @@ func HoleskyConfig() *BeaconChainConfig {
 	cfg.CapellaForkVersion = []byte{0x4, 0x1, 0x70, 0x0}
 	cfg.DenebForkEpoch = 29696
 	cfg.DenebForkVersion = []byte{0x05, 0x1, 0x70, 0x0}
-	cfg.ElectraForkEpoch = math.MaxUint64
-	cfg.ElectraForkVersion = []byte{0x06, 0x1, 0x70, 0x0} // TODO: Define holesky fork version for electra. This is a placeholder value.
+	cfg.ElectraForkEpoch = 115968 // Mon, Feb 24 at 21:55:12 UTC
+	cfg.ElectraForkVersion = []byte{0x06, 0x1, 0x70, 0x0}
 	cfg.FuluForkEpoch = math.MaxUint64
 	cfg.FuluForkVersion = []byte{0x07, 0x1, 0x70, 0x0} // TODO: Define holesky fork version for fulu. This is a placeholder value.
 	cfg.TerminalTotalDifficulty = "0"

--- a/config/params/testnet_sepolia_config.go
+++ b/config/params/testnet_sepolia_config.go
@@ -44,8 +44,8 @@ func SepoliaConfig() *BeaconChainConfig {
 	cfg.CapellaForkVersion = []byte{0x90, 0x00, 0x00, 0x72}
 	cfg.DenebForkEpoch = 132608
 	cfg.DenebForkVersion = []byte{0x90, 0x00, 0x00, 0x73}
-	cfg.ElectraForkEpoch = math.MaxUint64
-	cfg.ElectraForkVersion = []byte{0x90, 0x00, 0x00, 0x74} // TODO: Define sepolia fork version for electra. This is a placeholder value.
+	cfg.ElectraForkEpoch = 222464 // Wed, Mar 5 at 07:29:36 UTC
+	cfg.ElectraForkVersion = []byte{0x90, 0x00, 0x00, 0x74}
 	cfg.FuluForkEpoch = math.MaxUint64
 	cfg.FuluForkVersion = []byte{0x90, 0x00, 0x00, 0x75} // TODO: Define sepolia fork version for fulu. This is a placeholder value.
 	cfg.TerminalTotalDifficulty = "17000000000000000"


### PR DESCRIPTION
- Holesky upgrades at slot 3710976 → Feb 24, 21:55 UTC
- Sepolia upgrades at slot 7118848 → Mar 5, 07:29 UTC