### PR TITLE
Return the genesis block root from last validated checkpoint if zero

### DIFF
--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -582,6 +582,7 @@ func TestService_IsOptimisticForRoot_StateSummaryRecovered(t *testing.T) {
 	br, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	util.SaveBlock(t, context.Background(), beaconDB, b)
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, [32]byte{}))
 	_, err = c.IsOptimisticForRoot(ctx, br)
 	assert.NoError(t, err)
 	summ, err := beaconDB.StateSummary(ctx, br)

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2117,6 +2117,7 @@ func TestNoViableHead_Reboot(t *testing.T) {
 	require.NoError(t, service.cfg.BeaconDB.SaveState(ctx, genesisState, jroot))
 	service.cfg.ForkChoiceStore.SetBalancesByRooter(service.cfg.StateGen.ActiveNonSlashedBalancesByRoot)
 	require.NoError(t, service.StartFromSavedState(genesisState))
+	require.NoError(t, service.cfg.BeaconDB.SaveGenesisBlockRoot(ctx, genesisRoot))
 
 	// Forkchoice has the genesisRoot loaded at startup
 	require.Equal(t, genesisRoot, service.ensureRootNotZeros(service.cfg.ForkChoiceStore.CachedHeadRoot()))

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -1983,6 +1983,7 @@ func TestNoViableHead_Reboot(t *testing.T) {
 
 	require.NoError(t, service.cfg.BeaconDB.SaveState(ctx, genesisState, genesisRoot), "Could not save genesis state")
 	require.NoError(t, service.cfg.BeaconDB.SaveHeadBlockRoot(ctx, genesisRoot), "Could not save genesis state")
+	require.NoError(t, service.cfg.BeaconDB.SaveGenesisBlockRoot(ctx, genesisRoot), "Could not save genesis state")
 
 	for i := 1; i < 6; i++ {
 		driftGenesisTime(service, int64(i), 0)
@@ -2127,7 +2128,7 @@ func TestNoViableHead_Reboot(t *testing.T) {
 	require.Equal(t, genesisRoot, bytesutil.ToBytes32(headRoot))
 	optimistic, err := service.IsOptimistic(ctx)
 	require.NoError(t, err)
-	require.Equal(t, true, optimistic)
+	require.Equal(t, false, optimistic)
 
 	// Check that the node's justified checkpoint does not agree with the
 	// last valid state's justified checkpoint

--- a/beacon-chain/db/kv/validated_checkpoint.go
+++ b/beacon-chain/db/kv/validated_checkpoint.go
@@ -1,8 +1,10 @@
 package kv
 
 import (
+	"bytes"
 	"context"
 
+	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	bolt "go.etcd.io/bbolt"
@@ -19,7 +21,17 @@ func (s *Store) LastValidatedCheckpoint(ctx context.Context) (*ethpb.Checkpoint,
 		if enc == nil {
 			var finErr error
 			checkpoint, finErr = s.FinalizedCheckpoint(ctx)
-			return finErr
+			if finErr != nil {
+				return finErr
+			}
+			if bytes.Equal(checkpoint.Root, params.BeaconConfig().ZeroHash[:]) {
+				genesisRoot, genErr := s.GenesisBlockRoot(ctx)
+				if genErr != nil {
+					return genErr
+				}
+				checkpoint.Root = genesisRoot[:]
+			}
+			return nil
 		}
 		checkpoint = &ethpb.Checkpoint{}
 		return decode(ctx, enc, checkpoint)

--- a/beacon-chain/db/kv/validated_checkpoint.go
+++ b/beacon-chain/db/kv/validated_checkpoint.go
@@ -25,11 +25,11 @@ func (s *Store) LastValidatedCheckpoint(ctx context.Context) (*ethpb.Checkpoint,
 				return finErr
 			}
 			if bytes.Equal(checkpoint.Root, params.BeaconConfig().ZeroHash[:]) {
-				genesisRoot, genErr := s.GenesisBlockRoot(ctx)
-				if genErr != nil {
-					return genErr
+				bkt = tx.Bucket(blocksBucket)
+				r := bkt.Get(genesisBlockRootKey)
+				if r != nil {
+					checkpoint.Root = r
 				}
-				checkpoint.Root = genesisRoot[:]
 			}
 			return nil
 		}

--- a/changelog/potuz_last_validated.md
+++ b/changelog/potuz_last_validated.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- When starting a node, check that the last validated checkpoint has zero as root and return the genesis block root


### PR DESCRIPTION
When starting a node we load the last validated checkpoint. On tests or a new node this checkpoint can have the zero blockroot (it returns the finalized checkpoint). This PR ensures that it returns the genesis block root instead. 

It can't affect runnning code since the root is only used at startup in `setup_forkchoice`. But it may affect tests because now `OptimisticForRoot` will error out if there is no genesis block root set on db. 