### PR TITLE
Save orphaned Electra attestations properly

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -410,7 +410,11 @@ func (s *Service) saveOrphanedOperations(ctx context.Context, orphanedRoot [32]b
 					return err
 				}
 			} else {
-				if a.IsAggregated() {
+				if orphanedBlk.Version() >= version.Electra {
+					if err = s.cfg.AttPool.SaveBlockAttestation(a); err != nil {
+						return err
+					}
+				} else if a.IsAggregated() {
 					if err = s.cfg.AttPool.SaveAggregatedAttestation(a); err != nil {
 						return err
 					}

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -324,6 +324,72 @@ func TestSaveOrphanedAtts(t *testing.T) {
 	require.DeepEqual(t, wantAtts, atts)
 }
 
+func TestSaveOrphanedAttsElectra(t *testing.T) {
+	ctx := context.Background()
+	beaconDB := testDB.SetupDB(t)
+	service := setupBeaconChain(t, beaconDB)
+	service.genesisTime = time.Now().Add(time.Duration(-10*int64(1)*int64(params.BeaconConfig().SecondsPerSlot)) * time.Second)
+
+	// Chain setup
+	// 0 -- 1 -- 2 -- 3
+	//  \-4
+	st, keys := util.DeterministicGenesisStateElectra(t, 64)
+	blkG, err := util.GenerateFullBlockElectra(st, keys, util.DefaultBlockGenConfig(), 1)
+	assert.NoError(t, err)
+
+	util.SaveBlock(t, ctx, service.cfg.BeaconDB, blkG)
+	rG, err := blkG.Block.HashTreeRoot()
+	require.NoError(t, err)
+
+	blk1, err := util.GenerateFullBlockElectra(st, keys, util.DefaultBlockGenConfig(), 2)
+	assert.NoError(t, err)
+	blk1.Block.ParentRoot = rG[:]
+	r1, err := blk1.Block.HashTreeRoot()
+	require.NoError(t, err)
+
+	blk2, err := util.GenerateFullBlockElectra(st, keys, util.DefaultBlockGenConfig(), 3)
+	assert.NoError(t, err)
+	blk2.Block.ParentRoot = r1[:]
+	r2, err := blk2.Block.HashTreeRoot()
+	require.NoError(t, err)
+
+	blk3, err := util.GenerateFullBlockElectra(st, keys, util.DefaultBlockGenConfig(), 4)
+	assert.NoError(t, err)
+	blk3.Block.ParentRoot = r2[:]
+	r3, err := blk3.Block.HashTreeRoot()
+	require.NoError(t, err)
+
+	blk4 := util.NewBeaconBlockElectra()
+	blk4.Block.Slot = 4
+	blk4.Block.ParentRoot = rG[:]
+	r4, err := blk4.Block.HashTreeRoot()
+	require.NoError(t, err)
+	ojc := &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
+	ofc := &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
+
+	for _, blk := range []*ethpb.SignedBeaconBlockElectra{blkG, blk1, blk2, blk3, blk4} {
+		r, err := blk.Block.HashTreeRoot()
+		require.NoError(t, err)
+		state, blkRoot, err := prepareForkchoiceState(ctx, blk.Block.Slot, r, bytesutil.ToBytes32(blk.Block.ParentRoot), [32]byte{}, ojc, ofc)
+		require.NoError(t, err)
+		require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, state, blkRoot))
+		util.SaveBlock(t, ctx, beaconDB, blk)
+	}
+
+	require.NoError(t, service.saveOrphanedOperations(ctx, r3, r4))
+	require.Equal(t, 3, len(service.cfg.AttPool.BlockAttestations()))
+	wantAtts := []ethpb.Att{
+		blk3.Block.Body.Attestations[0],
+		blk2.Block.Body.Attestations[0],
+		blk1.Block.Body.Attestations[0],
+	}
+	atts := service.cfg.AttPool.BlockAttestations()
+	sort.Slice(atts, func(i, j int) bool {
+		return atts[i].GetData().Slot > atts[j].GetData().Slot
+	})
+	require.DeepEqual(t, wantAtts, atts)
+}
+
 func TestSaveOrphanedOps(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	config := params.BeaconConfig()

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -61,31 +61,21 @@ func (s *Service) batchForkChoiceAtts(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "Operations.attestations.batchForkChoiceAtts")
 	defer span.End()
 
-	postElectra := false
-	if slots.ToEpoch(slots.CurrentSlot(s.genesisTime)) >= params.BeaconConfig().ElectraForkEpoch {
-		postElectra = true
-	}
-
-	var attsToAggregate []ethpb.Att
+	var atts []ethpb.Att
 	if features.Get().EnableExperimentalAttestationPool {
-		attsToAggregate = append(s.cfg.Cache.GetAll(), s.cfg.Cache.ForkchoiceAttestations()...)
+		atts = append(s.cfg.Cache.GetAll(), s.cfg.Cache.ForkchoiceAttestations()...)
 	} else {
 		if err := s.cfg.Pool.AggregateUnaggregatedAttestations(ctx); err != nil {
 			return err
 		}
-		attsToAggregate = append(s.cfg.Pool.AggregatedAttestations(), s.cfg.Pool.ForkchoiceAttestations()...)
-
-		// Post-Electra every block attestation will very likely consist of attestations
-		// for multiple committees and therefore will not be aggregatable.
-		if !postElectra {
-			attsToAggregate = append(attsToAggregate, s.cfg.Pool.BlockAttestations()...)
-		}
+		atts = append(s.cfg.Pool.AggregatedAttestations(), s.cfg.Pool.BlockAttestations()...)
+		atts = append(atts, s.cfg.Pool.ForkchoiceAttestations()...)
 	}
 
-	attsById := make(map[attestation.Id][]ethpb.Att, len(attsToAggregate))
+	attsById := make(map[attestation.Id][]ethpb.Att, len(atts))
 
 	// Consolidate attestations by aggregating them by similar data root.
-	for _, att := range attsToAggregate {
+	for _, att := range atts {
 		seen, err := s.seen(att)
 		if err != nil {
 			return err
@@ -103,15 +93,6 @@ func (s *Service) batchForkChoiceAtts(ctx context.Context) error {
 
 	for _, atts := range attsById {
 		if err := s.aggregateAndSaveForkChoiceAtts(atts); err != nil {
-			return err
-		}
-	}
-
-	// Post-Electra every block attestation will very likely consist of attestations
-	// for multiple committees and therefore will not be aggregatable.
-	// For this reason we save them separately.
-	if postElectra {
-		if err := s.cfg.Pool.SaveForkchoiceAttestations(s.cfg.Pool.BlockAttestations()); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -61,21 +61,31 @@ func (s *Service) batchForkChoiceAtts(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "Operations.attestations.batchForkChoiceAtts")
 	defer span.End()
 
-	var atts []ethpb.Att
+	postElectra := false
+	if slots.ToEpoch(slots.CurrentSlot(s.genesisTime)) >= params.BeaconConfig().ElectraForkEpoch {
+		postElectra = true
+	}
+
+	var attsToAggregate []ethpb.Att
 	if features.Get().EnableExperimentalAttestationPool {
-		atts = append(s.cfg.Cache.GetAll(), s.cfg.Cache.ForkchoiceAttestations()...)
+		attsToAggregate = append(s.cfg.Cache.GetAll(), s.cfg.Cache.ForkchoiceAttestations()...)
 	} else {
 		if err := s.cfg.Pool.AggregateUnaggregatedAttestations(ctx); err != nil {
 			return err
 		}
-		atts = append(s.cfg.Pool.AggregatedAttestations(), s.cfg.Pool.BlockAttestations()...)
-		atts = append(atts, s.cfg.Pool.ForkchoiceAttestations()...)
+		attsToAggregate = append(s.cfg.Pool.AggregatedAttestations(), s.cfg.Pool.ForkchoiceAttestations()...)
+
+		// Post-Electra every block attestation will very likely consist of attestations
+		// for multiple committees and therefore will not be aggregatable.
+		if !postElectra {
+			attsToAggregate = append(attsToAggregate, s.cfg.Pool.BlockAttestations()...)
+		}
 	}
 
-	attsById := make(map[attestation.Id][]ethpb.Att, len(atts))
+	attsById := make(map[attestation.Id][]ethpb.Att, len(attsToAggregate))
 
 	// Consolidate attestations by aggregating them by similar data root.
-	for _, att := range atts {
+	for _, att := range attsToAggregate {
 		seen, err := s.seen(att)
 		if err != nil {
 			return err
@@ -93,6 +103,15 @@ func (s *Service) batchForkChoiceAtts(ctx context.Context) error {
 
 	for _, atts := range attsById {
 		if err := s.aggregateAndSaveForkChoiceAtts(atts); err != nil {
+			return err
+		}
+	}
+
+	// Post-Electra every block attestation will very likely consist of attestations
+	// for multiple committees and therefore will not be aggregatable.
+	// For this reason we save them separately.
+	if postElectra {
+		if err := s.cfg.Pool.SaveForkchoiceAttestations(s.cfg.Pool.BlockAttestations()); err != nil {
 			return err
 		}
 	}

--- a/changelog/radek_forkchoice-and-block-atts.md
+++ b/changelog/radek_forkchoice-and-block-atts.md
@@ -1,4 +1,3 @@
 ### Changed
 
 - Save Electra orphaned attestations into attestations pool's block attestations.
-- Do not try to aggregate Electra block attestations in `batchForkChoiceAtts`.

--- a/changelog/radek_forkchoice-and-block-atts.md
+++ b/changelog/radek_forkchoice-and-block-atts.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Save Electra orphaned attestations into attestations pool's block attestations.
+- Do not try to aggregate Electra block attestations in `batchForkChoiceAtts`.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

After Electra, it is very likely that all block attestations will contain attestations for more than one committee. Because of this orphaned attestations shouldn't be saved as aggregated attestations, but as block attestations.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
