### PR TITLE
Emit IL event upon successfully receive an IL over the P2P

### DIFF
--- a/api/client/event/event_stream.go
+++ b/api/client/event/event_stream.go
@@ -28,6 +28,7 @@ const (
 	EventLightClientOptimisticUpdate = "light_client_optimistic_update"
 	EventPayloadAttributes           = "payload_attributes"
 	EventBlobSidecar                 = "blob_sidecar"
+	EventInclusionList               = "inclusion_list"
 	EventError                       = "error"
 	EventConnectionError             = "connection_error"
 )

--- a/api/server/structs/conversions.go
+++ b/api/server/structs/conversions.go
@@ -133,6 +133,66 @@ func SignedBLSChangesFromConsensus(src []*eth.SignedBLSToExecutionChange) []*Sig
 	return changes
 }
 
+func SignedInclusionListFromConsensus(src *eth.SignedInclusionList) *SignedInclusionList {
+	transactions := make([]string, len(src.Message.Transactions))
+	for i, transaction := range src.Message.Transactions {
+		transactions[i] = hexutil.Encode(transaction)
+	}
+
+	return &SignedInclusionList{
+		Message: &InclusionList{
+			Slot:                       fmt.Sprintf("%d", src.Message.Slot),
+			ValidatorIndex:             fmt.Sprintf("%d", src.Message.ValidatorIndex),
+			InclusionListCommitteeRoot: hexutil.Encode(src.Message.InclusionListCommitteeRoot),
+			Transactions:               transactions,
+		},
+		Signature: hexutil.Encode(src.Signature),
+	}
+}
+
+func (s *SignedInclusionList) ToConsensus() (*eth.SignedInclusionList, error) {
+	message, err := s.Message.ToConsensus()
+	if err != nil {
+		return nil, server.NewDecodeError(err, "Message")
+	}
+	signature, err := bytesutil.DecodeHexWithLength(s.Signature, fieldparams.BLSSignatureLength)
+	if err != nil {
+		return nil, server.NewDecodeError(err, "Signature")
+	}
+	return &eth.SignedInclusionList{
+		Message:   message,
+		Signature: signature,
+	}, nil
+}
+
+func (s *InclusionList) ToConsensus() (*eth.InclusionList, error) {
+	slot, err := strconv.ParseUint(s.Slot, 10, 64)
+	if err != nil {
+		return nil, server.NewDecodeError(err, "Slot")
+	}
+	validatorIndex, err := strconv.ParseUint(s.ValidatorIndex, 10, 64)
+	if err != nil {
+		return nil, server.NewDecodeError(err, "ValidatorIndex")
+	}
+	inclusionListCommitteeRoot, err := bytesutil.DecodeHexWithLength(s.InclusionListCommitteeRoot, fieldparams.RootLength)
+	if err != nil {
+		return nil, server.NewDecodeError(err, "InclusionListCommitteeRoot")
+	}
+	transactions := make([][]byte, len(s.Transactions))
+	for i, transaction := range s.Transactions {
+		transactions[i], err = bytesutil.DecodeHexWithMaxLength(transaction, fieldparams.MaxBytesPerTxLength)
+		if err != nil {
+			return nil, server.NewDecodeError(err, fmt.Sprintf("Transactions[%d]", i))
+		}
+	}
+	return &eth.InclusionList{
+		Slot:                       primitives.Slot(slot),
+		ValidatorIndex:             primitives.ValidatorIndex(validatorIndex),
+		InclusionListCommitteeRoot: inclusionListCommitteeRoot,
+		Transactions:               transactions,
+	}, nil
+}
+
 func (s *Fork) ToConsensus() (*eth.Fork, error) {
 	previousVersion, err := bytesutil.DecodeHexWithLength(s.PreviousVersion, 4)
 	if err != nil {

--- a/api/server/structs/endpoints_events.go
+++ b/api/server/structs/endpoints_events.go
@@ -91,6 +91,11 @@ type BlobSidecarEvent struct {
 	VersionedHash string `json:"versioned_hash"`
 }
 
+type InclusionListEvent struct {
+	Version string               `json:"version"`
+	Data    *SignedInclusionList `json:"data"`
+}
+
 type LightClientFinalityUpdateEvent struct {
 	Version string                     `json:"version"`
 	Data    *LightClientFinalityUpdate `json:"data"`

--- a/api/server/structs/other.go
+++ b/api/server/structs/other.go
@@ -262,3 +262,15 @@ type PendingConsolidation struct {
 	SourceIndex string `json:"source_index"`
 	TargetIndex string `json:"target_index"`
 }
+
+type SignedInclusionList struct {
+	Message   *InclusionList `json:"message"`
+	Signature string         `json:"signature"`
+}
+
+type InclusionList struct {
+	Slot                       string   `json:"slot"`
+	ValidatorIndex             string   `json:"validator_index"`
+	InclusionListCommitteeRoot string   `json:"inclusion_list_committee_root"`
+	Transactions               []string `json:"transactions"`
+}

--- a/beacon-chain/core/feed/operation/events.go
+++ b/beacon-chain/core/feed/operation/events.go
@@ -35,6 +35,9 @@ const (
 
 	// SingleAttReceived is sent after a single attestation object is received from gossip or rpc
 	SingleAttReceived = 9
+
+	// InclusionListReceived is sent after an inclusion list is received from gossip or rpc
+	InclusionListReceived = 10
 )
 
 // UnAggregatedAttReceivedData is the data sent with UnaggregatedAttReceived events.
@@ -69,6 +72,11 @@ type BLSToExecutionChangeReceivedData struct {
 // BlobSidecarReceivedData is the data sent with BlobSidecarReceived events.
 type BlobSidecarReceivedData struct {
 	Blob *blocks.VerifiedROBlob
+}
+
+// InclusionListReceivedData is the data sent with InclusionListReceived events.
+type InclusionListReceivedData struct {
+	SignedInclusionList *ethpb.SignedInclusionList
 }
 
 // ProposerSlashingReceivedData is the data sent with ProposerSlashingReceived events.

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -61,6 +61,8 @@ const (
 	PayloadAttributesTopic = "payload_attributes"
 	// BlobSidecarTopic represents a new blob sidecar event topic
 	BlobSidecarTopic = "blob_sidecar"
+	// InclusionListTopic represents a new inclusion list event topic
+	InclusionListTopic = "inclusion_list"
 	// ProposerSlashingTopic represents a new proposer slashing event topic
 	ProposerSlashingTopic = "proposer_slashing"
 	// AttesterSlashingTopic represents a new attester slashing event topic
@@ -99,6 +101,7 @@ var opsFeedEventTopics = map[feed.EventType]string{
 	operation.SyncCommitteeContributionReceived: SyncCommitteeContributionTopic,
 	operation.BLSToExecutionChangeReceived:      BLSToExecutionChangeTopic,
 	operation.BlobSidecarReceived:               BlobSidecarTopic,
+	operation.InclusionListReceived:             InclusionListTopic,
 	operation.AttesterSlashingReceived:          AttesterSlashingTopic,
 	operation.ProposerSlashingReceived:          ProposerSlashingTopic,
 }
@@ -428,6 +431,8 @@ func topicForEvent(event *feed.Event) string {
 		return BLSToExecutionChangeTopic
 	case *operation.BlobSidecarReceivedData:
 		return BlobSidecarTopic
+	case *operation.InclusionListReceivedData:
+		return InclusionListTopic
 	case *operation.AttesterSlashingReceivedData:
 		return AttesterSlashingTopic
 	case *operation.ProposerSlashingReceivedData:
@@ -529,6 +534,13 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 				Slot:          fmt.Sprintf("%d", v.Blob.Slot()),
 				VersionedHash: versionedHash.String(),
 				KzgCommitment: hexutil.Encode(v.Blob.KzgCommitment),
+			})
+		}, nil
+	case *operation.InclusionListReceivedData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.InclusionListEvent{
+				Version: "eip7805",
+				Data:    structs.SignedInclusionListFromConsensus(v.SignedInclusionList),
 			})
 		}, nil
 	case *operation.AttesterSlashingReceivedData:

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -115,6 +115,7 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 		SyncCommitteeContributionTopic,
 		BLSToExecutionChangeTopic,
 		BlobSidecarTopic,
+		InclusionListTopic,
 		AttesterSlashingTopic,
 		ProposerSlashingTopic,
 	})
@@ -194,6 +195,20 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 			Type: operation.BlobSidecarReceived,
 			Data: &operation.BlobSidecarReceivedData{
 				Blob: &vblob,
+			},
+		},
+		{
+			Type: operation.InclusionListReceived,
+			Data: &operation.InclusionListReceivedData{
+				SignedInclusionList: &eth.SignedInclusionList{
+					Message: &eth.InclusionList{
+						Slot:                       0,
+						ValidatorIndex:             0,
+						InclusionListCommitteeRoot: make([]byte, fieldparams.RootLength),
+						Transactions:               [][]byte{},
+					},
+					Signature: make([]byte, fieldparams.BLSSignatureLength),
+				},
 			},
 		},
 		{

--- a/beacon-chain/sync/inclusion_list.go
+++ b/beacon-chain/sync/inclusion_list.go
@@ -8,6 +8,8 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed"
+	opfeed "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/feed/operation"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/encoding/ssz"
@@ -146,5 +148,13 @@ func (s *Service) subscriberInclusionList(ctx context.Context, msg proto.Message
 		slots.TimeIntoSlot(uint64(s.cfg.clock.GenesisTime().Unix())) < time.Duration(params.BeaconConfig().InclusionListFreezeDeadLine)*time.Second
 
 	s.inclusionLists.Add(il.Message.Slot, il.Message.ValidatorIndex, il.Message.Transactions, isBeforeFreezeDeadline)
+
+	s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
+		Type: opfeed.InclusionListReceived,
+		Data: &opfeed.InclusionListReceivedData{
+			SignedInclusionList: il,
+		},
+	})
+
 	return nil
 }


### PR DESCRIPTION
This PR makes Prysm to emit IL event following this [spec](https://github.com/ethereum/beacon-APIs/pull/490/files). Dora successfully made to receives IL events and display ILs on the explorer.

