### PR TITLE
refactor: use the built-in min to simplify the code

### DIFF
--- a/changelog/riyueguang_use_builtin_min.md
+++ b/changelog/riyueguang_use_builtin_min.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use the built-in min to simplify the code

--- a/tools/analyzers/maligned/maligned.go
+++ b/tools/analyzers/maligned/maligned.go
@@ -147,10 +147,7 @@ func (s *gcSizes) Alignof(T types.Type) int64 {
 	if a < 1 {
 		return 1
 	}
-	if a > s.MaxAlign {
-		return s.MaxAlign
-	}
-	return a
+	return min(a, s.MaxAlign)
 }
 
 var basicSizes = [...]byte{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**


> Other

**What does this PR do? Why is it needed?**

In Go 1.21, the standard library includes built-in [min](https://pkg.go.dev/builtin@go1.21.0#min) function, which can greatly simplify the code.


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
