### PR TITLE
Clean up infinity signature usages

### DIFF
--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//consensus-types/validator:go_default_library",
+        "//crypto/bls/common:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
         "//network/httputil:go_default_library",

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -16,6 +16,7 @@ import (
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/crypto/bls/common"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
 	"github.com/prysmaticlabs/prysm/v5/network/httputil"
@@ -57,7 +58,7 @@ func (s *Server) ProduceBlockV2(w http.ResponseWriter, r *http.Request) {
 
 	var randaoReveal []byte
 	if rawSkipRandaoVerification == "true" {
-		randaoReveal = primitives.PointAtInfinity
+		randaoReveal = common.InfiniteSignature[:]
 	} else {
 		rr, err := bytesutil.DecodeHexWithLength(rawRandaoReveal, fieldparams.BLSSignatureLength)
 		if err != nil {
@@ -109,7 +110,7 @@ func (s *Server) ProduceBlindedBlock(w http.ResponseWriter, r *http.Request) {
 
 	var randaoReveal []byte
 	if rawSkipRandaoVerification == "true" {
-		randaoReveal = primitives.PointAtInfinity
+		randaoReveal = common.InfiniteSignature[:]
 	} else {
 		rr, err := bytesutil.DecodeHexWithLength(rawRandaoReveal, fieldparams.BLSSignatureLength)
 		if err != nil {
@@ -174,7 +175,7 @@ func (s *Server) ProduceBlockV3(w http.ResponseWriter, r *http.Request) {
 
 	var randaoReveal []byte
 	if rawSkipRandaoVerification == "true" {
-		randaoReveal = primitives.PointAtInfinity
+		randaoReveal = common.InfiniteSignature[:]
 	} else {
 		rr, err := bytesutil.DecodeHexWithLength(rawRandaoReveal, fieldparams.BLSSignatureLength)
 		if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
         "//container/trie:go_default_library",
         "//contracts/deposit:go_default_library",
         "//crypto/bls:go_default_library",
+        "//crypto/bls/common:go_default_library",
         "//crypto/hash:go_default_library",
         "//crypto/rand:go_default_library",
         "//encoding/bytesutil:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/crypto/bls"
+	"github.com/prysmaticlabs/prysm/v5/crypto/bls/common"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
@@ -96,7 +97,7 @@ func (vs *Server) getSyncAggregate(ctx context.Context, slot primitives.Slot, ro
 	syncSig := bls.AggregateSignatures(sigsHolder)
 	var syncSigBytes [96]byte
 	if syncSig == nil {
-		syncSigBytes = [96]byte{0xC0} // Infinity signature if itself is nil.
+		syncSigBytes = common.InfiniteSignature // Infinity signature if itself is nil.
 	} else {
 		syncSigBytes = bytesutil.ToBytes96(syncSig.Marshal())
 	}

--- a/changelog/tt_clean_up.md
+++ b/changelog/tt_clean_up.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Clean up infinity signature usages

--- a/consensus-types/primitives/BUILD.bazel
+++ b/consensus-types/primitives/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "execution_address.go",
         "kzg.go",
         "payload_id.go",
-        "randao.go",
         "slot.go",
         "sszbytes.go",
         "sszuint64.go",

--- a/consensus-types/primitives/randao.go
+++ b/consensus-types/primitives/randao.go
@@ -1,3 +1,0 @@
-package primitives
-
-var PointAtInfinity = append([]byte{0xC0}, make([]byte, 95)...)

--- a/crypto/bls/blst/signature_test.go
+++ b/crypto/bls/blst/signature_test.go
@@ -171,8 +171,7 @@ func TestEth2FastAggregateVerify_ReturnsTrueOnG2PointAtInfinity(t *testing.T) {
 	var pubkeys []common.PublicKey
 	msg := [32]byte{'h', 'e', 'l', 'l', 'o'}
 
-	g2PointAtInfinity := append([]byte{0xC0}, make([]byte, 95)...)
-	aggSig, err := SignatureFromBytes(g2PointAtInfinity)
+	aggSig, err := SignatureFromBytes(common.InfiniteSignature[:])
 	require.NoError(t, err)
 	assert.Equal(t, true, aggSig.Eth2FastAggregateVerify(pubkeys, msg))
 }


### PR DESCRIPTION
Uses `common.InfiniteSignature` instead of defining infinite signature in many places