### PR TITLE
OCL forked changed-files pin; pin others

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Download unclog binary
         uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # 1.1.2
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get new changelog files
         id: new-changelog-files
-        uses: tj-actions/changed-files@v45
+        uses: OffchainLabs/gh-action-changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v4.0.8
         with:
           files: |
             changelog/**.md

--- a/changelog/kasey_pinned-changelog-action.md
+++ b/changelog/kasey_pinned-changelog-action.md
@@ -1,0 +1,2 @@
+### Ignored
+- prysmaticlabs/prysm repo security fix: use forked version of tj-actions/changed-files and version pin other actions to commit sha in the changelog workflow.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix
Security

**What does this PR do? Why is it needed?**

Switches to a forked version of the tj-actions/changed-files repo was [exploited yesterday](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised). I have confirmed that the OffchainLabs/changed-files fork no longer contains the exploit commit after clearing all references to it and using aggressive gc to remove it.

**Other notes for review**

I'm not touching the other workflows in this PR but I will update pins for those in a follow-up PR.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
