### PR TITLE
Handle unaggregated attestations when decomposing

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -503,6 +503,10 @@ func (s *Service) pruneCoveredElectraAttsFromPool(ctx context.Context, headState
 			if err = s.cfg.AttestationCache.DeleteCovered(a); err != nil {
 				return errors.Wrap(err, "could not delete covered attestation")
 			}
+		} else if !a.IsAggregated() {
+			if err = s.cfg.AttPool.DeleteUnaggregatedAttestation(a); err != nil {
+				return errors.Wrap(err, "could not delete unaggregated attestation")
+			}
 		} else if err = s.cfg.AttPool.DeleteAggregatedAttestation(a); err != nil {
 			return errors.Wrap(err, "could not delete aggregated attestation")
 		}

--- a/changelog/radek_minor-attestation-tweaks.md
+++ b/changelog/radek_minor-attestation-tweaks.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Handle unaggregated attestations when decomposing Electra block attestations.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When decomposing block attestations in `pruneCoveredElectraAttsFromPool`, there is a possibility that an aggregate has only 1 bit set, in which case `DeleteUnaggregatedAttestation` should be called on the decomposed aggregate.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
