### PR TITLE
Fix Gossip Validation of Electra Attester Slashings

### DIFF
--- a/beacon-chain/p2p/types/object_mapping.go
+++ b/beacon-chain/p2p/types/object_mapping.go
@@ -33,6 +33,9 @@ var (
 	// AggregateAttestationMap maps the fork-version to the underlying data type for that
 	// particular fork period.
 	AggregateAttestationMap map[[4]byte]func() (ethpb.SignedAggregateAttAndProof, error)
+	// AttesterSlashingMap maps the fork-version to the underlying data type for that particular
+	// fork period.
+	AttesterSlashingMap map[[4]byte]func() (ethpb.AttSlashing, error)
 )
 
 // InitializeDataMaps initializes all the relevant object maps. This function is called to
@@ -149,6 +152,31 @@ func InitializeDataMaps() {
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().FuluForkVersion): func() (ethpb.SignedAggregateAttAndProof, error) {
 			return &ethpb.SignedAggregateAttestationAndProofElectra{}, nil
+		},
+	}
+
+	// Reset our aggregate attestation map.
+	AttesterSlashingMap = map[[4]byte]func() (ethpb.AttSlashing, error){
+		bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion): func() (ethpb.AttSlashing, error) {
+			return &ethpb.AttesterSlashing{}, nil
+		},
+		bytesutil.ToBytes4(params.BeaconConfig().AltairForkVersion): func() (ethpb.AttSlashing, error) {
+			return &ethpb.AttesterSlashing{}, nil
+		},
+		bytesutil.ToBytes4(params.BeaconConfig().BellatrixForkVersion): func() (ethpb.AttSlashing, error) {
+			return &ethpb.AttesterSlashing{}, nil
+		},
+		bytesutil.ToBytes4(params.BeaconConfig().CapellaForkVersion): func() (ethpb.AttSlashing, error) {
+			return &ethpb.AttesterSlashing{}, nil
+		},
+		bytesutil.ToBytes4(params.BeaconConfig().DenebForkVersion): func() (ethpb.AttSlashing, error) {
+			return &ethpb.AttesterSlashing{}, nil
+		},
+		bytesutil.ToBytes4(params.BeaconConfig().ElectraForkVersion): func() (ethpb.AttSlashing, error) {
+			return &ethpb.AttesterSlashingElectra{}, nil
+		},
+		bytesutil.ToBytes4(params.BeaconConfig().FuluForkVersion): func() (ethpb.AttSlashing, error) {
+			return &ethpb.AttesterSlashingElectra{}, nil
 		},
 	}
 }

--- a/beacon-chain/p2p/types/object_mapping_test.go
+++ b/beacon-chain/p2p/types/object_mapping_test.go
@@ -76,6 +76,13 @@ func TestInitializeDataMaps(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, version.Phase0, agg.Version())
 			}
+			attSlashFunc, ok := AttesterSlashingMap[bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)]
+			assert.Equal(t, tt.exists, ok)
+			if tt.exists {
+				attSlash, err := attSlashFunc()
+				require.NoError(t, err)
+				assert.Equal(t, version.Phase0, attSlash.Version())
+			}
 		})
 	}
 }

--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -87,6 +87,8 @@ func extractValidDataTypeFromTopic(topic string, digest []byte, clock *startup.C
 		return extractDataTypeFromTypeMap(types.AttestationMap, digest, clock)
 	case p2p.AggregateAndProofSubnetTopicFormat:
 		return extractDataTypeFromTypeMap(types.AggregateAttestationMap, digest, clock)
+	case p2p.AttesterSlashingSubnetTopicFormat:
+		return extractDataTypeFromTypeMap(types.AttesterSlashingMap, digest, clock)
 	}
 	return nil, nil
 }

--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -137,13 +137,14 @@ func TestExtractDataType(t *testing.T) {
 		chain  blockchain.ChainInfoFetcher
 	}
 	tests := []struct {
-		name          string
-		args          args
-		wantBlock     interfaces.ReadOnlySignedBeaconBlock
-		wantMd        metadata.Metadata
-		wantAtt       ethpb.Att
-		wantAggregate ethpb.SignedAggregateAttAndProof
-		wantErr       bool
+		name            string
+		args            args
+		wantBlock       interfaces.ReadOnlySignedBeaconBlock
+		wantMd          metadata.Metadata
+		wantAtt         ethpb.Att
+		wantAggregate   ethpb.SignedAggregateAttAndProof
+		wantAttSlashing ethpb.AttSlashing
+		wantErr         bool
 	}{
 		{
 			name: "no digest",
@@ -156,10 +157,11 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantMd:        wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{}),
-			wantAtt:       &ethpb.Attestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProof{},
-			wantErr:       false,
+			wantMd:          wrapper.WrappedMetadataV0(&ethpb.MetaDataV0{}),
+			wantAtt:         &ethpb.Attestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProof{},
+			wantAttSlashing: &ethpb.AttesterSlashing{},
+			wantErr:         false,
 		},
 		{
 			name: "invalid digest",
@@ -167,11 +169,12 @@ func TestExtractDataType(t *testing.T) {
 				digest: []byte{0x00, 0x01},
 				chain:  &mock.ChainService{ValidatorsRoot: [32]byte{}},
 			},
-			wantBlock:     nil,
-			wantMd:        nil,
-			wantAtt:       nil,
-			wantAggregate: nil,
-			wantErr:       true,
+			wantBlock:       nil,
+			wantMd:          nil,
+			wantAtt:         nil,
+			wantAggregate:   nil,
+			wantAttSlashing: nil,
+			wantErr:         true,
 		},
 		{
 			name: "non existent digest",
@@ -179,11 +182,12 @@ func TestExtractDataType(t *testing.T) {
 				digest: []byte{0x00, 0x01, 0x02, 0x03},
 				chain:  &mock.ChainService{ValidatorsRoot: [32]byte{}},
 			},
-			wantBlock:     nil,
-			wantMd:        nil,
-			wantAtt:       nil,
-			wantAggregate: nil,
-			wantErr:       true,
+			wantBlock:       nil,
+			wantMd:          nil,
+			wantAtt:         nil,
+			wantAggregate:   nil,
+			wantAttSlashing: nil,
+			wantErr:         true,
 		},
 		{
 			name: "genesis fork version",
@@ -196,9 +200,10 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantAtt:       &ethpb.Attestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProof{},
-			wantErr:       false,
+			wantAtt:         &ethpb.Attestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProof{},
+			wantAttSlashing: &ethpb.AttesterSlashing{},
+			wantErr:         false,
 		},
 		{
 			name: "altair fork version",
@@ -211,10 +216,11 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantMd:        wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
-			wantAtt:       &ethpb.Attestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProof{},
-			wantErr:       false,
+			wantMd:          wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
+			wantAtt:         &ethpb.Attestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProof{},
+			wantAttSlashing: &ethpb.AttesterSlashing{},
+			wantErr:         false,
 		},
 		{
 			name: "bellatrix fork version",
@@ -227,10 +233,11 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantMd:        wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
-			wantAtt:       &ethpb.Attestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProof{},
-			wantErr:       false,
+			wantMd:          wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
+			wantAtt:         &ethpb.Attestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProof{},
+			wantAttSlashing: &ethpb.AttesterSlashing{},
+			wantErr:         false,
 		},
 		{
 			name: "capella fork version",
@@ -243,10 +250,11 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantMd:        wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
-			wantAtt:       &ethpb.Attestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProof{},
-			wantErr:       false,
+			wantMd:          wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
+			wantAtt:         &ethpb.Attestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProof{},
+			wantAttSlashing: &ethpb.AttesterSlashing{},
+			wantErr:         false,
 		},
 		{
 			name: "deneb fork version",
@@ -259,10 +267,11 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantMd:        wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
-			wantAtt:       &ethpb.Attestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProof{},
-			wantErr:       false,
+			wantMd:          wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
+			wantAtt:         &ethpb.Attestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProof{},
+			wantAttSlashing: &ethpb.AttesterSlashing{},
+			wantErr:         false,
 		},
 		{
 			name: "electra fork version",
@@ -275,10 +284,11 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantMd:        wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
-			wantAtt:       &ethpb.SingleAttestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProofElectra{},
-			wantErr:       false,
+			wantMd:          wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
+			wantAtt:         &ethpb.SingleAttestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProofElectra{},
+			wantAttSlashing: &ethpb.AttesterSlashingElectra{},
+			wantErr:         false,
 		},
 		{
 			name: "fulu fork version",
@@ -291,10 +301,11 @@ func TestExtractDataType(t *testing.T) {
 				require.NoError(t, err)
 				return wsb
 			}(),
-			wantMd:        wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
-			wantAtt:       &ethpb.SingleAttestation{},
-			wantAggregate: &ethpb.SignedAggregateAttestationAndProofElectra{},
-			wantErr:       false,
+			wantMd:          wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}),
+			wantAtt:         &ethpb.SingleAttestation{},
+			wantAggregate:   &ethpb.SignedAggregateAttestationAndProofElectra{},
+			wantAttSlashing: &ethpb.AttesterSlashingElectra{},
+			wantErr:         false,
 		},
 	}
 	for _, tt := range tests {
@@ -322,6 +333,14 @@ func TestExtractDataType(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotAggregate, tt.wantAggregate) {
 				t.Errorf("aggregate: got = %v, want %v", gotAggregate, tt.wantAggregate)
+			}
+			gotAttSlashing, err := extractDataTypeFromTypeMap(types.AttesterSlashingMap, tt.args.digest, tt.args.chain)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("attester slashing: error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotAttSlashing, tt.wantAttSlashing) {
+				t.Errorf("attester slashin: got = %v, want %v", gotAttSlashing, tt.wantAttSlashing)
 			}
 		})
 	}

--- a/changelog/nisdas_fix_attester_slashing_validation.md
+++ b/changelog/nisdas_fix_attester_slashing_validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Check for the correct attester slashing type during gossip validation.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

This PR fixes our gossip validation path for attester slashings to make sure that we are only using the correct types when deserializing them.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
