### PR TITLE
Use go-cmp and protocmp for assertion diff printing

### DIFF
--- a/changelog/pvl_go-cmp.md
+++ b/changelog/pvl_go-cmp.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use go-cmp for printing better diffs for assertions.DeepEqual

--- a/testing/assertions/BUILD.bazel
+++ b/testing/assertions/BUILD.bazel
@@ -8,8 +8,10 @@ go_library(
     deps = [
         "//encoding/ssz/equality:go_default_library",
         "@com_github_d4l3k_messagediff//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     ],
 )
 

--- a/testing/assertions/assertions.go
+++ b/testing/assertions/assertions.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 
 	"github.com/d4l3k/messagediff"
+	"github.com/google/go-cmp/cmp"
 	"github.com/prysmaticlabs/prysm/v5/encoding/ssz/equality"
 	"github.com/sirupsen/logrus/hooks/test"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 // AssertionTestingTB exposes enough testing.TB methods for assertions.
@@ -52,13 +54,12 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	if !isDeepEqual(expected, actual) {
 		errMsg := parseMsg("Values are not equal", msg...)
 		_, file, line, _ := runtime.Caller(2)
-		var diff string
+		opts := cmp.Options{cmp.AllowUnexported(expected), cmp.AllowUnexported(actual)}
 		if _, isProto := expected.(proto.Message); isProto {
-			diff = ProtobufPrettyDiff(expected, actual)
-		} else {
-			diff, _ = messagediff.PrettyDiff(expected, actual)
+			opts = append(opts, protocmp.Transform())
 		}
-		loggerFn("%s:%d %s, want: %#v, got: %#v, diff: %s", filepath.Base(file), line, errMsg, expected, actual, diff)
+		diff := cmp.Diff(expected, actual, opts...)
+		loggerFn("%s:%d %s, expected != actual, diff: %s", filepath.Base(file), line, errMsg, diff)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Testing only library. This makes for much better printing of diffs.

Before:
```
Values are not equal, want: struct { a uint64; b uint64 }{a:0x1, b:0x2}, got: struct { a uint64; b uint64 }{a:0x1, b:0x3}, diff: modified: 
.b = 0x3
```

After:
```
Values are not equal, expected != actual, diff:   struct{ a uint64; b uint64 }{                                                           
        a: 1,
-       b: 2,
+       b: 3,
  }
```

**Which issues(s) does this PR fix?**

**Other notes for review**

No production code, testing only library.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
