### PR TITLE
refactor: Remove redundant string conversion in BeaconDbStater.State

### DIFF
--- a/beacon-chain/rpc/lookup/stater.go
+++ b/beacon-chain/rpc/lookup/stater.go
@@ -143,8 +143,7 @@ func (p *BeaconDbStater) State(ctx context.Context, stateId []byte) (state.Beaco
 			return nil, errors.Wrap(err, "could not get justified state")
 		}
 	default:
-		stringId := strings.ToLower(string(stateId))
-		if len(stringId) >= 2 && stringId[:2] == "0x" {
+		if len(stateIdString) >= 2 && stateIdString[:2] == "0x" {
 			decoded, parseErr := hexutil.Decode(string(stateId))
 			if parseErr != nil {
 				e := NewStateIdParseError(parseErr)

--- a/changelog/jyap808-staterrefactor.md
+++ b/changelog/jyap808-staterrefactor.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Removed redundant string conversion in `BeaconDbStater.State` to improve code clarity and maintainability.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Removed Redundancy:

The redundant `stringId := strings.ToLower(string(stateId))` line is removed. This conversion is done earlier in the function here:
https://github.com/prysmaticlabs/prysm/blob/2351064e8d6abc1ccbb407e7cf68c3e8552aaee4/beacon-chain/rpc/lookup/stater.go#L105

`stateIdString` is reused for all string-based operations.

Improved Readability:

The code is now cleaner and easier to understand.

Maintained Functionality:

The logic remains unchanged, ensuring no impact on functionality.

**Which issues(s) does this PR fix?**

None but I was taking a look at https://github.com/prysmaticlabs/prysm/issues/15049 when I noticed this.

**Other notes for review**

N/A.

**Acknowledgements**

- [X] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [X] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [X] I have added a description to this PR with sufficient context for reviewers to understand this PR.
