### PR TITLE
fix: use io.ReadFull instead of stream.Read

### DIFF
--- a/beacon-chain/sync/context.go
+++ b/beacon-chain/sync/context.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"io"
+
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/pkg/errors"
@@ -40,7 +42,7 @@ func readContextFromStream(stream network.Stream) ([]byte, error) {
 	}
 	// Read context (fork-digest) from stream
 	b := make([]byte, forkDigestLength)
-	if _, err := stream.Read(b); err != nil {
+	if _, err := io.ReadFull(stream, b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/changelog/gazzua_use_io_stream.md
+++ b/changelog/gazzua_use_io_stream.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed to use io stream instead of stream read


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Bug fix  
<!-- Feature  
Documentation  
Other -->

---

**What does this PR do? Why is it needed?**

This PR fixes an issue in `readContextFromStream` where `stream.Read` could result in a **partial read** of the expected `forkDigestLength` bytes. When reading from a network stream, `stream.Read` does not guarantee returning all requested bytes in one call, leading to potential truncation or corruption of the context data (e.g., encountering unexpected `0x00` bytes seemed to prematurely "split" the data).  

By replacing `stream.Read` with `io.ReadFull`, we ensure that:
- The full `forkDigestLength` bytes are read correctly.
- If the stream does not provide enough data, the function returns an error rather than silently returning incomplete data.

This change prevents any unexpected partial reads and ensures the fork digest is always read in full.

---

**Which issues(s) does this PR fix?**

---

**Other notes for review**

- The change is minimal but crucial for ensuring data integrity from the stream.
---

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.