### PR TITLE
Optimize processing of slashings

### DIFF
--- a/api/server/httprest/options.go
+++ b/api/server/httprest/options.go
@@ -1,9 +1,8 @@
 package httprest
 
 import (
-	"time"
-
 	"net/http"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
 )

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -42,10 +42,11 @@ func ProcessAttesterSlashings(
 	slashings []ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
+	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
+		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitInfo, totalActiveBalance)
 		if err != nil {
 			return nil, err
 		}
@@ -60,6 +61,7 @@ func ProcessAttesterSlashing(
 	slashing ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
+	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	if err := VerifyAttesterSlashing(ctx, beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify attester slashing")
@@ -78,7 +80,7 @@ func ProcessAttesterSlashing(
 			return nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo)
+			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo, totalActiveBalance)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not slash validator index %d", validatorIndex)
 			}

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -40,16 +40,16 @@ func ProcessAttesterSlashings(
 	beaconState state.BeaconState,
 	slashings []ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
-	exitData *validators.ExitData,
-) (state.BeaconState, error) {
+	exitInfo *validators.ExitInfo,
+) (state.BeaconState, *validators.ExitInfo, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitData)
+		beaconState, exitInfo, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return beaconState, nil
+	return beaconState, exitInfo, nil
 }
 
 // ProcessAttesterSlashing processes individual attester slashing.
@@ -58,10 +58,10 @@ func ProcessAttesterSlashing(
 	beaconState state.BeaconState,
 	slashing ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
-	exitData *validators.ExitData,
-) (state.BeaconState, error) {
+	exitInfo *validators.ExitInfo,
+) (state.BeaconState, *validators.ExitInfo, error) {
 	if err := VerifyAttesterSlashing(ctx, beaconState, slashing); err != nil {
-		return nil, errors.Wrap(err, "could not verify attester slashing")
+		return nil, nil, errors.Wrap(err, "could not verify attester slashing")
 	}
 	slashableIndices := SlashableAttesterIndices(slashing)
 	sort.SliceStable(slashableIndices, func(i, j int) bool {
@@ -74,21 +74,21 @@ func ProcessAttesterSlashing(
 	for _, validatorIndex := range slashableIndices {
 		val, err = beaconState.ValidatorAtIndexReadOnly(primitives.ValidatorIndex(validatorIndex))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitData)
+			beaconState, _, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not slash validator index %d",
+				return nil, nil, errors.Wrapf(err, "could not slash validator index %d",
 					validatorIndex)
 			}
 			slashedAny = true
 		}
 	}
 	if !slashedAny {
-		return nil, errors.New("unable to slash any validator despite confirmed attester slashing")
+		return nil, nil, errors.New("unable to slash any validator despite confirmed attester slashing")
 	}
-	return beaconState, nil
+	return beaconState, exitInfo, nil
 }
 
 // VerifyAttesterSlashing validates the attestation data in both attestations in the slashing object.

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -42,8 +42,9 @@ func ProcessAttesterSlashings(
 	slashFunc slashValidatorFunc,
 ) (state.BeaconState, error) {
 	var err error
+	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(s)
 	for _, slashing := range slashings {
-		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc)
+		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, maxExitEpoch, churn)
 		if err != nil {
 			return nil, err
 		}
@@ -57,6 +58,8 @@ func ProcessAttesterSlashing(
 	beaconState state.BeaconState,
 	slashing ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
+	maxEpoch primitives.Epoch,
+	churn uint64,
 ) (state.BeaconState, error) {
 	if err := VerifyAttesterSlashing(ctx, beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify attester slashing")
@@ -75,7 +78,7 @@ func ProcessAttesterSlashing(
 			return nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex))
+			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), maxEpoch, churn)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not slash validator index %d",
 					validatorIndex)

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -40,9 +40,10 @@ func ProcessAttesterSlashings(
 	beaconState state.BeaconState,
 	slashings []ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
+	maxExitEpoch primitives.Epoch,
+	churn uint64,
 ) (state.BeaconState, error) {
 	var err error
-	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(s)
 	for _, slashing := range slashings {
 		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, maxExitEpoch, churn)
 		if err != nil {

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -40,13 +40,12 @@ func ProcessAttesterSlashings(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	slashings []ethpb.AttSlashing,
-	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
 	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitInfo, totalActiveBalance)
+		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, exitInfo, totalActiveBalance)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +58,6 @@ func ProcessAttesterSlashing(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	slashing ethpb.AttSlashing,
-	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
 	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
@@ -80,7 +78,7 @@ func ProcessAttesterSlashing(
 			return nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo, totalActiveBalance)
+			beaconState, err = validators.SlashValidator(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo, totalActiveBalance)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not slash validator index %d", validatorIndex)
 			}

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -42,15 +42,15 @@ func ProcessAttesterSlashings(
 	slashings []ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
-) (state.BeaconState, *validators.ExitInfo, error) {
+) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, exitInfo, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
+		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-	return beaconState, exitInfo, nil
+	return beaconState, nil
 }
 
 // ProcessAttesterSlashing processes individual attester slashing.
@@ -60,9 +60,9 @@ func ProcessAttesterSlashing(
 	slashing ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
-) (state.BeaconState, *validators.ExitInfo, error) {
+) (state.BeaconState, error) {
 	if err := VerifyAttesterSlashing(ctx, beaconState, slashing); err != nil {
-		return nil, nil, errors.Wrap(err, "could not verify attester slashing")
+		return nil, errors.Wrap(err, "could not verify attester slashing")
 	}
 	slashableIndices := SlashableAttesterIndices(slashing)
 	sort.SliceStable(slashableIndices, func(i, j int) bool {
@@ -75,21 +75,20 @@ func ProcessAttesterSlashing(
 	for _, validatorIndex := range slashableIndices {
 		val, err = beaconState.ValidatorAtIndexReadOnly(primitives.ValidatorIndex(validatorIndex))
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			beaconState, _, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo)
+			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo)
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "could not slash validator index %d",
-					validatorIndex)
+				return nil, errors.Wrapf(err, "could not slash validator index %d", validatorIndex)
 			}
 			slashedAny = true
 		}
 	}
 	if !slashedAny {
-		return nil, nil, errors.New("unable to slash any validator despite confirmed attester slashing")
+		return nil, errors.New("unable to slash any validator despite confirmed attester slashing")
 	}
-	return beaconState, exitInfo, nil
+	return beaconState, nil
 }
 
 // VerifyAttesterSlashing validates the attestation data in both attestations in the slashing object.

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -41,11 +41,10 @@ func ProcessAttesterSlashings(
 	beaconState state.BeaconState,
 	slashings []ethpb.AttSlashing,
 	exitInfo *validators.ExitInfo,
-	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, exitInfo, totalActiveBalance)
+		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, exitInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +58,6 @@ func ProcessAttesterSlashing(
 	beaconState state.BeaconState,
 	slashing ethpb.AttSlashing,
 	exitInfo *validators.ExitInfo,
-	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	if err := VerifyAttesterSlashing(ctx, beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify attester slashing")
@@ -78,7 +76,7 @@ func ProcessAttesterSlashing(
 			return nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			beaconState, err = validators.SlashValidator(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo, totalActiveBalance)
+			beaconState, err = validators.SlashValidator(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitInfo)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not slash validator index %d", validatorIndex)
 			}

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -40,12 +40,11 @@ func ProcessAttesterSlashings(
 	beaconState state.BeaconState,
 	slashings []ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
-	maxExitEpoch primitives.Epoch,
-	churn uint64,
+	exitData *validators.ExitData,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, maxExitEpoch, churn)
+		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, slashFunc, exitData)
 		if err != nil {
 			return nil, err
 		}
@@ -59,8 +58,7 @@ func ProcessAttesterSlashing(
 	beaconState state.BeaconState,
 	slashing ethpb.AttSlashing,
 	slashFunc slashValidatorFunc,
-	maxEpoch primitives.Epoch,
-	churn uint64,
+	exitData *validators.ExitData,
 ) (state.BeaconState, error) {
 	if err := VerifyAttesterSlashing(ctx, beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify attester slashing")
@@ -79,7 +77,7 @@ func ProcessAttesterSlashing(
 			return nil, err
 		}
 		if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
-			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), maxEpoch, churn)
+			beaconState, err = slashFunc(ctx, beaconState, primitives.ValidatorIndex(validatorIndex), exitData)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not slash validator index %d",
 					validatorIndex)

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/container/slice"

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
@@ -44,11 +45,10 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 				Target: &ethpb.Checkpoint{Epoch: 1}},
 		})}}
 
-	var registry []*ethpb.Validator
 	currentSlot := primitives.Slot(0)
 
 	beaconState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
-		Validators: registry,
+		Validators: []*ethpb.Validator{{}},
 		Slot:       currentSlot,
 	})
 	require.NoError(t, err)
@@ -62,16 +62,17 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, "attestations are not slashable", err)
 }
 
 func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T) {
-	var registry []*ethpb.Validator
 	currentSlot := primitives.Slot(0)
 
 	beaconState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
-		Validators: registry,
+		Validators: []*ethpb.Validator{{}},
 		Slot:       currentSlot,
 	})
 	require.NoError(t, err)
@@ -101,7 +102,9 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, "validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE", err)
 }
 
@@ -243,7 +246,9 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
 			require.NoError(t, tc.st.SetSlot(currentSlot))
 
-			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.ExitInformation(tc.st))
+			activeBal, err := helpers.TotalActiveBalance(tc.st)
+			require.NoError(t, err)
+			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.ExitInformation(tc.st), primitives.Gwei(activeBal))
 			require.NoError(t, err)
 			newRegistry := newState.Validators()
 
@@ -264,4 +269,86 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			require.Equal(t, uint64(32000000000), newState.Balances()[2])
 		})
 	}
+}
+
+func TestProcessAttesterSlashing_ExitEpochGetsUpdated(t *testing.T) {
+	st, keys := util.DeterministicGenesisStateElectra(t, 8)
+	bal, err := helpers.TotalActiveBalance(st)
+	require.NoError(t, err)
+	perEpochChurn := helpers.ActivationExitChurnLimit(primitives.Gwei(bal))
+	vals := st.Validators()
+
+	// We set the total effective balance of slashed validators
+	// higher than the churn limit for a single epoch.
+	vals[0].EffectiveBalance = uint64(perEpochChurn / 3)
+	vals[1].EffectiveBalance = uint64(perEpochChurn / 3)
+	vals[2].EffectiveBalance = uint64(perEpochChurn / 3)
+	vals[3].EffectiveBalance = uint64(perEpochChurn / 3)
+	require.NoError(t, st.SetValidators(vals))
+
+	sl1att1 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 1},
+		},
+		AttestingIndices: []uint64{0, 1},
+	})
+	sl1att2 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
+		AttestingIndices: []uint64{0, 1},
+	})
+	slashing1 := &ethpb.AttesterSlashingElectra{
+		Attestation_1: sl1att1,
+		Attestation_2: sl1att2,
+	}
+	sl2att1 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 1},
+		},
+		AttestingIndices: []uint64{2, 3},
+	})
+	sl2att2 := util.HydrateIndexedAttestationElectra(&ethpb.IndexedAttestationElectra{
+		AttestingIndices: []uint64{2, 3},
+	})
+	slashing2 := &ethpb.AttesterSlashingElectra{
+		Attestation_1: sl2att1,
+		Attestation_2: sl2att2,
+	}
+
+	domain, err := signing.Domain(st.Fork(), 0, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorsRoot())
+	require.NoError(t, err)
+
+	signingRoot, err := signing.ComputeSigningRoot(sl1att1.GetData(), domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 := keys[0].Sign(signingRoot[:])
+	sig1 := keys[1].Sign(signingRoot[:])
+	aggregateSig := bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	sl1att1.Signature = aggregateSig.Marshal()
+
+	signingRoot, err = signing.ComputeSigningRoot(sl1att2.GetData(), domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 = keys[0].Sign(signingRoot[:])
+	sig1 = keys[1].Sign(signingRoot[:])
+	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	sl1att2.Signature = aggregateSig.Marshal()
+
+	signingRoot, err = signing.ComputeSigningRoot(sl2att1.GetData(), domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 = keys[2].Sign(signingRoot[:])
+	sig1 = keys[3].Sign(signingRoot[:])
+	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	sl2att1.Signature = aggregateSig.Marshal()
+
+	signingRoot, err = signing.ComputeSigningRoot(sl2att2.GetData(), domain)
+	assert.NoError(t, err, "Could not get signing root of beacon block header")
+	sig0 = keys[2].Sign(signingRoot[:])
+	sig1 = keys[3].Sign(signingRoot[:])
+	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
+	sl2att2.Signature = aggregateSig.Marshal()
+
+	activeBal, err := helpers.TotalActiveBalance(st)
+	require.NoError(t, err)
+	exitInfo := v.ExitInformation(st)
+	assert.Equal(t, primitives.Epoch(0), exitInfo.HighestExitEpoch)
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), st, []ethpb.AttSlashing{slashing1, slashing2}, v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	require.NoError(t, err)
+	assert.Equal(t, primitives.Epoch(6), exitInfo.HighestExitEpoch)
 }

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -64,7 +64,7 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	}
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, "attestations are not slashable", err)
 }
 
@@ -104,7 +104,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	}
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, "validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE", err)
 }
 
@@ -248,7 +248,7 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 
 			activeBal, err := helpers.TotalActiveBalance(tc.st)
 			require.NoError(t, err)
-			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.ExitInformation(tc.st), primitives.Gwei(activeBal))
+			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.ExitInformation(tc.st), primitives.Gwei(activeBal))
 			require.NoError(t, err)
 			newRegistry := newState.Validators()
 
@@ -348,7 +348,7 @@ func TestProcessAttesterSlashing_ExitEpochGetsUpdated(t *testing.T) {
 	require.NoError(t, err)
 	exitInfo := v.ExitInformation(st)
 	assert.Equal(t, primitives.Epoch(0), exitInfo.HighestExitEpoch)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), st, []ethpb.AttSlashing{slashing1, slashing2}, v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), st, []ethpb.AttSlashing{slashing1, slashing2}, exitInfo, primitives.Gwei(activeBal))
 	require.NoError(t, err)
 	assert.Equal(t, primitives.Epoch(6), exitInfo.HighestExitEpoch)
 }

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -62,8 +62,7 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, maxExitEpoch, churn)
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	assert.ErrorContains(t, "attestations are not slashable", err)
 }
 
@@ -102,8 +101,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, maxExitEpoch, churn)
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	assert.ErrorContains(t, "validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE", err)
 }
 
@@ -245,8 +243,7 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
 			require.NoError(t, tc.st.SetSlot(currentSlot))
 
-			maxExitEpoch, churn := v.MaxExitEpochAndChurn(tc.st)
-			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, maxExitEpoch, churn)
+			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.MaxExitEpochAndChurn(tc.st))
 			require.NoError(t, err)
 			newRegistry := newState.Validators()
 

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -62,7 +62,7 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, _, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, "attestations are not slashable", err)
 }
 
@@ -101,7 +101,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, _, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, "validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE", err)
 }
 
@@ -243,7 +243,7 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
 			require.NoError(t, tc.st.SetSlot(currentSlot))
 
-			newState, _, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.ExitInformation(tc.st))
+			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.ExitInformation(tc.st))
 			require.NoError(t, err)
 			newRegistry := newState.Validators()
 

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -62,7 +62,8 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, maxExitEpoch, churn)
 	assert.ErrorContains(t, "attestations are not slashable", err)
 }
 
@@ -101,7 +102,8 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, maxExitEpoch, churn)
 	assert.ErrorContains(t, "validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE", err)
 }
 
@@ -243,7 +245,8 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
 			require.NoError(t, tc.st.SetSlot(currentSlot))
 
-			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator)
+			maxExitEpoch, churn := v.MaxExitEpochAndChurn(tc.st)
+			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, maxExitEpoch, churn)
 			require.NoError(t, err)
 			newRegistry := newState.Validators()
 

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -62,9 +62,7 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, "attestations are not slashable", err)
 }
 
@@ -102,9 +100,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, "validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE", err)
 }
 
@@ -246,9 +242,7 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
 			require.NoError(t, tc.st.SetSlot(currentSlot))
 
-			activeBal, err := helpers.TotalActiveBalance(tc.st)
-			require.NoError(t, err)
-			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.ExitInformation(tc.st), primitives.Gwei(activeBal))
+			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.ExitInformation(tc.st))
 			require.NoError(t, err)
 			newRegistry := newState.Validators()
 
@@ -344,11 +338,9 @@ func TestProcessAttesterSlashing_ExitEpochGetsUpdated(t *testing.T) {
 	aggregateSig = bls.AggregateSignatures([]bls.Signature{sig0, sig1})
 	sl2att2.Signature = aggregateSig.Marshal()
 
-	activeBal, err := helpers.TotalActiveBalance(st)
-	require.NoError(t, err)
 	exitInfo := v.ExitInformation(st)
 	assert.Equal(t, primitives.Epoch(0), exitInfo.HighestExitEpoch)
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), st, []ethpb.AttSlashing{slashing1, slashing2}, exitInfo, primitives.Gwei(activeBal))
+	_, err = blocks.ProcessAttesterSlashings(t.Context(), st, []ethpb.AttSlashing{slashing1, slashing2}, exitInfo)
 	require.NoError(t, err)
 	assert.Equal(t, primitives.Epoch(6), exitInfo.HighestExitEpoch)
 }

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -62,7 +62,7 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	_, _, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, "attestations are not slashable", err)
 }
 
@@ -101,7 +101,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	_, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	_, _, err = blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, "validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE", err)
 }
 
@@ -243,7 +243,7 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
 			require.NoError(t, tc.st.SetSlot(currentSlot))
 
-			newState, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.MaxExitEpochAndChurn(tc.st))
+			newState, _, err := blocks.ProcessAttesterSlashings(t.Context(), tc.st, []ethpb.AttSlashing{tc.slashing}, v.SlashValidator, v.ExitInformation(tc.st))
 			require.NoError(t, err)
 			newRegistry := newState.Validators()
 

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -191,7 +191,7 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(p)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, _, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.ExitInformation(s))
+		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
@@ -224,7 +224,7 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(a)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, _, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.ExitInformation(s))
+		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}
@@ -334,7 +334,7 @@ func TestFuzzProcessVoluntaryExits_10000(t *testing.T) {
 		fuzzer.Fuzz(e)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, _, err := ProcessVoluntaryExits(ctx, s, []*ethpb.SignedVoluntaryExit{e}, v.ExitInformation(s))
+		r, err := ProcessVoluntaryExits(ctx, s, []*ethpb.SignedVoluntaryExit{e}, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and exit: %v", r, err, state, e)
 		}
@@ -351,7 +351,7 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 		fuzzer.Fuzz(e)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, _, err := ProcessVoluntaryExits(t.Context(), s, []*ethpb.SignedVoluntaryExit{e}, v.ExitInformation(s))
+		r, err := ProcessVoluntaryExits(t.Context(), s, []*ethpb.SignedVoluntaryExit{e}, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, e)
 		}

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -191,8 +191,7 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(p)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
-		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, maxExitEpoch, churn)
+		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.MaxExitEpochAndChurn(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
@@ -225,8 +224,7 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(a)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
-		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, maxExitEpoch, churn)
+		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.MaxExitEpochAndChurn(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}
@@ -336,7 +334,7 @@ func TestFuzzProcessVoluntaryExits_10000(t *testing.T) {
 		fuzzer.Fuzz(e)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessVoluntaryExits(ctx, s, []*ethpb.SignedVoluntaryExit{e})
+		r, err := ProcessVoluntaryExits(ctx, s, []*ethpb.SignedVoluntaryExit{e}, v.MaxExitEpochAndChurn(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and exit: %v", r, err, state, e)
 		}
@@ -353,7 +351,7 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 		fuzzer.Fuzz(e)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessVoluntaryExits(t.Context(), s, []*ethpb.SignedVoluntaryExit{e})
+		r, err := ProcessVoluntaryExits(t.Context(), s, []*ethpb.SignedVoluntaryExit{e}, v.MaxExitEpochAndChurn(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, e)
 		}

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -191,7 +191,7 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(p)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.MaxExitEpochAndChurn(s))
+		r, _, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
@@ -224,7 +224,7 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(a)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.MaxExitEpochAndChurn(s))
+		r, _, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}
@@ -334,7 +334,7 @@ func TestFuzzProcessVoluntaryExits_10000(t *testing.T) {
 		fuzzer.Fuzz(e)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessVoluntaryExits(ctx, s, []*ethpb.SignedVoluntaryExit{e}, v.MaxExitEpochAndChurn(s))
+		r, _, err := ProcessVoluntaryExits(ctx, s, []*ethpb.SignedVoluntaryExit{e}, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and exit: %v", r, err, state, e)
 		}
@@ -351,7 +351,7 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 		fuzzer.Fuzz(e)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessVoluntaryExits(t.Context(), s, []*ethpb.SignedVoluntaryExit{e}, v.MaxExitEpochAndChurn(s))
+		r, _, err := ProcessVoluntaryExits(t.Context(), s, []*ethpb.SignedVoluntaryExit{e}, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, e)
 		}

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -3,6 +3,7 @@ package blocks
 import (
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	state_native "github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native"
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
@@ -191,7 +192,12 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(p)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.ExitInformation(s))
+		activeBal, err := helpers.TotalActiveBalance(s)
+		if err == nil {
+			// Getting total active balance can fail for reasons such as nil validators in the state.
+			continue
+		}
+		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
@@ -224,7 +230,12 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(a)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.ExitInformation(s))
+		activeBal, err := helpers.TotalActiveBalance(s)
+		if err == nil {
+			// Getting total active balance can fail for reasons such as nil validators in the state.
+			continue
+		}
+		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -197,7 +197,7 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 			// Getting total active balance can fail for reasons such as nil validators in the state.
 			continue
 		}
-		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
+		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.ExitInformation(s), primitives.Gwei(activeBal))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
@@ -235,7 +235,7 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 			// Getting total active balance can fail for reasons such as nil validators in the state.
 			continue
 		}
-		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
+		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.ExitInformation(s), primitives.Gwei(activeBal))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -191,7 +191,8 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(p)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator)
+		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
+		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.SlashValidator, maxExitEpoch, churn)
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
@@ -224,7 +225,8 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(a)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator)
+		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
+		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.SlashValidator, maxExitEpoch, churn)
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -3,7 +3,6 @@ package blocks
 import (
 	"testing"
 
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	state_native "github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native"
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
@@ -192,12 +191,7 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(p)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		activeBal, err := helpers.TotalActiveBalance(s)
-		if err == nil {
-			// Getting total active balance can fail for reasons such as nil validators in the state.
-			continue
-		}
-		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.ExitInformation(s), primitives.Gwei(activeBal))
+		r, err := ProcessProposerSlashings(ctx, s, []*ethpb.ProposerSlashing{p}, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
@@ -230,12 +224,7 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 		fuzzer.Fuzz(a)
 		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
 		require.NoError(t, err)
-		activeBal, err := helpers.TotalActiveBalance(s)
-		if err == nil {
-			// Getting total active balance can fail for reasons such as nil validators in the state.
-			continue
-		}
-		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.ExitInformation(s), primitives.Gwei(activeBal))
+		r, err := ProcessAttesterSlashings(ctx, s, []ethpb.AttSlashing{a}, v.ExitInformation(s))
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}

--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/config/params"
@@ -95,9 +94,7 @@ func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
-	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 	newRegistry := newState.Validators()
 	if !newRegistry[expectedSlashedVal].Slashed {

--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -94,8 +94,7 @@ func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, maxExitEpoch, churn)
+	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	require.NoError(t, err)
 	newRegistry := newState.Validators()
 	if !newRegistry[expectedSlashedVal].Slashed {

--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -94,7 +94,7 @@ func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	newState, _, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 	newRegistry := newState.Validators()
 	if !newRegistry[expectedSlashedVal].Slashed {

--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -94,7 +94,7 @@ func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	newState, _, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
+	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 	newRegistry := newState.Validators()
 	if !newRegistry[expectedSlashedVal].Slashed {

--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/config/params"
@@ -94,7 +95,9 @@ func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState))
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
+	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 	newRegistry := newState.Validators()
 	if !newRegistry[expectedSlashedVal].Slashed {

--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -97,7 +97,7 @@ func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
 	}
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
-	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 	newRegistry := newState.Validators()
 	if !newRegistry[expectedSlashedVal].Slashed {

--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -94,7 +94,8 @@ func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
 	for i, s := range b.Block.Body.AttesterSlashings {
 		ss[i] = s
 	}
-	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	newState, err := blocks.ProcessAttesterSlashings(t.Context(), beaconState, ss, v.SlashValidator, maxExitEpoch, churn)
 	require.NoError(t, err)
 	newRegistry := newState.Validators()
 	if !newRegistry[expectedSlashedVal].Slashed {

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -9,7 +9,6 @@ import (
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/config/params"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/OffchainLabs/prysm/v6/time/slots"

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -50,29 +50,29 @@ func ProcessVoluntaryExits(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	exits []*ethpb.SignedVoluntaryExit,
-	exitData *v.ExitData,
-) (state.BeaconState, error) {
+	exitInfo *v.ExitInfo,
+) (state.BeaconState, *v.ExitInfo, error) {
 	// Avoid calculating the epoch churn if no exits exist.
 	if len(exits) == 0 {
-		return beaconState, nil
+		return beaconState, exitInfo, nil
 	}
 	for idx, exit := range exits {
 		if exit == nil || exit.Exit == nil {
-			return nil, errors.New("nil voluntary exit in block body")
+			return nil, nil, errors.New("nil voluntary exit in block body")
 		}
 		val, err := beaconState.ValidatorAtIndexReadOnly(exit.Exit.ValidatorIndex)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if err := VerifyExitAndSignature(val, beaconState, exit); err != nil {
-			return nil, errors.Wrapf(err, "could not verify exit %d", idx)
+			return nil, nil, errors.Wrapf(err, "could not verify exit %d", idx)
 		}
-		beaconState, _, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitData)
+		beaconState, _, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitInfo)
 		if err != nil && !errors.Is(err, v.ErrValidatorAlreadyExited) {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return beaconState, nil
+	return beaconState, exitInfo, nil
 }
 
 // VerifyExitAndSignature implements the spec defined validation for voluntary exits.

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -50,13 +50,12 @@ func ProcessVoluntaryExits(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	exits []*ethpb.SignedVoluntaryExit,
+	exitData *v.ExitData,
 ) (state.BeaconState, error) {
 	// Avoid calculating the epoch churn if no exits exist.
 	if len(exits) == 0 {
 		return beaconState, nil
 	}
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	var exitEpoch primitives.Epoch
 	for idx, exit := range exits {
 		if exit == nil || exit.Exit == nil {
 			return nil, errors.New("nil voluntary exit in block body")
@@ -68,15 +67,8 @@ func ProcessVoluntaryExits(
 		if err := VerifyExitAndSignature(val, beaconState, exit); err != nil {
 			return nil, errors.Wrapf(err, "could not verify exit %d", idx)
 		}
-		beaconState, exitEpoch, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, maxExitEpoch, churn)
-		if err == nil {
-			if exitEpoch > maxExitEpoch {
-				maxExitEpoch = exitEpoch
-				churn = 1
-			} else if exitEpoch == maxExitEpoch {
-				churn++
-			}
-		} else if !errors.Is(err, v.ErrValidatorAlreadyExited) {
+		beaconState, _, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitData)
+		if !errors.Is(err, v.ErrValidatorAlreadyExited) {
 			return nil, err
 		}
 	}

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -50,28 +50,28 @@ func ProcessVoluntaryExits(
 	beaconState state.BeaconState,
 	exits []*ethpb.SignedVoluntaryExit,
 	exitInfo *v.ExitInfo,
-) (state.BeaconState, *v.ExitInfo, error) {
+) (state.BeaconState, error) {
 	// Avoid calculating the epoch churn if no exits exist.
 	if len(exits) == 0 {
-		return beaconState, exitInfo, nil
+		return beaconState, nil
 	}
 	for idx, exit := range exits {
 		if exit == nil || exit.Exit == nil {
-			return nil, nil, errors.New("nil voluntary exit in block body")
+			return nil, errors.New("nil voluntary exit in block body")
 		}
 		val, err := beaconState.ValidatorAtIndexReadOnly(exit.Exit.ValidatorIndex)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if err := VerifyExitAndSignature(val, beaconState, exit); err != nil {
-			return nil, nil, errors.Wrapf(err, "could not verify exit %d", idx)
+			return nil, errors.Wrapf(err, "could not verify exit %d", idx)
 		}
-		beaconState, exitInfo, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitInfo)
+		beaconState, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitInfo)
 		if err != nil && !errors.Is(err, v.ErrValidatorAlreadyExited) {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-	return beaconState, exitInfo, nil
+	return beaconState, nil
 }
 
 // VerifyExitAndSignature implements the spec defined validation for voluntary exits.

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -67,7 +67,7 @@ func ProcessVoluntaryExits(
 		if err := VerifyExitAndSignature(val, beaconState, exit); err != nil {
 			return nil, nil, errors.Wrapf(err, "could not verify exit %d", idx)
 		}
-		beaconState, _, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitInfo)
+		beaconState, exitInfo, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitInfo)
 		if err != nil && !errors.Is(err, v.ErrValidatorAlreadyExited) {
 			return nil, nil, err
 		}

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -68,7 +68,7 @@ func ProcessVoluntaryExits(
 			return nil, errors.Wrapf(err, "could not verify exit %d", idx)
 		}
 		beaconState, _, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex, exitData)
-		if !errors.Is(err, v.ErrValidatorAlreadyExited) {
+		if err != nil && !errors.Is(err, v.ErrValidatorAlreadyExited) {
 			return nil, err
 		}
 	}

--- a/beacon-chain/core/blocks/exit_test.go
+++ b/beacon-chain/core/blocks/exit_test.go
@@ -47,7 +47,7 @@ func TestProcessVoluntaryExits_NotActiveLongEnoughToExit(t *testing.T) {
 	}
 
 	want := "validator has not been active long enough to exit"
-	_, _, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
+	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -77,7 +77,7 @@ func TestProcessVoluntaryExits_ExitAlreadySubmitted(t *testing.T) {
 	}
 
 	want := "validator with index 0 has already submitted an exit, which will take place at epoch: 10"
-	_, _, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
+	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -125,7 +125,7 @@ func TestProcessVoluntaryExits_AppliesCorrectStatus(t *testing.T) {
 		},
 	}
 
-	newState, _, err := blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
+	newState, err := blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not process exits")
 	newRegistry := newState.Validators()
 	if newRegistry[0].ExitEpoch != helpers.ActivationExitEpoch(primitives.Epoch(state.Slot()/params.BeaconConfig().SlotsPerEpoch)) {

--- a/beacon-chain/core/blocks/exit_test.go
+++ b/beacon-chain/core/blocks/exit_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/time"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	state_native "github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native"
 	"github.com/OffchainLabs/prysm/v6/config/params"

--- a/beacon-chain/core/blocks/exit_test.go
+++ b/beacon-chain/core/blocks/exit_test.go
@@ -46,7 +46,7 @@ func TestProcessVoluntaryExits_NotActiveLongEnoughToExit(t *testing.T) {
 	}
 
 	want := "validator has not been active long enough to exit"
-	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.MaxExitEpochAndChurn(state))
+	_, _, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -76,7 +76,7 @@ func TestProcessVoluntaryExits_ExitAlreadySubmitted(t *testing.T) {
 	}
 
 	want := "validator with index 0 has already submitted an exit, which will take place at epoch: 10"
-	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.MaxExitEpochAndChurn(state))
+	_, _, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -124,7 +124,7 @@ func TestProcessVoluntaryExits_AppliesCorrectStatus(t *testing.T) {
 		},
 	}
 
-	newState, err := blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.MaxExitEpochAndChurn(state))
+	newState, _, err := blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not process exits")
 	newRegistry := newState.Validators()
 	if newRegistry[0].ExitEpoch != helpers.ActivationExitEpoch(primitives.Epoch(state.Slot()/params.BeaconConfig().SlotsPerEpoch)) {

--- a/beacon-chain/core/blocks/exit_test.go
+++ b/beacon-chain/core/blocks/exit_test.go
@@ -46,7 +46,7 @@ func TestProcessVoluntaryExits_NotActiveLongEnoughToExit(t *testing.T) {
 	}
 
 	want := "validator has not been active long enough to exit"
-	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits)
+	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.MaxExitEpochAndChurn(state))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -76,7 +76,7 @@ func TestProcessVoluntaryExits_ExitAlreadySubmitted(t *testing.T) {
 	}
 
 	want := "validator with index 0 has already submitted an exit, which will take place at epoch: 10"
-	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits)
+	_, err = blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.MaxExitEpochAndChurn(state))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -124,7 +124,7 @@ func TestProcessVoluntaryExits_AppliesCorrectStatus(t *testing.T) {
 		},
 	}
 
-	newState, err := blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits)
+	newState, err := blocks.ProcessVoluntaryExits(t.Context(), state, b.Block.Body.VoluntaryExits, validators.MaxExitEpochAndChurn(state))
 	require.NoError(t, err, "Could not process exits")
 	newRegistry := newState.Validators()
 	if newRegistry[0].ExitEpoch != helpers.ActivationExitEpoch(primitives.Epoch(state.Slot()/params.BeaconConfig().SlotsPerEpoch)) {

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -25,6 +25,7 @@ type slashValidatorFunc func(
 	st state.BeaconState,
 	vid primitives.ValidatorIndex,
 	exitInfo *validators.ExitInfo,
+	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error)
 
 // ProcessProposerSlashings is one of the operations performed
@@ -59,10 +60,11 @@ func ProcessProposerSlashings(
 	slashings []*ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
+	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
+		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitInfo, totalActiveBalance)
 		if err != nil {
 			return nil, err
 		}
@@ -77,6 +79,7 @@ func ProcessProposerSlashing(
 	slashing *ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
+	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	if slashing == nil {
@@ -85,7 +88,7 @@ func ProcessProposerSlashing(
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo)
+	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo, totalActiveBalance)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -23,8 +23,7 @@ type slashValidatorFunc func(
 	ctx context.Context,
 	st state.BeaconState,
 	vid primitives.ValidatorIndex,
-	maxEpoch primitives.Epoch,
-	churn uint64,
+	exitData *validators.ExitData,
 ) (state.BeaconState, error)
 
 // ProcessProposerSlashings is one of the operations performed
@@ -58,12 +57,11 @@ func ProcessProposerSlashings(
 	beaconState state.BeaconState,
 	slashings []*ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
-	maxExitEpoch primitives.Epoch,
-	churn uint64,
+	exitData *validators.ExitData,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, maxExitEpoch, churn)
+		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitData)
 		if err != nil {
 			return nil, err
 		}
@@ -77,8 +75,7 @@ func ProcessProposerSlashing(
 	beaconState state.BeaconState,
 	slashing *ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
-	maxExitEpoch primitives.Epoch,
-	churn uint64,
+	exitData *validators.ExitData,
 ) (state.BeaconState, error) {
 	var err error
 	if slashing == nil {
@@ -87,7 +84,7 @@ func ProcessProposerSlashing(
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, maxExitEpoch, churn)
+	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitData)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -23,8 +23,8 @@ type slashValidatorFunc func(
 	ctx context.Context,
 	st state.BeaconState,
 	vid primitives.ValidatorIndex,
-	exitData *validators.ExitData,
-) (state.BeaconState, error)
+	exitInfo *validators.ExitInfo,
+) (state.BeaconState, *validators.ExitInfo, error)
 
 // ProcessProposerSlashings is one of the operations performed
 // on each processed beacon block to slash proposers based on
@@ -57,16 +57,16 @@ func ProcessProposerSlashings(
 	beaconState state.BeaconState,
 	slashings []*ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
-	exitData *validators.ExitData,
-) (state.BeaconState, error) {
+	exitInfo *validators.ExitInfo,
+) (state.BeaconState, *validators.ExitInfo, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitData)
+		beaconState, exitInfo, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return beaconState, nil
+	return beaconState, exitInfo, nil
 }
 
 // ProcessProposerSlashing processes individual proposer slashing.
@@ -75,20 +75,20 @@ func ProcessProposerSlashing(
 	beaconState state.BeaconState,
 	slashing *ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
-	exitData *validators.ExitData,
-) (state.BeaconState, error) {
+	exitInfo *validators.ExitInfo,
+) (state.BeaconState, *validators.ExitInfo, error) {
 	var err error
 	if slashing == nil {
-		return nil, errors.New("nil proposer slashings in block body")
+		return nil, nil, errors.New("nil proposer slashings in block body")
 	}
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
-		return nil, errors.Wrap(err, "could not verify proposer slashing")
+		return nil, nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitData)
+	beaconState, exitInfo, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
+		return nil, nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}
-	return beaconState, nil
+	return beaconState, exitInfo, nil
 }
 
 // VerifyProposerSlashing verifies that the data provided from slashing is valid.

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -25,7 +25,7 @@ type slashValidatorFunc func(
 	st state.BeaconState,
 	vid primitives.ValidatorIndex,
 	exitInfo *validators.ExitInfo,
-) (state.BeaconState, *validators.ExitInfo, error)
+) (state.BeaconState, error)
 
 // ProcessProposerSlashings is one of the operations performed
 // on each processed beacon block to slash proposers based on
@@ -59,15 +59,15 @@ func ProcessProposerSlashings(
 	slashings []*ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
-) (state.BeaconState, *validators.ExitInfo, error) {
+) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, exitInfo, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
+		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitInfo)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-	return beaconState, exitInfo, nil
+	return beaconState, nil
 }
 
 // ProcessProposerSlashing processes individual proposer slashing.
@@ -77,19 +77,19 @@ func ProcessProposerSlashing(
 	slashing *ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
-) (state.BeaconState, *validators.ExitInfo, error) {
+) (state.BeaconState, error) {
 	var err error
 	if slashing == nil {
-		return nil, nil, errors.New("nil proposer slashings in block body")
+		return nil, errors.New("nil proposer slashings in block body")
 	}
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
-		return nil, nil, errors.Wrap(err, "could not verify proposer slashing")
+		return nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	beaconState, exitInfo, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo)
+	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
+		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}
-	return beaconState, exitInfo, nil
+	return beaconState, nil
 }
 
 // VerifyProposerSlashing verifies that the data provided from slashing is valid.

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/time"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -10,7 +10,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/config/params"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	"github.com/pkg/errors"
@@ -51,11 +50,10 @@ func ProcessProposerSlashings(
 	beaconState state.BeaconState,
 	slashings []*ethpb.ProposerSlashing,
 	exitInfo *validators.ExitInfo,
-	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, exitInfo, totalActiveBalance)
+		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, exitInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +67,6 @@ func ProcessProposerSlashing(
 	beaconState state.BeaconState,
 	slashing *ethpb.ProposerSlashing,
 	exitInfo *validators.ExitInfo,
-	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	if slashing == nil {
@@ -78,7 +75,7 @@ func ProcessProposerSlashing(
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	beaconState, err = validators.SlashValidator(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo, totalActiveBalance)
+	beaconState, err = validators.SlashValidator(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -22,7 +22,8 @@ var ErrCouldNotVerifyBlockHeader = errors.New("could not verify beacon block hea
 type slashValidatorFunc func(
 	ctx context.Context,
 	st state.BeaconState,
-	vid primitives.ValidatorIndex) (state.BeaconState, error)
+	vid primitives.ValidatorIndex,
+	maxEpoch primitives.Epoch, churn uint64) (state.BeaconState, error)
 
 // ProcessProposerSlashings is one of the operations performed
 // on each processed beacon block to slash proposers based on

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -23,7 +23,9 @@ type slashValidatorFunc func(
 	ctx context.Context,
 	st state.BeaconState,
 	vid primitives.ValidatorIndex,
-	maxEpoch primitives.Epoch, churn uint64) (state.BeaconState, error)
+	maxEpoch primitives.Epoch,
+	churn uint64,
+) (state.BeaconState, error)
 
 // ProcessProposerSlashings is one of the operations performed
 // on each processed beacon block to slash proposers based on
@@ -56,10 +58,12 @@ func ProcessProposerSlashings(
 	beaconState state.BeaconState,
 	slashings []*ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
+	maxExitEpoch primitives.Epoch,
+	churn uint64,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc)
+		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, maxExitEpoch, churn)
 		if err != nil {
 			return nil, err
 		}
@@ -73,6 +77,8 @@ func ProcessProposerSlashing(
 	beaconState state.BeaconState,
 	slashing *ethpb.ProposerSlashing,
 	slashFunc slashValidatorFunc,
+	maxExitEpoch primitives.Epoch,
+	churn uint64,
 ) (state.BeaconState, error) {
 	var err error
 	if slashing == nil {
@@ -81,7 +87,7 @@ func ProcessProposerSlashing(
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex)
+	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, maxExitEpoch, churn)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -20,14 +20,6 @@ import (
 // ErrCouldNotVerifyBlockHeader is returned when a block header's signature cannot be verified.
 var ErrCouldNotVerifyBlockHeader = errors.New("could not verify beacon block header")
 
-type slashValidatorFunc func(
-	ctx context.Context,
-	st state.BeaconState,
-	vid primitives.ValidatorIndex,
-	exitInfo *validators.ExitInfo,
-	totalActiveBalance primitives.Gwei,
-) (state.BeaconState, error)
-
 // ProcessProposerSlashings is one of the operations performed
 // on each processed beacon block to slash proposers based on
 // slashing conditions if any slashable events occurred.
@@ -58,13 +50,12 @@ func ProcessProposerSlashings(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	slashings []*ethpb.ProposerSlashing,
-	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
 	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 	for _, slashing := range slashings {
-		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, slashFunc, exitInfo, totalActiveBalance)
+		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, exitInfo, totalActiveBalance)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +68,6 @@ func ProcessProposerSlashing(
 	ctx context.Context,
 	beaconState state.BeaconState,
 	slashing *ethpb.ProposerSlashing,
-	slashFunc slashValidatorFunc,
 	exitInfo *validators.ExitInfo,
 	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
@@ -88,7 +78,7 @@ func ProcessProposerSlashing(
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify proposer slashing")
 	}
-	beaconState, err = slashFunc(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo, totalActiveBalance)
+	beaconState, err = validators.SlashValidator(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo, totalActiveBalance)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 	}

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -50,8 +50,7 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 		},
 	}
 	want := "mismatched header slots"
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -84,8 +83,7 @@ func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
 		},
 	}
 	want := "expected slashing headers to differ"
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -135,8 +133,7 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 		"validator with key %#x is not slashable",
 		bytesutil.ToBytes48(beaconState.Validators()[0].PublicKey),
 	)
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -175,8 +172,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -224,8 +220,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusAltair(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -273,8 +268,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -322,8 +316,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -50,7 +50,7 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 		},
 	}
 	want := "mismatched header slots"
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	_, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -83,7 +83,7 @@ func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
 		},
 	}
 	want := "expected slashing headers to differ"
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	_, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -133,7 +133,7 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 		"validator with key %#x is not slashable",
 		bytesutil.ToBytes48(beaconState.Validators()[0].PublicKey),
 	)
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	_, _, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -172,7 +172,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -220,7 +220,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusAltair(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -268,7 +268,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -316,7 +316,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.MaxExitEpochAndChurn(beaconState))
+	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -50,7 +50,7 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 		},
 	}
 	want := "mismatched header slots"
-	_, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -83,7 +83,7 @@ func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
 		},
 	}
 	want := "expected slashing headers to differ"
-	_, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -133,7 +133,7 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 		"validator with key %#x is not slashable",
 		bytesutil.ToBytes48(beaconState.Validators()[0].PublicKey),
 	)
-	_, _, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -172,7 +172,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -220,7 +220,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusAltair(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -268,7 +268,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -316,7 +316,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, _, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
@@ -49,8 +50,10 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 			ProposerSlashings: slashings,
 		},
 	}
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
 	want := "mismatched header slots"
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -82,8 +85,10 @@ func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
 			ProposerSlashings: slashings,
 		},
 	}
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
 	want := "expected slashing headers to differ"
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -129,11 +134,13 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 			ProposerSlashings: slashings,
 		},
 	}
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
 	want := fmt.Sprintf(
 		"validator with key %#x is not slashable",
 		bytesutil.ToBytes48(beaconState.Validators()[0].PublicKey),
 	)
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -172,7 +179,9 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -220,7 +229,9 @@ func TestProcessProposerSlashings_AppliesCorrectStatusAltair(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -268,7 +279,9 @@ func TestProcessProposerSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -316,7 +329,9 @@ func TestProcessProposerSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState))
+	activeBal, err := helpers.TotalActiveBalance(beaconState)
+	require.NoError(t, err)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
@@ -50,10 +49,8 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 			ProposerSlashings: slashings,
 		},
 	}
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
 	want := "mismatched header slots"
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -85,10 +82,8 @@ func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
 			ProposerSlashings: slashings,
 		},
 	}
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
 	want := "expected slashing headers to differ"
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -134,13 +129,11 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 			ProposerSlashings: slashings,
 		},
 	}
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
 	want := fmt.Sprintf(
 		"validator with key %#x is not slashable",
 		bytesutil.ToBytes48(beaconState.Validators()[0].PublicKey),
 	)
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -179,9 +172,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -229,9 +220,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusAltair(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -279,9 +268,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -329,9 +316,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	activeBal, err := helpers.TotalActiveBalance(beaconState)
-	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -53,7 +53,7 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
 	want := "mismatched header slots"
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -88,7 +88,7 @@ func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
 	want := "expected slashing headers to differ"
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -140,7 +140,7 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 		"validator with key %#x is not slashable",
 		bytesutil.ToBytes48(beaconState.Validators()[0].PublicKey),
 	)
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	assert.ErrorContains(t, want, err)
 }
 
@@ -181,7 +181,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -231,7 +231,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusAltair(t *testing.T) {
 
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -281,7 +281,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
 
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -331,7 +331,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 
 	activeBal, err := helpers.TotalActiveBalance(beaconState)
 	require.NoError(t, err)
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.ExitInformation(beaconState), primitives.Gwei(activeBal))
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -50,7 +50,8 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 		},
 	}
 	want := "mismatched header slots"
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
 	assert.ErrorContains(t, want, err)
 }
 
@@ -83,7 +84,8 @@ func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
 		},
 	}
 	want := "expected slashing headers to differ"
-	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	_, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
 	assert.ErrorContains(t, want, err)
 }
 
@@ -133,7 +135,8 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 		"validator with key %#x is not slashable",
 		bytesutil.ToBytes48(beaconState.Validators()[0].PublicKey),
 	)
-	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	_, err = blocks.ProcessProposerSlashings(t.Context(), beaconState, b.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
 	assert.ErrorContains(t, want, err)
 }
 
@@ -172,7 +175,8 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -220,7 +224,8 @@ func TestProcessProposerSlashings_AppliesCorrectStatusAltair(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -268,7 +273,8 @@ func TestProcessProposerSlashings_AppliesCorrectStatusBellatrix(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()
@@ -316,7 +322,8 @@ func TestProcessProposerSlashings_AppliesCorrectStatusCapella(t *testing.T) {
 	block := util.NewBeaconBlock()
 	block.Block.Body.ProposerSlashings = slashings
 
-	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(beaconState)
+	newState, err := blocks.ProcessProposerSlashings(t.Context(), beaconState, block.Block.Body.ProposerSlashings, v.SlashValidator, maxExitEpoch, churn)
 	require.NoError(t, err)
 
 	newStateVals := newState.Validators()

--- a/beacon-chain/core/electra/registry_updates.go
+++ b/beacon-chain/core/electra/registry_updates.go
@@ -84,7 +84,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) error {
 	// Handle validator ejections.
 	for _, idx := range eligibleForEjection {
 		var err error
-		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, &validators.ExitData{})
+		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, &validators.ExitInfo{})
 		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return fmt.Errorf("failed to initiate validator exit at index %d: %w", idx, err)
 		}

--- a/beacon-chain/core/electra/registry_updates.go
+++ b/beacon-chain/core/electra/registry_updates.go
@@ -84,8 +84,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) error {
 	// Handle validator ejections.
 	for _, idx := range eligibleForEjection {
 		var err error
-		// exitQueueEpoch and churn arguments are not used in electra.
-		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, 0 /*exitQueueEpoch*/, 0 /*churn*/)
+		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, &validators.ExitData{})
 		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return fmt.Errorf("failed to initiate validator exit at index %d: %w", idx, err)
 		}

--- a/beacon-chain/core/electra/registry_updates.go
+++ b/beacon-chain/core/electra/registry_updates.go
@@ -84,6 +84,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) error {
 	// Handle validator ejections.
 	for _, idx := range eligibleForEjection {
 		var err error
+		// exit info is not used in electra
 		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, &validators.ExitInfo{})
 		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return fmt.Errorf("failed to initiate validator exit at index %d: %w", idx, err)

--- a/beacon-chain/core/electra/registry_updates.go
+++ b/beacon-chain/core/electra/registry_updates.go
@@ -85,7 +85,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) error {
 	for _, idx := range eligibleForEjection {
 		var err error
 		// exit info is not used in electra
-		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, &validators.ExitInfo{})
+		st, err = validators.InitiateValidatorExit(ctx, st, idx, &validators.ExitInfo{})
 		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return fmt.Errorf("failed to initiate validator exit at index %d: %w", idx, err)
 		}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -46,19 +46,18 @@ var (
 //      # [New in Electra:EIP7251]
 //      for_ops(body.execution_payload.consolidation_requests, process_consolidation_request)
 
-func ProcessOperations(
-	ctx context.Context,
-	st state.BeaconState,
-	block interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
+func ProcessOperations(ctx context.Context, st state.BeaconState, block interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
+	var err error
+
 	// 6110 validations are in VerifyOperationLengths
 	bb := block.Body()
 	// Electra extends the altair operations.
-	exitData := v.MaxExitEpochAndChurn(st)
-	st, err := ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitData)
+	exitInfo := v.ExitInformation(st)
+	st, exitInfo, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitData)
+	st, exitInfo, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -69,7 +68,7 @@ func ProcessOperations(
 	if _, err := ProcessDeposits(ctx, st, bb.Deposits()); err != nil { // new in electra
 		return nil, errors.Wrap(err, "could not process altair deposit")
 	}
-	st, err = ProcessVoluntaryExits(ctx, st, bb.VoluntaryExits(), exitData)
+	st, _, err = ProcessVoluntaryExits(ctx, st, bb.VoluntaryExits(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process voluntary exits")
 	}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -53,11 +53,12 @@ func ProcessOperations(
 	// 6110 validations are in VerifyOperationLengths
 	bb := block.Body()
 	// Electra extends the altair operations.
-	st, err := ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(st)
+	st, err := ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator)
+	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -53,12 +53,12 @@ func ProcessOperations(
 	// 6110 validations are in VerifyOperationLengths
 	bb := block.Body()
 	// Electra extends the altair operations.
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(st)
-	st, err := ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
+	exitData := v.MaxExitEpochAndChurn(st)
+	st, err := ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
+	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -69,7 +69,7 @@ func ProcessOperations(
 	if _, err := ProcessDeposits(ctx, st, bb.Deposits()); err != nil { // new in electra
 		return nil, errors.Wrap(err, "could not process altair deposit")
 	}
-	st, err = ProcessVoluntaryExits(ctx, st, bb.VoluntaryExits())
+	st, err = ProcessVoluntaryExits(ctx, st, bb.VoluntaryExits(), exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process voluntary exits")
 	}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -55,9 +55,9 @@ func ProcessOperations(ctx context.Context, st state.BeaconState, block interfac
 	bb := block.Body()
 	// Electra extends the altair operations.
 	exitInfo := v.ExitInformation(st)
-	activeBal, err := helpers.TotalActiveBalance(st)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get total active balance")
+	activeBal := exitInfo.TotalActiveBalance
+	if err := helpers.UpdateTotalActiveBalanceCache(st, activeBal); err != nil {
+		return nil, errors.Wrap(err, "could not update total active balance cache")
 	}
 	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -8,7 +8,6 @@ import (
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/pkg/errors"
 )
 
@@ -55,15 +54,14 @@ func ProcessOperations(ctx context.Context, st state.BeaconState, block interfac
 	bb := block.Body()
 	// Electra extends the altair operations.
 	exitInfo := v.ExitInformation(st)
-	activeBal := exitInfo.TotalActiveBalance
-	if err := helpers.UpdateTotalActiveBalanceCache(st, activeBal); err != nil {
+	if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
 		return nil, errors.Wrap(err, "could not update total active balance cache")
 	}
-	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -59,11 +59,11 @@ func ProcessOperations(ctx context.Context, st state.BeaconState, block interfac
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get total active balance")
 	}
-	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/pkg/errors"
 )
 
@@ -53,11 +55,15 @@ func ProcessOperations(ctx context.Context, st state.BeaconState, block interfac
 	bb := block.Body()
 	// Electra extends the altair operations.
 	exitInfo := v.ExitInformation(st)
-	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitInfo)
+	activeBal, err := helpers.TotalActiveBalance(st)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get total active balance")
+	}
+	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitInfo)
+	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}

--- a/beacon-chain/core/electra/transition_no_verify_sig.go
+++ b/beacon-chain/core/electra/transition_no_verify_sig.go
@@ -53,11 +53,11 @@ func ProcessOperations(ctx context.Context, st state.BeaconState, block interfac
 	bb := block.Body()
 	// Electra extends the altair operations.
 	exitInfo := v.ExitInformation(st)
-	st, exitInfo, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitInfo)
+	st, err = ProcessProposerSlashings(ctx, st, bb.ProposerSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, exitInfo, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitInfo)
+	st, err = ProcessAttesterSlashings(ctx, st, bb.AttesterSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -68,7 +68,7 @@ func ProcessOperations(ctx context.Context, st state.BeaconState, block interfac
 	if _, err := ProcessDeposits(ctx, st, bb.Deposits()); err != nil { // new in electra
 		return nil, errors.Wrap(err, "could not process altair deposit")
 	}
-	st, _, err = ProcessVoluntaryExits(ctx, st, bb.VoluntaryExits(), exitInfo)
+	st, err = ProcessVoluntaryExits(ctx, st, bb.VoluntaryExits(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process voluntary exits")
 	}

--- a/beacon-chain/core/electra/withdrawals.go
+++ b/beacon-chain/core/electra/withdrawals.go
@@ -148,7 +148,7 @@ func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []
 			// Only exit validator if it has no pending withdrawals in the queue
 			if pendingBalanceToWithdraw == 0 {
 				var err error
-				st, _, err = validators.InitiateValidatorExit(ctx, st, vIdx, validators.ExitInformation(st))
+				st, err = validators.InitiateValidatorExit(ctx, st, vIdx, validators.ExitInformation(st))
 				if err != nil {
 					return nil, err
 				}

--- a/beacon-chain/core/electra/withdrawals.go
+++ b/beacon-chain/core/electra/withdrawals.go
@@ -147,9 +147,8 @@ func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []
 		if isFullExitRequest {
 			// Only exit validator if it has no pending withdrawals in the queue
 			if pendingBalanceToWithdraw == 0 {
-				maxExitEpoch, churn := validators.MaxExitEpochAndChurn(st)
 				var err error
-				st, _, err = validators.InitiateValidatorExit(ctx, st, vIdx, maxExitEpoch, churn)
+				st, _, err = validators.InitiateValidatorExit(ctx, st, vIdx, validators.MaxExitEpochAndChurn(st))
 				if err != nil {
 					return nil, err
 				}

--- a/beacon-chain/core/electra/withdrawals.go
+++ b/beacon-chain/core/electra/withdrawals.go
@@ -148,7 +148,7 @@ func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []
 			// Only exit validator if it has no pending withdrawals in the queue
 			if pendingBalanceToWithdraw == 0 {
 				var err error
-				st, _, err = validators.InitiateValidatorExit(ctx, st, vIdx, validators.MaxExitEpochAndChurn(st))
+				st, _, err = validators.InitiateValidatorExit(ctx, st, vIdx, validators.ExitInformation(st))
 				if err != nil {
 					return nil, err
 				}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -99,8 +99,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) (state.Be
 	for _, idx := range eligibleForEjection {
 		// Here is fine to do a quadratic loop since this should
 		// barely happen
-		maxExitEpoch, churn := validators.MaxExitEpochAndChurn(st)
-		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, maxExitEpoch, churn)
+		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, validators.MaxExitEpochAndChurn(st))
 		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return nil, errors.Wrapf(err, "could not initiate exit for validator %d", idx)
 		}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -99,7 +99,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) (state.Be
 	for _, idx := range eligibleForEjection {
 		// Here is fine to do a quadratic loop since this should
 		// barely happen
-		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, validators.ExitInformation(st))
+		st, err = validators.InitiateValidatorExit(ctx, st, idx, validators.ExitInformation(st))
 		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return nil, errors.Wrapf(err, "could not initiate exit for validator %d", idx)
 		}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -99,7 +99,7 @@ func ProcessRegistryUpdates(ctx context.Context, st state.BeaconState) (state.Be
 	for _, idx := range eligibleForEjection {
 		// Here is fine to do a quadratic loop since this should
 		// barely happen
-		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, validators.MaxExitEpochAndChurn(st))
+		st, _, err = validators.InitiateValidatorExit(ctx, st, idx, validators.ExitInformation(st))
 		if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 			return nil, errors.Wrapf(err, "could not initiate exit for validator %d", idx)
 		}

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -87,6 +87,11 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 	return total, nil
 }
 
+// UpdateTotalActiveBalanceCache updates the cache with the given total active balance.
+func UpdateTotalActiveBalanceCache(s state.BeaconState, total uint64) error {
+	return balanceCache.AddTotalEffectiveBalance(s, total)
+}
+
 // IncreaseBalance increases validator with the given 'index' balance by 'delta' in Gwei.
 //
 // Spec pseudocode definition:

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -378,11 +378,11 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	st, exitInfo, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, exitInfo, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -393,7 +393,7 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 	if _, err := altair.ProcessDeposits(ctx, st, beaconBlock.Body().Deposits()); err != nil {
 		return nil, errors.Wrap(err, "could not process altair deposit")
 	}
-	st, _, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitInfo)
+	st, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process voluntary exits")
 	}
@@ -405,11 +405,11 @@ func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	st, exitInfo, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")
 	}
-	st, exitInfo, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}
@@ -420,7 +420,7 @@ func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock int
 	if _, err := altair.ProcessDeposits(ctx, st, beaconBlock.Body().Deposits()); err != nil {
 		return nil, errors.Wrap(err, "could not process deposits")
 	}
-	st, _, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitInfo)
+	st, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process voluntary exits")
 	}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -380,9 +380,9 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	activeBal, err := helpers.TotalActiveBalance(st)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get total active balance")
+	activeBal := exitInfo.TotalActiveBalance
+	if err := helpers.UpdateTotalActiveBalanceCache(st, activeBal); err != nil {
+		return nil, errors.Wrap(err, "could not update total active balance cache")
 	}
 	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
@@ -411,9 +411,9 @@ func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	activeBal, err := helpers.TotalActiveBalance(st)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get total active balance")
+	activeBal := exitInfo.TotalActiveBalance
+	if err := helpers.UpdateTotalActiveBalanceCache(st, activeBal); err != nil {
+		return nil, errors.Wrap(err, "could not update total active balance cache")
 	}
 	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -378,12 +378,13 @@ func altairOperations(
 	ctx context.Context,
 	st state.BeaconState,
 	beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(st)
-	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
+	// TODO It might be unclear that exitData is mutated
+	exitData := v.MaxExitEpochAndChurn(st)
+	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -394,7 +395,7 @@ func altairOperations(
 	if _, err := altair.ProcessDeposits(ctx, st, beaconBlock.Body().Deposits()); err != nil {
 		return nil, errors.Wrap(err, "could not process altair deposit")
 	}
-	st, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits())
+	st, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process voluntary exits")
 	}
@@ -406,12 +407,12 @@ func phase0Operations(
 	ctx context.Context,
 	st state.BeaconState,
 	beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
-	maxExitEpoch, churn := v.MaxExitEpochAndChurn(st)
-	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
+	exitData := v.MaxExitEpochAndChurn(st)
+	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}
@@ -422,5 +423,5 @@ func phase0Operations(
 	if _, err := altair.ProcessDeposits(ctx, st, beaconBlock.Body().Deposits()); err != nil {
 		return nil, errors.Wrap(err, "could not process deposits")
 	}
-	return b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits())
+	return b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitData)
 }

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -374,17 +374,15 @@ func ProcessBlockForStateRoot(
 }
 
 // This calls altair block operations.
-func altairOperations(
-	ctx context.Context,
-	st state.BeaconState,
-	beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
-	// TODO It might be unclear that exitData is mutated
-	exitData := v.MaxExitEpochAndChurn(st)
-	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitData)
+func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
+	var err error
+
+	exitInfo := v.ExitInformation(st)
+	st, exitInfo, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitData)
+	st, exitInfo, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -395,7 +393,7 @@ func altairOperations(
 	if _, err := altair.ProcessDeposits(ctx, st, beaconBlock.Body().Deposits()); err != nil {
 		return nil, errors.Wrap(err, "could not process altair deposit")
 	}
-	st, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitData)
+	st, _, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process voluntary exits")
 	}
@@ -403,16 +401,15 @@ func altairOperations(
 }
 
 // This calls phase 0 block operations.
-func phase0Operations(
-	ctx context.Context,
-	st state.BeaconState,
-	beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
-	exitData := v.MaxExitEpochAndChurn(st)
-	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitData)
+func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
+	var err error
+
+	exitInfo := v.ExitInformation(st)
+	st, exitInfo, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitData)
+	st, exitInfo, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}
@@ -423,5 +420,9 @@ func phase0Operations(
 	if _, err := altair.ProcessDeposits(ctx, st, beaconBlock.Body().Deposits()); err != nil {
 		return nil, errors.Wrap(err, "could not process deposits")
 	}
-	return b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitData)
+	st, _, err = b.ProcessVoluntaryExits(ctx, st, beaconBlock.Body().VoluntaryExits(), exitInfo)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not process voluntary exits")
+	}
+	return st, nil
 }

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -384,11 +384,11 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get total active balance")
 	}
-	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -415,11 +415,11 @@ func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock int
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get total active balance")
 	}
-	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -8,11 +8,13 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/altair"
 	b "github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/electra"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/transition/interop"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/crypto/bls"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
@@ -378,11 +380,15 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
+	activeBal, err := helpers.TotalActiveBalance(st)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get total active balance")
+	}
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -405,11 +411,15 @@ func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo)
+	activeBal, err := helpers.TotalActiveBalance(st)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get total active balance")
+	}
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -14,7 +14,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/crypto/bls"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
@@ -380,15 +379,14 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	activeBal := exitInfo.TotalActiveBalance
-	if err := helpers.UpdateTotalActiveBalanceCache(st, activeBal); err != nil {
+	if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
 		return nil, errors.Wrap(err, "could not update total active balance cache")
 	}
-	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -411,15 +409,14 @@ func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	exitInfo := v.ExitInformation(st)
-	activeBal := exitInfo.TotalActiveBalance
-	if err := helpers.UpdateTotalActiveBalanceCache(st, activeBal); err != nil {
+	if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
 		return nil, errors.Wrap(err, "could not update total active balance cache")
 	}
-	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), exitInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -378,11 +378,12 @@ func altairOperations(
 	ctx context.Context,
 	st state.BeaconState,
 	beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
-	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(st)
+	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair attester slashing")
 	}
@@ -405,11 +406,12 @@ func phase0Operations(
 	ctx context.Context,
 	st state.BeaconState,
 	beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
-	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator)
+	maxExitEpoch, churn := v.MaxExitEpochAndChurn(st)
+	st, err := b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")
 	}
-	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator)
+	st, err = b.ProcessAttesterSlashings(ctx, st, beaconBlock.Body().AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -76,13 +76,13 @@ func InitiateValidatorExit(
 	s state.BeaconState,
 	idx primitives.ValidatorIndex,
 	exitInfo *ExitInfo,
-) (state.BeaconState, *ExitInfo, error) {
+) (state.BeaconState, error) {
 	validator, err := s.ValidatorAtIndex(idx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
-		return s, exitInfo, ErrValidatorAlreadyExited
+		return s, ErrValidatorAlreadyExited
 	}
 
 	// Compute exit queue epoch.
@@ -101,14 +101,14 @@ func InitiateValidatorExit(
 		}
 		activeValidatorCount, err := helpers.ActiveValidatorCount(ctx, s, time.CurrentEpoch(s))
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "could not get active validator count")
+			return nil, errors.Wrap(err, "could not get active validator count")
 		}
 		currentChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 
 		if exitInfo.Churn >= currentChurn {
 			exitInfo.HighestExitEpoch, err = exitInfo.HighestExitEpoch.SafeAdd(1)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			exitInfo.Churn = 1
 		} else {
@@ -120,18 +120,18 @@ func InitiateValidatorExit(
 		var err error
 		exitInfo.HighestExitEpoch, err = s.ExitEpochAndUpdateChurn(primitives.Gwei(validator.EffectiveBalance))
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 	validator.ExitEpoch = exitInfo.HighestExitEpoch
 	validator.WithdrawableEpoch, err = exitInfo.HighestExitEpoch.SafeAddEpoch(params.BeaconConfig().MinValidatorWithdrawabilityDelay)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if err := s.UpdateValidatorAtIndex(idx, validator); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return s, exitInfo, nil
+	return s, nil
 }
 
 // SlashValidator slashes the malicious validator's balance and awards
@@ -169,24 +169,24 @@ func SlashValidator(
 	s state.BeaconState,
 	slashedIdx primitives.ValidatorIndex,
 	exitInfo *ExitInfo,
-) (state.BeaconState, *ExitInfo, error) {
+) (state.BeaconState, error) {
 	var err error
 
-	s, exitInfo, err = InitiateValidatorExit(ctx, s, slashedIdx, exitInfo)
+	s, err = InitiateValidatorExit(ctx, s, slashedIdx, exitInfo)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
-		return nil, nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
+		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
 	}
 	currentEpoch := slots.ToEpoch(s.Slot())
 	validator, err := s.ValidatorAtIndex(slashedIdx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	validator.Slashed = true
 	maxWithdrawableEpoch := primitives.MaxEpoch(validator.WithdrawableEpoch, currentEpoch+params.BeaconConfig().EpochsPerSlashingsVector)
 	validator.WithdrawableEpoch = maxWithdrawableEpoch
 
 	if err := s.UpdateValidatorAtIndex(slashedIdx, validator); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// The slashing amount is represented by epochs per slashing vector. The validator's effective balance is then applied to that amount.
@@ -196,42 +196,42 @@ func SlashValidator(
 		uint64(currentEpoch%params.BeaconConfig().EpochsPerSlashingsVector),
 		currentSlashing+validator.EffectiveBalance,
 	); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	slashingQuotient, proposerRewardQuotient, whistleblowerRewardQuotient, err := SlashingParamsPerVersion(s.Version())
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not get slashing parameters per version")
+		return nil, errors.Wrap(err, "could not get slashing parameters per version")
 	}
 
 	slashingPenalty, err := math.Div64(validator.EffectiveBalance, slashingQuotient)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to compute slashing slashingPenalty")
+		return nil, errors.Wrap(err, "failed to compute slashing slashingPenalty")
 	}
 	if err := helpers.DecreaseBalance(s, slashedIdx, slashingPenalty); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	proposerIdx, err := helpers.BeaconProposerIndex(ctx, s)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not get proposer idx")
+		return nil, errors.Wrap(err, "could not get proposer idx")
 	}
 	whistleBlowerIdx := proposerIdx
 	whistleblowerReward, err := math.Div64(validator.EffectiveBalance, whistleblowerRewardQuotient)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to compute whistleblowerReward")
+		return nil, errors.Wrap(err, "failed to compute whistleblowerReward")
 	}
 	proposerReward, err := math.Div64(whistleblowerReward, proposerRewardQuotient)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to compute proposer reward")
+		return nil, errors.Wrap(err, "failed to compute proposer reward")
 	}
 	if err := helpers.IncreaseBalance(s, proposerIdx, proposerReward); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if err := helpers.IncreaseBalance(s, whistleBlowerIdx, whistleblowerReward-proposerReward); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return s, exitInfo, nil
+	return s, nil
 }
 
 // ActivatedValidatorIndices determines the indices activated during the given epoch.

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ExitInfo provides information about validator exits.
+// ExitInfo provides information about validator exits in the state.
 type ExitInfo struct {
 	HighestExitEpoch primitives.Epoch
 	Churn            uint64
@@ -76,13 +76,13 @@ func InitiateValidatorExit(
 	s state.BeaconState,
 	idx primitives.ValidatorIndex,
 	exitInfo *ExitInfo,
-) (state.BeaconState, primitives.Epoch, error) {
+) (state.BeaconState, *ExitInfo, error) {
 	validator, err := s.ValidatorAtIndex(idx)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	}
 	if validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
-		return s, validator.ExitEpoch, ErrValidatorAlreadyExited
+		return s, exitInfo, ErrValidatorAlreadyExited
 	}
 
 	// Compute exit queue epoch.
@@ -101,14 +101,14 @@ func InitiateValidatorExit(
 		}
 		activeValidatorCount, err := helpers.ActiveValidatorCount(ctx, s, time.CurrentEpoch(s))
 		if err != nil {
-			return nil, 0, errors.Wrap(err, "could not get active validator count")
+			return nil, nil, errors.Wrap(err, "could not get active validator count")
 		}
 		currentChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 
 		if exitInfo.Churn >= currentChurn {
 			exitInfo.HighestExitEpoch, err = exitInfo.HighestExitEpoch.SafeAdd(1)
 			if err != nil {
-				return nil, 0, err
+				return nil, nil, err
 			}
 			exitInfo.Churn = 1
 		} else {
@@ -120,18 +120,18 @@ func InitiateValidatorExit(
 		var err error
 		exitInfo.HighestExitEpoch, err = s.ExitEpochAndUpdateChurn(primitives.Gwei(validator.EffectiveBalance))
 		if err != nil {
-			return nil, 0, err
+			return nil, nil, err
 		}
 	}
 	validator.ExitEpoch = exitInfo.HighestExitEpoch
 	validator.WithdrawableEpoch, err = exitInfo.HighestExitEpoch.SafeAddEpoch(params.BeaconConfig().MinValidatorWithdrawabilityDelay)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	}
 	if err := s.UpdateValidatorAtIndex(idx, validator); err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	}
-	return s, exitInfo.HighestExitEpoch, nil
+	return s, exitInfo, nil
 }
 
 // SlashValidator slashes the malicious validator's balance and awards
@@ -170,7 +170,9 @@ func SlashValidator(
 	slashedIdx primitives.ValidatorIndex,
 	exitInfo *ExitInfo,
 ) (state.BeaconState, *ExitInfo, error) {
-	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, exitInfo)
+	var err error
+
+	s, exitInfo, err = InitiateValidatorExit(ctx, s, slashedIdx, exitInfo)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -233,11 +233,10 @@ func SlashValidator(
 	s state.BeaconState,
 	slashedIdx primitives.ValidatorIndex,
 	exitInfo *ExitInfo,
-	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 
-	s, err = InitiateValidatorExitForTotalBal(ctx, s, slashedIdx, exitInfo, totalActiveBalance)
+	s, err = InitiateValidatorExitForTotalBal(ctx, s, slashedIdx, exitInfo, primitives.Gwei(exitInfo.TotalActiveBalance))
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -152,7 +152,9 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primiti
 func SlashValidator(
 	ctx context.Context,
 	s state.BeaconState,
-	slashedIdx primitives.ValidatorIndex) (state.BeaconState, error) {
+	slashedIdx primitives.ValidatorIndex,
+	maxExitEpoch primitives.Epoch,
+	churn uint64) (state.BeaconState, error) {
 	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, maxExitEpoch, churn)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -19,28 +19,36 @@ import (
 	"github.com/pkg/errors"
 )
 
+type ExitData struct {
+	MaxExitEpoch primitives.Epoch
+	Churn        uint64
+}
+
 // ErrValidatorAlreadyExited is an error raised when trying to process an exit of
 // an already exited validator
 var ErrValidatorAlreadyExited = errors.New("validator already exited")
 
+// TODO: rename
 // MaxExitEpochAndChurn returns the maximum non-FAR_FUTURE_EPOCH exit
 // epoch and the number of them
-func MaxExitEpochAndChurn(s state.BeaconState) (maxExitEpoch primitives.Epoch, churn uint64) {
+func MaxExitEpochAndChurn(s state.BeaconState) *ExitData {
+	exitData := &ExitData{}
+
 	farFutureEpoch := params.BeaconConfig().FarFutureEpoch
 	err := s.ReadFromEveryValidator(func(idx int, val state.ReadOnlyValidator) error {
 		e := val.ExitEpoch()
 		if e != farFutureEpoch {
-			if e > maxExitEpoch {
-				maxExitEpoch = e
-				churn = 1
-			} else if e == maxExitEpoch {
-				churn++
+			if e > exitData.MaxExitEpoch {
+				exitData.MaxExitEpoch = e
+				exitData.Churn = 1
+			} else if e == exitData.MaxExitEpoch {
+				exitData.Churn++
 			}
 		}
 		return nil
 	})
 	_ = err
-	return
+	return exitData
 }
 
 // InitiateValidatorExit takes in validator index and updates
@@ -64,7 +72,12 @@ func MaxExitEpochAndChurn(s state.BeaconState) (maxExitEpoch primitives.Epoch, c
 //	    # Set validator exit epoch and withdrawable epoch
 //	    validator.exit_epoch = exit_queue_epoch
 //	    validator.withdrawable_epoch = Epoch(validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
-func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primitives.ValidatorIndex, exitQueueEpoch primitives.Epoch, churn uint64) (state.BeaconState, primitives.Epoch, error) {
+func InitiateValidatorExit(
+	ctx context.Context,
+	s state.BeaconState,
+	idx primitives.ValidatorIndex,
+	exitData *ExitData,
+) (state.BeaconState, primitives.Epoch, error) {
 	validator, err := s.ValidatorAtIndex(idx)
 	if err != nil {
 		return nil, 0, err
@@ -83,9 +96,9 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primiti
 		//	if exit_queue_churn >= get_validator_churn_limit(state):
 		//	    exit_queue_epoch += Epoch(1)
 		exitableEpoch := helpers.ActivationExitEpoch(time.CurrentEpoch(s))
-		if exitableEpoch > exitQueueEpoch {
-			exitQueueEpoch = exitableEpoch
-			churn = 0
+		if exitableEpoch > exitData.MaxExitEpoch {
+			exitData.MaxExitEpoch = exitableEpoch
+			exitData.Churn = 0
 		}
 		activeValidatorCount, err := helpers.ActiveValidatorCount(ctx, s, time.CurrentEpoch(s))
 		if err != nil {
@@ -93,30 +106,33 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primiti
 		}
 		currentChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 
-		if churn >= currentChurn {
-			exitQueueEpoch, err = exitQueueEpoch.SafeAdd(1)
+		if exitData.Churn >= currentChurn {
+			exitData.MaxExitEpoch, err = exitData.MaxExitEpoch.SafeAdd(1)
 			if err != nil {
 				return nil, 0, err
 			}
+			exitData.Churn = 1
+		} else {
+			exitData.Churn = exitData.Churn + 1
 		}
 	} else {
 		// [Modified in Electra:EIP7251]
 		// exit_queue_epoch = compute_exit_epoch_and_update_churn(state, validator.effective_balance)
 		var err error
-		exitQueueEpoch, err = s.ExitEpochAndUpdateChurn(primitives.Gwei(validator.EffectiveBalance))
+		exitData.MaxExitEpoch, err = s.ExitEpochAndUpdateChurn(primitives.Gwei(validator.EffectiveBalance))
 		if err != nil {
 			return nil, 0, err
 		}
 	}
-	validator.ExitEpoch = exitQueueEpoch
-	validator.WithdrawableEpoch, err = exitQueueEpoch.SafeAddEpoch(params.BeaconConfig().MinValidatorWithdrawabilityDelay)
+	validator.ExitEpoch = exitData.MaxExitEpoch
+	validator.WithdrawableEpoch, err = exitData.MaxExitEpoch.SafeAddEpoch(params.BeaconConfig().MinValidatorWithdrawabilityDelay)
 	if err != nil {
 		return nil, 0, err
 	}
 	if err := s.UpdateValidatorAtIndex(idx, validator); err != nil {
 		return nil, 0, err
 	}
-	return s, exitQueueEpoch, nil
+	return s, exitData.MaxExitEpoch, nil
 }
 
 // SlashValidator slashes the malicious validator's balance and awards
@@ -153,9 +169,8 @@ func SlashValidator(
 	ctx context.Context,
 	s state.BeaconState,
 	slashedIdx primitives.ValidatorIndex,
-	maxExitEpoch primitives.Epoch,
-	churn uint64) (state.BeaconState, error) {
-	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, maxExitEpoch, churn)
+	exitData *ExitData) (state.BeaconState, error) {
+	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, exitData)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/math"
+	mathutil "github.com/OffchainLabs/prysm/v6/math"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
@@ -21,8 +22,9 @@ import (
 
 // ExitInfo provides information about validator exits in the state.
 type ExitInfo struct {
-	HighestExitEpoch primitives.Epoch
-	Churn            uint64
+	HighestExitEpoch   primitives.Epoch
+	Churn              uint64
+	TotalActiveBalance uint64
 }
 
 // ErrValidatorAlreadyExited is an error raised when trying to process an exit of
@@ -34,6 +36,9 @@ func ExitInformation(s state.BeaconState) *ExitInfo {
 	exitInfo := &ExitInfo{}
 
 	farFutureEpoch := params.BeaconConfig().FarFutureEpoch
+	currentEpoch := slots.ToEpoch(s.Slot())
+	totalActiveBalance := uint64(0)
+
 	err := s.ReadFromEveryValidator(func(idx int, val state.ReadOnlyValidator) error {
 		e := val.ExitEpoch()
 		if e != farFutureEpoch {
@@ -44,9 +49,18 @@ func ExitInformation(s state.BeaconState) *ExitInfo {
 				exitInfo.Churn++
 			}
 		}
+
+		// Calculate total active balance in the same loop
+		if helpers.IsActiveValidatorUsingTrie(val, currentEpoch) {
+			totalActiveBalance += val.EffectiveBalance()
+		}
+
 		return nil
 	})
 	_ = err
+
+	// Apply minimum balance as per spec
+	exitInfo.TotalActiveBalance = mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, totalActiveBalance)
 	return exitInfo
 }
 

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -153,7 +153,6 @@ func SlashValidator(
 	ctx context.Context,
 	s state.BeaconState,
 	slashedIdx primitives.ValidatorIndex) (state.BeaconState, error) {
-	maxExitEpoch, churn := MaxExitEpochAndChurn(s)
 	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, maxExitEpoch, churn)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -19,36 +19,35 @@ import (
 	"github.com/pkg/errors"
 )
 
-type ExitData struct {
-	MaxExitEpoch primitives.Epoch
-	Churn        uint64
+// ExitInfo provides information about validator exits.
+type ExitInfo struct {
+	HighestExitEpoch primitives.Epoch
+	Churn            uint64
 }
 
 // ErrValidatorAlreadyExited is an error raised when trying to process an exit of
 // an already exited validator
 var ErrValidatorAlreadyExited = errors.New("validator already exited")
 
-// TODO: rename
-// MaxExitEpochAndChurn returns the maximum non-FAR_FUTURE_EPOCH exit
-// epoch and the number of them
-func MaxExitEpochAndChurn(s state.BeaconState) *ExitData {
-	exitData := &ExitData{}
+// ExitInformation returns information about validator exits.
+func ExitInformation(s state.BeaconState) *ExitInfo {
+	exitInfo := &ExitInfo{}
 
 	farFutureEpoch := params.BeaconConfig().FarFutureEpoch
 	err := s.ReadFromEveryValidator(func(idx int, val state.ReadOnlyValidator) error {
 		e := val.ExitEpoch()
 		if e != farFutureEpoch {
-			if e > exitData.MaxExitEpoch {
-				exitData.MaxExitEpoch = e
-				exitData.Churn = 1
-			} else if e == exitData.MaxExitEpoch {
-				exitData.Churn++
+			if e > exitInfo.HighestExitEpoch {
+				exitInfo.HighestExitEpoch = e
+				exitInfo.Churn = 1
+			} else if e == exitInfo.HighestExitEpoch {
+				exitInfo.Churn++
 			}
 		}
 		return nil
 	})
 	_ = err
-	return exitData
+	return exitInfo
 }
 
 // InitiateValidatorExit takes in validator index and updates
@@ -76,7 +75,7 @@ func InitiateValidatorExit(
 	ctx context.Context,
 	s state.BeaconState,
 	idx primitives.ValidatorIndex,
-	exitData *ExitData,
+	exitInfo *ExitInfo,
 ) (state.BeaconState, primitives.Epoch, error) {
 	validator, err := s.ValidatorAtIndex(idx)
 	if err != nil {
@@ -96,9 +95,9 @@ func InitiateValidatorExit(
 		//	if exit_queue_churn >= get_validator_churn_limit(state):
 		//	    exit_queue_epoch += Epoch(1)
 		exitableEpoch := helpers.ActivationExitEpoch(time.CurrentEpoch(s))
-		if exitableEpoch > exitData.MaxExitEpoch {
-			exitData.MaxExitEpoch = exitableEpoch
-			exitData.Churn = 0
+		if exitableEpoch > exitInfo.HighestExitEpoch {
+			exitInfo.HighestExitEpoch = exitableEpoch
+			exitInfo.Churn = 0
 		}
 		activeValidatorCount, err := helpers.ActiveValidatorCount(ctx, s, time.CurrentEpoch(s))
 		if err != nil {
@@ -106,33 +105,33 @@ func InitiateValidatorExit(
 		}
 		currentChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 
-		if exitData.Churn >= currentChurn {
-			exitData.MaxExitEpoch, err = exitData.MaxExitEpoch.SafeAdd(1)
+		if exitInfo.Churn >= currentChurn {
+			exitInfo.HighestExitEpoch, err = exitInfo.HighestExitEpoch.SafeAdd(1)
 			if err != nil {
 				return nil, 0, err
 			}
-			exitData.Churn = 1
+			exitInfo.Churn = 1
 		} else {
-			exitData.Churn = exitData.Churn + 1
+			exitInfo.Churn = exitInfo.Churn + 1
 		}
 	} else {
 		// [Modified in Electra:EIP7251]
 		// exit_queue_epoch = compute_exit_epoch_and_update_churn(state, validator.effective_balance)
 		var err error
-		exitData.MaxExitEpoch, err = s.ExitEpochAndUpdateChurn(primitives.Gwei(validator.EffectiveBalance))
+		exitInfo.HighestExitEpoch, err = s.ExitEpochAndUpdateChurn(primitives.Gwei(validator.EffectiveBalance))
 		if err != nil {
 			return nil, 0, err
 		}
 	}
-	validator.ExitEpoch = exitData.MaxExitEpoch
-	validator.WithdrawableEpoch, err = exitData.MaxExitEpoch.SafeAddEpoch(params.BeaconConfig().MinValidatorWithdrawabilityDelay)
+	validator.ExitEpoch = exitInfo.HighestExitEpoch
+	validator.WithdrawableEpoch, err = exitInfo.HighestExitEpoch.SafeAddEpoch(params.BeaconConfig().MinValidatorWithdrawabilityDelay)
 	if err != nil {
 		return nil, 0, err
 	}
 	if err := s.UpdateValidatorAtIndex(idx, validator); err != nil {
 		return nil, 0, err
 	}
-	return s, exitData.MaxExitEpoch, nil
+	return s, exitInfo.HighestExitEpoch, nil
 }
 
 // SlashValidator slashes the malicious validator's balance and awards
@@ -169,22 +168,23 @@ func SlashValidator(
 	ctx context.Context,
 	s state.BeaconState,
 	slashedIdx primitives.ValidatorIndex,
-	exitData *ExitData) (state.BeaconState, error) {
-	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, exitData)
+	exitInfo *ExitInfo,
+) (state.BeaconState, *ExitInfo, error) {
+	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, exitInfo)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
-		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
+		return nil, nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
 	}
 	currentEpoch := slots.ToEpoch(s.Slot())
 	validator, err := s.ValidatorAtIndex(slashedIdx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	validator.Slashed = true
 	maxWithdrawableEpoch := primitives.MaxEpoch(validator.WithdrawableEpoch, currentEpoch+params.BeaconConfig().EpochsPerSlashingsVector)
 	validator.WithdrawableEpoch = maxWithdrawableEpoch
 
 	if err := s.UpdateValidatorAtIndex(slashedIdx, validator); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// The slashing amount is represented by epochs per slashing vector. The validator's effective balance is then applied to that amount.
@@ -194,42 +194,42 @@ func SlashValidator(
 		uint64(currentEpoch%params.BeaconConfig().EpochsPerSlashingsVector),
 		currentSlashing+validator.EffectiveBalance,
 	); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	slashingQuotient, proposerRewardQuotient, whistleblowerRewardQuotient, err := SlashingParamsPerVersion(s.Version())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get slashing parameters per version")
+		return nil, nil, errors.Wrap(err, "could not get slashing parameters per version")
 	}
 
 	slashingPenalty, err := math.Div64(validator.EffectiveBalance, slashingQuotient)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to compute slashing slashingPenalty")
+		return nil, nil, errors.Wrap(err, "failed to compute slashing slashingPenalty")
 	}
 	if err := helpers.DecreaseBalance(s, slashedIdx, slashingPenalty); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	proposerIdx, err := helpers.BeaconProposerIndex(ctx, s)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get proposer idx")
+		return nil, nil, errors.Wrap(err, "could not get proposer idx")
 	}
 	whistleBlowerIdx := proposerIdx
 	whistleblowerReward, err := math.Div64(validator.EffectiveBalance, whistleblowerRewardQuotient)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to compute whistleblowerReward")
+		return nil, nil, errors.Wrap(err, "failed to compute whistleblowerReward")
 	}
 	proposerReward, err := math.Div64(whistleblowerReward, proposerRewardQuotient)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to compute proposer reward")
+		return nil, nil, errors.Wrap(err, "failed to compute proposer reward")
 	}
 	if err := helpers.IncreaseBalance(s, proposerIdx, proposerReward); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := helpers.IncreaseBalance(s, whistleBlowerIdx, whistleblowerReward-proposerReward); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s, nil
+	return s, exitInfo, nil
 }
 
 // ActivatedValidatorIndices determines the indices activated during the given epoch.

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -87,32 +87,8 @@ func InitiateValidatorExit(
 
 	// Compute exit queue epoch.
 	if s.Version() < version.Electra {
-		// Relevant spec code from phase0:
-		//
-		//	exit_epochs = [v.exit_epoch for v in state.validators if v.exit_epoch != FAR_FUTURE_EPOCH]
-		//	exit_queue_epoch = max(exit_epochs + [compute_activation_exit_epoch(get_current_epoch(state))])
-		//	exit_queue_churn = len([v for v in state.validators if v.exit_epoch == exit_queue_epoch])
-		//	if exit_queue_churn >= get_validator_churn_limit(state):
-		//	    exit_queue_epoch += Epoch(1)
-		exitableEpoch := helpers.ActivationExitEpoch(time.CurrentEpoch(s))
-		if exitableEpoch > exitInfo.HighestExitEpoch {
-			exitInfo.HighestExitEpoch = exitableEpoch
-			exitInfo.Churn = 0
-		}
-		activeValidatorCount, err := helpers.ActiveValidatorCount(ctx, s, time.CurrentEpoch(s))
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get active validator count")
-		}
-		currentChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
-
-		if exitInfo.Churn >= currentChurn {
-			exitInfo.HighestExitEpoch, err = exitInfo.HighestExitEpoch.SafeAdd(1)
-			if err != nil {
-				return nil, err
-			}
-			exitInfo.Churn = 1
-		} else {
-			exitInfo.Churn = exitInfo.Churn + 1
+		if err = initiateValidatorExitPreElectra(ctx, s, exitInfo); err != nil {
+			return nil, err
 		}
 	} else {
 		// [Modified in Electra:EIP7251]
@@ -132,6 +108,80 @@ func InitiateValidatorExit(
 		return nil, err
 	}
 	return s, nil
+}
+
+// InitiateValidatorExitForTotalBal has the same functionality as InitiateValidatorExit,
+// the only difference being how total active balance is obtained. In InitiateValidatorExit
+// it is calculated inside the function and in InitiateValidatorExitForTotalBal it's a
+// function argument.
+func InitiateValidatorExitForTotalBal(
+	ctx context.Context,
+	s state.BeaconState,
+	idx primitives.ValidatorIndex,
+	exitInfo *ExitInfo,
+	totalActiveBalance primitives.Gwei,
+) (state.BeaconState, error) {
+	validator, err := s.ValidatorAtIndex(idx)
+	if err != nil {
+		return nil, err
+	}
+	if validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
+		return s, ErrValidatorAlreadyExited
+	}
+
+	// Compute exit queue epoch.
+	if s.Version() < version.Electra {
+		if err = initiateValidatorExitPreElectra(ctx, s, exitInfo); err != nil {
+			return nil, err
+		}
+	} else {
+		// [Modified in Electra:EIP7251]
+		// exit_queue_epoch = compute_exit_epoch_and_update_churn(state, validator.effective_balance)
+		var err error
+		exitInfo.HighestExitEpoch, err = s.ExitEpochAndUpdateChurnForTotalBal(totalActiveBalance, primitives.Gwei(validator.EffectiveBalance))
+		if err != nil {
+			return nil, err
+		}
+	}
+	validator.ExitEpoch = exitInfo.HighestExitEpoch
+	validator.WithdrawableEpoch, err = exitInfo.HighestExitEpoch.SafeAddEpoch(params.BeaconConfig().MinValidatorWithdrawabilityDelay)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.UpdateValidatorAtIndex(idx, validator); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func initiateValidatorExitPreElectra(ctx context.Context, s state.BeaconState, exitInfo *ExitInfo) error {
+	// Relevant spec code from phase0:
+	//
+	//	exit_epochs = [v.exit_epoch for v in state.validators if v.exit_epoch != FAR_FUTURE_EPOCH]
+	//	exit_queue_epoch = max(exit_epochs + [compute_activation_exit_epoch(get_current_epoch(state))])
+	//	exit_queue_churn = len([v for v in state.validators if v.exit_epoch == exit_queue_epoch])
+	//	if exit_queue_churn >= get_validator_churn_limit(state):
+	//	    exit_queue_epoch += Epoch(1)
+	exitableEpoch := helpers.ActivationExitEpoch(time.CurrentEpoch(s))
+	if exitableEpoch > exitInfo.HighestExitEpoch {
+		exitInfo.HighestExitEpoch = exitableEpoch
+		exitInfo.Churn = 0
+	}
+	activeValidatorCount, err := helpers.ActiveValidatorCount(ctx, s, time.CurrentEpoch(s))
+	if err != nil {
+		return errors.Wrap(err, "could not get active validator count")
+	}
+	currentChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
+	if exitInfo.Churn >= currentChurn {
+		exitInfo.HighestExitEpoch, err = exitInfo.HighestExitEpoch.SafeAdd(1)
+		if err != nil {
+			return err
+		}
+		exitInfo.Churn = 1
+	} else {
+		exitInfo.Churn = exitInfo.Churn + 1
+	}
+	return nil
 }
 
 // SlashValidator slashes the malicious validator's balance and awards
@@ -169,10 +219,11 @@ func SlashValidator(
 	s state.BeaconState,
 	slashedIdx primitives.ValidatorIndex,
 	exitInfo *ExitInfo,
+	totalActiveBalance primitives.Gwei,
 ) (state.BeaconState, error) {
 	var err error
 
-	s, err = InitiateValidatorExit(ctx, s, slashedIdx, exitInfo)
+	s, err = InitiateValidatorExitForTotalBal(ctx, s, slashedIdx, exitInfo, totalActiveBalance)
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
 	}

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -50,10 +50,10 @@ func TestInitiateValidatorExit_AlreadyExited(t *testing.T) {
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
 	exitInfo := &validators.ExitInfo{HighestExitEpoch: 199, Churn: 1}
-	newState, newExitInfo, err := validators.InitiateValidatorExit(t.Context(), state, 0, exitInfo)
+	newState, err := validators.InitiateValidatorExit(t.Context(), state, 0, exitInfo)
 	require.ErrorIs(t, err, validators.ErrValidatorAlreadyExited)
-	assert.Equal(t, primitives.Epoch(199), newExitInfo.HighestExitEpoch)
-	assert.Equal(t, uint64(1), newExitInfo.Churn)
+	assert.Equal(t, primitives.Epoch(199), exitInfo.HighestExitEpoch)
+	assert.Equal(t, uint64(1), exitInfo.Churn)
 	v, err := newState.ValidatorAtIndex(0)
 	require.NoError(t, err)
 	assert.Equal(t, exitEpoch, v.ExitEpoch, "Already exited")
@@ -71,10 +71,10 @@ func TestInitiateValidatorExit_ProperExit(t *testing.T) {
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
 	exitInfo := &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 1}
-	newState, newExitInfo, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitInfo)
+	newState, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitInfo)
 	require.NoError(t, err)
-	assert.Equal(t, exitedEpoch+2, newExitInfo.HighestExitEpoch)
-	assert.Equal(t, uint64(2), newExitInfo.Churn)
+	assert.Equal(t, exitedEpoch+2, exitInfo.HighestExitEpoch)
+	assert.Equal(t, uint64(2), exitInfo.Churn)
 	v, err := newState.ValidatorAtIndex(idx)
 	require.NoError(t, err)
 	assert.Equal(t, exitedEpoch+2, v.ExitEpoch, "Exit epoch was not the highest")
@@ -93,10 +93,10 @@ func TestInitiateValidatorExit_ChurnOverflow(t *testing.T) {
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
 	exitInfo := &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 4}
-	newState, newExitInfo, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitInfo)
+	newState, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitInfo)
 	require.NoError(t, err)
-	assert.Equal(t, exitedEpoch+3, newExitInfo.HighestExitEpoch)
-	assert.Equal(t, uint64(1), newExitInfo.Churn)
+	assert.Equal(t, exitedEpoch+3, exitInfo.HighestExitEpoch)
+	assert.Equal(t, uint64(1), exitInfo.Churn)
 
 	// Because of exit queue overflow,
 	// validator who init exited has to wait one more epoch.
@@ -117,7 +117,7 @@ func TestInitiateValidatorExit_WithdrawalOverflows(t *testing.T) {
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
 	exitInfo := &validators.ExitInfo{HighestExitEpoch: params.BeaconConfig().FarFutureEpoch - 1, Churn: 1}
-	_, _, err = validators.InitiateValidatorExit(t.Context(), state, 1, exitInfo)
+	_, err = validators.InitiateValidatorExit(t.Context(), state, 1, exitInfo)
 	require.ErrorContains(t, "addition overflows", err)
 }
 
@@ -153,7 +153,7 @@ func TestInitiateValidatorExit_ProperExit_Electra(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, primitives.Gwei(0), ebtc)
 
-	newState, _, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{}) // exit info is not used in electra
+	newState, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{}) // exit info is not used in electra
 	require.NoError(t, err)
 
 	// Expect that the exit epoch is the next available epoch with max seed lookahead.
@@ -196,7 +196,7 @@ func TestSlashValidator_OK(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, _, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Phase0)
 
@@ -250,7 +250,7 @@ func TestSlashValidator_Electra(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, _, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Electra)
 

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -196,9 +196,7 @@ func TestSlashValidator_OK(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	activeBal, err := helpers.TotalActiveBalance(state)
-	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state), primitives.Gwei(activeBal))
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Phase0)
 
@@ -252,9 +250,7 @@ func TestSlashValidator_Electra(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	activeBal, err := helpers.TotalActiveBalance(state)
-	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state), primitives.Gwei(activeBal))
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Electra)
 

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -49,7 +49,7 @@ func TestInitiateValidatorExit_AlreadyExited(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, 0, &validators.ExitData{MaxExitEpoch: 199, Churn: 1})
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, 0, &validators.ExitInfo{HighestExitEpoch: 199, Churn: 1})
 	require.ErrorIs(t, err, validators.ErrValidatorAlreadyExited)
 	require.Equal(t, exitEpoch, epoch)
 	v, err := newState.ValidatorAtIndex(0)
@@ -68,7 +68,7 @@ func TestInitiateValidatorExit_ProperExit(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitData{MaxExitEpoch: exitedEpoch + 2, Churn: 1})
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 1})
 	require.NoError(t, err)
 	require.Equal(t, exitedEpoch+2, epoch)
 	v, err := newState.ValidatorAtIndex(idx)
@@ -88,7 +88,7 @@ func TestInitiateValidatorExit_ChurnOverflow(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitData{MaxExitEpoch: exitedEpoch + 2, Churn: 4})
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 4})
 	require.NoError(t, err)
 	require.Equal(t, exitedEpoch+3, epoch)
 
@@ -110,7 +110,7 @@ func TestInitiateValidatorExit_WithdrawalOverflows(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	_, _, err = validators.InitiateValidatorExit(t.Context(), state, 1, &validators.ExitData{MaxExitEpoch: params.BeaconConfig().FarFutureEpoch - 1, Churn: 1})
+	_, _, err = validators.InitiateValidatorExit(t.Context(), state, 1, &validators.ExitInfo{HighestExitEpoch: params.BeaconConfig().FarFutureEpoch - 1, Churn: 1})
 	require.ErrorContains(t, "addition overflows", err)
 }
 
@@ -146,7 +146,7 @@ func TestInitiateValidatorExit_ProperExit_Electra(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, primitives.Gwei(0), ebtc)
 
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitData{}) // exitQueueEpoch and churn are not used in electra
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{}) // exitQueueEpoch and churn are not used in electra
 	require.NoError(t, err)
 
 	// Expect that the exit epoch is the next available epoch with max seed lookahead.
@@ -190,7 +190,7 @@ func TestSlashValidator_OK(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.MaxExitEpochAndChurn(state))
+	slashedState, _, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Phase0)
 
@@ -244,7 +244,7 @@ func TestSlashValidator_Electra(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.MaxExitEpochAndChurn(state))
+	slashedState, _, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Electra)
 
@@ -505,8 +505,8 @@ func TestValidatorMaxExitEpochAndChurn(t *testing.T) {
 	for _, tt := range tests {
 		s, err := state_native.InitializeFromProtoPhase0(tt.state)
 		require.NoError(t, err)
-		exitData := validators.MaxExitEpochAndChurn(s)
-		require.Equal(t, tt.wantedEpoch, exitData.MaxExitEpoch)
-		require.Equal(t, tt.wantedChurn, exitData.Churn)
+		exitInfo := validators.ExitInformation(s)
+		require.Equal(t, tt.wantedEpoch, exitInfo.HighestExitEpoch)
+		require.Equal(t, tt.wantedChurn, exitInfo.Churn)
 	}
 }

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -49,9 +49,11 @@ func TestInitiateValidatorExit_AlreadyExited(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, 0, &validators.ExitInfo{HighestExitEpoch: 199, Churn: 1})
+	exitInfo := &validators.ExitInfo{HighestExitEpoch: 199, Churn: 1}
+	newState, newExitInfo, err := validators.InitiateValidatorExit(t.Context(), state, 0, exitInfo)
 	require.ErrorIs(t, err, validators.ErrValidatorAlreadyExited)
-	require.Equal(t, exitEpoch, epoch)
+	assert.Equal(t, primitives.Epoch(199), newExitInfo.HighestExitEpoch)
+	assert.Equal(t, uint64(1), newExitInfo.Churn)
 	v, err := newState.ValidatorAtIndex(0)
 	require.NoError(t, err)
 	assert.Equal(t, exitEpoch, v.ExitEpoch, "Already exited")
@@ -68,9 +70,11 @@ func TestInitiateValidatorExit_ProperExit(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 1})
+	exitInfo := &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 1}
+	newState, newExitInfo, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitInfo)
 	require.NoError(t, err)
-	require.Equal(t, exitedEpoch+2, epoch)
+	assert.Equal(t, exitedEpoch+2, newExitInfo.HighestExitEpoch)
+	assert.Equal(t, uint64(2), newExitInfo.Churn)
 	v, err := newState.ValidatorAtIndex(idx)
 	require.NoError(t, err)
 	assert.Equal(t, exitedEpoch+2, v.ExitEpoch, "Exit epoch was not the highest")
@@ -88,9 +92,11 @@ func TestInitiateValidatorExit_ChurnOverflow(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 4})
+	exitInfo := &validators.ExitInfo{HighestExitEpoch: exitedEpoch + 2, Churn: 4}
+	newState, newExitInfo, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitInfo)
 	require.NoError(t, err)
-	require.Equal(t, exitedEpoch+3, epoch)
+	assert.Equal(t, exitedEpoch+3, newExitInfo.HighestExitEpoch)
+	assert.Equal(t, uint64(1), newExitInfo.Churn)
 
 	// Because of exit queue overflow,
 	// validator who init exited has to wait one more epoch.
@@ -110,7 +116,8 @@ func TestInitiateValidatorExit_WithdrawalOverflows(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	_, _, err = validators.InitiateValidatorExit(t.Context(), state, 1, &validators.ExitInfo{HighestExitEpoch: params.BeaconConfig().FarFutureEpoch - 1, Churn: 1})
+	exitInfo := &validators.ExitInfo{HighestExitEpoch: params.BeaconConfig().FarFutureEpoch - 1, Churn: 1}
+	_, _, err = validators.InitiateValidatorExit(t.Context(), state, 1, exitInfo)
 	require.ErrorContains(t, "addition overflows", err)
 }
 
@@ -146,12 +153,11 @@ func TestInitiateValidatorExit_ProperExit_Electra(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, primitives.Gwei(0), ebtc)
 
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{}) // exitQueueEpoch and churn are not used in electra
+	newState, _, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitInfo{}) // exit info is not used in electra
 	require.NoError(t, err)
 
 	// Expect that the exit epoch is the next available epoch with max seed lookahead.
 	want := helpers.ActivationExitEpoch(exitedEpoch + 1)
-	require.Equal(t, want, epoch)
 	v, err := newState.ValidatorAtIndex(idx)
 	require.NoError(t, err)
 	assert.Equal(t, want, v.ExitEpoch, "Exit epoch was not the highest")

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -190,7 +190,8 @@ func TestSlashValidator_OK(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx)
+	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(state)
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, maxExitEpoch, churn)
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Phase0)
 
@@ -244,7 +245,8 @@ func TestSlashValidator_Electra(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx)
+	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(state)
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, maxExitEpoch, churn)
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Electra)
 

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -196,7 +196,9 @@ func TestSlashValidator_OK(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
+	activeBal, err := helpers.TotalActiveBalance(state)
+	require.NoError(t, err)
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state), primitives.Gwei(activeBal))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Phase0)
 
@@ -250,7 +252,9 @@ func TestSlashValidator_Electra(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state))
+	activeBal, err := helpers.TotalActiveBalance(state)
+	require.NoError(t, err)
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.ExitInformation(state), primitives.Gwei(activeBal))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Electra)
 

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -49,7 +49,7 @@ func TestInitiateValidatorExit_AlreadyExited(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, 0, 199, 1)
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, 0, &validators.ExitData{MaxExitEpoch: 199, Churn: 1})
 	require.ErrorIs(t, err, validators.ErrValidatorAlreadyExited)
 	require.Equal(t, exitEpoch, epoch)
 	v, err := newState.ValidatorAtIndex(0)
@@ -68,7 +68,7 @@ func TestInitiateValidatorExit_ProperExit(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitedEpoch+2, 1)
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitData{MaxExitEpoch: exitedEpoch + 2, Churn: 1})
 	require.NoError(t, err)
 	require.Equal(t, exitedEpoch+2, epoch)
 	v, err := newState.ValidatorAtIndex(idx)
@@ -88,7 +88,7 @@ func TestInitiateValidatorExit_ChurnOverflow(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, exitedEpoch+2, 4)
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitData{MaxExitEpoch: exitedEpoch + 2, Churn: 4})
 	require.NoError(t, err)
 	require.Equal(t, exitedEpoch+3, epoch)
 
@@ -110,7 +110,7 @@ func TestInitiateValidatorExit_WithdrawalOverflows(t *testing.T) {
 	}}
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	_, _, err = validators.InitiateValidatorExit(t.Context(), state, 1, params.BeaconConfig().FarFutureEpoch-1, 1)
+	_, _, err = validators.InitiateValidatorExit(t.Context(), state, 1, &validators.ExitData{MaxExitEpoch: params.BeaconConfig().FarFutureEpoch - 1, Churn: 1})
 	require.ErrorContains(t, "addition overflows", err)
 }
 
@@ -146,7 +146,7 @@ func TestInitiateValidatorExit_ProperExit_Electra(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, primitives.Gwei(0), ebtc)
 
-	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, 0, 0) // exitQueueEpoch and churn are not used in electra
+	newState, epoch, err := validators.InitiateValidatorExit(t.Context(), state, idx, &validators.ExitData{}) // exitQueueEpoch and churn are not used in electra
 	require.NoError(t, err)
 
 	// Expect that the exit epoch is the next available epoch with max seed lookahead.
@@ -190,8 +190,7 @@ func TestSlashValidator_OK(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(state)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, maxExitEpoch, churn)
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.MaxExitEpochAndChurn(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Phase0)
 
@@ -245,8 +244,7 @@ func TestSlashValidator_Electra(t *testing.T) {
 	require.NoError(t, err, "Could not get proposer")
 	proposerBal, err := state.BalanceAtIndex(proposer)
 	require.NoError(t, err)
-	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(state)
-	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, maxExitEpoch, churn)
+	slashedState, err := validators.SlashValidator(t.Context(), state, slashedIdx, validators.MaxExitEpochAndChurn(state))
 	require.NoError(t, err, "Could not slash validator")
 	require.Equal(t, true, slashedState.Version() == version.Electra)
 
@@ -507,8 +505,8 @@ func TestValidatorMaxExitEpochAndChurn(t *testing.T) {
 	for _, tt := range tests {
 		s, err := state_native.InitializeFromProtoPhase0(tt.state)
 		require.NoError(t, err)
-		epoch, churn := validators.MaxExitEpochAndChurn(s)
-		require.Equal(t, tt.wantedEpoch, epoch)
-		require.Equal(t, tt.wantedChurn, churn)
+		exitData := validators.MaxExitEpochAndChurn(s)
+		require.Equal(t, tt.wantedEpoch, exitData.MaxExitEpoch)
+		require.Equal(t, tt.wantedChurn, exitData.Churn)
 	}
 }

--- a/beacon-chain/rpc/eth/rewards/BUILD.bazel
+++ b/beacon-chain/rpc/eth/rewards/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/epoch/precompute:go_default_library",
-        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/db:go_default_library",

--- a/beacon-chain/rpc/eth/rewards/BUILD.bazel
+++ b/beacon-chain/rpc/eth/rewards/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/epoch/precompute:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/db:go_default_library",

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -68,8 +68,8 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(st)
-	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, maxExitEpoch, churn)
+	exitData := validators.MaxExitEpochAndChurn(st)
+	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitData)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get attester slashing rewards: " + err.Error(),
@@ -83,7 +83,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, maxExitEpoch, churn)
+	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitData)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get proposer slashing rewards: " + err.Error(),

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -69,7 +69,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 		}
 	}
 	exitInfo := validators.ExitInformation(st)
-	st, exitInfo, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitInfo)
+	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get attester slashing rewards: " + err.Error(),
@@ -83,7 +83,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, _, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitInfo)
+	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get proposer slashing rewards: " + err.Error(),

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -78,7 +78,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get attester slashing rewards: " + err.Error(),
@@ -92,7 +92,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get proposer slashing rewards: " + err.Error(),

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/api/server/structs"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/altair"
 	coreblocks "github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db"
@@ -16,7 +15,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stategen"
 	consensusblocks "github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/network/httputil"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 )
@@ -71,14 +69,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 		}
 	}
 	exitInfo := validators.ExitInformation(st)
-	activeBal, err := helpers.TotalActiveBalance(st)
-	if err != nil {
-		return nil, &httputil.DefaultJsonError{
-			Message: "Could not get total active balance: " + err.Error(),
-			Code:    http.StatusInternalServerError,
-		}
-	}
-	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), exitInfo)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get attester slashing rewards: " + err.Error(),
@@ -92,7 +83,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), exitInfo, primitives.Gwei(activeBal))
+	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), exitInfo)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get proposer slashing rewards: " + err.Error(),

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -68,8 +68,8 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	exitData := validators.MaxExitEpochAndChurn(st)
-	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitData)
+	exitInfo := validators.ExitInformation(st)
+	st, exitInfo, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get attester slashing rewards: " + err.Error(),
@@ -83,7 +83,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitData)
+	st, _, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitInfo)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get proposer slashing rewards: " + err.Error(),

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -68,7 +68,8 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator)
+	maxExitEpoch, churn := validators.MaxExitEpochAndChurn(st)
+	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get attester slashing rewards: " + err.Error(),
@@ -82,7 +83,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator)
+	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, maxExitEpoch, churn)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get proposer slashing rewards: " + err.Error(),

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/api/server/structs"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/altair"
 	coreblocks "github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db"
@@ -15,6 +16,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stategen"
 	consensusblocks "github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/network/httputil"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 )
@@ -69,7 +71,14 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 		}
 	}
 	exitInfo := validators.ExitInformation(st)
-	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitInfo)
+	activeBal, err := helpers.TotalActiveBalance(st)
+	if err != nil {
+		return nil, &httputil.DefaultJsonError{
+			Message: "Could not get total active balance: " + err.Error(),
+			Code:    http.StatusInternalServerError,
+		}
+	}
+	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), validators.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get attester slashing rewards: " + err.Error(),
@@ -83,7 +92,7 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitInfo)
+	st, err = coreblocks.ProcessProposerSlashings(ctx, st, blk.Body().ProposerSlashings(), validators.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{
 			Message: "Could not get proposer slashing rewards: " + err.Error(),

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -17,10 +17,10 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 		return []*ethpb.ProposerSlashing{}, []ethpb.AttSlashing{}
 	}
 
-	exitData := v.MaxExitEpochAndChurn(head)
+	exitInfo := v.ExitInformation(head)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, err := blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitData)
+		_, _, err := blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
@@ -29,7 +29,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	}
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, err := blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitData)
+		_, _, err := blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -15,9 +15,9 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	var err error
 
 	exitInfo := v.ExitInformation(head)
-	activeBal, err := helpers.TotalActiveBalance(head)
-	if err != nil {
-		log.WithError(err).Warn("Could not get total active balance")
+	activeBal := exitInfo.TotalActiveBalance
+	if err := helpers.UpdateTotalActiveBalanceCache(head, activeBal); err != nil {
+		log.WithError(err).Warn("Could not update total active balance cache")
 	}
 	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -7,7 +7,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 )
 
@@ -15,14 +14,13 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	var err error
 
 	exitInfo := v.ExitInformation(head)
-	activeBal := exitInfo.TotalActiveBalance
-	if err := helpers.UpdateTotalActiveBalanceCache(head, activeBal); err != nil {
+	if err := helpers.UpdateTotalActiveBalanceCache(head, exitInfo.TotalActiveBalance); err != nil {
 		log.WithError(err).Warn("Could not update total active balance cache")
 	}
 	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, err = blocks.ProcessProposerSlashing(ctx, head, slashing, exitInfo, primitives.Gwei(activeBal))
+		_, err = blocks.ProcessProposerSlashing(ctx, head, slashing, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
@@ -32,7 +30,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, exitInfo, primitives.Gwei(activeBal))
+		_, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 )
 
@@ -13,10 +15,14 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	var err error
 
 	exitInfo := v.ExitInformation(head)
+	activeBal, err := helpers.TotalActiveBalance(head)
+	if err != nil {
+		log.WithError(err).Warn("Could not get total active balance")
+	}
 	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, err = blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
+		_, err = blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
@@ -26,7 +32,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
+		_, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -16,7 +16,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, exitInfo, err = blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
+		_, err = blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
@@ -26,7 +26,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, exitInfo, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
+		_, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -10,26 +10,23 @@ import (
 )
 
 func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*ethpb.ProposerSlashing, []ethpb.AttSlashing) {
-	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
-	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
-
-	if len(proposerSlashings) == 0 && len(attSlashings) == 0 {
-		return []*ethpb.ProposerSlashing{}, []ethpb.AttSlashing{}
-	}
+	var err error
 
 	exitInfo := v.ExitInformation(head)
+	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, _, err := blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
+		_, exitInfo, err = blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
 		}
 		validProposerSlashings = append(validProposerSlashings, slashing)
 	}
+	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, _, err := blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
+		_, exitInfo, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -22,7 +22,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, err = blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+		_, err = blocks.ProcessProposerSlashing(ctx, head, slashing, exitInfo, primitives.Gwei(activeBal))
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
@@ -32,7 +32,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitInfo, primitives.Gwei(activeBal))
+		_, err = blocks.ProcessAttesterSlashing(ctx, head, slashing, exitInfo, primitives.Gwei(activeBal))
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -11,19 +11,26 @@ import (
 
 func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*ethpb.ProposerSlashing, []ethpb.AttSlashing) {
 	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
+	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
+	var maxExitEpoch types.Epoch
+	var churn uint64
+
+	if len(proposerSlashings) >= 0 || len(attSlashings) >= 0 {
+		maxExitEpoch, churn = v.MaxExitEpochAndChurn(head)
+	}
+
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, err := blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator)
+		_, err := blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, maxExitEpoch, churn)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
 		}
 		validProposerSlashings = append(validProposerSlashings, slashing)
 	}
-	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, err := blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator)
+		_, err := blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, maxExitEpoch, churn)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_slashings.go
@@ -12,16 +12,15 @@ import (
 func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*ethpb.ProposerSlashing, []ethpb.AttSlashing) {
 	proposerSlashings := vs.SlashingsPool.PendingProposerSlashings(ctx, head, false /*noLimit*/)
 	attSlashings := vs.SlashingsPool.PendingAttesterSlashings(ctx, head, false /*noLimit*/)
-	var maxExitEpoch types.Epoch
-	var churn uint64
 
-	if len(proposerSlashings) >= 0 || len(attSlashings) >= 0 {
-		maxExitEpoch, churn = v.MaxExitEpochAndChurn(head)
+	if len(proposerSlashings) == 0 && len(attSlashings) == 0 {
+		return []*ethpb.ProposerSlashing{}, []ethpb.AttSlashing{}
 	}
 
+	exitData := v.MaxExitEpochAndChurn(head)
 	validProposerSlashings := make([]*ethpb.ProposerSlashing, 0, len(proposerSlashings))
 	for _, slashing := range proposerSlashings {
-		_, err := blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, maxExitEpoch, churn)
+		_, err := blocks.ProcessProposerSlashing(ctx, head, slashing, v.SlashValidator, exitData)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate proposer slashing for block inclusion")
 			continue
@@ -30,7 +29,7 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	}
 	validAttSlashings := make([]ethpb.AttSlashing, 0, len(attSlashings))
 	for _, slashing := range attSlashings {
-		_, err := blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, maxExitEpoch, churn)
+		_, err := blocks.ProcessAttesterSlashing(ctx, head, slashing, v.SlashValidator, exitData)
 		if err != nil {
 			log.WithError(err).Warn("Could not validate attester slashing for block inclusion")
 			continue

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -265,6 +265,7 @@ type WriteOnlyEth1Data interface {
 	AppendEth1DataVotes(val *ethpb.Eth1Data) error
 	SetEth1DepositIndex(val uint64) error
 	ExitEpochAndUpdateChurn(exitBalance primitives.Gwei) (primitives.Epoch, error)
+	ExitEpochAndUpdateChurnForTotalBal(totalActiveBalance primitives.Gwei, exitBalance primitives.Gwei) (primitives.Epoch, error)
 }
 
 // WriteOnlyValidators defines a struct which only has write access to validators methods.

--- a/changelog/radek_fix-max-epoch-calculation-once.md
+++ b/changelog/radek_fix-max-epoch-calculation-once.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Call `MaxExitEpochAndChurn` just once before processing any slashings to reduce CPU load.

--- a/changelog/radek_fix-max-epoch-calculation-once.md
+++ b/changelog/radek_fix-max-epoch-calculation-once.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- Call `MaxExitEpochAndChurn` just once before processing any slashings to reduce CPU load.
+- Pre-calculate exit epoch, churn and active balance before processing slashings to reduce CPU load.

--- a/runtime/logging/logrus-prefixed-formatter/README.md
+++ b/runtime/logging/logrus-prefixed-formatter/README.md
@@ -35,8 +35,8 @@ Here is how it should be used:
 package main
 
 import (
-	"github.com/sirupsen/logrus"
 	prefixed "github.com/prysmaticlabs/prysm/runtime/logging/logrus-prefixed-formatter"
+	"github.com/sirupsen/logrus"
 )
 
 var log = logrus.New()

--- a/testing/spectest/shared/common/operations/BUILD.bazel
+++ b/testing/spectest/shared/common/operations/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
-        "//consensus-types/primitives:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",

--- a/testing/spectest/shared/common/operations/BUILD.bazel
+++ b/testing/spectest/shared/common/operations/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",

--- a/testing/spectest/shared/common/operations/attester_slashing.go
+++ b/testing/spectest/shared/common/operations/attester_slashing.go
@@ -5,20 +5,13 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
-	"github.com/pkg/errors"
 )
 
 func RunAttesterSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "attester_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		activeBal, err := helpers.TotalActiveBalance(s)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get total active balance")
-		}
-		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.ExitInformation(s), primitives.Gwei(activeBal))
+		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.ExitInformation(s))
 	})
 }

--- a/testing/spectest/shared/common/operations/attester_slashing.go
+++ b/testing/spectest/shared/common/operations/attester_slashing.go
@@ -19,6 +19,6 @@ func RunAttesterSlashingTest(t *testing.T, config string, fork string, block blo
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get total active balance")
 		}
-		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
+		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.ExitInformation(s), primitives.Gwei(activeBal))
 	})
 }

--- a/testing/spectest/shared/common/operations/attester_slashing.go
+++ b/testing/spectest/shared/common/operations/attester_slashing.go
@@ -5,13 +5,20 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
+	"github.com/pkg/errors"
 )
 
 func RunAttesterSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "attester_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.ExitInformation(s))
+		activeBal, err := helpers.TotalActiveBalance(s)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get total active balance")
+		}
+		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
 	})
 }

--- a/testing/spectest/shared/common/operations/attester_slashing.go
+++ b/testing/spectest/shared/common/operations/attester_slashing.go
@@ -12,7 +12,6 @@ import (
 
 func RunAttesterSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "attester_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		st, _, err := blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.ExitInformation(s))
-		return st, err
+		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.ExitInformation(s))
 	})
 }

--- a/testing/spectest/shared/common/operations/attester_slashing.go
+++ b/testing/spectest/shared/common/operations/attester_slashing.go
@@ -12,6 +12,7 @@ import (
 
 func RunAttesterSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "attester_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.MaxExitEpochAndChurn(s))
+		st, _, err := blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.ExitInformation(s))
+		return st, err
 	})
 }

--- a/testing/spectest/shared/common/operations/attester_slashing.go
+++ b/testing/spectest/shared/common/operations/attester_slashing.go
@@ -12,7 +12,6 @@ import (
 
 func RunAttesterSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "attester_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
-		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
+		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, v.MaxExitEpochAndChurn(s))
 	})
 }

--- a/testing/spectest/shared/common/operations/attester_slashing.go
+++ b/testing/spectest/shared/common/operations/attester_slashing.go
@@ -12,6 +12,7 @@ import (
 
 func RunAttesterSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "attester_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator)
+		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
+		return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	})
 }

--- a/testing/spectest/shared/common/operations/proposer_slashing.go
+++ b/testing/spectest/shared/common/operations/proposer_slashing.go
@@ -12,7 +12,6 @@ import (
 
 func RunProposerSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "proposer_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		st, _, err := blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.ExitInformation(s))
-		return st, err
+		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.ExitInformation(s))
 	})
 }

--- a/testing/spectest/shared/common/operations/proposer_slashing.go
+++ b/testing/spectest/shared/common/operations/proposer_slashing.go
@@ -12,6 +12,7 @@ import (
 
 func RunProposerSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "proposer_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator)
+		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
+		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
 	})
 }

--- a/testing/spectest/shared/common/operations/proposer_slashing.go
+++ b/testing/spectest/shared/common/operations/proposer_slashing.go
@@ -12,6 +12,7 @@ import (
 
 func RunProposerSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "proposer_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.MaxExitEpochAndChurn(s))
+		st, _, err := blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.ExitInformation(s))
+		return st, err
 	})
 }

--- a/testing/spectest/shared/common/operations/proposer_slashing.go
+++ b/testing/spectest/shared/common/operations/proposer_slashing.go
@@ -19,6 +19,6 @@ func RunProposerSlashingTest(t *testing.T, config string, fork string, block blo
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get total active balance")
 		}
-		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
+		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.ExitInformation(s), primitives.Gwei(activeBal))
 	})
 }

--- a/testing/spectest/shared/common/operations/proposer_slashing.go
+++ b/testing/spectest/shared/common/operations/proposer_slashing.go
@@ -12,7 +12,6 @@ import (
 
 func RunProposerSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "proposer_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		maxExitEpoch, churn := v.MaxExitEpochAndChurn(s)
-		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, maxExitEpoch, churn)
+		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.MaxExitEpochAndChurn(s))
 	})
 }

--- a/testing/spectest/shared/common/operations/proposer_slashing.go
+++ b/testing/spectest/shared/common/operations/proposer_slashing.go
@@ -5,20 +5,13 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
-	"github.com/pkg/errors"
 )
 
 func RunProposerSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "proposer_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		activeBal, err := helpers.TotalActiveBalance(s)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get total active balance")
-		}
-		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.ExitInformation(s), primitives.Gwei(activeBal))
+		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.ExitInformation(s))
 	})
 }

--- a/testing/spectest/shared/common/operations/proposer_slashing.go
+++ b/testing/spectest/shared/common/operations/proposer_slashing.go
@@ -5,13 +5,20 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
+	"github.com/pkg/errors"
 )
 
 func RunProposerSlashingTest(t *testing.T, config string, fork string, block blockWithSSZObject, sszToState SSZToState) {
 	runSlashingTest(t, config, fork, "proposer_slashing", block, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.ExitInformation(s))
+		activeBal, err := helpers.TotalActiveBalance(s)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get total active balance")
+		}
+		return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator, v.ExitInformation(s), primitives.Gwei(activeBal))
 	})
 }

--- a/testing/spectest/shared/common/operations/voluntary_exit.go
+++ b/testing/spectest/shared/common/operations/voluntary_exit.go
@@ -31,8 +31,7 @@ func RunVoluntaryExitTest(t *testing.T, config string, fork string, block blockW
 			blk, err := block(exitSSZ)
 			require.NoError(t, err)
 			RunBlockOperationTest(t, folderPath, blk, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-				st, _, err := blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits(), validators.ExitInformation(s))
-				return st, err
+				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits(), validators.ExitInformation(s))
 			})
 		})
 	}

--- a/testing/spectest/shared/common/operations/voluntary_exit.go
+++ b/testing/spectest/shared/common/operations/voluntary_exit.go
@@ -30,7 +30,8 @@ func RunVoluntaryExitTest(t *testing.T, config string, fork string, block blockW
 			blk, err := block(exitSSZ)
 			require.NoError(t, err)
 			RunBlockOperationTest(t, folderPath, blk, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits(), validators.MaxExitEpochAndChurn(s))
+				st, _, err := blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits(), validators.ExitInformation(s))
+				return st, err
 			})
 		})
 	}

--- a/testing/spectest/shared/common/operations/voluntary_exit.go
+++ b/testing/spectest/shared/common/operations/voluntary_exit.go
@@ -30,7 +30,7 @@ func RunVoluntaryExitTest(t *testing.T, config string, fork string, block blockW
 			blk, err := block(exitSSZ)
 			require.NoError(t, err)
 			RunBlockOperationTest(t, folderPath, blk, sszToState, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits())
+				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits(), validators.MaxExitEpochAndChurn(s))
 			})
 		})
 	}

--- a/testing/spectest/shared/common/operations/voluntary_exit.go
+++ b/testing/spectest/shared/common/operations/voluntary_exit.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v6/testing/require"


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

When processing a slashing, we need to know the max exit epoch and the validator churn. The function that returns these values is `MaxExitEpochAndChurn`, which internally calls `ReadFromEveryValidator` on the state, which is an expensive operation. Currently we call `MaxExitEpochAndChurn` for every proposer slashing and every validator index of an attester slashing. It can get very expensive especially in the case of an attester slashing with many validators being slashed. Since `MaxExitEpochAndChurn` only requires the state, it can be called just once before any slashing processing.

The gist of this PR is having an `ExitInfo` type which is populated once before any slashings and then updated whenever an exit takes place.
```
type ExitInfo struct {
    HighestExitEpoch primitives.Epoch
    Churn            uint64
}
```

We also precalculate the total active balance to avoid calling `ReadFromEveryValidator` each time `ExitEpochAndUpdateChurn` is called. Several functions will have an `XXXForTotalBal` version that takes the total active balance as a parameter. These functions are utilized when processing slashings.

Here is an image showing that processing slashings was very CPU intensive on Holesky

![image](https://github.com/user-attachments/assets/87fc78aa-95ac-4b23-9338-b239dcb4ad41)

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
