### PR TITLE
fix: /eth/v2/beacon/blocks post api to handle electra and fulu blocks correctly 

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -791,6 +791,7 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
+
 	if versionHeader == version.String(version.Electra) {
 		electraBlock := &eth.SignedBeaconBlockContentsElectra{}
 		if err = electraBlock.UnmarshalSSZ(body); err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -723,23 +723,45 @@ func (s *Server) PublishBlockV2(w http.ResponseWriter, r *http.Request) {
 		s.publishBlock(ctx, w, r, true)
 	}
 }
-func (s *Server) versionHeaderFromCurrentSlot() string {
-	// attempt to get the current fork information
-	ce := slots.ToEpoch(s.GenesisTimeFetcher.CurrentSlot())
+
+type signedBlockContentPeeker struct {
+	Block json.RawMessage `json:"signed_block"`
+}
+type slotPeeker struct {
+	Block struct {
+		Slot primitives.Slot `json:"slot,string"`
+	} `json:"message"`
+}
+
+func (s *Server) versionHeaderFromBlockSlot(body []byte) (string, error) {
+	// check is required for post deneb fork blocks contents
+	p := &signedBlockContentPeeker{}
+	if err := json.Unmarshal(body, p); err != nil {
+		return "", errors.Wrap(err, "unable to peek slot from block contents")
+	}
+	data := body
+	if len(p.Block) > 0 {
+		data = p.Block
+	}
+	sp := &slotPeeker{}
+	if err := json.Unmarshal(data, sp); err != nil {
+		return "", errors.Wrap(err, "unable to peek slot from block")
+	}
+	ce := slots.ToEpoch(sp.Block.Slot)
 	if ce >= params.BeaconConfig().FuluForkEpoch {
-		return version.String(version.Fulu)
+		return version.String(version.Fulu), nil
 	} else if ce >= params.BeaconConfig().ElectraForkEpoch {
-		return version.String(version.Electra)
+		return version.String(version.Electra), nil
 	} else if ce >= params.BeaconConfig().DenebForkEpoch {
-		return version.String(version.Deneb)
+		return version.String(version.Deneb), nil
 	} else if ce >= params.BeaconConfig().CapellaForkEpoch {
-		return version.String(version.Capella)
+		return version.String(version.Capella), nil
 	} else if ce >= params.BeaconConfig().BellatrixForkEpoch {
-		return version.String(version.Bellatrix)
+		return version.String(version.Bellatrix), nil
 	} else if ce >= params.BeaconConfig().AltairForkEpoch {
-		return version.String(version.Altair)
+		return version.String(version.Altair), nil
 	} else {
-		return version.String(version.Phase0)
+		return version.String(version.Phase0), nil
 	}
 }
 
@@ -756,7 +778,14 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		return
 	}
 	if !versionRequired && versionHeader == "" {
-		versionHeader = s.versionHeaderFromCurrentSlot()
+		versionHeader, err = s.versionHeaderFromBlockSlot(body)
+		if err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body for version header: %s", err.Error()),
+				http.StatusBadRequest,
+			)
+		}
 	}
 
 	if versionHeader == version.String(version.Fulu) {
@@ -969,7 +998,14 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 	if !versionRequired && versionHeader == "" {
-		versionHeader = s.versionHeaderFromCurrentSlot()
+		versionHeader, err = s.versionHeaderFromBlockSlot(body)
+		if err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body for version header: %s", err.Error()),
+				http.StatusBadRequest,
+			)
+		}
 	}
 
 	var consensusBlock *eth.GenericSignedBeaconBlock

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -743,6 +743,7 @@ func (s *Server) versionHeaderFromCurrentSlot() string {
 	}
 }
 
+// nolint:gocognit
 func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *http.Request, versionRequired bool) { // nolint:gocognit
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -952,6 +953,7 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 	httputil.HandleError(w, "Body does not represent a valid block type", http.StatusBadRequest)
 }
 
+// nolint:gocognit
 func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *http.Request, versionRequired bool) { // nolint:gocognit
 	body, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -723,6 +723,25 @@ func (s *Server) PublishBlockV2(w http.ResponseWriter, r *http.Request) {
 		s.publishBlock(ctx, w, r, true)
 	}
 }
+func (s *Server) versionHeaderFromCurrentSlot() string {
+	// attempt to get the current fork information
+	ce := slots.ToEpoch(s.GenesisTimeFetcher.CurrentSlot())
+	if ce >= params.BeaconConfig().FuluForkEpoch {
+		return version.String(version.Fulu)
+	} else if ce >= params.BeaconConfig().ElectraForkEpoch {
+		return version.String(version.Electra)
+	} else if ce >= params.BeaconConfig().DenebForkEpoch {
+		return version.String(version.Deneb)
+	} else if ce >= params.BeaconConfig().CapellaForkEpoch {
+		return version.String(version.Capella)
+	} else if ce >= params.BeaconConfig().BellatrixForkEpoch {
+		return version.String(version.Bellatrix)
+	} else if ce >= params.BeaconConfig().AltairForkEpoch {
+		return version.String(version.Altair)
+	} else {
+		return version.String(version.Phase0)
+	}
+}
 
 func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *http.Request, versionRequired bool) { // nolint:gocognit
 	body, err := io.ReadAll(r.Body)
@@ -735,9 +754,20 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		httputil.HandleError(w, api.VersionHeader+" header is required", http.StatusBadRequest)
 		return
 	}
+	if !versionRequired && versionHeader == "" {
+		versionHeader = s.versionHeaderFromCurrentSlot()
+	}
+	if versionHeader == version.String(version.Fulu) {
+		fuluBlock := &eth.SignedBeaconBlockContentsFulu{}
+		if err = fuluBlock.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Fulu), err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
 
-	fuluBlock := &eth.SignedBeaconBlockContentsFulu{}
-	if err = fuluBlock.UnmarshalSSZ(body); err == nil {
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Fulu{
 				Fulu: fuluBlock,
@@ -760,17 +790,16 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
-	if versionHeader == version.String(version.Fulu) {
-		httputil.HandleError(
-			w,
-			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Fulu), err.Error()),
-			http.StatusBadRequest,
-		)
-		return
-	}
-
-	electraBlock := &eth.SignedBeaconBlockContentsElectra{}
-	if err = electraBlock.UnmarshalSSZ(body); err == nil {
+	if versionHeader == version.String(version.Electra) {
+		electraBlock := &eth.SignedBeaconBlockContentsElectra{}
+		if err = electraBlock.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Electra), err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Electra{
 				Electra: electraBlock,
@@ -793,17 +822,17 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
-	if versionHeader == version.String(version.Electra) {
-		httputil.HandleError(
-			w,
-			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Electra), err.Error()),
-			http.StatusBadRequest,
-		)
-		return
-	}
 
-	denebBlock := &eth.SignedBeaconBlockContentsDeneb{}
-	if err = denebBlock.UnmarshalSSZ(body); err == nil {
+	if versionHeader == version.String(version.Deneb) {
+		denebBlock := &eth.SignedBeaconBlockContentsDeneb{}
+		if err = denebBlock.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Deneb), err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Deneb{
 				Deneb: denebBlock,
@@ -826,17 +855,17 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
-	if versionHeader == version.String(version.Deneb) {
-		httputil.HandleError(
-			w,
-			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Deneb), err.Error()),
-			http.StatusBadRequest,
-		)
-		return
-	}
+	if versionHeader == version.String(version.Capella) {
+		capellaBlock := &eth.SignedBeaconBlockCapella{}
+		if err = capellaBlock.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Capella), err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
 
-	capellaBlock := &eth.SignedBeaconBlockCapella{}
-	if err = capellaBlock.UnmarshalSSZ(body); err == nil {
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Capella{
 				Capella: capellaBlock,
@@ -849,17 +878,17 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
-	if versionHeader == version.String(version.Capella) {
-		httputil.HandleError(
-			w,
-			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Capella), err.Error()),
-			http.StatusBadRequest,
-		)
-		return
-	}
 
-	bellatrixBlock := &eth.SignedBeaconBlockBellatrix{}
-	if err = bellatrixBlock.UnmarshalSSZ(body); err == nil {
+	if versionHeader == version.String(version.Bellatrix) {
+		bellatrixBlock := &eth.SignedBeaconBlockBellatrix{}
+		if err = bellatrixBlock.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Bellatrix), err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Bellatrix{
 				Bellatrix: bellatrixBlock,
@@ -872,17 +901,18 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
-	if versionHeader == version.String(version.Bellatrix) {
-		httputil.HandleError(
-			w,
-			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Bellatrix), err.Error()),
-			http.StatusBadRequest,
-		)
-		return
-	}
 
-	altairBlock := &eth.SignedBeaconBlockAltair{}
-	if err = altairBlock.UnmarshalSSZ(body); err == nil {
+	if versionHeader == version.String(version.Altair) {
+		altairBlock := &eth.SignedBeaconBlockAltair{}
+		if err = altairBlock.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Altair), err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
+
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Altair{
 				Altair: altairBlock,
@@ -895,17 +925,17 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
-	if versionHeader == version.String(version.Altair) {
-		httputil.HandleError(
-			w,
-			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Altair), err.Error()),
-			http.StatusBadRequest,
-		)
-		return
-	}
+	if versionHeader == version.String(version.Phase0) {
+		phase0Block := &eth.SignedBeaconBlock{}
+		if err = phase0Block.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(
+				w,
+				fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Phase0), err.Error()),
+				http.StatusBadRequest,
+			)
+			return
 
-	phase0Block := &eth.SignedBeaconBlock{}
-	if err = phase0Block.UnmarshalSSZ(body); err == nil {
+		}
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Phase0{
 				Phase0: phase0Block,
@@ -916,14 +946,6 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 			return
 		}
 		s.proposeBlock(ctx, w, genericBlock)
-		return
-	}
-	if versionHeader == version.String(version.Phase0) {
-		httputil.HandleError(
-			w,
-			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Phase0), err.Error()),
-			http.StatusBadRequest,
-		)
 		return
 	}
 
@@ -941,32 +963,34 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		httputil.HandleError(w, api.VersionHeader+" header is required", http.StatusBadRequest)
 		return
 	}
+	if !versionRequired && versionHeader == "" {
+		versionHeader = s.versionHeaderFromCurrentSlot()
+	}
 
 	var consensusBlock *eth.GenericSignedBeaconBlock
-
-	var fuluBlockContents *structs.SignedBeaconBlockContentsFulu
-	if err = unmarshalStrict(body, &fuluBlockContents); err == nil {
-		consensusBlock, err = fuluBlockContents.ToGeneric()
-		if err == nil {
-			if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
-				if errors.Is(err, errEquivocatedBlock) {
-					b, err := blocks.NewSignedBeaconBlock(consensusBlock)
-					if err != nil {
-						httputil.HandleError(w, err.Error(), http.StatusBadRequest)
-						return
+	if versionHeader == version.String(version.Fulu) {
+		var fuluBlockContents *structs.SignedBeaconBlockContentsFulu
+		if err = unmarshalStrict(body, &fuluBlockContents); err == nil {
+			consensusBlock, err = fuluBlockContents.ToGeneric()
+			if err == nil {
+				if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
+					if errors.Is(err, errEquivocatedBlock) {
+						b, err := blocks.NewSignedBeaconBlock(consensusBlock)
+						if err != nil {
+							httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						if err := s.broadcastSeenBlockSidecars(ctx, b, consensusBlock.GetFulu().Blobs, consensusBlock.GetFulu().KzgProofs); err != nil {
+							log.WithError(err).Error("Failed to broadcast blob sidecars")
+						}
 					}
-					if err := s.broadcastSeenBlockSidecars(ctx, b, consensusBlock.GetFulu().Blobs, consensusBlock.GetFulu().KzgProofs); err != nil {
-						log.WithError(err).Error("Failed to broadcast blob sidecars")
-					}
+					httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+					return
 				}
-				httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+				s.proposeBlock(ctx, w, consensusBlock)
 				return
 			}
-			s.proposeBlock(ctx, w, consensusBlock)
-			return
 		}
-	}
-	if versionHeader == version.String(version.Fulu) {
 		httputil.HandleError(
 			w,
 			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Fulu), err.Error()),
@@ -975,29 +999,29 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 
-	var electraBlockContents *structs.SignedBeaconBlockContentsElectra
-	if err = unmarshalStrict(body, &electraBlockContents); err == nil {
-		consensusBlock, err = electraBlockContents.ToGeneric()
-		if err == nil {
-			if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
-				if errors.Is(err, errEquivocatedBlock) {
-					b, err := blocks.NewSignedBeaconBlock(consensusBlock)
-					if err != nil {
-						httputil.HandleError(w, err.Error(), http.StatusBadRequest)
-						return
+	if versionHeader == version.String(version.Electra) {
+		var electraBlockContents *structs.SignedBeaconBlockContentsElectra
+		if err = unmarshalStrict(body, &electraBlockContents); err == nil {
+			consensusBlock, err = electraBlockContents.ToGeneric()
+			if err == nil {
+				if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
+					if errors.Is(err, errEquivocatedBlock) {
+						b, err := blocks.NewSignedBeaconBlock(consensusBlock)
+						if err != nil {
+							httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						if err := s.broadcastSeenBlockSidecars(ctx, b, consensusBlock.GetElectra().Blobs, consensusBlock.GetElectra().KzgProofs); err != nil {
+							log.WithError(err).Error("Failed to broadcast blob sidecars")
+						}
 					}
-					if err := s.broadcastSeenBlockSidecars(ctx, b, consensusBlock.GetElectra().Blobs, consensusBlock.GetElectra().KzgProofs); err != nil {
-						log.WithError(err).Error("Failed to broadcast blob sidecars")
-					}
+					httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+					return
 				}
-				httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+				s.proposeBlock(ctx, w, consensusBlock)
 				return
 			}
-			s.proposeBlock(ctx, w, consensusBlock)
-			return
 		}
-	}
-	if versionHeader == version.String(version.Electra) {
 		httputil.HandleError(
 			w,
 			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Electra), err.Error()),
@@ -1006,29 +1030,29 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 
-	var denebBlockContents *structs.SignedBeaconBlockContentsDeneb
-	if err = unmarshalStrict(body, &denebBlockContents); err == nil {
-		consensusBlock, err = denebBlockContents.ToGeneric()
-		if err == nil {
-			if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
-				if errors.Is(err, errEquivocatedBlock) {
-					b, err := blocks.NewSignedBeaconBlock(consensusBlock)
-					if err != nil {
-						httputil.HandleError(w, err.Error(), http.StatusBadRequest)
-						return
+	if versionHeader == version.String(version.Deneb) {
+		var denebBlockContents *structs.SignedBeaconBlockContentsDeneb
+		if err = unmarshalStrict(body, &denebBlockContents); err == nil {
+			consensusBlock, err = denebBlockContents.ToGeneric()
+			if err == nil {
+				if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
+					if errors.Is(err, errEquivocatedBlock) {
+						b, err := blocks.NewSignedBeaconBlock(consensusBlock)
+						if err != nil {
+							httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						if err := s.broadcastSeenBlockSidecars(ctx, b, consensusBlock.GetDeneb().Blobs, consensusBlock.GetDeneb().KzgProofs); err != nil {
+							log.WithError(err).Error("Failed to broadcast blob sidecars")
+						}
 					}
-					if err := s.broadcastSeenBlockSidecars(ctx, b, consensusBlock.GetDeneb().Blobs, consensusBlock.GetDeneb().KzgProofs); err != nil {
-						log.WithError(err).Error("Failed to broadcast blob sidecars")
-					}
+					httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+					return
 				}
-				httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+				s.proposeBlock(ctx, w, consensusBlock)
 				return
 			}
-			s.proposeBlock(ctx, w, consensusBlock)
-			return
 		}
-	}
-	if versionHeader == version.String(version.Deneb) {
 		httputil.HandleError(
 			w,
 			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Deneb), err.Error()),
@@ -1037,19 +1061,20 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 
-	var capellaBlock *structs.SignedBeaconBlockCapella
-	if err = unmarshalStrict(body, &capellaBlock); err == nil {
-		consensusBlock, err = capellaBlock.ToGeneric()
-		if err == nil {
-			if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
-				httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+	if versionHeader == version.String(version.Capella) {
+		var capellaBlock *structs.SignedBeaconBlockCapella
+		if err = unmarshalStrict(body, &capellaBlock); err == nil {
+			consensusBlock, err = capellaBlock.ToGeneric()
+			if err == nil {
+				if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
+					httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				s.proposeBlock(ctx, w, consensusBlock)
 				return
 			}
-			s.proposeBlock(ctx, w, consensusBlock)
-			return
 		}
-	}
-	if versionHeader == version.String(version.Capella) {
+
 		httputil.HandleError(
 			w,
 			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Capella), err.Error()),
@@ -1058,19 +1083,20 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 
-	var bellatrixBlock *structs.SignedBeaconBlockBellatrix
-	if err = unmarshalStrict(body, &bellatrixBlock); err == nil {
-		consensusBlock, err = bellatrixBlock.ToGeneric()
-		if err == nil {
-			if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
-				httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+	if versionHeader == version.String(version.Bellatrix) {
+		var bellatrixBlock *structs.SignedBeaconBlockBellatrix
+		if err = unmarshalStrict(body, &bellatrixBlock); err == nil {
+			consensusBlock, err = bellatrixBlock.ToGeneric()
+			if err == nil {
+				if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
+					httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				s.proposeBlock(ctx, w, consensusBlock)
 				return
 			}
-			s.proposeBlock(ctx, w, consensusBlock)
-			return
 		}
-	}
-	if versionHeader == version.String(version.Bellatrix) {
+
 		httputil.HandleError(
 			w,
 			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Bellatrix), err.Error()),
@@ -1079,19 +1105,20 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 
-	var altairBlock *structs.SignedBeaconBlockAltair
-	if err = unmarshalStrict(body, &altairBlock); err == nil {
-		consensusBlock, err = altairBlock.ToGeneric()
-		if err == nil {
-			if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
-				httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+	if versionHeader == version.String(version.Altair) {
+		var altairBlock *structs.SignedBeaconBlockAltair
+		if err = unmarshalStrict(body, &altairBlock); err == nil {
+			consensusBlock, err = altairBlock.ToGeneric()
+			if err == nil {
+				if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
+					httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				s.proposeBlock(ctx, w, consensusBlock)
 				return
 			}
-			s.proposeBlock(ctx, w, consensusBlock)
-			return
 		}
-	}
-	if versionHeader == version.String(version.Altair) {
+
 		httputil.HandleError(
 			w,
 			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Altair), err.Error()),
@@ -1100,19 +1127,20 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 
-	var phase0Block *structs.SignedBeaconBlock
-	if err = unmarshalStrict(body, &phase0Block); err == nil {
-		consensusBlock, err = phase0Block.ToGeneric()
-		if err == nil {
-			if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
-				httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+	if versionHeader == version.String(version.Phase0) {
+		var phase0Block *structs.SignedBeaconBlock
+		if err = unmarshalStrict(body, &phase0Block); err == nil {
+			consensusBlock, err = phase0Block.ToGeneric()
+			if err == nil {
+				if err = s.validateBroadcast(ctx, r, consensusBlock); err != nil {
+					httputil.HandleError(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				s.proposeBlock(ctx, w, consensusBlock)
 				return
 			}
-			s.proposeBlock(ctx, w, consensusBlock)
-			return
 		}
-	}
-	if versionHeader == version.String(version.Phase0) {
+
 		httputil.HandleError(
 			w,
 			fmt.Sprintf("Could not decode request body into %s consensus block: %v", version.String(version.Phase0), err.Error()),

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -926,6 +926,7 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
+
 	if versionHeader == version.String(version.Phase0) {
 		phase0Block := &eth.SignedBeaconBlock{}
 		if err = phase0Block.UnmarshalSSZ(body); err != nil {
@@ -935,7 +936,6 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 				http.StatusBadRequest,
 			)
 			return
-
 		}
 		genericBlock := &eth.GenericSignedBeaconBlock{
 			Block: &eth.GenericSignedBeaconBlock_Phase0{

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -858,6 +858,7 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		s.proposeBlock(ctx, w, genericBlock)
 		return
 	}
+
 	if versionHeader == version.String(version.Capella) {
 		capellaBlock := &eth.SignedBeaconBlockCapella{}
 		if err = capellaBlock.UnmarshalSSZ(body); err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -733,7 +733,7 @@ type slotPeeker struct {
 	} `json:"message"`
 }
 
-func (s *Server) versionHeaderFromBlockSlot(body []byte) (string, error) {
+func versionHeaderFromRequest(body []byte) (string, error) {
 	// check is required for post deneb fork blocks contents
 	p := &signedBlockContentPeeker{}
 	if err := json.Unmarshal(body, p); err != nil {
@@ -778,7 +778,7 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 		return
 	}
 	if !versionRequired && versionHeader == "" {
-		versionHeader, err = s.versionHeaderFromBlockSlot(body)
+		versionHeader, err = versionHeaderFromRequest(body)
 		if err != nil {
 			httputil.HandleError(
 				w,
@@ -998,7 +998,7 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 		return
 	}
 	if !versionRequired && versionHeader == "" {
-		versionHeader, err = s.versionHeaderFromBlockSlot(body)
+		versionHeader, err = versionHeaderFromRequest(body)
 		if err != nil {
 			httputil.HandleError(
 				w,

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -758,6 +758,7 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 	if !versionRequired && versionHeader == "" {
 		versionHeader = s.versionHeaderFromCurrentSlot()
 	}
+
 	if versionHeader == version.String(version.Fulu) {
 		fuluBlock := &eth.SignedBeaconBlockContentsFulu{}
 		if err = fuluBlock.UnmarshalSSZ(body); err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -1433,11 +1433,10 @@ func TestPublishBlock(t *testing.T) {
 	t.Run("Electra", func(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().ProposeBeaconBlock(gomock.Any(), mock.MatchedBy(func(req *eth.GenericSignedBeaconBlock) bool {
-			// Convert back Fulu to Electra when there is at least one difference between Electra and Fulu blocks.
-			block, ok := req.Block.(*eth.GenericSignedBeaconBlock_Fulu)
-			converted, err := structs.SignedBeaconBlockContentsFuluFromConsensus(block.Fulu)
+			block, ok := req.Block.(*eth.GenericSignedBeaconBlock_Electra)
+			converted, err := structs.SignedBeaconBlockContentsElectraFromConsensus(block.Electra)
 			require.NoError(t, err)
-			var signedblock *structs.SignedBeaconBlockContentsFulu
+			var signedblock *structs.SignedBeaconBlockContentsElectra
 			err = json.Unmarshal([]byte(rpctesting.FuluBlockContents), &signedblock)
 			require.NoError(t, err)
 			require.DeepEqual(t, converted, signedblock)
@@ -1453,6 +1452,54 @@ func TestPublishBlock(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlock(writer, request)
 		assert.Equal(t, http.StatusOK, writer.Code)
+	})
+	t.Run("Electra block without version header succeeds", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.ElectraForkEpoch = 6
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().ProposeBeaconBlock(gomock.Any(), mock.MatchedBy(func(req *eth.GenericSignedBeaconBlock) bool {
+			block, ok := req.Block.(*eth.GenericSignedBeaconBlock_Electra)
+			converted, err := structs.SignedBeaconBlockContentsElectraFromConsensus(block.Electra)
+			require.NoError(t, err)
+			var signedblock *structs.SignedBeaconBlockContentsElectra
+			err = json.Unmarshal([]byte(rpctesting.FuluBlockContents), &signedblock)
+			require.NoError(t, err)
+			require.DeepEqual(t, converted, signedblock)
+			return ok
+		}))
+		electraFork := params.BeaconConfig().ElectraForkEpoch
+		timeToFork := time.Duration(params.BeaconConfig().SecondsPerSlot*uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(electraFork)) * time.Second
+		currentTime := time.Now().Add(-1 * timeToFork)
+		server := &Server{
+			V1Alpha1ValidatorServer: v1alpha1Server,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: currentTime,
+			},
+			SyncChecker: &mockSync.Sync{IsSyncing: false},
+		}
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte(rpctesting.ElectraBlockContents)))
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.PublishBlock(writer, request)
+		assert.Equal(t, http.StatusOK, writer.Code)
+	})
+	t.Run("Electra block without version header on wrong fork time", func(t *testing.T) {
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		server := &Server{
+			V1Alpha1ValidatorServer: v1alpha1Server,
+			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
+				Genesis: time.Now(),
+			},
+			SyncChecker: &mockSync.Sync{IsSyncing: false},
+		}
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte(rpctesting.ElectraBlockContents)))
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.PublishBlock(writer, request)
+		assert.Equal(t, http.StatusBadRequest, writer.Code)
+		assert.StringContains(t, fmt.Sprintf("Could not decode request body into %s consensus block", version.String(version.Phase0)), writer.Body.String())
 	})
 	t.Run("Fulu", func(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
@@ -2352,12 +2399,11 @@ func TestPublishBlockV2(t *testing.T) {
 	t.Run("Electra", func(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().ProposeBeaconBlock(gomock.Any(), mock.MatchedBy(func(req *eth.GenericSignedBeaconBlock) bool {
-			// Convert back Fulu to Electra when there is at least one difference between Electra and Fulu blocks.
-			block, ok := req.Block.(*eth.GenericSignedBeaconBlock_Fulu)
-			converted, err := structs.SignedBeaconBlockContentsFuluFromConsensus(block.Fulu)
+			block, ok := req.Block.(*eth.GenericSignedBeaconBlock_Electra)
+			converted, err := structs.SignedBeaconBlockContentsElectraFromConsensus(block.Electra)
 			require.NoError(t, err)
-			var signedblock *structs.SignedBeaconBlockContentsFulu
-			err = json.Unmarshal([]byte(rpctesting.FuluBlockContents), &signedblock)
+			var signedblock *structs.SignedBeaconBlockContentsElectra
+			err = json.Unmarshal([]byte(rpctesting.ElectraBlockContents), &signedblock)
 			require.NoError(t, err)
 			require.DeepEqual(t, converted, signedblock)
 			return ok

--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -1517,14 +1517,11 @@ func TestPublishBlock(t *testing.T) {
 		server.PublishBlock(writer, request)
 		assert.Equal(t, http.StatusOK, writer.Code)
 	})
-	t.Run("Electra block without version header on wrong fork time", func(t *testing.T) {
+	t.Run("Electra block without version header on wrong fork", func(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		server := &Server{
 			V1Alpha1ValidatorServer: v1alpha1Server,
-			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
-				Genesis: time.Now(),
-			},
-			SyncChecker: &mockSync.Sync{IsSyncing: false},
+			SyncChecker:             &mockSync.Sync{IsSyncing: false},
 		}
 		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte(rpctesting.ElectraBlockContents)))
 		writer := httptest.NewRecorder()
@@ -1597,6 +1594,107 @@ func TestPublishBlock(t *testing.T) {
 		server.PublishBlock(writer, request)
 		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
 		assert.StringContains(t, "Beacon node is currently syncing and not serving request on that endpoint", writer.Body.String())
+	})
+}
+
+func TestVersionHeaderFromRequest(t *testing.T) {
+	t.Run("Fulu block contents returns fulu header", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.FuluForkEpoch = 7
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockContentsFulu
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.FuluBlockContents), &signedblock))
+		signedblock.SignedBlock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().FuluForkEpoch))
+		newContents, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		versionHead, err := versionHeaderFromRequest(newContents)
+		require.NoError(t, err)
+		require.Equal(t, version.String(version.Fulu), versionHead)
+	})
+	t.Run("Electra block contents returns electra header", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.ElectraForkEpoch = 6
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockContentsElectra
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.ElectraBlockContents), &signedblock))
+		signedblock.SignedBlock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().ElectraForkEpoch))
+		newContents, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		versionHead, err := versionHeaderFromRequest(newContents)
+		require.NoError(t, err)
+		require.Equal(t, version.String(version.Electra), versionHead)
+	})
+	t.Run("Deneb block contents returns deneb header", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.DenebForkEpoch = 5
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockContentsDeneb
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.DenebBlockContents), &signedblock))
+		signedblock.SignedBlock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().DenebForkEpoch))
+		newContents, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		versionHead, err := versionHeaderFromRequest(newContents)
+		require.NoError(t, err)
+		require.Equal(t, version.String(version.Deneb), versionHead)
+	})
+	t.Run("Capella block returns capella header", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.CapellaForkEpoch = 4
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockCapella
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.CapellaBlock), &signedblock))
+		signedblock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().CapellaForkEpoch))
+		newBlock, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		versionHead, err := versionHeaderFromRequest(newBlock)
+		require.NoError(t, err)
+		require.Equal(t, version.String(version.Capella), versionHead)
+	})
+	t.Run("Bellatrix block returns capella header", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.BellatrixForkEpoch = 3
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockBellatrix
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.BellatrixBlock), &signedblock))
+		signedblock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().BellatrixForkEpoch))
+		newBlock, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		versionHead, err := versionHeaderFromRequest(newBlock)
+		require.NoError(t, err)
+		require.Equal(t, version.String(version.Bellatrix), versionHead)
+	})
+	t.Run("Altair block returns capella header", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.AltairForkEpoch = 2
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockAltair
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.AltairBlock), &signedblock))
+		signedblock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().AltairForkEpoch))
+		newBlock, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		versionHead, err := versionHeaderFromRequest(newBlock)
+		require.NoError(t, err)
+		require.Equal(t, version.String(version.Altair), versionHead)
+	})
+	t.Run("Phase0 block returns capella header", func(t *testing.T) {
+		var signedblock *structs.SignedBeaconBlock
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.Phase0Block), &signedblock))
+		newBlock, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		versionHead, err := versionHeaderFromRequest(newBlock)
+		require.NoError(t, err)
+		require.Equal(t, version.String(version.Phase0), versionHead)
+	})
+	t.Run("Malformed json returns error unable to peek slot from block contents", func(t *testing.T) {
+		malformedJSON := []byte(`{"age": 30,}`)
+		_, err := versionHeaderFromRequest(malformedJSON)
+		require.ErrorContains(t, "unable to peek slot", err)
 	})
 }
 

--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -1407,6 +1407,38 @@ func TestPublishBlock(t *testing.T) {
 		server.PublishBlock(writer, request)
 		assert.Equal(t, http.StatusOK, writer.Code)
 	})
+	t.Run("Capella block without version header succeeds", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.CapellaForkEpoch = 4
+		params.OverrideBeaconConfig(cfg)
+		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockCapella
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.CapellaBlock), &signedblock))
+		signedblock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().CapellaForkEpoch))
+		newBlock, err := json.Marshal(signedblock)
+		require.NoError(t, err)
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().ProposeBeaconBlock(gomock.Any(), mock.MatchedBy(func(req *eth.GenericSignedBeaconBlock) bool {
+			block, ok := req.Block.(*eth.GenericSignedBeaconBlock_Capella)
+			converted, err := structs.BeaconBlockCapellaFromConsensus(block.Capella.Block)
+			require.NoError(t, err)
+			var signedblock *structs.SignedBeaconBlockCapella
+			err = json.Unmarshal(newBlock, &signedblock)
+			require.NoError(t, err)
+			require.DeepEqual(t, converted, signedblock.Message)
+			return ok
+		}))
+		server := &Server{
+			V1Alpha1ValidatorServer: v1alpha1Server,
+			SyncChecker:             &mockSync.Sync{IsSyncing: false},
+		}
+
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(newBlock))
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.PublishBlock(writer, request)
+		assert.Equal(t, http.StatusOK, writer.Code)
+	})
 	t.Run("Deneb", func(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().ProposeBeaconBlock(gomock.Any(), mock.MatchedBy(func(req *eth.GenericSignedBeaconBlock) bool {
@@ -1458,28 +1490,28 @@ func TestPublishBlock(t *testing.T) {
 		cfg.ElectraForkEpoch = 6
 		params.OverrideBeaconConfig(cfg)
 		params.SetupTestConfigCleanup(t)
+		var signedblock *structs.SignedBeaconBlockContentsElectra
+		require.NoError(t, json.Unmarshal([]byte(rpctesting.ElectraBlockContents), &signedblock))
+		signedblock.SignedBlock.Message.Slot = fmt.Sprintf("%d", uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(params.BeaconConfig().ElectraForkEpoch))
+		newContents, err := json.Marshal(signedblock)
+		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().ProposeBeaconBlock(gomock.Any(), mock.MatchedBy(func(req *eth.GenericSignedBeaconBlock) bool {
 			block, ok := req.Block.(*eth.GenericSignedBeaconBlock_Electra)
 			converted, err := structs.SignedBeaconBlockContentsElectraFromConsensus(block.Electra)
 			require.NoError(t, err)
 			var signedblock *structs.SignedBeaconBlockContentsElectra
-			err = json.Unmarshal([]byte(rpctesting.FuluBlockContents), &signedblock)
+			err = json.Unmarshal(newContents, &signedblock)
 			require.NoError(t, err)
 			require.DeepEqual(t, converted, signedblock)
 			return ok
 		}))
-		electraFork := params.BeaconConfig().ElectraForkEpoch
-		timeToFork := time.Duration(params.BeaconConfig().SecondsPerSlot*uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(electraFork)) * time.Second
-		currentTime := time.Now().Add(-1 * timeToFork)
 		server := &Server{
 			V1Alpha1ValidatorServer: v1alpha1Server,
-			GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
-				Genesis: currentTime,
-			},
-			SyncChecker: &mockSync.Sync{IsSyncing: false},
+			SyncChecker:             &mockSync.Sync{IsSyncing: false},
 		}
-		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte(rpctesting.ElectraBlockContents)))
+
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader(newContents))
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.PublishBlock(writer, request)

--- a/changelog/james-prysm_fix-block-api-electra.md
+++ b/changelog/james-prysm_fix-block-api-electra.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix block api endpoint to handle blocks with the same structure but on different forks (i.e. fulu and electra)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

The following error was reported by Chris Berry on the vouch team on POST request endpoint ` /eth/v2/beacon/blocks`
```
{
  "message": "rpc error: code = Internal desc = Could not broadcast/receive block: broadcast/receive block failed: failed to validate consensus state transition function: could not execute state transition: could not process block: state and block are different version. 5 != 6",
  "code": 500
}
```

this error is caused by how we have handled blocks in our publish block function. a new fork block type ( FULU) was added which has the same structure as the electra block type, the existing code believed the block was a fulu type.
This fix handles the API in 2 different ways. 
- v2 requires a header type for the fork version, this should be checked before unmarshalling.
- v1 does not require this header type so we try to retrieve this header type by calculating the current fork from the current slot. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
