### PR TITLE
Don't use MaxCover for Electra on-chain aggregates

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -2,8 +2,10 @@ package validator
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -277,7 +279,14 @@ func (a proposerAtts) sortOnChainAggregates() (proposerAtts, error) {
 		return a, nil
 	}
 
-	return a.sortByProfitabilityUsingMaxCover()
+	// Sort by slot first, then by bit count.
+	slices.SortFunc(a, func(a, b ethpb.Att) int {
+		return cmp.Or(
+			-cmp.Compare(a.GetData().Slot, b.GetData().Slot),
+			-cmp.Compare(a.GetAggregationBits().Count(), b.GetAggregationBits().Count()))
+	})
+
+	return a, nil
 }
 
 // Separate attestations by slot, as slot number takes higher precedence when sorting.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -794,17 +794,19 @@ func Test_packAttestations_ElectraOnChainAggregates(t *testing.T) {
 
 	require.NoError(t, st.SetSlot(params.BeaconConfig().SlotsPerEpoch+1))
 
-	atts, err := s.packAttestations(ctx, st, params.BeaconConfig().SlotsPerEpoch)
-	require.NoError(t, err)
-	require.Equal(t, 6, len(atts))
-	assert.Equal(t, true,
-		atts[0].GetAggregationBits().Count() >= atts[1].GetAggregationBits().Count() &&
-			atts[1].GetAggregationBits().Count() >= atts[2].GetAggregationBits().Count() &&
-			atts[2].GetAggregationBits().Count() >= atts[3].GetAggregationBits().Count() &&
-			atts[3].GetAggregationBits().Count() >= atts[4].GetAggregationBits().Count() &&
-			atts[4].GetAggregationBits().Count() >= atts[5].GetAggregationBits().Count(),
-		"on-chain aggregates are not sorted by aggregation bit count",
-	)
+	t.Run("ok", func(t *testing.T) {
+		atts, err := s.packAttestations(ctx, st, params.BeaconConfig().SlotsPerEpoch)
+		require.NoError(t, err)
+		require.Equal(t, 6, len(atts))
+		assert.Equal(t, true,
+			atts[0].GetAggregationBits().Count() >= atts[1].GetAggregationBits().Count() &&
+				atts[1].GetAggregationBits().Count() >= atts[2].GetAggregationBits().Count() &&
+				atts[2].GetAggregationBits().Count() >= atts[3].GetAggregationBits().Count() &&
+				atts[3].GetAggregationBits().Count() >= atts[4].GetAggregationBits().Count() &&
+				atts[4].GetAggregationBits().Count() >= atts[5].GetAggregationBits().Count(),
+			"on-chain aggregates are not sorted by aggregation bit count",
+		)
+	})
 
 	t.Run("slot takes precedence", func(t *testing.T) {
 		moreRecentAtt := &ethpb.AttestationElectra{
@@ -814,7 +816,7 @@ func Test_packAttestations_ElectraOnChainAggregates(t *testing.T) {
 			Signature:       sig.Marshal(),
 		}
 		require.NoError(t, pool.SaveUnaggregatedAttestations([]ethpb.Att{moreRecentAtt}))
-		atts, err = s.packAttestations(ctx, st, params.BeaconConfig().SlotsPerEpoch)
+		atts, err := s.packAttestations(ctx, st, params.BeaconConfig().SlotsPerEpoch)
 		require.NoError(t, err)
 		require.Equal(t, 7, len(atts))
 		assert.Equal(t, true, atts[0].GetData().Slot == 1)

--- a/changelog/radek_no-maxcover-for-electra.md
+++ b/changelog/radek_no-maxcover-for-electra.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Don't use MaxCover for Electra on-chain attestations.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Before creating on-chain attestations we perform MaxCover on the aggregated attestations from the pool:
```
for id, as := range attsById {
	as, err := attaggregation.Aggregate(as)
	if err != nil {
		return nil, err
	}
	attsById[id] = as
}
```
After creating on-chain attestations we perform MaxCover on them inside `sortOnChainAggregates`:
```
return a.sortByProfitabilityUsingMaxCover()
```
But this doesn't make sense. There's no way any of them can be aggregated further since they consist of attestations already aggregated with MaxCover. The bigger issue is not redundancy, though. Our MaxCover algorithm expects that every attestation will have the same number of attestation bits: https://github.com/prysmaticlabs/prysm/blob/3eec5a5cb6095591e25ff3c08fabd513eb465434/proto/prysm/v1alpha1/attestation/aggregation/maxcover.go#L124
This leads to unexpected results for on-chain attestations, which can have variable attestation bit lengths, placing better attestations after worse ones.

A simple solution is to stop using MaxCover for on-chain aggregates and use a simple comparison function to order them as we want, which is currently by slot and then by attestation bit count.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
