### PR TITLE
Add blobs by range electra test

### DIFF
--- a/beacon-chain/sync/rpc_send_request_test.go
+++ b/beacon-chain/sync/rpc_send_request_test.go
@@ -810,4 +810,70 @@ func TestSendBlobsByRangeRequest(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int(totalExpectedBlobs), len(blobs))
 	})
+
+	t.Run("Starting from Electra", func(t *testing.T) {
+		cfg := params.BeaconConfig()
+		cfg.ElectraForkEpoch = cfg.DenebForkEpoch + 1
+		undo, err := params.SetActiveWithUndo(cfg)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, undo())
+		}()
+
+		s := uint64(slots.UnsafeEpochStart(params.BeaconConfig().ElectraForkEpoch)) * params.BeaconConfig().SecondsPerSlot
+		clock := startup.NewClock(time.Now().Add(-time.Second*time.Duration(s)), [32]byte{})
+		ctxByte, err := ContextByteVersionsForValRoot(clock.GenesisValidatorsRoot())
+		require.NoError(t, err)
+		// Setup peers
+		p1 := p2ptest.NewTestP2P(t)
+		p2 := p2ptest.NewTestP2P(t)
+		p1.Connect(p2)
+
+		slot := slots.UnsafeEpochStart(params.BeaconConfig().ElectraForkEpoch)
+		// Create a simple handler that will return a valid response.
+		p2.SetStreamHandler(topic, func(stream network.Stream) {
+			defer func() {
+				assert.NoError(t, stream.Close())
+			}()
+
+			req := &ethpb.BlobSidecarsByRangeRequest{}
+			assert.NoError(t, p2.Encoding().DecodeWithMaxLength(stream, req))
+			assert.Equal(t, slot, req.StartSlot)
+			assert.Equal(t, uint64(params.BeaconConfig().SlotsPerEpoch)*3, req.Count)
+
+			// Create a sequential set of blobs with the appropriate header information.
+			var prevRoot [32]byte
+			for i := req.StartSlot; i < req.StartSlot+primitives.Slot(req.Count); i++ {
+				maxBlobsForSlot := cfg.MaxBlobsPerBlock(i)
+				parentRoot := prevRoot
+				header := util.HydrateSignedBeaconHeader(&ethpb.SignedBeaconBlockHeader{})
+				header.Header.Slot = i
+				header.Header.ParentRoot = parentRoot[:]
+				bRoot, err := header.Header.HashTreeRoot()
+				require.NoError(t, err)
+				prevRoot = bRoot
+				// Send the maximum possible blobs per slot.
+				for j := 0; j < maxBlobsForSlot; j++ {
+					b := util.HydrateBlobSidecar(&ethpb.BlobSidecar{})
+					b.SignedBlockHeader = header
+					b.Index = uint64(j)
+					ro, err := blocks.NewROBlob(b)
+					require.NoError(t, err)
+					vro := blocks.NewVerifiedROBlob(ro)
+					assert.NoError(t, WriteBlobSidecarChunk(stream, clock, p2.Encoding(), vro))
+				}
+			}
+		})
+		req := &ethpb.BlobSidecarsByRangeRequest{
+			StartSlot: slot,
+			Count:     uint64(params.BeaconConfig().SlotsPerEpoch) * 3,
+		}
+
+		maxElectraBlobs := cfg.MaxBlobsPerBlockAtEpoch(cfg.ElectraForkEpoch)
+		totalElectraBlobs := primitives.Slot(maxElectraBlobs) * 3 * params.BeaconConfig().SlotsPerEpoch
+
+		blobs, err := SendBlobsByRangeRequest(ctx, clock, p1, p2.PeerID(), ctxByte, req)
+		assert.NoError(t, err)
+		assert.Equal(t, int(totalElectraBlobs), len(blobs))
+	})
 }

--- a/changelog/tt_blob_by_range_electra_test.md
+++ b/changelog/tt_blob_by_range_electra_test.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Add blobs by range electra test


### PR DESCRIPTION
Covers blobs by range electra the following conditions:
```go
	maxBlobsPerBlock := uint64(params.BeaconConfig().MaxBlobsPerBlock(req.StartSlot + primitives.Slot(req.Count)))
	max := params.BeaconConfig().MaxRequestBlobSidecars
	if slots.ToEpoch(req.StartSlot) >= params.BeaconConfig().ElectraForkEpoch {
		max = params.BeaconConfig().MaxRequestBlobSidecarsElectra
	}
	if max > req.Count*maxBlobsPerBlock {
		max = req.Count * maxBlobsPerBlock
	}
```