### PR TITLE
Add get pending deposits endpoint

### DIFF
--- a/api/server/structs/endpoints_beacon.go
+++ b/api/server/structs/endpoints_beacon.go
@@ -250,3 +250,10 @@ type ChainHead struct {
 	PreviousJustifiedBlockRoot string `json:"previous_justified_block_root"`
 	OptimisticStatus           bool   `json:"optimistic_status"`
 }
+
+type GetPendingDepositsResponse struct {
+	Version             string            `json:"version"`
+	ExecutionOptimistic bool              `json:"execution_optimistic"`
+	Finalized           bool              `json:"finalized"`
+	Data                []*PendingDeposit `json:"data"`
+}

--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -884,6 +884,15 @@ func (s *Service) beaconEndpoints(
 			handler: server.GetDepositSnapshot,
 			methods: []string{http.MethodGet},
 		},
+		{
+			template: "/eth/v1/beacon/states/{state_id}/pending_deposits",
+			name:     namespace + ".GetPendingDeposits",
+			middleware: []middleware.Middleware{
+				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
+			},
+			handler: server.GetPendingDeposits,
+			methods: []string{http.MethodGet},
+		},
 	}
 }
 

--- a/beacon-chain/rpc/endpoints_test.go
+++ b/beacon-chain/rpc/endpoints_test.go
@@ -27,6 +27,7 @@ func Test_endpoints(t *testing.T) {
 		"/eth/v1/beacon/states/{state_id}/committees":                {http.MethodGet},
 		"/eth/v1/beacon/states/{state_id}/sync_committees":           {http.MethodGet},
 		"/eth/v1/beacon/states/{state_id}/randao":                    {http.MethodGet},
+		"/eth/v1/beacon/states/{state_id}/pending_deposits":          {http.MethodGet},
 		"/eth/v1/beacon/headers":                                     {http.MethodGet},
 		"/eth/v1/beacon/headers/{block_id}":                          {http.MethodGet},
 		"/eth/v1/beacon/blinded_blocks":                              {http.MethodPost},

--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//api/server/structs:go_default_library",
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/cache/depositsnapshot:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/signing:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/core/transition:go_default_library",

--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -82,7 +82,6 @@ go_test(
         "//api/server/structs:go_default_library",
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/cache/depositsnapshot:go_default_library",
-        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/signing:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/core/transition:go_default_library",

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -1611,6 +1611,7 @@ func (s *Server) broadcastSeenBlockSidecars(
 
 // GetPendingDeposits returns pending deposits for state with given 'stateId'.
 // Should return 400 if the state retrieved is prior to Electra.
+// Supports both JSON and SSZ responses based on Accept header.
 func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "beacon.GetPendingDeposits")
 	defer span.End()

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -1637,7 +1637,7 @@ func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set(api.VersionHeader, version.String(st.Version()))
 	if httputil.RespondWithSsz(r) {
-		sszData, err := s.serializePendingDeposits(pd)
+		sszData, err := serializePendingDeposits(pd)
 		if err != nil {
 			httputil.HandleError(w, "Failed to serialize pending deposits: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1666,7 +1666,7 @@ func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
 }
 
 // serializePendingDeposits serializes a slice of PendingDeposit objects into a single byte array.
-func (s *Server) serializePendingDeposits(pd []*eth.PendingDeposit) ([]byte, error) {
+func serializePendingDeposits(pd []*eth.PendingDeposit) ([]byte, error) {
 	var result []byte
 	for _, d := range pd {
 		b, err := d.MarshalSSZ()

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -1647,7 +1647,7 @@ func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
 		httputil.HandleError(w, "Could not get pending deposits: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set(api.VersionHeader, stateId)
+	w.Header().Set(api.VersionHeader, version.String(st.Version()))
 	if httputil.RespondWithSsz(r) {
 		sszData, err := s.serializePendingDeposits(pd)
 		if err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -1630,18 +1630,6 @@ func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
 		httputil.HandleError(w, "state_id is prior to electra", http.StatusBadRequest)
 		return
 	}
-	isOptimistic, err := helpers.IsOptimistic(ctx, []byte(stateId), s.OptimisticModeFetcher, s.Stater, s.ChainInfoFetcher, s.BeaconDB)
-	if err != nil {
-		httputil.HandleError(w, "Could not check optimistic status: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	blockRoot, err := st.LatestBlockHeader().HashTreeRoot()
-	if err != nil {
-		httputil.HandleError(w, "Could not calculate root of latest block header: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	isFinalized := s.FinalizationFetcher.IsFinalized(ctx, blockRoot)
-
 	pd, err := st.PendingDeposits()
 	if err != nil {
 		httputil.HandleError(w, "Could not get pending deposits: "+err.Error(), http.StatusInternalServerError)
@@ -1656,6 +1644,17 @@ func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
 		}
 		httputil.WriteSsz(w, sszData, "pending_deposits.ssz")
 	} else {
+		isOptimistic, err := helpers.IsOptimistic(ctx, []byte(stateId), s.OptimisticModeFetcher, s.Stater, s.ChainInfoFetcher, s.BeaconDB)
+		if err != nil {
+			httputil.HandleError(w, "Could not check optimistic status: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		blockRoot, err := st.LatestBlockHeader().HashTreeRoot()
+		if err != nil {
+			httputil.HandleError(w, "Could not calculate root of latest block header: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		isFinalized := s.FinalizationFetcher.IsFinalized(ctx, blockRoot)
 		resp := structs.GetPendingDepositsResponse{
 			Version:             version.String(st.Version()),
 			ExecutionOptimistic: isOptimistic,

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -1608,3 +1608,72 @@ func (s *Server) broadcastSeenBlockSidecars(
 	}
 	return nil
 }
+
+// GetPendingDeposits returns pending deposits for state with given 'stateId'.
+// Should return 400 if the state retrieved is prior to Electra.
+func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
+	ctx, span := trace.StartSpan(r.Context(), "beacon.GetPendingDeposits")
+	defer span.End()
+
+	stateId := r.PathValue("state_id")
+	if stateId == "" {
+		httputil.HandleError(w, "state_id is required in URL params", http.StatusBadRequest)
+		return
+	}
+	st, err := s.Stater.State(ctx, []byte(stateId))
+	if err != nil {
+		shared.WriteStateFetchError(w, err)
+		return
+	}
+	if st.Version() < version.Electra {
+		httputil.HandleError(w, "state_id is prior to electra", http.StatusBadRequest)
+		return
+	}
+	isOptimistic, err := helpers.IsOptimistic(ctx, []byte(stateId), s.OptimisticModeFetcher, s.Stater, s.ChainInfoFetcher, s.BeaconDB)
+	if err != nil {
+		httputil.HandleError(w, "Could not check optimistic status: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	blockRoot, err := st.LatestBlockHeader().HashTreeRoot()
+	if err != nil {
+		httputil.HandleError(w, "Could not calculate root of latest block header: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	isFinalized := s.FinalizationFetcher.IsFinalized(ctx, blockRoot)
+
+	pd, err := st.PendingDeposits()
+	if err != nil {
+		httputil.HandleError(w, "Could not get pending deposits: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set(api.VersionHeader, stateId)
+	if httputil.RespondWithSsz(r) {
+		sszData, err := s.serializePendingDeposits(pd)
+		if err != nil {
+			httputil.HandleError(w, "Failed to serialize pending deposits: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		httputil.WriteSsz(w, sszData, "pending_deposits.ssz")
+	} else {
+		resp := structs.GetPendingDepositsResponse{
+			Version:             version.String(st.Version()),
+			ExecutionOptimistic: isOptimistic,
+			Finalized:           isFinalized,
+			Data:                structs.PendingDepositsFromConsensus(pd),
+		}
+		httputil.WriteJson(w, resp)
+	}
+}
+
+// serializePendingDeposits serializes a slice of PendingDeposit objects into a single byte array.
+func (s *Server) serializePendingDeposits(pd []*eth.PendingDeposit) ([]byte, error) {
+	var result []byte
+	for _, d := range pd {
+		b, err := d.MarshalSSZ()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, b...)
+	}
+	return result, nil
+}

--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/api/server/structs"
 	chainMock "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache/depositsnapshot"
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/db"
 	dbTest "github.com/prysmaticlabs/prysm/v5/beacon-chain/db/testing"
@@ -4757,20 +4756,19 @@ func Test_validateBlobSidecars(t *testing.T) {
 }
 
 func TestGetPendingDeposits(t *testing.T) {
-	config := params.BeaconConfig()
-	st, _ := util.DeterministicGenesisStateElectra(t, config.MaxValidatorsPerCommittee)
+	st, _ := util.DeterministicGenesisStateElectra(t, 10)
 
 	validators := st.Validators()
-	deps := make([]*eth.PendingDeposit, 20)
+	dummySig := make([]byte, 96)
+	for j := 0; j < 96; j++ {
+		dummySig[j] = byte(j)
+	}
+	deps := make([]*eth.PendingDeposit, 10)
 	for i := 0; i < len(deps); i += 1 {
-		dummySig := make([]byte, 96)
-		for j := 0; j < 96; j++ {
-			dummySig[j] = byte(i)
-		}
 		deps[i] = &eth.PendingDeposit{
 			PublicKey:             validators[i].PublicKey,
 			WithdrawalCredentials: validators[i].WithdrawalCredentials,
-			Amount:                uint64(helpers.ActivationExitChurnLimit(1_000*1e9)) / 10,
+			Amount:                uint64(100),
 			Slot:                  0,
 			Signature:             dummySig,
 		}
@@ -4787,8 +4785,6 @@ func TestGetPendingDeposits(t *testing.T) {
 		},
 		OptimisticModeFetcher: chainService,
 		FinalizationFetcher:   chainService,
-		BeaconDB:              nil,
-		ChainInfoFetcher:      chainService,
 	}
 
 	t.Run("json response", func(t *testing.T) {
@@ -4799,7 +4795,7 @@ func TestGetPendingDeposits(t *testing.T) {
 
 		server.GetPendingDeposits(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
-		require.Equal(t, "head", rec.Header().Get(api.VersionHeader))
+		require.Equal(t, "electra", rec.Header().Get(api.VersionHeader))
 
 		var resp structs.GetPendingDepositsResponse
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
@@ -4822,19 +4818,13 @@ func TestGetPendingDeposits(t *testing.T) {
 
 		server.GetPendingDeposits(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
-		require.Equal(t, "head", rec.Header().Get(api.VersionHeader))
+		require.Equal(t, "electra", rec.Header().Get(api.VersionHeader))
 
 		responseBytes := rec.Body.Bytes()
 		var recoveredDeposits []*eth.PendingDeposit
 
-		// Each deposit should have the same size when serialized
-		depositSize := 0
-		if len(deps) > 0 {
-			firstDeposit, err := deps[0].MarshalSSZ()
-			require.NoError(t, err)
-			depositSize = len(firstDeposit)
-		}
 		// Verify total size matches expected number of deposits
+		depositSize := (&eth.PendingDeposit{}).SizeSSZ()
 		require.Equal(t, len(responseBytes), depositSize*len(deps))
 
 		for i := 0; i < len(deps); i++ {
@@ -4848,9 +4838,7 @@ func TestGetPendingDeposits(t *testing.T) {
 		require.DeepEqual(t, deps, recoveredDeposits)
 	})
 	t.Run("pre electra state", func(t *testing.T) {
-		// Create a pre-Electra state (e.g., Deneb)
-		preElectraSt, _ := util.DeterministicGenesisStateDeneb(t, config.MaxValidatorsPerCommittee)
-
+		preElectraSt, _ := util.DeterministicGenesisStateDeneb(t, 1)
 		preElectraServer := &Server{
 			Stater: &testutil.MockStater{
 				BeaconState: preElectraSt,
@@ -4910,7 +4898,7 @@ func TestGetPendingDeposits(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
 		require.Equal(t, "state_id is required in URL params", errResp.Message)
 	})
-	t.Run("optimistic state", func(t *testing.T) {
+	t.Run("state_id=optimistic", func(t *testing.T) {
 		optimisticChainService := &chainMock.ChainService{
 			Optimistic:     true,
 			FinalizedRoots: map[[32]byte]bool{},
@@ -4919,8 +4907,6 @@ func TestGetPendingDeposits(t *testing.T) {
 			Stater:                server.Stater,
 			OptimisticModeFetcher: optimisticChainService,
 			FinalizationFetcher:   optimisticChainService,
-			BeaconDB:              nil,
-			ChainInfoFetcher:      optimisticChainService,
 		}
 
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
@@ -4936,7 +4922,7 @@ func TestGetPendingDeposits(t *testing.T) {
 		require.Equal(t, true, resp.ExecutionOptimistic)
 	})
 
-	t.Run("finalized state", func(t *testing.T) {
+	t.Run("state_id=finalized", func(t *testing.T) {
 		blockRoot, err := st.LatestBlockHeader().HashTreeRoot()
 		require.NoError(t, err)
 
@@ -4948,8 +4934,6 @@ func TestGetPendingDeposits(t *testing.T) {
 			Stater:                server.Stater,
 			OptimisticModeFetcher: finalizedChainService,
 			FinalizationFetcher:   finalizedChainService,
-			BeaconDB:              nil,
-			ChainInfoFetcher:      finalizedChainService,
 		}
 
 		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)

--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/api/server/structs"
 	chainMock "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache/depositsnapshot"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/db"
 	dbTest "github.com/prysmaticlabs/prysm/v5/beacon-chain/db/testing"
@@ -4753,4 +4754,214 @@ func Test_validateBlobSidecars(t *testing.T) {
 	b, err = blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
 	require.ErrorContains(t, "could not verify blob proof: can't verify opening proof", s.validateBlobSidecars(b, [][]byte{blob[:]}, [][]byte{proof[:]}))
+}
+
+func TestGetPendingDeposits(t *testing.T) {
+	config := params.BeaconConfig()
+	st, _ := util.DeterministicGenesisStateElectra(t, config.MaxValidatorsPerCommittee)
+
+	validators := st.Validators()
+	deps := make([]*eth.PendingDeposit, 20)
+	for i := 0; i < len(deps); i += 1 {
+		dummySig := make([]byte, 96)
+		for j := 0; j < 96; j++ {
+			dummySig[j] = byte(i)
+		}
+		deps[i] = &eth.PendingDeposit{
+			PublicKey:             validators[i].PublicKey,
+			WithdrawalCredentials: validators[i].WithdrawalCredentials,
+			Amount:                uint64(helpers.ActivationExitChurnLimit(1_000*1e9)) / 10,
+			Slot:                  0,
+			Signature:             dummySig,
+		}
+	}
+	require.NoError(t, st.SetPendingDeposits(deps))
+
+	chainService := &chainMock.ChainService{
+		Optimistic:     false,
+		FinalizedRoots: map[[32]byte]bool{},
+	}
+	server := &Server{
+		Stater: &testutil.MockStater{
+			BeaconState: st,
+		},
+		OptimisticModeFetcher: chainService,
+		FinalizationFetcher:   chainService,
+		BeaconDB:              nil,
+		ChainInfoFetcher:      chainService,
+	}
+
+	t.Run("json response", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
+		req.SetPathValue("state_id", "head")
+		rec := httptest.NewRecorder()
+		rec.Body = new(bytes.Buffer)
+
+		server.GetPendingDeposits(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "head", rec.Header().Get(api.VersionHeader))
+
+		var resp structs.GetPendingDepositsResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+		expectedVersion := version.String(st.Version())
+		require.Equal(t, expectedVersion, resp.Version)
+
+		require.Equal(t, false, resp.ExecutionOptimistic)
+		require.Equal(t, false, resp.Finalized)
+
+		expectedDeposits := structs.PendingDepositsFromConsensus(deps)
+		require.DeepEqual(t, expectedDeposits, resp.Data)
+	})
+	t.Run("ssz response", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
+		req.Header.Set("Accept", "application/octet-stream")
+		req.SetPathValue("state_id", "head")
+		rec := httptest.NewRecorder()
+		rec.Body = new(bytes.Buffer)
+
+		server.GetPendingDeposits(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "head", rec.Header().Get(api.VersionHeader))
+
+		responseBytes := rec.Body.Bytes()
+		var recoveredDeposits []*eth.PendingDeposit
+
+		// Each deposit should have the same size when serialized
+		depositSize := 0
+		if len(deps) > 0 {
+			firstDeposit, err := deps[0].MarshalSSZ()
+			require.NoError(t, err)
+			depositSize = len(firstDeposit)
+		}
+		// Verify total size matches expected number of deposits
+		require.Equal(t, len(responseBytes), depositSize*len(deps))
+
+		for i := 0; i < len(deps); i++ {
+			start := i * depositSize
+			end := start + depositSize
+
+			var deposit eth.PendingDeposit
+			require.NoError(t, deposit.UnmarshalSSZ(responseBytes[start:end]))
+			recoveredDeposits = append(recoveredDeposits, &deposit)
+		}
+		require.DeepEqual(t, deps, recoveredDeposits)
+	})
+	t.Run("pre electra state", func(t *testing.T) {
+		// Create a pre-Electra state (e.g., Deneb)
+		preElectraSt, _ := util.DeterministicGenesisStateDeneb(t, config.MaxValidatorsPerCommittee)
+
+		preElectraServer := &Server{
+			Stater: &testutil.MockStater{
+				BeaconState: preElectraSt,
+			},
+			OptimisticModeFetcher: chainService,
+			FinalizationFetcher:   chainService,
+			BeaconDB:              nil,
+			ChainInfoFetcher:      chainService,
+		}
+
+		// Test JSON request
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
+		req.SetPathValue("state_id", "head")
+		rec := httptest.NewRecorder()
+		rec.Body = new(bytes.Buffer)
+
+		preElectraServer.GetPendingDeposits(rec, req)
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+
+		var errResp struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+		require.Equal(t, "state_id is prior to electra", errResp.Message)
+
+		// Test SSZ request
+		sszReq := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
+		sszReq.Header.Set("Accept", "application/octet-stream")
+		sszReq.SetPathValue("state_id", "head")
+		sszRec := httptest.NewRecorder()
+		sszRec.Body = new(bytes.Buffer)
+
+		preElectraServer.GetPendingDeposits(sszRec, sszReq)
+		require.Equal(t, http.StatusBadRequest, sszRec.Code)
+
+		var sszErrResp struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		require.NoError(t, json.Unmarshal(sszRec.Body.Bytes(), &sszErrResp))
+		require.Equal(t, "state_id is prior to electra", sszErrResp.Message)
+	})
+	t.Run("missing state_id parameter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
+		// Intentionally not setting state_id
+		rec := httptest.NewRecorder()
+		rec.Body = new(bytes.Buffer)
+
+		server.GetPendingDeposits(rec, req)
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+
+		var errResp struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+		require.Equal(t, "state_id is required in URL params", errResp.Message)
+	})
+	t.Run("optimistic state", func(t *testing.T) {
+		optimisticChainService := &chainMock.ChainService{
+			Optimistic:     true,
+			FinalizedRoots: map[[32]byte]bool{},
+		}
+		optimisticServer := &Server{
+			Stater:                server.Stater,
+			OptimisticModeFetcher: optimisticChainService,
+			FinalizationFetcher:   optimisticChainService,
+			BeaconDB:              nil,
+			ChainInfoFetcher:      optimisticChainService,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
+		req.SetPathValue("state_id", "head")
+		rec := httptest.NewRecorder()
+		rec.Body = new(bytes.Buffer)
+
+		optimisticServer.GetPendingDeposits(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp structs.GetPendingDepositsResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Equal(t, true, resp.ExecutionOptimistic)
+	})
+
+	t.Run("finalized state", func(t *testing.T) {
+		blockRoot, err := st.LatestBlockHeader().HashTreeRoot()
+		require.NoError(t, err)
+
+		finalizedChainService := &chainMock.ChainService{
+			Optimistic:     false,
+			FinalizedRoots: map[[32]byte]bool{blockRoot: true},
+		}
+		finalizedServer := &Server{
+			Stater:                server.Stater,
+			OptimisticModeFetcher: finalizedChainService,
+			FinalizationFetcher:   finalizedChainService,
+			BeaconDB:              nil,
+			ChainInfoFetcher:      finalizedChainService,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/states/{state_id}/pending_deposits", nil)
+		req.SetPathValue("state_id", "head")
+		rec := httptest.NewRecorder()
+		rec.Body = new(bytes.Buffer)
+
+		finalizedServer.GetPendingDeposits(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp structs.GetPendingDepositsResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Equal(t, true, resp.Finalized)
+	})
 }

--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -4768,7 +4768,7 @@ func TestGetPendingDeposits(t *testing.T) {
 		deps[i] = &eth.PendingDeposit{
 			PublicKey:             validators[i].PublicKey,
 			WithdrawalCredentials: validators[i].WithdrawalCredentials,
-			Amount:                uint64(100),
+			Amount:                100,
 			Slot:                  0,
 			Signature:             dummySig,
 		}
@@ -4845,8 +4845,6 @@ func TestGetPendingDeposits(t *testing.T) {
 			},
 			OptimisticModeFetcher: chainService,
 			FinalizationFetcher:   chainService,
-			BeaconDB:              nil,
-			ChainInfoFetcher:      chainService,
 		}
 
 		// Test JSON request
@@ -4898,7 +4896,7 @@ func TestGetPendingDeposits(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
 		require.Equal(t, "state_id is required in URL params", errResp.Message)
 	})
-	t.Run("state_id=optimistic", func(t *testing.T) {
+	t.Run("optimistic node", func(t *testing.T) {
 		optimisticChainService := &chainMock.ChainService{
 			Optimistic:     true,
 			FinalizedRoots: map[[32]byte]bool{},
@@ -4922,7 +4920,7 @@ func TestGetPendingDeposits(t *testing.T) {
 		require.Equal(t, true, resp.ExecutionOptimistic)
 	})
 
-	t.Run("state_id=finalized", func(t *testing.T) {
+	t.Run("finalized node", func(t *testing.T) {
 		blockRoot, err := st.LatestBlockHeader().HashTreeRoot()
 		require.NoError(t, err)
 

--- a/changelog/saolyn_add-GetPendingDeposits.md
+++ b/changelog/saolyn_add-GetPendingDeposits.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add missing endpoint for getting pending deposits.

--- a/changelog/saolyn_add-GetPendingDeposits.md
+++ b/changelog/saolyn_add-GetPendingDeposits.md
@@ -1,3 +1,3 @@
 ### Added
 
-- Add missing endpoint for getting pending deposits.
+- Add endpoint for getting pending deposits.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
Added the endpoint that retrieves pending deposits.
Spec on the endpoint can be found [here](https://github.com/ethereum/beacon-APIs/pull/500)

**Which issues(s) does this PR fix?**

https://github.com/prysmaticlabs/prysm/issues/14935

**Other notes for review**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
