### PR TITLE
Beacon API: Broadcasting BLS to execution changes should not use the request context in a go routine

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -633,7 +633,7 @@ func (s *Server) SubmitBLSToExecutionChanges(w http.ResponseWriter, r *http.Requ
 			toBroadcast = append(toBroadcast, sbls)
 		}
 	}
-	go s.broadcastBLSChanges(ctx, toBroadcast)
+	go s.broadcastBLSChanges(context.Background(), toBroadcast)
 	if len(failures) > 0 {
 		failuresErr := &server.IndexedVerificationFailureError{
 			Code:     http.StatusBadRequest,

--- a/changelog/pvl_bls-ctx.md
+++ b/changelog/pvl_bls-ctx.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Broadcasting BLS to execution changes should not use the request context in a go routine. Use context.Background() for the broadcasting go routine.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The request context is cancelled after the request concludes. However, we are launch a go routine after the request to broadcast the BLS to execution changes. This can lead to the BLS changes not be broadcasted.

**Which issues(s) does this PR fix?**

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
