### PR TITLE
cleanup block indices for missing blocks

### DIFF
--- a/beacon-chain/db/filters/BUILD.bazel
+++ b/beacon-chain/db/filters/BUILD.bazel
@@ -18,5 +18,6 @@ go_test(
     deps = [
         "//consensus-types/primitives:go_default_library",
         "//testing/assert:go_default_library",
+        "//testing/require:go_default_library",
     ],
 )

--- a/beacon-chain/db/filters/filter.go
+++ b/beacon-chain/db/filters/filter.go
@@ -132,3 +132,21 @@ func (q *QueryFilter) SetSlotStep(val uint64) *QueryFilter {
 	q.queries[SlotStep] = val
 	return q
 }
+
+// SimpleSlotRange returns the start and end slot of a query filter if it is a simple slot range query.
+// A simple slot range query is one where the filter only contains a start slot and an end slot.
+// If the query is not a simple slot range query, the bool return value will be false.
+func (q *QueryFilter) SimpleSlotRange() (primitives.Slot, primitives.Slot, bool) {
+	if len(q.queries) != 2 || q.queries[StartSlot] == nil || q.queries[EndSlot] == nil {
+		return 0, 0, false
+	}
+	start, ok := q.queries[StartSlot].(primitives.Slot)
+	if !ok {
+		return 0, 0, false
+	}
+	end, ok := q.queries[EndSlot].(primitives.Slot)
+	if !ok {
+		return 0, 0, false
+	}
+	return start, end, true
+}

--- a/beacon-chain/db/filters/filter_test.go
+++ b/beacon-chain/db/filters/filter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/testing/assert"
+	"github.com/prysmaticlabs/prysm/v5/testing/require"
 )
 
 func TestQueryFilter_ChainsCorrectly(t *testing.T) {
@@ -26,5 +27,66 @@ func TestQueryFilter_ChainsCorrectly(t *testing.T) {
 		default:
 			t.Log("Unknown filter type")
 		}
+	}
+}
+
+func TestSimpleSlotRange(t *testing.T) {
+	type tc struct {
+		name        string
+		applFilters []func(*QueryFilter) *QueryFilter
+		isSimple    bool
+		start       primitives.Slot
+		end         primitives.Slot
+	}
+	cases := []tc{
+		{
+			name:        "no filters",
+			applFilters: []func(*QueryFilter) *QueryFilter{},
+			isSimple:    false,
+		},
+		{
+			name: "start slot",
+			applFilters: []func(*QueryFilter) *QueryFilter{
+				func(f *QueryFilter) *QueryFilter {
+					return f.SetStartSlot(3)
+				},
+			},
+			isSimple: false,
+		},
+		{
+			name: "end slot",
+			applFilters: []func(*QueryFilter) *QueryFilter{
+				func(f *QueryFilter) *QueryFilter {
+					return f.SetEndSlot(3)
+				},
+			},
+			isSimple: false,
+		},
+		{
+			name: "end slot",
+			applFilters: []func(*QueryFilter) *QueryFilter{
+				func(f *QueryFilter) *QueryFilter {
+					return f.SetStartSlot(3)
+				},
+				func(f *QueryFilter) *QueryFilter {
+					return f.SetEndSlot(7)
+				},
+			},
+			start:    3,
+			end:      7,
+			isSimple: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := NewFilter()
+			for _, filt := range c.applFilters {
+				f = filt(f)
+			}
+			start, end, isSimple := f.SimpleSlotRange()
+			require.Equal(t, c.isSimple, isSimple)
+			require.Equal(t, c.start, start)
+			require.Equal(t, c.end, end)
+		})
 	}
 }

--- a/changelog/kasey_repair-idx-on-read.md
+++ b/changelog/kasey_repair-idx-on-read.md
@@ -1,0 +1,2 @@
+### Fixed
+- Clean up dangling block index entries for blocks that were previously deleted by incomplete cleanup code.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

For any existing nodes impacted by the block cleanup bug fixed [recently](https://github.com/prysmaticlabs/prysm/pull/15011), this is a hack to help those nodes self-heal and avoid a complete db wipe and resync.

**Notes for reviewers **

`blockParentRootIndicesBucket` maps from a block root to its children. When the db is in this state, we don't have the parent root of the missing block to clean up the index going the other direction. As I was wrapping this PR up I did think a couple ways to do it. 

1) Before we delete the slot -> root index, we can seek a db cursor to the key for the slot of the dangling block. We can then use Prev to look at the previous slot, which should contain the parent (there can be multiple block roots backed into the slot->root index). Check each of those keys and remove the deleted root if found.
2) Since we're looping over slot/root pairs in `blocksForSlotRange`, we could keep track of roots in the previous slot so that when we add something to the `badBlocks` slice for cleanup we have parent roots to check for the missing root. If the block root is in the first slot of the range we won't have seen its possible parents and need to fall back to method 1, so this is really just an optimization for method 1 and might not be worth the complexity.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
