### PR TITLE
change lc flag name from `enable-lightclient` to `enable-light-client`

### DIFF
--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -144,7 +144,7 @@ var (
 		Usage: "Informs the engine to prepare all local payloads. Useful for relayers and builders.",
 	}
 	EnableLightClient = &cli.BoolFlag{
-		Name:  "enable-lightclient",
+		Name:  "enable-light-client",
 		Usage: "Enables the light client support in the beacon node",
 	}
 	disableResourceManager = &cli.BoolFlag{


### PR DESCRIPTION
Changes the light client flag name from `enable-lightclient` to `enable-light-client`

Needed for #12991 