### PR TITLE
add log for committee index on electra attesation

### DIFF
--- a/changelog/james-prysm_committee-index-log.md
+++ b/changelog/james-prysm_committee-index-log.md
@@ -1,0 +1,3 @@
+### Added
+
+- add log to committee index when committeebits are not the expected length of 1

--- a/proto/prysm/v1alpha1/BUILD.bazel
+++ b/proto/prysm/v1alpha1/BUILD.bazel
@@ -333,6 +333,7 @@ go_library(
     srcs = [
         "attestation.go",
         "beacon_block.go",
+        "log.go",
         "cloners.go",
         "eip_7521.go",
         "sync_committee_mainnet.go",
@@ -373,6 +374,8 @@ go_library(
         "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
         "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )
 

--- a/proto/prysm/v1alpha1/attestation.go
+++ b/proto/prysm/v1alpha1/attestation.go
@@ -291,6 +291,8 @@ func (a *AttestationElectra) GetCommitteeIndex() primitives.CommitteeIndex {
 	indices := a.CommitteeBits.BitIndices()
 	if len(indices) == 0 {
 		return 0
+	} else if len(indices) != 1 {
+		log.WithField("indices", a.CommitteeBits).Debugf("expected 1 committee bit indice got %d", len(indices))
 	}
 	return primitives.CommitteeIndex(uint64(indices[0]))
 }

--- a/proto/prysm/v1alpha1/log.go
+++ b/proto/prysm/v1alpha1/log.go
@@ -1,0 +1,6 @@
+package eth
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.StandardLogger()
+var log = logger.WithField("prefix", "protobuf")


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Other

**What does this PR do? Why is it needed?**

electra attestations need to calculate their committee index from the committee bits, this should only be 1 set value, but we should log in the case of this not being true. It would mean this function is called improperly 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
