### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cmd/beacon-chain/sync/checkpoint/options.go
+++ b/cmd/beacon-chain/sync/checkpoint/options.go
@@ -1,8 +1,6 @@
 package checkpoint
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/node"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/sync/checkpoint"
@@ -53,10 +51,10 @@ func BeaconNodeOptions(c *cli.Context) ([]node.Option, error) {
 		return nil, nil
 	}
 	if blockPath != "" && statePath == "" {
-		return nil, fmt.Errorf("--checkpoint-block specified, but not --checkpoint-state. both are required")
+		return nil, errors.New("--checkpoint-block specified, but not --checkpoint-state. both are required")
 	}
 	if blockPath == "" && statePath != "" {
-		return nil, fmt.Errorf("--checkpoint-state specified, but not --checkpoint-block. both are required")
+		return nil, errors.New("--checkpoint-state specified, but not --checkpoint-block. both are required")
 	}
 
 	opt := func(node *node.BeaconNode) (err error) {

--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -74,7 +74,7 @@ func AggregateCompressedSignatures(multiSigs [][]byte) (common.Signature, error)
 // MultipleSignaturesFromBytes creates a group of BLS signatures from a LittleEndian 2d-byte slice.
 func MultipleSignaturesFromBytes(multiSigs [][]byte) ([]common.Signature, error) {
 	if len(multiSigs) == 0 {
-		return nil, fmt.Errorf("0 signatures provided to the method")
+		return nil, errors.New("0 signatures provided to the method")
 	}
 	for _, s := range multiSigs {
 		if len(s) != fieldparams.BLSSignatureLength {


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.