### PR TITLE
single attestation cleanup

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -168,7 +168,7 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 		return
 	}
 
-	// Decide if the attestation is a SingleAttestation (Electra) or a legacy unaggregated attestation
+	// Decide if the attestation is an Electra SingleAttestation or a Phase0 unaggregated attestation
 	var (
 		attForValidation ethpb.Att
 		broadcastAtt     ethpb.Att

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -217,7 +217,7 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 				return
 			}
 		}
-		s.setSeenCommitteeIndicesSlot(data.Slot, data.GetCommitteeIndex(), attForValidation.GetAggregationBits())
+		s.setSeenCommitteeIndicesSlot(data.Slot, attForValidation.GetCommitteeIndex(), attForValidation.GetAggregationBits())
 
 		valCount, err := helpers.ActiveValidatorCount(ctx, preState, slots.ToEpoch(data.Slot))
 		if err != nil {

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -182,6 +182,7 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 			log.Debugf("Attestation has wrong type (expected %T, got %T)", &ethpb.SingleAttestation{}, att)
 			return
 		}
+        // Convert Electra SingleAttestation to unaggregated ElectraAttestation. This is needed because many parts of the codebase assume that attestations have a certain structure and SingleAttestation validates these assumptions.
 		attForValidation = singleAtt.ToAttestationElectra(committee)
 		broadcastAtt = singleAtt
 		eventType = operation.SingleAttReceived

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -182,7 +182,7 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 			log.Debugf("Attestation has wrong type (expected %T, got %T)", &ethpb.SingleAttestation{}, att)
 			return
 		}
-        // Convert Electra SingleAttestation to unaggregated ElectraAttestation. This is needed because many parts of the codebase assume that attestations have a certain structure and SingleAttestation validates these assumptions.
+		// Convert Electra SingleAttestation to unaggregated ElectraAttestation. This is needed because many parts of the codebase assume that attestations have a certain structure and SingleAttestation validates these assumptions.
 		attForValidation = singleAtt.ToAttestationElectra(committee)
 		broadcastAtt = singleAtt
 		eventType = operation.SingleAttReceived

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -189,7 +189,7 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 			Attestation: singleAtt,
 		}
 	} else {
-		// Older version (non-SingleAttestation)
+		// Phase0 attestation
 		attForValidation = att
 		broadcastAtt = att
 		eventType = operation.UnaggregatedAttReceived

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -140,8 +140,7 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 	data := att.GetData()
 
 	// This is an important validation before retrieving attestation pre state to defend against
-	// attestation's target intentionally reference checkpoint that's long ago.
-	// Verify current finalized checkpoint is an ancestor of the block defined by the attestation's beacon block root.
+	// attestation's target intentionally referencing a checkpoint that's long ago.
 	if !s.cfg.chain.InForkchoice(bytesutil.ToBytes32(data.BeaconBlockRoot)) {
 		log.WithError(blockchain.ErrNotDescendantOfFinalized).Debug("Could not verify finalized consistency")
 		return
@@ -169,35 +168,55 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 		return
 	}
 
-	var singleAtt *ethpb.SingleAttestation
+	// Decide if the attestation is a SingleAttestation (Electra) or a legacy unaggregated attestation
+	var (
+		attForValidation ethpb.Att
+		broadcastAtt     ethpb.Att
+		eventType        feed.EventType
+		eventData        interface{}
+	)
+
 	if att.Version() >= version.Electra {
-		var ok bool
-		singleAtt, ok = att.(*ethpb.SingleAttestation)
+		singleAtt, ok := att.(*ethpb.SingleAttestation)
 		if !ok {
 			log.Debugf("Attestation has wrong type (expected %T, got %T)", &ethpb.SingleAttestation{}, att)
 			return
 		}
-		att = singleAtt.ToAttestationElectra(committee)
+		attForValidation = singleAtt.ToAttestationElectra(committee)
+		broadcastAtt = singleAtt
+		eventType = operation.SingleAttReceived
+		eventData = &operation.SingleAttReceivedData{
+			Attestation: singleAtt,
+		}
+	} else {
+		// Older version (non-SingleAttestation)
+		attForValidation = att
+		broadcastAtt = att
+		eventType = operation.UnaggregatedAttReceived
+		eventData = &operation.UnAggregatedAttReceivedData{
+			Attestation: att,
+		}
 	}
 
-	valid, err = s.validateUnaggregatedAttWithState(ctx, att, preState)
+	valid, err = s.validateUnaggregatedAttWithState(ctx, attForValidation, preState)
 	if err != nil {
 		log.WithError(err).Debug("Pending unaggregated attestation failed validation")
 		return
 	}
+
 	if valid == pubsub.ValidationAccept {
 		if features.Get().EnableExperimentalAttestationPool {
-			if err = s.cfg.attestationCache.Add(att); err != nil {
+			if err = s.cfg.attestationCache.Add(attForValidation); err != nil {
 				log.WithError(err).Debug("Could not save unaggregated attestation")
 				return
 			}
 		} else {
-			if err := s.cfg.attPool.SaveUnaggregatedAttestation(att); err != nil {
+			if err := s.cfg.attPool.SaveUnaggregatedAttestation(attForValidation); err != nil {
 				log.WithError(err).Debug("Could not save unaggregated attestation")
 				return
 			}
 		}
-		s.setSeenCommitteeIndicesSlot(data.Slot, data.CommitteeIndex, att.GetAggregationBits())
+		s.setSeenCommitteeIndicesSlot(data.Slot, data.GetCommitteeIndex(), attForValidation.GetAggregationBits())
 
 		valCount, err := helpers.ActiveValidatorCount(ctx, preState, slots.ToEpoch(data.Slot))
 		if err != nil {
@@ -205,34 +224,16 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 			return
 		}
 
-		// Broadcasting the signed attestation again once a node is able to process it.
-		var attToBroadcast ethpb.Att
-		if singleAtt != nil {
-			attToBroadcast = singleAtt
-		} else {
-			attToBroadcast = att
-		}
-		if err := s.cfg.p2p.BroadcastAttestation(ctx, helpers.ComputeSubnetForAttestation(valCount, attToBroadcast), attToBroadcast); err != nil {
+		// Broadcast the final 'broadcastAtt' object
+		if err := s.cfg.p2p.BroadcastAttestation(ctx, helpers.ComputeSubnetForAttestation(valCount, broadcastAtt), broadcastAtt); err != nil {
 			log.WithError(err).Debug("Could not broadcast")
 		}
 
-		// Broadcast the unaggregated attestation on a feed to notify other services in the beacon node
-		// of a received unaggregated attestation.
-		if singleAtt != nil {
-			s.cfg.attestationNotifier.OperationFeed().Send(&feed.Event{
-				Type: operation.SingleAttReceived,
-				Data: &operation.SingleAttReceivedData{
-					Attestation: singleAtt,
-				},
-			})
-		} else {
-			s.cfg.attestationNotifier.OperationFeed().Send(&feed.Event{
-				Type: operation.UnaggregatedAttReceived,
-				Data: &operation.UnAggregatedAttReceivedData{
-					Attestation: att,
-				},
-			})
-		}
+		// Feed event notification for other services
+		s.cfg.attestationNotifier.OperationFeed().Send(&feed.Event{
+			Type: eventType,
+			Data: eventData,
+		})
 	}
 }
 

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -34,12 +34,14 @@ import (
 // - The attestation is unaggregated -- that is, it has exactly one participating validator (len(get_attesting_indices(state, attestation.data, attestation.aggregation_bits)) == 1).
 // - attestation.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot).
 // - The signature of attestation is valid.
-func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, pid peer.ID, msg *pubsub.Message) (pubsub.ValidationResult, error) {
+func (s *Service) validateCommitteeIndexBeaconAttestation(
+	ctx context.Context,
+	pid peer.ID,
+	msg *pubsub.Message,
+) (pubsub.ValidationResult, error) {
 	if pid == s.cfg.p2p.PeerID() {
 		return pubsub.ValidationAccept, nil
 	}
-	// Attestation processing requires the target block to be present in the database, so we'll skip
-	// validating or processing attestations until fully synced.
 	if s.cfg.initialSync.Syncing() {
 		return pubsub.ValidationIgnore, nil
 	}
@@ -64,6 +66,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 	if err := helpers.ValidateNilAttestation(att); err != nil {
 		return pubsub.ValidationReject, err
 	}
+
 	data := att.GetData()
 
 	// Do not process slot 0 attestations.
@@ -71,10 +74,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return pubsub.ValidationIgnore, nil
 	}
 
-	// Attestation's slot is within ATTESTATION_PROPAGATION_SLOT_RANGE and early attestation
-	// processing tolerance.
-	if err := helpers.ValidateAttestationTime(data.Slot, s.cfg.clock.GenesisTime(),
-		earlyAttestationProcessingTolerance); err != nil {
+	if err := helpers.ValidateAttestationTime(data.Slot, s.cfg.clock.GenesisTime(), earlyAttestationProcessingTolerance); err != nil {
 		tracing.AnnotateError(span, err)
 		return pubsub.ValidationIgnore, err
 	}
@@ -85,12 +85,9 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 	committeeIndex := att.GetCommitteeIndex()
 
 	if !features.Get().EnableSlasher {
-		// Verify this the first attestation received for the participating validator for the slot.
 		if s.hasSeenCommitteeIndicesSlot(data.Slot, committeeIndex, att.GetAggregationBits()) {
 			return pubsub.ValidationIgnore, nil
 		}
-
-		// Reject an attestation if it references an invalid block.
 		if s.hasBadBlock(bytesutil.ToBytes32(data.BeaconBlockRoot)) ||
 			s.hasBadBlock(bytesutil.ToBytes32(data.Target.Root)) ||
 			s.hasBadBlock(bytesutil.ToBytes32(data.Source.Root)) {
@@ -99,15 +96,11 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		}
 	}
 
-	var validationRes pubsub.ValidationResult
-
-	// Verify the block being voted and the processed state is in beaconDB and the block has passed validation if it's in the beaconDB.
 	blockRoot := bytesutil.ToBytes32(data.BeaconBlockRoot)
 	if !s.hasBlockAndState(ctx, blockRoot) {
 		return s.saveToPendingAttPool(att)
 	}
-
-	if !s.cfg.chain.InForkchoice(bytesutil.ToBytes32(data.BeaconBlockRoot)) {
+	if !s.cfg.chain.InForkchoice(blockRoot) {
 		tracing.AnnotateError(span, blockchain.ErrNotDescendantOfFinalized)
 		return pubsub.ValidationIgnore, blockchain.ErrNotDescendantOfFinalized
 	}
@@ -123,12 +116,12 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return pubsub.ValidationIgnore, err
 	}
 
-	validationRes, err = s.validateUnaggregatedAttTopic(ctx, att, preState, *msg.Topic)
+	validationRes, err := s.validateUnaggregatedAttTopic(ctx, att, preState, *msg.Topic)
 	if validationRes != pubsub.ValidationAccept {
 		return validationRes, err
 	}
 
-	committee, err := helpers.BeaconCommitteeFromState(ctx, preState, att.GetData().Slot, committeeIndex)
+	committee, err := helpers.BeaconCommitteeFromState(ctx, preState, data.Slot, committeeIndex)
 	if err != nil {
 		tracing.AnnotateError(span, err)
 		return pubsub.ValidationIgnore, err
@@ -139,26 +132,45 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return validationRes, err
 	}
 
-	var singleAtt *eth.SingleAttestation
+	// Consolidated handling of SingleAttestation vs. legacy unaggregated
+	var (
+		attForValidation eth.Att // what we'll pass to further validation
+		eventType        feed.EventType
+		eventData        interface{}
+	)
+
 	if att.Version() >= version.Electra {
-		singleAtt, ok = att.(*eth.SingleAttestation)
+		singleAtt, ok := att.(*eth.SingleAttestation)
 		if !ok {
-			return pubsub.ValidationIgnore, fmt.Errorf("attestation has wrong type (expected %T, got %T)", &eth.SingleAttestation{}, att)
+			return pubsub.ValidationIgnore, fmt.Errorf(
+				"attestation has wrong type (expected %T, got %T)",
+				&eth.SingleAttestation{}, att,
+			)
 		}
-		att = singleAtt.ToAttestationElectra(committee)
+		// Convert Electra singleAttestation to the unaggregated form needed for local validation
+		attForValidation = singleAtt.ToAttestationElectra(committee)
+		eventType = operation.SingleAttReceived
+		eventData = &operation.SingleAttReceivedData{
+			Attestation: singleAtt,
+		}
+	} else {
+		// Non-Electra (unaggregated) attestation
+		attForValidation = att
+		eventType = operation.UnaggregatedAttReceived
+		eventData = &operation.UnAggregatedAttReceivedData{
+			Attestation: att,
+		}
 	}
 
-	validationRes, err = s.validateUnaggregatedAttWithState(ctx, att, preState)
+	// Validate final attestation object
+	validationRes, err = s.validateUnaggregatedAttWithState(ctx, attForValidation, preState)
 	if validationRes != pubsub.ValidationAccept {
 		return validationRes, err
 	}
 
+	// If slasher is enabled, process in background
 	if features.Get().EnableSlasher {
-		// Feed the indexed attestation to slasher if enabled. This action
-		// is done in the background to avoid adding more load to this critical code path.
 		go func() {
-			// Using a different context to prevent timeouts as this operation can be expensive
-			// and we want to avoid affecting the critical code path.
 			ctx := context.TODO()
 			preState, err := s.cfg.chain.AttestationTargetState(ctx, data.Target)
 			if err != nil {
@@ -172,7 +184,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 				tracing.AnnotateError(span, err)
 				return
 			}
-			indexedAtt, err := attestation.ConvertToIndexed(ctx, att, committee)
+			indexedAtt, err := attestation.ConvertToIndexed(ctx, attForValidation, committee)
 			if err != nil {
 				log.WithError(err).Error("Could not convert to indexed attestation")
 				tracing.AnnotateError(span, err)
@@ -182,27 +194,16 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		}()
 	}
 
-	// Broadcast the unaggregated attestation on a feed to notify other services in the beacon node
-	// of a received unaggregated attestation.
-	if singleAtt != nil {
-		s.cfg.attestationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.SingleAttReceived,
-			Data: &operation.SingleAttReceivedData{
-				Attestation: singleAtt,
-			},
-		})
-	} else {
-		s.cfg.attestationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.UnaggregatedAttReceived,
-			Data: &operation.UnAggregatedAttReceivedData{
-				Attestation: att,
-			},
-		})
-	}
+	// Notify other services in the beacon node
+	s.cfg.attestationNotifier.OperationFeed().Send(&feed.Event{
+		Type: eventType,
+		Data: eventData,
+	})
 
-	s.setSeenCommitteeIndicesSlot(data.Slot, committeeIndex, att.GetAggregationBits())
+	s.setSeenCommitteeIndicesSlot(data.Slot, committeeIndex, attForValidation.GetAggregationBits())
 
-	msg.ValidatorData = att
+	// Attach final validated attestation to the message for further pipeline use
+	msg.ValidatorData = attForValidation
 
 	return pubsub.ValidationAccept, nil
 }

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -173,7 +173,6 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		return validationRes, err
 	}
 
-	// If slasher is enabled, process in background
 	if features.Get().EnableSlasher {
 		// Feed the indexed attestation to slasher if enabled. This action
 		// is done in the background to avoid adding more load to this critical code path.

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -152,7 +152,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 				&eth.SingleAttestation{}, att,
 			)
 		}
-		// Convert Electra singleAttestation to the unaggregated form needed for local validation
+		// Convert Electra SingleAttestation to unaggregated ElectraAttestation. This is needed because many parts of the codebase assume that attestations have a certain structure and SingleAttestation validates these assumptions.
 		attForValidation = singleAtt.ToAttestationElectra(committee)
 		eventType = operation.SingleAttReceived
 		eventData = &operation.SingleAttReceivedData{

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -137,7 +137,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		return validationRes, err
 	}
 
-	// Consolidated handling of SingleAttestation vs. legacy unaggregated
+	// Consolidated handling of Electra SingleAttestation vs Phase0 unaggregated attestation
 	var (
 		attForValidation eth.Att // what we'll pass to further validation
 		eventType        feed.EventType

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -74,6 +74,8 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		return pubsub.ValidationIgnore, nil
 	}
 
+	// Attestation's slot is within ATTESTATION_PROPAGATION_SLOT_RANGE and early attestation
+	// processing tolerance.
 	if err := helpers.ValidateAttestationTime(data.Slot, s.cfg.clock.GenesisTime(), earlyAttestationProcessingTolerance); err != nil {
 		tracing.AnnotateError(span, err)
 		return pubsub.ValidationIgnore, err
@@ -85,9 +87,11 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	committeeIndex := att.GetCommitteeIndex()
 
 	if !features.Get().EnableSlasher {
+		// Verify this the first attestation received for the participating validator for the slot.
 		if s.hasSeenCommitteeIndicesSlot(data.Slot, committeeIndex, att.GetAggregationBits()) {
 			return pubsub.ValidationIgnore, nil
 		}
+		// Reject an attestation if it references an invalid block.
 		if s.hasBadBlock(bytesutil.ToBytes32(data.BeaconBlockRoot)) ||
 			s.hasBadBlock(bytesutil.ToBytes32(data.Target.Root)) ||
 			s.hasBadBlock(bytesutil.ToBytes32(data.Source.Root)) {
@@ -96,6 +100,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		}
 	}
 
+	// Verify the block being voted and the processed state is in beaconDB and the block has passed validation if it's in the beaconDB.
 	blockRoot := bytesutil.ToBytes32(data.BeaconBlockRoot)
 	if !s.hasBlockAndState(ctx, blockRoot) {
 		return s.saveToPendingAttPool(att)
@@ -170,7 +175,11 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 
 	// If slasher is enabled, process in background
 	if features.Get().EnableSlasher {
+		// Feed the indexed attestation to slasher if enabled. This action
+		// is done in the background to avoid adding more load to this critical code path.
 		go func() {
+			// Using a different context to prevent timeouts as this operation can be expensive
+			// and we want to avoid affecting the critical code path.
 			ctx := context.TODO()
 			preState, err := s.cfg.chain.AttestationTargetState(ctx, data.Target)
 			if err != nil {

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -159,7 +159,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 			Attestation: singleAtt,
 		}
 	} else {
-		// Non-Electra (unaggregated) attestation
+		// Phase0 unaggregated attestation
 		attForValidation = att
 		eventType = operation.UnaggregatedAttReceived
 		eventData = &operation.UnAggregatedAttReceivedData{

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -167,7 +167,6 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		}
 	}
 
-	// Validate final attestation object
 	validationRes, err = s.validateUnaggregatedAttWithState(ctx, attForValidation, preState)
 	if validationRes != pubsub.ValidationAccept {
 		return validationRes, err

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -42,6 +42,8 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	if pid == s.cfg.p2p.PeerID() {
 		return pubsub.ValidationAccept, nil
 	}
+	// Attestation processing requires the target block to be present in the database, so we'll skip
+	// validating or processing attestations until fully synced.
 	if s.cfg.initialSync.Syncing() {
 		return pubsub.ValidationIgnore, nil
 	}

--- a/changelog/james-prysm_attestation-cleanup-suggestions.md
+++ b/changelog/james-prysm_attestation-cleanup-suggestions.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fixed using GetCommitteeIndex() function in setSeenCommitteeIndicesSlot instead of .CommitteeIndex for post electra

--- a/changelog/james-prysm_attestation-cleanup-suggestions.md
+++ b/changelog/james-prysm_attestation-cleanup-suggestions.md
@@ -1,3 +1,4 @@
-### Fixed
+### Ignored
 
-- fixed using GetCommitteeIndex() function in setSeenCommitteeIndicesSlot instead of .CommitteeIndex for post electra
+- Cleanup single attestation code for readability.
+


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR does some minor cleanup to reduce cognitive load when reading what should be a single attestation vs regular attestation

kurtosis run with devnet 6 settings 3 nodes ( teku/nethermind, 2x prysm/geth)
![image](https://github.com/user-attachments/assets/b5a188d4-8a1f-40e8-b8fc-3c3089c9ad4b)


attestation events still working
![image](https://github.com/user-attachments/assets/e9b949f6-4294-4305-8c68-1affedf53618)


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
