### PR TITLE
Fix Bugs In Sync From Head

### DIFF
--- a/beacon-chain/blockchain/setup_forchoice.go
+++ b/beacon-chain/blockchain/setup_forchoice.go
@@ -41,6 +41,7 @@ func (s *Service) startupHeadRoot() [32]byte {
 			log.WithError(err).Error("could not get head block root, starting with finalized block as head")
 			return fRoot
 		}
+		log.Infof("Using Head root of %#x", root)
 		return root
 	}
 	root, err := bytesutil.DecodeHexWithLength(headStr, 32)
@@ -55,24 +56,42 @@ func (s *Service) setupForkchoiceTree(st state.BeaconState) error {
 	headRoot := s.startupHeadRoot()
 	cp := s.FinalizedCheckpt()
 	fRoot := s.ensureRootNotZeros([32]byte(cp.Root))
+	if err := s.setupForkchoiceRoot(st); err != nil {
+		return errors.Wrap(err, "could not set up forkchoice root")
+	}
+	fBlk, err := s.cfg.BeaconDB.Block(s.ctx, fRoot)
+	if err != nil {
+		return errors.Wrap(err, "could not get finalized block")
+	}
+	if err := s.setHead(&head{
+		fRoot,
+		fBlk,
+		st,
+		fBlk.Block().Slot(),
+		false,
+	}); err != nil {
+		return errors.Wrap(err, "could not set head")
+	}
+
 	if headRoot == fRoot {
-		return s.setupForkchoiceRoot(st)
+		return nil
 	}
 	blk, err := s.cfg.BeaconDB.Block(s.ctx, headRoot)
 	if err != nil {
 		log.WithError(err).Error("could not get head block, starting with finalized block as head")
-		return s.setupForkchoiceRoot(st)
+		return nil
 	}
 	if slots.ToEpoch(blk.Block().Slot()) < cp.Epoch {
 		log.WithField("headRoot", fmt.Sprintf("%#x", headRoot)).Error("head block is older than finalized block, starting with finalized block as head")
-		return s.setupForkchoiceRoot(st)
+		return nil
 	}
 	chain, err := s.buildForkchoiceChain(s.ctx, blk)
 	if err != nil {
 		log.WithError(err).Error("could not build forkchoice chain, starting with finalized block as head")
-		return s.setupForkchoiceRoot(st)
+		return nil
 	}
 	s.cfg.ForkChoiceStore.Lock()
+	defer s.cfg.ForkChoiceStore.Unlock()
 	return s.cfg.ForkChoiceStore.InsertChain(s.ctx, chain)
 }
 
@@ -93,7 +112,7 @@ func (s *Service) buildForkchoiceChain(ctx context.Context, head interfaces.Read
 		// This chain sets the justified checkpoint for every block, including some that are older than jp.
 		// This should be however safe for forkchoice at startup.
 		chain = append(chain, &forkchoicetypes.BlockAndCheckpoints{Block: roblock, JustifiedCheckpoint: jp, FinalizedCheckpoint: cp})
-		root := head.Block().ParentRoot()
+		root = head.Block().ParentRoot()
 		if root == fRoot {
 			break
 		}
@@ -155,6 +174,7 @@ func (s *Service) setupForkchoiceCheckpoints() error {
 	fRoot := s.ensureRootNotZeros(bytesutil.ToBytes32(finalized.Root))
 	s.cfg.ForkChoiceStore.Lock()
 	defer s.cfg.ForkChoiceStore.Unlock()
+	log.Infof("jp %#x and %d, fp %#x and %d", justified.Root, justified.Epoch, finalized.Root, finalized.Epoch)
 	if err := s.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(s.ctx, &forkchoicetypes.Checkpoint{Epoch: justified.Epoch,
 		Root: bytesutil.ToBytes32(justified.Root)}); err != nil {
 		return errors.Wrap(err, "could not update forkchoice's justified checkpoint")

--- a/beacon-chain/blockchain/setup_forchoice.go
+++ b/beacon-chain/blockchain/setup_forchoice.go
@@ -174,7 +174,6 @@ func (s *Service) setupForkchoiceCheckpoints() error {
 	fRoot := s.ensureRootNotZeros(bytesutil.ToBytes32(finalized.Root))
 	s.cfg.ForkChoiceStore.Lock()
 	defer s.cfg.ForkChoiceStore.Unlock()
-	log.Infof("jp %#x and %d, fp %#x and %d", justified.Root, justified.Epoch, finalized.Root, finalized.Epoch)
 	if err := s.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(s.ctx, &forkchoicetypes.Checkpoint{Epoch: justified.Epoch,
 		Root: bytesutil.ToBytes32(justified.Root)}); err != nil {
 		return errors.Wrap(err, "could not update forkchoice's justified checkpoint")

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -276,8 +276,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(enableExperimentalAttestationPool)
 		cfg.EnableExperimentalAttestationPool = true
 	}
-
-	cfg.ForceHead = forceHeadFlag.Value
+	if ctx.IsSet(forceHeadFlag.Name) {
+		logEnabled(forceHeadFlag)
+		cfg.ForceHead = ctx.String(forceHeadFlag.Name)
+	}
 
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
 	Init(cfg)


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] When setting up the forkchoice tree it sets the head as the finalized block at the start.
- [x] In `buildForkchoiceChain` we were overshadowing the `root` variable which led to the incorrect root being  used when building `roblock` 
- [x] Add a defered unlock for the forkchoice mutex
- [x] Fix our feature config to take the correct flag values from the cli context.

**Which issues(s) does this PR fix?**

Fixes Bugs with #15000

**Other notes for review**

**Acknowledgements**

- [x ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
