### PR TITLE
`ServiceRegistry.StartAll`: Remove redundant log.

### DIFF
--- a/changelog/manu_services_start_log_removal.md
+++ b/changelog/manu_services_start_log_removal.md
@@ -1,0 +1,2 @@
+### Removed
+- Removed the log summarizing all started services.

--- a/runtime/service_registry.go
+++ b/runtime/service_registry.go
@@ -40,7 +40,6 @@ func NewServiceRegistry() *ServiceRegistry {
 
 // StartAll initialized each service in order of registration.
 func (s *ServiceRegistry) StartAll() {
-	log.Debugf("Starting %d services: %v", len(s.serviceTypes), s.serviceTypes)
 	for _, kind := range s.serviceTypes {
 		log.Debugf("Starting service type %v", kind)
 		go s.services[kind].Start()


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
When starting a beacon node, there is:
- 1 log where all the started services are printed on the same line, and
- 1 log **per** new started service

Example:

```
[2025-02-19 16:32:21.53]  DEBUG registry: Starting 12 services: [*p2p.Service *backfill.Service *execution.Service *attestations.Service *blockchain.Service *initialsync.Service *sync.Service *slashings.PoolService *builder.Service *rpc.Service *httprest.Server *prometheus.Service]
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *p2p.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *backfill.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *execution.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *attestations.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *blockchain.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *initialsync.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *sync.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *slashings.PoolService
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *builder.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *rpc.Service
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *httprest.Server
[2025-02-19 16:32:21.53]  DEBUG registry: Starting service type *prometheus.Service
```

This PR removes the first, redundant log

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
