### PR TITLE
fix path parsing bug on windows

### DIFF
--- a/beacon-chain/db/filesystem/iteration.go
+++ b/beacon-chain/db/filesystem/iteration.go
@@ -3,7 +3,6 @@ package filesystem
 import (
 	"fmt"
 	"io"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -193,7 +192,7 @@ func rootFromPath(p string) ([32]byte, error) {
 }
 
 func idxFromPath(p string) (uint64, error) {
-	p = path.Base(p)
+	p = filepath.Base(p)
 
 	if !isSszFile(p) {
 		return 0, errors.Wrap(errNotBlobSSZ, "does not have .ssz extension")

--- a/changelog/kasey_windows-layout-fix.md
+++ b/changelog/kasey_windows-layout-fix.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed bug that breaks new blob storage layout code on Windows, caused by accidental use of platform-dependent path parsing package.


### PR DESCRIPTION

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

https://github.com/prysmaticlabs/prysm/pull/14023 introduced a bug where the wrong path parsing library was used to parse out the blob file name from the directory. This PR switches to the correct platform-independent package.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
