### PR TITLE
cache uses wrong seen committee index for electra

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -197,7 +197,7 @@ func (s *Service) processUnaggregated(ctx context.Context, att ethpb.Att) {
 				return
 			}
 		}
-		s.setSeenCommitteeIndicesSlot(data.Slot, data.CommitteeIndex, att.GetAggregationBits())
+		s.setSeenCommitteeIndicesSlot(data.Slot, att.GetCommitteeIndex(), att.GetAggregationBits())
 
 		valCount, err := helpers.ActiveValidatorCount(ctx, preState, slots.ToEpoch(data.Slot))
 		if err != nil {

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -743,31 +743,4 @@ func Test_SeenCommitteeIndicesSlot(t *testing.T) {
 		_, ok := s.seenUnAggregatedAttestationCache.Get(string(b))
 		require.Equal(t, true, ok)
 	})
-	t.Run("electra fails using wrong getter ", func(t *testing.T) {
-		s := &Service{
-			seenUnAggregatedAttestationCache: lruwrpr.New(1),
-		}
-		// committee index is 0 post electra for attestation electra
-		data := &ethpb.AttestationData{Slot: 1, CommitteeIndex: 0}
-		cb := primitives.NewAttestationCommitteeBits()
-		cb.SetBitAt(uint64(63), true)
-		att := &ethpb.AttestationElectra{
-			AggregationBits: bitfield.Bitlist{0x01},
-			Data:            data,
-			CommitteeBits:   cb,
-		}
-		ci := data.CommitteeIndex
-		s.setSeenCommitteeIndicesSlot(data.Slot, ci, att.GetAggregationBits())
-		b := append(bytesutil.Bytes32(uint64(1)), bytesutil.Bytes32(uint64(63))...)
-		b = append(b, bytesutil.SafeCopyBytes(att.GetAggregationBits())...)
-		_, ok := s.seenUnAggregatedAttestationCache.Get(string(b))
-		require.Equal(t, false, ok)
-
-		// using the incorrect value searches it up
-		b = append(bytesutil.Bytes32(uint64(1)), bytesutil.Bytes32(uint64(0))...)
-		b = append(b, bytesutil.SafeCopyBytes(att.GetAggregationBits())...)
-		_, ok = s.seenUnAggregatedAttestationCache.Get(string(b))
-		require.Equal(t, true, ok)
-	})
-
 }

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -706,3 +706,68 @@ func Test_attsAreEqual_Committee(t *testing.T) {
 		assert.Equal(t, false, attsAreEqual(att1, att2))
 	})
 }
+
+func Test_SeenCommitteeIndicesSlot(t *testing.T) {
+	t.Run("phase 0 success", func(t *testing.T) {
+		s := &Service{
+			seenUnAggregatedAttestationCache: lruwrpr.New(1),
+		}
+		data := &ethpb.AttestationData{Slot: 1, CommitteeIndex: 44}
+		att := &ethpb.Attestation{
+			AggregationBits: bitfield.Bitlist{0x01},
+			Data:            data,
+		}
+		s.setSeenCommitteeIndicesSlot(data.Slot, att.GetCommitteeIndex(), att.GetAggregationBits())
+		b := append(bytesutil.Bytes32(uint64(1)), bytesutil.Bytes32(uint64(44))...)
+		b = append(b, bytesutil.SafeCopyBytes(att.GetAggregationBits())...)
+		_, ok := s.seenUnAggregatedAttestationCache.Get(string(b))
+		require.Equal(t, true, ok)
+	})
+	t.Run("electra success", func(t *testing.T) {
+		s := &Service{
+			seenUnAggregatedAttestationCache: lruwrpr.New(1),
+		}
+		// committee index is 0 post electra for attestation electra
+		data := &ethpb.AttestationData{Slot: 1, CommitteeIndex: 0}
+		cb := primitives.NewAttestationCommitteeBits()
+		cb.SetBitAt(uint64(63), true)
+		att := &ethpb.AttestationElectra{
+			AggregationBits: bitfield.Bitlist{0x01},
+			Data:            data,
+			CommitteeBits:   cb,
+		}
+		ci := att.GetCommitteeIndex()
+		s.setSeenCommitteeIndicesSlot(data.Slot, ci, att.GetAggregationBits())
+		b := append(bytesutil.Bytes32(uint64(1)), bytesutil.Bytes32(uint64(63))...)
+		b = append(b, bytesutil.SafeCopyBytes(att.GetAggregationBits())...)
+		_, ok := s.seenUnAggregatedAttestationCache.Get(string(b))
+		require.Equal(t, true, ok)
+	})
+	t.Run("electra fails using wrong getter ", func(t *testing.T) {
+		s := &Service{
+			seenUnAggregatedAttestationCache: lruwrpr.New(1),
+		}
+		// committee index is 0 post electra for attestation electra
+		data := &ethpb.AttestationData{Slot: 1, CommitteeIndex: 0}
+		cb := primitives.NewAttestationCommitteeBits()
+		cb.SetBitAt(uint64(63), true)
+		att := &ethpb.AttestationElectra{
+			AggregationBits: bitfield.Bitlist{0x01},
+			Data:            data,
+			CommitteeBits:   cb,
+		}
+		ci := data.CommitteeIndex
+		s.setSeenCommitteeIndicesSlot(data.Slot, ci, att.GetAggregationBits())
+		b := append(bytesutil.Bytes32(uint64(1)), bytesutil.Bytes32(uint64(63))...)
+		b = append(b, bytesutil.SafeCopyBytes(att.GetAggregationBits())...)
+		_, ok := s.seenUnAggregatedAttestationCache.Get(string(b))
+		require.Equal(t, false, ok)
+
+		// using the incorrect value searches it up
+		b = append(bytesutil.Bytes32(uint64(1)), bytesutil.Bytes32(uint64(0))...)
+		b = append(b, bytesutil.SafeCopyBytes(att.GetAggregationBits())...)
+		_, ok = s.seenUnAggregatedAttestationCache.Get(string(b))
+		require.Equal(t, true, ok)
+	})
+
+}

--- a/changelog/james-prysm_fix-wrong-committee-seen.md
+++ b/changelog/james-prysm_fix-wrong-committee-seen.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix inserting the wrong committee index into the seen cache for electra attestations


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

PR fixes a small bug with using the wrong committee index for electra attestations. adds some unit tests as well.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
