### PR TITLE
validator: Use health tracker in wait_for_activation.go

### DIFF
--- a/validator/client/wait_for_activation.go
+++ b/validator/client/wait_for_activation.go
@@ -84,9 +84,27 @@ func (v *validator) retryWaitForActivation(ctx context.Context, span octrace.Spa
 	tracing.AnnotateError(span, err)
 	attempts := activationAttempts(ctx)
 	log.WithError(err).WithField("attempts", attempts).Error(message)
-	// Reconnection attempt backoff, up to 60s.
-	time.Sleep(time.Second * time.Duration(math.Min(uint64(attempts), 60)))
-	// TODO: refactor this to use the health tracker instead for reattempt
+
+	// Use the health tracker to determine if we should retry
+	healthTracker := v.HealthTracker()
+	if !healthTracker.IsHealthy() {
+		// Wait for the health tracker to signal that the connection is healthy again
+		select {
+		case <-ctx.Done():
+			log.Debug("Context closed, exiting retryWaitForActivation")
+			return ctx.Err()
+		case isHealthy := <-healthTracker.HealthUpdates():
+			if !isHealthy {
+				// If still not healthy, continue with exponential backoff
+				time.Sleep(time.Second * time.Duration(math.Min(uint64(attempts), 60)))
+			}
+		}
+	} else {
+		// If the health tracker says we're healthy but we still got an error,
+		// use exponential backoff before retrying
+		time.Sleep(time.Second * time.Duration(math.Min(uint64(attempts), 60)))
+	}
+
 	return v.internalWaitForActivation(incrementRetries(ctx), accountsChangedChan)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR refactors the `retryWaitForActivation` function in the validator client to use the health tracker instead of a simple time-based retry mechanism. The health tracker provides a more robust way to detect when the beacon node is healthy again, allowing for more efficient reconnection attempts.

The implementation now:
1. Checks if the node is healthy using the health tracker
2. If not healthy, waits for a health update through the health tracker's channel
3. Maintains exponential backoff for cases where the health tracker reports the node is healthy but we still encounter errors
4. Adds proper context cancellation handling

This change improves the validator client's resilience to network issues and provides a more consistent approach to handling connection problems across the codebase.

**Which issues(s) does this PR fix?**

Fixes a TODO in validator/client/wait_for_activation.go: "refactor this to use the health tracker instead for reattempt"

**Other notes for review**

The changes are minimal and focused on the specific TODO item. I've maintained the same code style and structure as the rest of the file, and ensured that the changes are consistent with how the health tracker is used in other parts of the codebase.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.