### PR TITLE
Fix Block Decoding During State Deletion

### DIFF
--- a/changelog/nisdas_fix_block_decoding.md
+++ b/changelog/nisdas_fix_block_decoding.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Allow any block type to be unmarshaled rather than only phase0 blocks in `slotByBlockRoot`. 


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

During state deletion, we have a potential code path which unmarshals a block in the event the state summary cannot be found. This code path was only unmarshalling for phase0 blocks, every alternate fork type would fail with a ssz error. This PR fixes it and adds in a regression test.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
