### PR TITLE
Mark rest endpoints as deprecated for electra

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -161,6 +161,7 @@ func (s *Service) builderEndpoints(stater lookup.Stater) []endpoint {
 	const namespace = "builder"
 	return []endpoint{
 		{
+			// Deprecated: use SSE from /eth/v1/events for `Payload Attributes` instead
 			template: "/eth/v1/builder/states/{state_id}/expected_withdrawals",
 			name:     namespace + ".ExpectedWithdrawals",
 			middleware: []middleware.Middleware{
@@ -225,6 +226,7 @@ func (s *Service) validatorEndpoints(
 	const namespace = "validator"
 	return []endpoint{
 		{
+			// Deprecated: use /eth/v2/validator/aggregate_attestation instead
 			template: "/eth/v1/validator/aggregate_attestation",
 			name:     namespace + ".GetAggregateAttestation",
 			middleware: []middleware.Middleware{
@@ -253,6 +255,7 @@ func (s *Service) validatorEndpoints(
 			methods: []string{http.MethodPost},
 		},
 		{
+			// Deprecated: use /eth/v2/validator/aggregate_and_proofs instead
 			template: "/eth/v1/validator/aggregate_and_proofs",
 			name:     namespace + ".SubmitAggregateAndProofs",
 			middleware: []middleware.Middleware{
@@ -583,6 +586,7 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodGet},
 		},
 		{
+			// Deprecated: use /eth/v2/beacon/blocks instead
 			template: "/eth/v1/beacon/blocks",
 			name:     namespace + ".PublishBlock",
 			middleware: []middleware.Middleware{
@@ -593,6 +597,7 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodPost},
 		},
 		{
+			// Deprecated: use /eth/v2/beacon/blinded_blocks instead
 			template: "/eth/v1/beacon/blinded_blocks",
 			name:     namespace + ".PublishBlindedBlock",
 			middleware: []middleware.Middleware{
@@ -632,6 +637,7 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodGet},
 		},
 		{
+			// Deprecated: use /eth/v2/beacon/blocks/{block_id}/attestations instead
 			template: "/eth/v1/beacon/blocks/{block_id}/attestations",
 			name:     namespace + ".GetBlockAttestations",
 			middleware: []middleware.Middleware{
@@ -668,6 +674,7 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodGet},
 		},
 		{
+			// Deprecated: use /eth/v2/beacon/pool/attestations instead
 			template: "/eth/v1/beacon/pool/attestations",
 			name:     namespace + ".ListAttestations",
 			middleware: []middleware.Middleware{
@@ -754,6 +761,7 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodPost},
 		},
 		{
+			// Deprecated: use /eth/v2/beacon/pool/attester_slashings instead
 			template: "/eth/v1/beacon/pool/attester_slashings",
 			name:     namespace + ".GetAttesterSlashings",
 			middleware: []middleware.Middleware{
@@ -876,6 +884,7 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodGet, http.MethodPost},
 		},
 		{
+			// Deprecated: no longer needed post Electra
 			template: "/eth/v1/beacon/deposit_snapshot",
 			name:     namespace + ".GetDepositSnapshot",
 			middleware: []middleware.Middleware{

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -292,6 +292,7 @@ func (s *Server) getBlockResponseBodyJson(ctx context.Context, blk interfaces.Re
 	}, nil
 }
 
+// Deprecated: use GetBlockAttestationsV2 instead
 // GetBlockAttestations retrieves attestation included in requested block.
 func (s *Server) GetBlockAttestations(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "beacon.GetBlockAttestations")
@@ -394,6 +395,7 @@ func (s *Server) blockData(ctx context.Context, w http.ResponseWriter, r *http.R
 	return blk, isOptimistic, root
 }
 
+// Deprecated: use PublishBlindedBlockV2 instead
 // PublishBlindedBlock instructs the beacon node to use the components of the `SignedBlindedBeaconBlock` to construct
 // and publish a SignedBeaconBlock by swapping out the transactions_root for the corresponding full list of `transactions`.
 // The beacon node should broadcast a newly constructed SignedBeaconBlock to the beacon network, to be included in the
@@ -624,6 +626,7 @@ func decodeBlindedBellatrixJSON(body []byte) (*eth.GenericSignedBeaconBlock, err
 	)
 }
 
+// Deprecated: use PublishBlockV2 instead
 // PublishBlock instructs the beacon node to broadcast a newly signed beacon block to the beacon network,
 // to be included in the beacon chain. A success response (20x) indicates that the block
 // passed gossip validation and was successfully broadcast onto the network.
@@ -1534,6 +1537,7 @@ func (s *Server) GetGenesis(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJson(w, resp)
 }
 
+// Deprecated: no longer needed post Electra
 // GetDepositSnapshot retrieves the EIP-4881 Deposit Tree Snapshot. Either a JSON or,
 // if the Accept header was added, bytes serialized by SSZ will be returned.
 func (s *Server) GetDepositSnapshot(w http.ResponseWriter, r *http.Request) {

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -34,6 +34,7 @@ import (
 
 const broadcastBLSChangesRateLimit = 128
 
+// Deprecated: use ListAttestationsV2 instead
 // ListAttestations retrieves attestations known by the node but
 // not necessarily incorporated into any block. Allows filtering by committee index or slot.
 func (s *Server) ListAttestations(w http.ResponseWriter, r *http.Request) {
@@ -707,6 +708,7 @@ func (s *Server) ListBLSToExecutionChanges(w http.ResponseWriter, r *http.Reques
 	})
 }
 
+// Deprecated: use GetAttesterSlashingsV2 instead
 // GetAttesterSlashings retrieves attester slashings known by the node but
 // not necessarily incorporated into any block.
 func (s *Server) GetAttesterSlashings(w http.ResponseWriter, r *http.Request) {

--- a/beacon-chain/rpc/eth/builder/handlers.go
+++ b/beacon-chain/rpc/eth/builder/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
 
+// Deprecated: use SSE from events for `payload attributes` instead
 // ExpectedWithdrawals get the withdrawals computed from the specified state, that will be included in the block that gets built on the specified state.
 func (s *Server) ExpectedWithdrawals(w http.ResponseWriter, r *http.Request) {
 	// Retrieve beacon state

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -43,6 +43,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Deprecated: use GetAggregateAttestationV2 instead
 // GetAggregateAttestation aggregates all attestations matching the given attestation data root and slot, returning the aggregated result.
 func (s *Server) GetAggregateAttestation(w http.ResponseWriter, r *http.Request) {
 	_, span := trace.StartSpan(r.Context(), "validator.GetAggregateAttestation")
@@ -256,6 +257,7 @@ func (s *Server) SubmitContributionAndProofs(w http.ResponseWriter, r *http.Requ
 	}
 }
 
+// Deprecated: use SubmitAggregateAndProofsV2 instead
 // SubmitAggregateAndProofs verifies given aggregate and proofs and publishes them on appropriate gossipsub topic.
 func (s *Server) SubmitAggregateAndProofs(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "validator.SubmitAggregateAndProofs")

--- a/changelog/james-prysm_deprecate-apis-for-electra.md
+++ b/changelog/james-prysm_deprecate-apis-for-electra.md
@@ -1,0 +1,3 @@
+### Changed
+
+- deprecate beacon api endpoints based on [3.0.0 release](https://github.com/ethereum/beacon-APIs/pull/506) for electra


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

deprecated the following endpoints for beacon API rest 
- /eth/v1/builder/states/{state_id}/expected_withdrawals
- /eth/v1/validator/aggregate_attestation
- /eth/v1/validator/aggregate_and_proofs
- /eth/v1/beacon/blocks
- /eth/v1/beacon/blinded_blocks
- /eth/v1/beacon/blocks/{block_id}/attestations
- /eth/v1/beacon/pool/attestations
- /eth/v1/beacon/pool/attester_slashings
- /eth/v1/beacon/deposit_snapshot


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
