### PR TITLE
Fix reconstruct blob sidecars to account `HasIndex` updates

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -543,9 +543,11 @@ func (s *Service) ReconstructBlobSidecars(ctx context.Context, block interfaces.
 
 	// Collect KZG hashes for non-existing blobs
 	var kzgHashes []common.Hash
+	kzgIndexes := make(map[int]bool)
 	for i, commitment := range kzgCommitments {
 		if !hasIndex(uint64(i)) {
 			kzgHashes = append(kzgHashes, primitives.ConvertKzgCommitmentToVersionedHash(commitment))
+			kzgIndexes[i] = true
 		}
 	}
 	if len(kzgHashes) == 0 {
@@ -569,7 +571,7 @@ func (s *Service) ReconstructBlobSidecars(ctx context.Context, block interfaces.
 	// Reconstruct verified blob sidecars
 	var verifiedBlobs []blocks.VerifiedROBlob
 	for i, blobIndex := 0, 0; i < len(kzgCommitments); i++ {
-		if hasIndex(uint64(i)) {
+		if !kzgIndexes[i] {
 			continue
 		}
 

--- a/changelog/tt_fix_reconstruct_blob_sidecars.md
+++ b/changelog/tt_fix_reconstruct_blob_sidecars.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix reconstruct blob sidecars for reference bug.


### PR DESCRIPTION
`HasIndex` returns a reference that gets mutated throughout the function, making it unsafe to use. Here, we use `kzgIndexes` as a copy to track which sidecars have been seen at the time.