### PR TITLE
Validate blob sidecar: check bad parent first

### DIFF
--- a/beacon-chain/sync/validate_blob.go
+++ b/beacon-chain/sync/validate_blob.go
@@ -92,11 +92,11 @@ func (s *Service) validateBlob(ctx context.Context, pid peer.ID, msg *pubsub.Mes
 		return pubsub.ValidationIgnore, err
 	}
 
-	if err := vf.ValidProposerSignature(ctx); err != nil {
+	if err := vf.SidecarParentValid(s.hasBadBlock); err != nil {
 		return pubsub.ValidationReject, err
 	}
 
-	if err := vf.SidecarParentValid(s.hasBadBlock); err != nil {
+	if err := vf.ValidProposerSignature(ctx); err != nil {
 		return pubsub.ValidationReject, err
 	}
 

--- a/changelog/tt_validate_block.md
+++ b/changelog/tt_validate_block.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Validate blob sidecar re-order signature and bad parent block.


### PR DESCRIPTION
Mainly a cosmetic change to emit the correct log when receiving a blob sidecar that builds on an invalid parent. The end result remains the same—the peer gets penalized.  

Currently, if a blob sidecar builds on top of an invalid parent, the following happens:  
- `SidecarParentSeen` returns `nil`  
- `ValidProposerSignature` returns "block not found"  

What we want instead is for `SidecarParentSeen` to return `nil`, but for `SidecarParentValid` to return an error subsequently. This ensures the logs are emitted in the correct order, making them less confusing to read.  

**Note to the reviewer:** I don’t see any downside to switching the order of validation. `SidecarParentValid` is a cheap check, and it’s unclear why it was always placed after `ValidProposerSignature`. The original intent is not obvious