### PR TITLE
tracing: Add otel tracer transport to all http clients

### DIFF
--- a/api/client/builder/BUILD.bazel
+++ b/api/client/builder/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_fastssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -25,6 +25,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -108,7 +109,7 @@ func NewClient(host string, opts ...ClientOpt) (*Client, error) {
 		return nil, err
 	}
 	c := &Client{
-		hc:      &http.Client{},
+		hc:      &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 		baseURL: u,
 	}
 	for _, o := range opts {

--- a/changelog/pvl_otel_http.md
+++ b/changelog/pvl_otel_http.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added support for otel tracing transport in HTTP clients in Prysm. This allows for tracing headers to be sent with http requests such that spans between the validator and beacon chain can be connected in the tracing graph. This change does nothing without `--enable-tracing`.

--- a/deps.bzl
+++ b/deps.bzl
@@ -806,6 +806,12 @@ def prysm_deps():
         version = "v0.9.3",
     )
     go_repository(
+        name = "com_github_felixge_httpsnoop",
+        importpath = "github.com/felixge/httpsnoop",
+        sum = "h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=",
+        version = "v1.0.4",
+    )
+    go_repository(
         name = "com_github_ferranbt_fastssz",
         importpath = "github.com/ferranbt/fastssz",
         sum = "h1:ZI+z3JH05h4kgmFXdHuR1aWYsgrg7o+Fw7/NCzM16Mo=",
@@ -4584,6 +4590,12 @@ def prysm_deps():
         importpath = "go.opentelemetry.io/contrib/detectors/gcp",
         sum = "h1:G1JQOreVrfhRkner+l4mrGxmfqYCAuy76asTDAo0xsA=",
         version = "v1.31.0",
+    )
+    go_repository(
+        name = "io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp",
+        importpath = "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+        sum = "h1:CV7UdSGJt/Ao6Gp4CXckLxVRRsRgDHoI8XjbL3PDl8s=",
+        version = "v0.59.0",
     )
     go_repository(
         name = "io_opentelemetry_go_otel",

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.1.3
 	go.etcd.io/bbolt v1.3.6
 	go.opencensus.io v0.24.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.34.0
 	go.opentelemetry.io/otel/sdk v1.34.0
@@ -136,6 +137,7 @@ require (
 	github.com/elastic/gosigar v0.14.3 // indirect
 	github.com/ethereum/c-kzg-4844 v1.0.0 // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/ferranbt/fastssz v0.1.3 // indirect
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzF
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/ferranbt/fastssz v0.0.0-20210120143747-11b9eff30ea9/go.mod h1:DyEu2iuLBnb/T51BlsiO3yLYdJC6UbGMrIkqK1KmQxM=
 github.com/ferranbt/fastssz v0.1.3 h1:ZI+z3JH05h4kgmFXdHuR1aWYsgrg7o+Fw7/NCzM16Mo=
 github.com/ferranbt/fastssz v0.1.3/go.mod h1:0Y9TEd/9XuFlh7mskMPfXiI2Dkw4Ddg9EyXt1W7MRvE=
@@ -1100,6 +1102,8 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 h1:CV7UdSGJt/Ao6Gp4CXckLxVRRsRgDHoI8XjbL3PDl8s=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0/go.mod h1:FRmFuRJfag1IZ2dPkHnEoSFVgTVPUd2qf5Vi69hLb8I=
 go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=
 go.opentelemetry.io/otel v1.34.0/go.mod h1:OWFPOQ+h4G8xpyjgqo4SxJYdDQ/qmRH+wivy7zzx9oI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 h1:OeNbIYk/2C15ckl7glBlOBp5+WlYsOElzTNmiPW/x60=

--- a/monitoring/tracing/BUILD.bazel
+++ b/monitoring/tracing/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "@io_opentelemetry_go_otel//:go_default_library",
         "@io_opentelemetry_go_otel//attribute:go_default_library",
         "@io_opentelemetry_go_otel//codes:go_default_library",
+        "@io_opentelemetry_go_otel//propagation:go_default_library",
         "@io_opentelemetry_go_otel//semconv/v1.17.0:go_default_library",
         "@io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracehttp//:go_default_library",
         "@io_opentelemetry_go_otel_sdk//resource:go_default_library",

--- a/monitoring/tracing/tracer.go
+++ b/monitoring/tracing/tracer.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -55,5 +56,7 @@ func Setup(ctx context.Context, serviceName, processName, endpoint string, sampl
 	)
 
 	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+
 	return nil
 }

--- a/network/BUILD.bazel
+++ b/network/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "@com_github_golang_jwt_jwt_v4//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
     ],
 )
 

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -12,6 +12,7 @@ import (
 	gethRPC "github.com/ethereum/go-ethereum/rpc"
 	"github.com/prysmaticlabs/prysm/v5/network/authorization"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Endpoint is an endpoint with authorization data.
@@ -36,7 +37,7 @@ func (e Endpoint) Equals(other Endpoint) bool {
 // on the properties of the network endpoint.
 func (e Endpoint) HttpClient() *http.Client {
 	if e.Auth.Method != authorization.Bearer {
-		return http.DefaultClient
+		return &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 	}
 	return NewHttpClientWithSecret(e.Auth.Value, e.Auth.JwtId)
 }
@@ -121,7 +122,7 @@ func NewHttpClientWithSecret(secret, id string) *http.Client {
 	}
 	return &http.Client{
 		Timeout:   DefaultRPCHTTPTimeout,
-		Transport: authTransport,
+		Transport: otelhttp.NewTransport(authTransport),
 	}
 }
 

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -85,6 +85,7 @@ go_library(
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//plugin/ocgrpc:go_default_library",
+        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
         "@io_opentelemetry_go_otel_trace//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/validator/keymanager/local"
 	remoteweb3signer "github.com/prysmaticlabs/prysm/v5/validator/keymanager/remote-web3signer"
 	"go.opencensus.io/plugin/ocgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -173,7 +174,7 @@ func (v *ValidatorService) Start() {
 		return
 	}
 	restHandler := beaconApi.NewBeaconApiJsonRestHandler(
-		http.Client{Timeout: v.conn.GetBeaconApiTimeout()},
+		http.Client{Timeout: v.conn.GetBeaconApiTimeout(), Transport: otelhttp.NewTransport(http.DefaultTransport)},
 		hosts[0],
 	)
 

--- a/validator/keymanager/remote-web3signer/internal/BUILD.bazel
+++ b/validator/keymanager/remote-web3signer/internal/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
     ],
 )
 

--- a/validator/keymanager/remote-web3signer/internal/client.go
+++ b/validator/keymanager/remote-web3signer/internal/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -56,7 +57,7 @@ func NewApiClient(baseEndpoint string) (*ApiClient, error) {
 	}
 	return &ApiClient{
 		BaseURL:    u,
-		RestClient: &http.Client{},
+		RestClient: &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 	}, nil
 }
 

--- a/validator/rpc/BUILD.bazel
+++ b/validator/rpc/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "@com_github_tyler_smith_go_bip39//:go_default_library",
         "@com_github_tyler_smith_go_bip39//wordlists:go_default_library",
         "@com_github_wealdtech_go_eth2_wallet_encryptor_keystorev4//:go_default_library",
+        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",

--- a/validator/rpc/beacon.go
+++ b/validator/rpc/beacon.go
@@ -16,6 +16,7 @@ import (
 	nodeClientFactory "github.com/prysmaticlabs/prysm/v5/validator/client/node-client-factory"
 	validatorClientFactory "github.com/prysmaticlabs/prysm/v5/validator/client/validator-client-factory"
 	validatorHelpers "github.com/prysmaticlabs/prysm/v5/validator/helpers"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"google.golang.org/grpc"
 )
 
@@ -55,7 +56,7 @@ func (s *Server) registerBeaconClient() error {
 	)
 
 	restHandler := beaconApi.NewBeaconApiJsonRestHandler(
-		http.Client{Timeout: s.beaconApiTimeout},
+		http.Client{Timeout: s.beaconApiTimeout, Transport: otelhttp.NewTransport(http.DefaultTransport)},
 		s.beaconApiEndpoint,
 	)
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Allows for tracing headers to be sent during http requests such that spans across the validator <> beacon-chain can be connected in the tracing graphs.

**Which issues(s) does this PR fix?**

**Other notes for review**

Supersedes #14825

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
