### PR TITLE
Deprecate broken and unused debug flags in favor of --pprof

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -61,7 +61,6 @@ go_library(
         "//monitoring/prometheus:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//runtime:go_default_library",
-        "//runtime/debug:go_default_library",
         "//runtime/prereqs:go_default_library",
         "//runtime/version:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -64,7 +64,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/prometheus"
 	"github.com/prysmaticlabs/prysm/v5/runtime"
-	"github.com/prysmaticlabs/prysm/v5/runtime/debug"
 	"github.com/prysmaticlabs/prysm/v5/runtime/prereqs"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/sirupsen/logrus"
@@ -432,7 +431,6 @@ func (b *BeaconNode) Start() {
 		defer signal.Stop(sigc)
 		<-sigc
 		log.Info("Got interrupt, shutting down...")
-		debug.Exit(b.cliCtx) // Ensure trace and CPU profile data are flushed.
 		go b.Close()
 		for i := 10; i > 0; i-- {
 			<-sigc

--- a/changelog/james-prysm_deprecate-non-pprof.md
+++ b/changelog/james-prysm_deprecate-non-pprof.md
@@ -1,3 +1,3 @@
-### Removed
+### Deprecated
 
 - deprecates and removes usage of the `--trace` flag and`--cpuprofile` flag in favor of just using `--pprof`

--- a/changelog/james-prysm_deprecate-non-pprof.md
+++ b/changelog/james-prysm_deprecate-non-pprof.md
@@ -1,0 +1,3 @@
+### Removed
+
+- deprecates and removes usage of the `--trace` flag and`--cpuprofile` flag in favor of just using `--pprof`

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -211,6 +211,8 @@ var appHelpFlagGroups = []flagGroup{
 		Name: "deprecated",
 		Flags: []cli.Flag{
 			cmd.BackupWebhookOutputDir,
+			debug.CPUProfileFlag,
+			debug.TraceFlag,
 		},
 	},
 	{ // Flags used in debugging Prysm. These are flags not usually run by end users.
@@ -218,13 +220,11 @@ var appHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			cmd.MaxGoroutines,
 			debug.BlockProfileRateFlag,
-			debug.CPUProfileFlag,
 			debug.MemProfileRateFlag,
 			debug.MutexProfileFractionFlag,
 			debug.PProfAddrFlag,
 			debug.PProfFlag,
 			debug.PProfPortFlag,
-			debug.TraceFlag,
 			flags.SetGCPercent,
 		},
 	},

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -199,10 +199,6 @@ func main() {
 
 			return cmd.ValidateNoArgs(ctx)
 		},
-		After: func(ctx *cli.Context) error {
-			debug.Exit(ctx)
-			return nil
-		},
 	}
 
 	defer func() {

--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -85,8 +85,6 @@ var appHelpFlagGroups = []flagGroup{
 			debug.PProfAddrFlag,
 			debug.PProfPortFlag,
 			debug.MemProfileRateFlag,
-			debug.CPUProfileFlag,
-			debug.TraceFlag,
 			debug.BlockProfileRateFlag,
 			debug.MutexProfileFractionFlag,
 		},
@@ -155,6 +153,13 @@ var appHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			flags.InteropNumValidators,
 			flags.InteropStartIndex,
+		},
+	},
+	{
+		Name: "deprecated",
+		Flags: []cli.Flag{
+			debug.CPUProfileFlag,
+			debug.TraceFlag,
 		},
 	},
 }

--- a/runtime/debug/debug.go
+++ b/runtime/debug/debug.go
@@ -78,15 +78,15 @@ var (
 		Name:  "blockprofilerate",
 		Usage: "Turns on block profiling with the given rate.",
 	}
-	// CPUProfileFlag to specify where to write the CPU profile.
+	// deprecated: CPUProfileFlag
 	CPUProfileFlag = &cli.StringFlag{
 		Name:  "cpuprofile",
-		Usage: "Writes CPU profile to the given file.",
+		Usage: "Do not use, deprecated",
 	}
-	// TraceFlag to specify where to write the trace execution profile.
+	// deprecated: TraceFlag
 	TraceFlag = &cli.StringFlag{
 		Name:  "trace",
-		Usage: "Writes execution trace to the given file.",
+		Usage: "Do not use, deprecated",
 	}
 )
 
@@ -328,17 +328,6 @@ func Setup(ctx *cli.Context) error {
 	if ctx.IsSet(MutexProfileFractionFlag.Name) {
 		runtime.SetMutexProfileFraction(ctx.Int(MutexProfileFractionFlag.Name))
 	}
-	if traceFile := ctx.String(TraceFlag.Name); traceFile != "" {
-		if err := Handler.StartGoTrace(TraceFlag.Name); err != nil {
-			return err
-		}
-	}
-	if cpuFile := ctx.String(CPUProfileFlag.Name); cpuFile != "" {
-		if err := Handler.StartCPUProfile(cpuFile); err != nil {
-			return err
-		}
-	}
-
 	// pprof server
 	if ctx.Bool(PProfFlag.Name) {
 		address := fmt.Sprintf("%s:%d", ctx.String(PProfAddrFlag.Name), ctx.Int(PProfPortFlag.Name))
@@ -358,19 +347,4 @@ func startPProf(address string) {
 			log.Error("Failure in running pprof server", "err", err)
 		}
 	}()
-}
-
-// Exit stops all running profiles, flushing their output to the
-// respective file.
-func Exit(ctx *cli.Context) {
-	if traceFile := ctx.String(TraceFlag.Name); traceFile != "" {
-		if err := Handler.StopGoTrace(); err != nil {
-			log.WithError(err).Error("Failed to stop go tracing")
-		}
-	}
-	if cpuFile := ctx.String(CPUProfileFlag.Name); cpuFile != "" {
-		if err := Handler.StopCPUProfile(); err != nil {
-			log.WithError(err).Error("Failed to stop CPU profiling")
-		}
-	}
 }

--- a/runtime/debug/debug.go
+++ b/runtime/debug/debug.go
@@ -80,13 +80,15 @@ var (
 	}
 	// deprecated: CPUProfileFlag
 	CPUProfileFlag = &cli.StringFlag{
-		Name:  "cpuprofile",
-		Usage: "Do not use, deprecated",
+		Name:   "cpuprofile",
+		Hidden: true,
+		Usage:  "Do not use, deprecated",
 	}
 	// deprecated: TraceFlag
 	TraceFlag = &cli.StringFlag{
-		Name:  "trace",
-		Usage: "Do not use, deprecated",
+		Name:   "trace",
+		Hidden: true,
+		Usage:  "Do not use, deprecated",
 	}
 )
 

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//monitoring/prometheus:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//runtime:go_default_library",
-        "//runtime/debug:go_default_library",
         "//runtime/prereqs:go_default_library",
         "//runtime/version:go_default_library",
         "//validator/accounts/wallet:go_default_library",

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -32,7 +32,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/monitoring/prometheus"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing"
 	"github.com/prysmaticlabs/prysm/v5/runtime"
-	"github.com/prysmaticlabs/prysm/v5/runtime/debug"
 	"github.com/prysmaticlabs/prysm/v5/runtime/prereqs"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/validator/accounts/wallet"
@@ -154,7 +153,6 @@ func (c *ValidatorClient) Start() {
 		defer signal.Stop(sigc)
 		<-sigc
 		log.Info("Got interrupt, shutting down...")
-		debug.Exit(c.cliCtx) // Ensure trace and CPU profile data are flushed.
 		go c.Close()
 		for i := 10; i > 0; i-- {
 			<-sigc


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

I noticed the `--trace` flag had been broken for several years without issue reports meaning the flag was most likely not used. This PR adds some cleanup deprecating these unused flags and set for removal at a later date.

tracing and CPU profiling are supported through the `--pprof` flag

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
