### PR TITLE
Add missing hex conversion

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -175,7 +175,11 @@ func (s *Service) NewPayload(
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to encode execution requests")
 			}
-			err = s.rpcClient.CallContext(ctx, result, NewPayloadMethodV5, payloadPb, versionedHashes, parentBlockRoot, flattenedRequests, ilTxs)
+			hexIlTxs := make([]hexutil.Bytes, len(ilTxs))
+			for i, tx := range ilTxs {
+				hexIlTxs[i] = tx
+			}
+			err = s.rpcClient.CallContext(ctx, result, NewPayloadMethodV5, payloadPb, versionedHashes, parentBlockRoot, flattenedRequests, hexIlTxs)
 			if err != nil {
 				return nil, handleRPCError(err)
 			}


### PR DESCRIPTION
There are three new engine APIs so there should be three conversions. Previous commit missed one.