### PR TITLE
Populate pubkey cache at genesis

### DIFF
--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -121,9 +121,10 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 		return nil, err
 	}
 	fRoot := bytesutil.ToBytes32(c.Root)
+	st := fState
 	// Resume as genesis state if last finalized root is zero hashes.
 	if fRoot == params.BeaconConfig().ZeroHash {
-		st, err := s.beaconDB.GenesisState(ctx)
+		st, err = s.beaconDB.GenesisState(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get genesis state")
 		}
@@ -132,10 +133,13 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 		if err != nil {
 			return nil, stderrors.Join(ErrNoGenesisBlock, err)
 		}
-		return st, s.SaveState(ctx, gbr, st)
+		fRoot = gbr
+		if err := s.SaveState(ctx, gbr, st); err != nil {
+			return nil, errors.Wrap(err, "could not save genesis state")
+		}
 	}
 
-	if fState == nil || fState.IsNil() {
+	if st == nil || st.IsNil() {
 		return nil, errors.New("finalized state is nil")
 	}
 
@@ -145,20 +149,22 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 		}
 	}()
 
-	s.finalizedInfo = &finalizedInfo{slot: fState.Slot(), root: fRoot, state: fState.Copy()}
-	fEpoch := slots.ToEpoch(fState.Slot())
+	s.finalizedInfo = &finalizedInfo{slot: st.Slot(), root: fRoot, state: st.Copy()}
+	populatePubkeyCache(ctx, st)
+	return st, nil
+}
 
-	// Pre-populate the pubkey cache with the validator public keys from the finalized state.
-	// This process takes about 30 seconds on mainnet with 450,000 validators.
+func populatePubkeyCache(ctx context.Context, st state.BeaconState) {
+	epoch := slots.ToEpoch(st.Slot())
 	go populatePubkeyCacheOnce.Do(func() {
 		log.Debug("Populating pubkey cache")
 		start := time.Now()
-		if err := fState.ReadFromEveryValidator(func(_ int, val state.ReadOnlyValidator) error {
+		if err := st.ReadFromEveryValidator(func(_ int, val state.ReadOnlyValidator) error {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
 			// Do not cache for non-active validators.
-			if !helpers.IsActiveValidatorUsingTrie(val, fEpoch) {
+			if !helpers.IsActiveValidatorUsingTrie(val, epoch) {
 				return nil
 			}
 			pub := val.PublicKey()
@@ -169,8 +175,6 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 		}
 		log.WithField("duration", time.Since(start)).Debug("Done populating pubkey cache")
 	})
-
-	return fState, nil
 }
 
 // SaveFinalizedState saves the finalized slot, root and state into memory to be used by state gen service.

--- a/changelog/potuz_populate_pubkey.md
+++ b/changelog/potuz_populate_pubkey.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Populate pubkey cache at genesis.


### PR DESCRIPTION
When starting with a zero root finalized checkpoint instead of returning early also populate the pubkey cache.