### PR TITLE
feat(proposer): add gas limit range warnings

### DIFF
--- a/changelog/volodymyrbg_gas_limit_warnings.md
+++ b/changelog/volodymyrbg_gas_limit_warnings.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add warning messages for gas limit ranges that might be problematic. Low gas limits (≤10% of default) may cause transactions to fail, while high gas limits (>150% of default) could lead to block propagation issues. 

--- a/config/proposer/loader/loader.go
+++ b/config/proposer/loader/loader.go
@@ -333,7 +333,7 @@ func reviewGasLimit(gasLimit validator.Uint64) validator.Uint64 {
 	// Warning for ranges that might be problematic
 	defaultGasLimit := params.BeaconConfig().DefaultBuilderGasLimit
 	// If gas limit is very low (below 10% of default), warn about potential issues
-	if gasLimit < validator.Uint64(defaultGasLimit/10) {
+	if gasLimit <= validator.Uint64(defaultGasLimit/10) {
 		log.Warnf("Gas limit %d is very low compared to default %d, which may cause transactions to fail", gasLimit, defaultGasLimit)
 	}
 	// If gas limit is very high (above 150% of default), warn about potential block propagation issues

--- a/config/proposer/loader/loader.go
+++ b/config/proposer/loader/loader.go
@@ -338,7 +338,7 @@ func reviewGasLimit(gasLimit validator.Uint64) validator.Uint64 {
 	}
 	// If gas limit is very high (above 150% of default), warn about potential block propagation issues
 	if gasLimit > validator.Uint64(defaultGasLimit*3/2) {
-		log.Warnf("Gas limit %d is very high compared to default %d, which may cause block propagation issues", gasLimit, defaultGasLimit)
+		log.Warnf("Gas limit %d is very high compared to default %d", gasLimit, defaultGasLimit)
 	}
 
 	return gasLimit

--- a/config/proposer/loader/loader.go
+++ b/config/proposer/loader/loader.go
@@ -329,6 +329,17 @@ func reviewGasLimit(gasLimit validator.Uint64) validator.Uint64 {
 	if gasLimit == 0 {
 		return validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit)
 	}
-	// TODO(10810): add in warning for ranges
+
+	// Warning for ranges that might be problematic
+	defaultGasLimit := params.BeaconConfig().DefaultBuilderGasLimit
+	// If gas limit is very low (below 10% of default), warn about potential issues
+	if gasLimit < validator.Uint64(defaultGasLimit/10) {
+		log.Warnf("Gas limit %d is very low compared to default %d, which may cause transactions to fail", gasLimit, defaultGasLimit)
+	}
+	// If gas limit is very high (above 150% of default), warn about potential block propagation issues
+	if gasLimit > validator.Uint64(defaultGasLimit*3/2) {
+		log.Warnf("Gas limit %d is very high compared to default %d, which may cause block propagation issues", gasLimit, defaultGasLimit)
+	}
+
 	return gasLimit
 }


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR adds warning messages when users configure gas limits that are significantly different from the default value. When the gas limit is too low (below 10% of default), a warning is logged that transactions might fail. When it's too high (above 150% of default), a warning is shown about potential block propagation issues.
These warnings help validators set appropriate gas limits without forcing specific values, improving user experience by providing guidance while maintaining flexibility.

**Which issues(s) does this PR fix?**

Fixes #10810 

**Other notes for review**

The implementation uses a simple percentage-based approach to determine what constitutes "extreme" gas limit values. The thresholds (10% and 150%) were chosen based on common practices, but could be adjusted if needed.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
