### PR TITLE
Fix Blob Reconstruction

### DIFF
--- a/changelog/nisdas_fix_mutating_blob_mask.md
+++ b/changelog/nisdas_fix_mutating_blob_mask.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- We change how we track blob indexes during their reconstruction from the EL to prevent
+a mutating blob mask from causing invalid sidecars from being.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In the event the blob index mask is mutated by another routine, Prysm would end up building invalid blob sidecars. In order to prevent this from happening we now track the indexes of all the unseen commitments in a separate slice and use that as the canonical source of truth on which is the correct blob index. This allows us to not use the mutating bitmask and also only iterate through the unseen kzg commitments. 

**Which issues(s) does this PR fix?**

Alternative to #14908

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
