### PR TITLE
refactor state-by-root tests to table-driven

### DIFF
--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -2,12 +2,16 @@ package stategen
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/db"
 	testDB "github.com/prysmaticlabs/prysm/v5/beacon-chain/db/testing"
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v5/beacon-chain/forkchoice/doubly-linked-tree"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
+	blt "github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
@@ -110,65 +114,6 @@ func TestStateByRootIfCachedNoCopy_ColdState(t *testing.T) {
 	require.Equal(t, loadedState, nil)
 }
 
-func TestStateByRoot_HotStateUsingEpochBoundaryCacheNoReplay(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	require.NoError(t, beaconState.SetSlot(10))
-	blk := util.NewBeaconBlock()
-	blkRoot, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: blkRoot[:]}))
-	require.NoError(t, service.epochBoundaryStateCache.put(blkRoot, beaconState))
-	loadedState, err := service.StateByRoot(ctx, blkRoot)
-	require.NoError(t, err)
-	assert.Equal(t, primitives.Slot(10), loadedState.Slot(), "Did not correctly load state")
-}
-
-func TestStateByRoot_HotStateUsingEpochBoundaryCacheWithReplay(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	blk := util.NewBeaconBlock()
-	blkRoot, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, service.epochBoundaryStateCache.put(blkRoot, beaconState))
-	targetSlot := primitives.Slot(10)
-	targetBlock := util.NewBeaconBlock()
-	targetBlock.Block.Slot = 11
-	targetBlock.Block.ParentRoot = blkRoot[:]
-	targetBlock.Block.ProposerIndex = 8
-	util.SaveBlock(t, ctx, service.beaconDB, targetBlock)
-	targetRoot, err := targetBlock.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: targetSlot, Root: targetRoot[:]}))
-	loadedState, err := service.StateByRoot(ctx, targetRoot)
-	require.NoError(t, err)
-	assert.Equal(t, targetSlot, loadedState.Slot(), "Did not correctly load state")
-}
-
-func TestStateByRoot_HotStateCached(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	r := [32]byte{'A'}
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: r[:]}))
-	service.hotStateCache.put(r, beaconState)
-
-	loadedState, err := service.StateByRoot(ctx, r)
-	require.NoError(t, err)
-	require.DeepSSZEqual(t, loadedState.ToProtoUnsafe(), beaconState.ToProtoUnsafe())
-}
-
 func TestDeleteStateFromCaches(t *testing.T) {
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(t)
@@ -198,173 +143,349 @@ func TestDeleteStateFromCaches(t *testing.T) {
 	require.Equal(t, false, has)
 }
 
-func TestStateByRoot_StateByRootInitialSync(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-
-	service := New(beaconDB, doublylinkedtree.New())
-	b := util.NewBeaconBlock()
-	bRoot, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	require.NoError(t, service.beaconDB.SaveState(ctx, beaconState, bRoot))
-	util.SaveBlock(t, ctx, service.beaconDB, b)
-	require.NoError(t, service.beaconDB.SaveGenesisBlockRoot(ctx, bRoot))
-	loadedState, err := service.StateByRootInitialSync(ctx, params.BeaconConfig().ZeroHash) // Zero hash is genesis state root.
-	require.NoError(t, err)
-	require.DeepSSZEqual(t, loadedState.ToProtoUnsafe(), beaconState.ToProtoUnsafe())
+// testChainSlot represents one slot of the test chain
+type testChainSlot struct {
+	st   state.BeaconState
+	root [32]byte
+	blk  blt.ROBlock
 }
 
-func TestStateByRootInitialSync_UseEpochStateCache(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	targetSlot := primitives.Slot(10)
-	require.NoError(t, beaconState.SetSlot(targetSlot))
-	blk := util.NewBeaconBlock()
-	blkRoot, err := blk.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, service.epochBoundaryStateCache.put(blkRoot, beaconState))
-	loadedState, err := service.StateByRootInitialSync(ctx, blkRoot)
-	require.NoError(t, err)
-	assert.Equal(t, targetSlot, loadedState.Slot(), "Did not correctly load state")
+// testChain represents the test block chain that is written to the DB / cache.
+// Used to test the StateByRoot, StateByRootInitSync and loadStateByRoot methods.
+type testChain struct {
+	t      *testing.T
+	ctx    context.Context
+	d      db.Database
+	srv    *State
+	cslots map[primitives.Slot]testChainSlot
 }
 
-func TestStateByRootInitialSync_UseCache(t *testing.T) {
+// the following are helpers used in the test cases and helpers to concisely get the different
+// components of the chain by slot.
+func (c testChain) cslot(t *testing.T, s primitives.Slot) testChainSlot {
+	cs, ok := c.cslots[s]
+	require.Equal(t, true, ok, fmt.Sprintf("state not found for slot %d", s))
+	return cs
+}
+
+func (c testChain) state(t *testing.T, s primitives.Slot) state.BeaconState {
+	return c.cslot(t, s).st
+}
+
+func (c testChain) blockRoot(t *testing.T, s primitives.Slot) [32]byte {
+	return c.cslot(t, s).root
+}
+
+func (c testChain) block(t *testing.T, s primitives.Slot) blt.ROBlock {
+	return c.cslot(t, s).blk
+}
+
+type testSetupSlots struct {
+	stateAt   primitives.Slot
+	lastblock primitives.Slot
+}
+
+func TestLoadStateByRoot(t *testing.T) {
 	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	r := [32]byte{'A'}
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: r[:]}))
-	service.hotStateCache.put(r, beaconState)
-
-	loadedState, err := service.StateByRootInitialSync(ctx, r)
-	require.NoError(t, err)
-	require.DeepSSZEqual(t, loadedState.ToProtoUnsafe(), beaconState.ToProtoUnsafe())
-	if service.hotStateCache.has(r) {
-		t.Error("Hot state cache was not invalidated")
+	persistEpochBoundary := func(r testChain, slot primitives.Slot) {
+		require.NoError(t, r.srv.epochBoundaryStateCache.put(r.blockRoot(r.t, slot), r.state(t, slot)))
 	}
-}
+	persistHotStateCache := func(r testChain, slot primitives.Slot) {
+		r.srv.hotStateCache.put(r.blockRoot(t, slot), r.state(t, slot))
+	}
+	persistDB := func(r testChain, slot primitives.Slot) {
+		require.NoError(r.t, r.d.SaveState(r.ctx, r.state(t, slot), r.blockRoot(t, slot)))
+	}
+	persistFinalizedStruct := func(r testChain, slot primitives.Slot) {
+		st := r.state(t, slot)
+		r.srv.finalizedInfo.state = st
+		r.srv.finalizedInfo.slot = st.Slot()
+		r.srv.finalizedInfo.root = r.blockRoot(t, slot)
+	}
 
-func TestStateByRootInitialSync_CanProcessUpTo(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-	service := New(beaconDB, doublylinkedtree.New())
+	type testLoader func(r testChain) (state.BeaconState, error)
+	lsbr := func(slot primitives.Slot) testLoader {
+		return func(tc testChain) (state.BeaconState, error) {
+			return tc.srv.loadStateByRoot(tc.ctx, tc.blockRoot(t, slot))
+		}
+	}
+	sbrInit := func(slot primitives.Slot) testLoader {
+		return func(tc testChain) (state.BeaconState, error) {
+			return tc.srv.StateByRootInitialSync(tc.ctx, tc.blockRoot(t, slot))
+		}
+	}
+	sbr := func(slot primitives.Slot) testLoader {
+		return func(tc testChain) (state.BeaconState, error) {
+			return tc.srv.StateByRoot(tc.ctx, tc.blockRoot(t, slot))
+		}
+	}
 
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	blk := util.NewBeaconBlock()
-	blkRoot, err := blk.Block.HashTreeRoot()
+	cases := []struct {
+		name         string
+		slots        testSetupSlots
+		persistState func(r testChain, s primitives.Slot)
+		loader       testLoader // ie loadStateByRoot; StateByRootInitialSync; StateByRoot
+	}{
+		// loadStateByRoot tests
+		{
+			name:         "loadStateByRoot - using epoch boundary cache",
+			persistState: persistEpochBoundary,
+			loader:       lsbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "loadStateByRoot - with replay - using epoch boundary cache",
+			persistState: persistEpochBoundary,
+			loader:       lsbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "loadStateByRoot - using hot state cache",
+			persistState: persistHotStateCache,
+			loader:       lsbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "loadStateByRoot - with replay - using hot state cache",
+			persistState: persistHotStateCache,
+			loader:       lsbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "loadStateByRoot - using db",
+			persistState: persistDB,
+			loader:       lsbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "loadStateByRoot - with replay - using db",
+			persistState: persistDB,
+			loader:       lsbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "loadStateByRoot - using finalizedInfo struct field",
+			persistState: persistFinalizedStruct,
+			loader:       lsbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "loadStateByRoot - with replay - using finalizedInfo struct field",
+			persistState: persistFinalizedStruct,
+			loader:       lsbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		// StateByRootInitSync tests
+		{
+			name:         "StateByRootInitSync - using epoch boundary cache",
+			persistState: persistEpochBoundary,
+			loader:       sbrInit(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRootInitSync - with replay - using epoch boundary cache",
+			persistState: persistEpochBoundary,
+			loader:       sbrInit(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "StateByRootInitSync - using hot state cache",
+			persistState: persistHotStateCache,
+			loader:       sbrInit(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRootInitSync - with replay - using hot state cache",
+			persistState: persistHotStateCache,
+			loader:       sbrInit(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "StateByRootInitSync - using db",
+			persistState: persistDB,
+			loader:       sbrInit(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRootInitSync - with replay - using db",
+			persistState: persistDB,
+			loader:       sbrInit(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "StateByRootInitSync - using finalizedInfo struct field",
+			persistState: persistFinalizedStruct,
+			loader:       sbrInit(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRootInitSync - with replay - using finalizedInfo struct field",
+			persistState: persistFinalizedStruct,
+			loader:       sbrInit(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		// StateByRoot tests
+		{
+			name:         "StateByRoot - using epoch boundary cache",
+			persistState: persistEpochBoundary,
+			loader:       sbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRoot - with replay - using epoch boundary cache",
+			persistState: persistEpochBoundary,
+			loader:       sbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "StateByRoot - using hot state cache",
+			persistState: persistHotStateCache,
+			loader:       sbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRoot - with replay - using hot state cache",
+			persistState: persistHotStateCache,
+			loader:       sbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "StateByRoot - using db",
+			persistState: persistDB,
+			loader:       sbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRoot - with replay - using db",
+			persistState: persistDB,
+			loader:       sbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+		{
+			name:         "StateByRoot - using finalizedInfo struct field",
+			persistState: persistFinalizedStruct,
+			loader:       sbr(10),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 10},
+		},
+		{
+			name:         "StateByRoot - with replay - using finalizedInfo struct field",
+			persistState: persistFinalizedStruct,
+			loader:       sbr(11),
+			slots:        testSetupSlots{stateAt: 9, lastblock: 11},
+		},
+	}
+
+	// Do all the state setup just once
+
+	// generate state and wind up to slot 9
+	st9, _ := util.DeterministicGenesisState(t, 32)
+	st9, err := ReplayProcessSlots(ctx, st9, 9)
 	require.NoError(t, err)
-	require.NoError(t, service.epochBoundaryStateCache.put(blkRoot, beaconState))
-	targetSlot := primitives.Slot(10)
-	targetBlk := util.NewBeaconBlock()
-	targetBlk.Block.Slot = 11
-	targetBlk.Block.ParentRoot = blkRoot[:]
-	targetRoot, err := targetBlk.Block.HashTreeRoot()
+	// take latest block header at slot 9 as parent root for block at slot 10
+	hdr := st9.LatestBlockHeader()
+	hdrRoot, err := hdr.HashTreeRoot()
 	require.NoError(t, err)
-	util.SaveBlock(t, ctx, service.beaconDB, targetBlk)
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: targetSlot, Root: targetRoot[:]}))
 
-	loadedState, err := service.StateByRootInitialSync(ctx, targetRoot)
+	st10 := st9.Copy()
+	// set up block at slot 10, pointed to the latest block header as parent root
+	// at slot 10
+	// using correctly computed proposer index
+	blk10 := util.NewBeaconBlock()
+	blk10.Block.Slot = 10
+	blk10.Block.ParentRoot = hdrRoot[:]
+	idx10, err := helpers.BeaconProposerIndexAtSlot(ctx, st10, blk10.Block.Slot)
 	require.NoError(t, err)
-	assert.Equal(t, targetSlot, loadedState.Slot(), "Did not correctly load state")
-}
-
-func TestLoadeStateByRoot_Cached(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	r := [32]byte{'A'}
-	service.hotStateCache.put(r, beaconState)
-
-	// This tests where hot state was already cached.
-	loadedState, err := service.loadStateByRoot(ctx, r)
+	blk10.Block.ProposerIndex = idx10
+	// modernized block types for slot 10
+	ib10, err := blt.NewSignedBeaconBlock(blk10)
 	require.NoError(t, err)
-	require.DeepSSZEqual(t, loadedState.ToProtoUnsafe(), beaconState.ToProtoUnsafe())
-}
 
-func TestLoadeStateByRoot_FinalizedState(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	genesisStateRoot, err := beaconState.HashTreeRoot(ctx)
+	// make state at slot 10 by transitioning a copy of st9 with ib10 (aka blk10)
+	st10, err = executeStateTransitionStateGen(context.Background(), st10, ib10)
 	require.NoError(t, err)
-	genesis := blocks.NewGenesisBlock(genesisStateRoot[:])
-	util.SaveBlock(t, ctx, beaconDB, genesis)
-	gRoot, err := genesis.Block.HashTreeRoot()
+	st10Root, err := st10.HashTreeRoot(context.Background())
 	require.NoError(t, err)
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 0, Root: gRoot[:]}))
-
-	service.finalizedInfo.state = beaconState
-	service.finalizedInfo.slot = beaconState.Slot()
-	service.finalizedInfo.root = gRoot
-
-	// This tests where hot state was already cached.
-	loadedState, err := service.loadStateByRoot(ctx, gRoot)
+	// update state root for block 10 now that its been through stf
+	blk10.Block.StateRoot = st10Root[:]
+	ib10, err = blt.NewSignedBeaconBlock(blk10)
 	require.NoError(t, err)
-	require.DeepSSZEqual(t, loadedState.ToProtoUnsafe(), beaconState.ToProtoUnsafe())
-}
-
-func TestLoadeStateByRoot_EpochBoundaryStateCanProcess(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	gBlk := util.NewBeaconBlock()
-	gBlkRoot, err := gBlk.Block.HashTreeRoot()
+	rob10, err := blt.NewROBlock(ib10)
 	require.NoError(t, err)
-	require.NoError(t, service.epochBoundaryStateCache.put(gBlkRoot, beaconState))
 
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = 11
-	blk.Block.ProposerIndex = 8
-	blk.Block.ParentRoot = gBlkRoot[:]
-	util.SaveBlock(t, ctx, service.beaconDB, blk)
-	blkRoot, err := blk.Block.HashTreeRoot()
+	// same series of steps for block at slot 11 - pointing to block 10 as parent
+	blk11 := util.NewBeaconBlock()
+	blk11.Block.Slot = 11
+	blk11.Block.ParentRoot = rob10.RootSlice()
+	idx11, err := helpers.BeaconProposerIndexAtSlot(context.Background(), st10, blk11.Block.Slot)
 	require.NoError(t, err)
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 10, Root: blkRoot[:]}))
-
-	// This tests where hot state was not cached and needs processing.
-	loadedState, err := service.loadStateByRoot(ctx, blkRoot)
+	blk11.Block.ProposerIndex = idx11
+	ib11, err := blt.NewSignedBeaconBlock(blk11)
 	require.NoError(t, err)
-	assert.Equal(t, primitives.Slot(10), loadedState.Slot(), "Did not correctly load state")
-}
 
-func TestLoadeStateByRoot_FromDBBoundaryCase(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	gBlk := util.NewBeaconBlock()
-	gBlkRoot, err := gBlk.Block.HashTreeRoot()
+	// same steps as 9->10; stf 10->11, then block update
+	st11 := st10.Copy()
+	st11, err = executeStateTransitionStateGen(context.Background(), st11, ib11)
 	require.NoError(t, err)
-	require.NoError(t, service.epochBoundaryStateCache.put(gBlkRoot, beaconState))
-
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = 11
-	blk.Block.ProposerIndex = 8
-	blk.Block.ParentRoot = gBlkRoot[:]
-	util.SaveBlock(t, ctx, service.beaconDB, blk)
-	blkRoot, err := blk.Block.HashTreeRoot()
+	st11Root, err := st11.HashTreeRoot(context.Background())
 	require.NoError(t, err)
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Slot: 10, Root: blkRoot[:]}))
-
-	// This tests where hot state was not cached and needs processing.
-	loadedState, err := service.loadStateByRoot(ctx, blkRoot)
+	// update state root for block 11 now that its been through stf
+	blk11.Block.StateRoot = st11Root[:]
+	ib11, err = blt.NewSignedBeaconBlock(blk11)
 	require.NoError(t, err)
-	assert.Equal(t, primitives.Slot(10), loadedState.Slot(), "Did not correctly load state")
+	rob11, err := blt.NewROBlock(ib11)
+	require.NoError(t, err)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			helpers.ClearCache()
+			beaconDB := testDB.SetupDB(t)
+			service := New(beaconDB, doublylinkedtree.New())
+			r := testChain{
+				t:   t,
+				ctx: ctx,
+				d:   beaconDB,
+				srv: service,
+				cslots: map[primitives.Slot]testChainSlot{
+					9: testChainSlot{
+						// note blk is nil for slot 9
+						st:   st9.Copy(),
+						root: hdrRoot,
+					},
+					10: testChainSlot{
+						st:   st10.Copy(),
+						blk:  rob10,
+						root: rob10.Root(),
+					},
+					11: testChainSlot{
+						st:   st11.Copy(),
+						blk:  rob11,
+						root: rob11.Root(),
+					},
+				},
+			}
+			slots := c.slots
+			sumRoot := r.blockRoot(t, slots.stateAt)
+			require.NoError(t, r.srv.beaconDB.SaveStateSummary(r.ctx, &ethpb.StateSummary{Slot: slots.stateAt, Root: sumRoot[:]}))
+			// Second param controls the highest slot that we save blocks for, save all blocks <= that slot
+			for _, ut := range []primitives.Slot{10, 11} {
+				if ut <= slots.lastblock {
+					require.NoError(t, r.d.SaveBlock(r.ctx, r.block(t, ut)))
+				}
+			}
+			c.persistState(r, slots.stateAt)
+			// DeepSSZEqual spams full state diffs on failures, so try to fail faster with more specific assertions.
+			expect := r.state(t, slots.lastblock)
+			got, err := c.loader(r)
+			require.NoError(t, err)
+			require.Equal(t, slots.lastblock, got.Slot())
+			lbrE, err := expect.LatestBlockHeader().HashTreeRoot()
+			require.NoError(t, err)
+			lbrG, err := got.LatestBlockHeader().HashTreeRoot()
+			require.NoError(t, err)
+			require.Equal(t, lbrE, lbrG)
+			require.DeepSSZEqual(t, expect.ToProtoUnsafe(), got.ToProtoUnsafe())
+		})
+	}
 }
 
 func TestLastAncestorState_CanGetUsingDB(t *testing.T) {

--- a/changelog/kasey_stategen-test-refactor.md
+++ b/changelog/kasey_stategen-test-refactor.md
@@ -1,0 +1,2 @@
+### Ignored
+- consolidate several statagen tests into a comprehensive/consistent table-drive test.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The previous tests were not covering the state by root methods well. Several of the replay tests were not actually causing blocks to be loaded from the database. This PR consolidates a number of tests into table-driven tests that work in a more consistent way and reuse helpers to make it more clear how each test case differs.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
