### PR TITLE
`SingleAttestation` support in the monitor service

### DIFF
--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -166,6 +166,23 @@ func (s *Service) processIncludedAttestation(ctx context.Context, state state.Be
 	}
 }
 
+// processSingleAttestation logs when the beacon node observes a single attestation from tracked validator.
+func (s *Service) processSingleAttestation(att ethpb.Att) {
+	s.RLock()
+	defer s.RUnlock()
+
+	single, ok := att.(*ethpb.SingleAttestation)
+	if !ok {
+		log.Errorf("wrong attestation type (expected %T, got %T)", &ethpb.SingleAttestation{}, att)
+		return
+	}
+
+	if s.canUpdateAttestedValidator(single.AttesterIndex, single.GetData().Slot) {
+		logFields := logMessageTimelyFlagsForIndex(single.AttesterIndex, att.GetData())
+		log.WithFields(logFields).Info("Processed unaggregated attestation")
+	}
+}
+
 // processUnaggregatedAttestation logs when the beacon node observes an unaggregated attestation from tracked validator.
 func (s *Service) processUnaggregatedAttestation(ctx context.Context, att ethpb.Att) {
 	s.RLock()

--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -173,7 +173,7 @@ func (s *Service) processSingleAttestation(att ethpb.Att) {
 
 	single, ok := att.(*ethpb.SingleAttestation)
 	if !ok {
-		log.Errorf("wrong attestation type (expected %T, got %T)", &ethpb.SingleAttestation{}, att)
+		log.Errorf("Wrong attestation type (expected %T, got %T)", &ethpb.SingleAttestation{}, att)
 		return
 	}
 

--- a/beacon-chain/monitor/service.go
+++ b/beacon-chain/monitor/service.go
@@ -241,7 +241,7 @@ func (s *Service) monitorRoutine(stateChannel chan *feed.Event, stateSub event.S
 				if !ok {
 					log.Error("Event feed data is not of type *operation.SingleAttReceivedData")
 				} else {
-					s.processUnaggregatedAttestation(s.ctx, data.Attestation)
+					s.processSingleAttestation(data.Attestation)
 				}
 			case operation.ExitReceived:
 				data, ok := e.Data.(*operation.ExitReceivedData)

--- a/changelog/radek_monitor-single-atts.md
+++ b/changelog/radek_monitor-single-atts.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Dedicated processing of `SingleAttestation` in the monitor service.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The monitor service currently handles Electra's `SingleAttestation` in the same way as unaggregated attestations from Phase0. This can't work because single attestations don't have attestation bits.

Error logs:
```
level=error msg="Could not get attesting indices" error="bitfield length 0 is not equal to committee length 8" prefix=monitor
```

The PR adds a new `processSingleAttestation` function to handle single attestations.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
