### PR TITLE
fixing electra committee logs

### DIFF
--- a/changelog/james-prysm_fix-electra-committee-log.md
+++ b/changelog/james-prysm_fix-electra-committee-log.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- cosmetic fix for post electra validator logs displaying attestation committee information correctly.

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "aggregate_test.go",
         "attest_test.go",
         "key_reload_test.go",
+        "log_test.go",
         "metrics_test.go",
         "propose_test.go",
         "registration_test.go",

--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -158,7 +158,7 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot primitives
 		}
 	}
 
-	if err := v.saveSubmittedAtt(agg.AggregateVal().GetData(), pubKey[:], true); err != nil {
+	if err := v.saveSubmittedAtt(agg.AggregateVal(), pubKey[:], true); err != nil {
 		log.WithError(err).Error("Could not add aggregator indices to logs")
 		if v.emitAccountMetrics {
 			ValidatorAggFailVec.WithLabelValues(fmtKey).Inc()

--- a/validator/client/log.go
+++ b/validator/client/log.go
@@ -49,10 +49,10 @@ func (k submittedAttKey) FromAttData(data *ethpb.AttestationData) error {
 
 // saveSubmittedAtt saves the submitted attestation data along with the attester's pubkey.
 // The purpose of this is to display combined attesting logs for all keys managed by the validator client.
-func (v *validator) saveSubmittedAtt(data *ethpb.AttestationData, pubkey []byte, isAggregate bool) error {
+func (v *validator) saveSubmittedAtt(att ethpb.Att, pubkey []byte, isAggregate bool) error {
 	v.attLogsLock.Lock()
 	defer v.attLogsLock.Unlock()
-
+	data := att.GetData()
 	key := submittedAttKey{}
 	if err := key.FromAttData(data); err != nil {
 		return errors.Wrapf(err, "could not create submitted attestation key")
@@ -80,7 +80,7 @@ func (v *validator) saveSubmittedAtt(data *ethpb.AttestationData, pubkey []byte,
 	submittedAtts[key] = &submittedAtt{
 		d,
 		append(submittedAtts[key].pubkeys, pubkey),
-		append(submittedAtts[key].committees, data.CommitteeIndex),
+		append(submittedAtts[key].committees, att.GetCommitteeIndex()),
 	}
 
 	return nil

--- a/validator/client/log_test.go
+++ b/validator/client/log_test.go
@@ -32,11 +32,10 @@ func TestLogSubmittedAtts(t *testing.T) {
 		att := util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
 		att.Data.CommitteeIndex = 0
 		att.CommitteeBits = primitives.NewAttestationCommitteeBits()
-		att.CommitteeBits[0] = 44
-		att.CommitteeBits[1] = 73
+		att.CommitteeBits.SetBitAt(44, true)
 		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), false))
 		v.LogSubmittedAtts(0)
-		assert.LogsContain(t, logHook, "committeeIndices=\"[2]\"")
+		assert.LogsContain(t, logHook, "committeeIndices=\"[44]\"")
 	})
 	t.Run("electra attestations multiple saved", func(t *testing.T) {
 		logHook := logTest.NewGlobal()
@@ -46,16 +45,15 @@ func TestLogSubmittedAtts(t *testing.T) {
 		att := util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
 		att.Data.CommitteeIndex = 0
 		att.CommitteeBits = primitives.NewAttestationCommitteeBits()
-		att.CommitteeBits[0] = 44
-		att.CommitteeBits[1] = 33
+		att.CommitteeBits.SetBitAt(23, true)
 		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), false))
 		att2 := util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
 		att2.Data.CommitteeIndex = 0
 		att2.CommitteeBits = primitives.NewAttestationCommitteeBits()
-		att2.CommitteeBits[0] = 2
+		att2.CommitteeBits.SetBitAt(2, true)
 		require.NoError(t, v.saveSubmittedAtt(att2, make([]byte, field_params.BLSPubkeyLength), false))
 		v.LogSubmittedAtts(0)
-		assert.LogsContain(t, logHook, "committeeIndices=\"[2 1]\"")
+		assert.LogsContain(t, logHook, "committeeIndices=\"[23 2]\"")
 	})
 	t.Run("phase0 aggregates", func(t *testing.T) {
 		logHook := logTest.NewGlobal()
@@ -78,9 +76,9 @@ func TestLogSubmittedAtts(t *testing.T) {
 		agg.Aggregate = util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
 		agg.Aggregate.Data.CommitteeIndex = 0
 		agg.Aggregate.CommitteeBits = primitives.NewAttestationCommitteeBits()
-		agg.Aggregate.CommitteeBits[0] = 66
+		agg.Aggregate.CommitteeBits.SetBitAt(63, true)
 		require.NoError(t, v.saveSubmittedAtt(agg.AggregateVal(), make([]byte, field_params.BLSPubkeyLength), true))
 		v.LogSubmittedAtts(0)
-		assert.LogsContain(t, logHook, "committeeIndices=\"[1]\"")
+		assert.LogsContain(t, logHook, "committeeIndices=\"[63]\"")
 	})
 }

--- a/validator/client/log_test.go
+++ b/validator/client/log_test.go
@@ -20,7 +20,7 @@ func TestLogSubmittedAtts(t *testing.T) {
 		}
 		att := util.HydrateAttestation(&ethpb.Attestation{})
 		att.Data.CommitteeIndex = 12
-		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), true))
+		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), false))
 		v.LogSubmittedAtts(0)
 		assert.LogsContain(t, logHook, "committeeIndices=\"[12]\"")
 	})
@@ -34,7 +34,7 @@ func TestLogSubmittedAtts(t *testing.T) {
 		att.CommitteeBits = primitives.NewAttestationCommitteeBits()
 		att.CommitteeBits[0] = 44
 		att.CommitteeBits[1] = 73
-		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), true))
+		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), false))
 		v.LogSubmittedAtts(0)
 		assert.LogsContain(t, logHook, "committeeIndices=\"[2]\"")
 	})

--- a/validator/client/log_test.go
+++ b/validator/client/log_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"testing"
+
+	field_params "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/testing/assert"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
+	"github.com/prysmaticlabs/prysm/v5/testing/util"
+	logTest "github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestLogSubmittedAtts(t *testing.T) {
+	t.Run("phase0 attestations", func(t *testing.T) {
+		logHook := logTest.NewGlobal()
+		v := validator{
+			submittedAtts: make(map[submittedAttKey]*submittedAtt),
+		}
+		att := util.HydrateAttestation(&ethpb.Attestation{})
+		att.Data.CommitteeIndex = 12
+		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), true))
+		v.LogSubmittedAtts(0)
+		assert.LogsContain(t, logHook, "committeeIndices=\"[12]\"")
+	})
+	t.Run("electra attestations", func(t *testing.T) {
+		logHook := logTest.NewGlobal()
+		v := validator{
+			submittedAtts: make(map[submittedAttKey]*submittedAtt),
+		}
+		att := util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
+		att.Data.CommitteeIndex = 0
+		att.CommitteeBits = primitives.NewAttestationCommitteeBits()
+		att.CommitteeBits[0] = 44
+		att.CommitteeBits[1] = 73
+		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), true))
+		v.LogSubmittedAtts(0)
+		assert.LogsContain(t, logHook, "committeeIndices=\"[2]\"")
+	})
+	t.Run("phase0 aggregates", func(t *testing.T) {
+		logHook := logTest.NewGlobal()
+		v := validator{
+			submittedAggregates: make(map[submittedAttKey]*submittedAtt),
+		}
+		agg := &ethpb.AggregateAttestationAndProof{}
+		agg.Aggregate = util.HydrateAttestation(&ethpb.Attestation{})
+		agg.Aggregate.Data.CommitteeIndex = 12
+		require.NoError(t, v.saveSubmittedAtt(agg.AggregateVal(), make([]byte, field_params.BLSPubkeyLength), true))
+		v.LogSubmittedAtts(0)
+		assert.LogsContain(t, logHook, "committeeIndices=\"[12]\"")
+	})
+	t.Run("electra aggregates", func(t *testing.T) {
+		logHook := logTest.NewGlobal()
+		v := validator{
+			submittedAggregates: make(map[submittedAttKey]*submittedAtt),
+		}
+		agg := &ethpb.AggregateAttestationAndProofElectra{}
+		agg.Aggregate = util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
+		agg.Aggregate.Data.CommitteeIndex = 0
+		agg.Aggregate.CommitteeBits = primitives.NewAttestationCommitteeBits()
+		agg.Aggregate.CommitteeBits[0] = 66
+		require.NoError(t, v.saveSubmittedAtt(agg.AggregateVal(), make([]byte, field_params.BLSPubkeyLength), true))
+		v.LogSubmittedAtts(0)
+		assert.LogsContain(t, logHook, "committeeIndices=\"[1]\"")
+	})
+}

--- a/validator/client/log_test.go
+++ b/validator/client/log_test.go
@@ -38,6 +38,25 @@ func TestLogSubmittedAtts(t *testing.T) {
 		v.LogSubmittedAtts(0)
 		assert.LogsContain(t, logHook, "committeeIndices=\"[2]\"")
 	})
+	t.Run("electra attestations multiple saved", func(t *testing.T) {
+		logHook := logTest.NewGlobal()
+		v := validator{
+			submittedAtts: make(map[submittedAttKey]*submittedAtt),
+		}
+		att := util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
+		att.Data.CommitteeIndex = 0
+		att.CommitteeBits = primitives.NewAttestationCommitteeBits()
+		att.CommitteeBits[0] = 44
+		att.CommitteeBits[1] = 33
+		require.NoError(t, v.saveSubmittedAtt(att, make([]byte, field_params.BLSPubkeyLength), false))
+		att2 := util.HydrateAttestationElectra(&ethpb.AttestationElectra{})
+		att2.Data.CommitteeIndex = 0
+		att2.CommitteeBits = primitives.NewAttestationCommitteeBits()
+		att2.CommitteeBits[0] = 2
+		require.NoError(t, v.saveSubmittedAtt(att2, make([]byte, field_params.BLSPubkeyLength), false))
+		v.LogSubmittedAtts(0)
+		assert.LogsContain(t, logHook, "committeeIndices=\"[2 1]\"")
+	})
 	t.Run("phase0 aggregates", func(t *testing.T) {
 		logHook := logTest.NewGlobal()
 		v := validator{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

Electra attestation logs have been printing out incorrect indicies
![image](https://github.com/user-attachments/assets/fad83bde-8639-44df-94b6-9cdb44a3cbf5)

this pr solves the issue by correctly using the committee bits to get the committee index for electra attestation logs

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
