### PR TITLE
Fix cannot determine context bytes for unrecognized object

### DIFF
--- a/beacon-chain/sync/rpc_chunked_response.go
+++ b/beacon-chain/sync/rpc_chunked_response.go
@@ -75,6 +75,12 @@ func WriteBlockChunk(stream libp2pcore.Stream, tor blockchain.TemporalOracle, en
 			return err
 		}
 		obtainedCtx = digest[:]
+	case version.EPBS:
+		digest, err := forks.ForkDigestFromEpoch(params.BeaconConfig().EPBSForkEpoch, valRoot[:])
+		if err != nil {
+			return err
+		}
+		obtainedCtx = digest[:]
 	default:
 		return errors.Wrapf(ErrUnrecognizedVersion, "block version %d is not recognized", blk.Version())
 	}


### PR DESCRIPTION
This PR fixes:
```
[2025-02-11 01:21:28]  DEBUG sync: Could not handle p2p RPC error=block version 7 is not recognized: cannot determine context bytes for unrecognized object peer=16Uiu2HAmMC87uxtpjUPUXYyXZZpefc8qX5wzVxuYnFWF5mytrAAf 

```