### PR TITLE
Add more verbosity to validate range message

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -49,7 +49,12 @@ func (s *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interfa
 	}
 	available := s.validateRangeAvailability(rp)
 	if !available {
-		log.Debug("error in validating range availability")
+		log.WithFields(logrus.Fields{
+			"startSlot": rp.start,
+			"endSlot":   rp.end,
+			"size":      rp.size,
+			"current":   s.cfg.clock.CurrentSlot(),
+		}).Debug("error in validating range availability")
 		s.writeErrorResponseToStream(responseCodeResourceUnavailable, p2ptypes.ErrResourceUnavailable.Error(), stream)
 		tracing.AnnotateError(span, err)
 		return nil

--- a/changelog/tt_validate_range.md
+++ b/changelog/tt_validate_range.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Add more debugging information to validate range debug message


### PR DESCRIPTION
We should add more verbosity to this log

```
time="2025-02-21 11:46:31" level=debug msg="error in validating range availability" prefix=sync
```