### PR TITLE
Remove content disposition header from `httputil.WriteSSZ`

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -219,7 +219,7 @@ func (s *Server) getBlockV2Ssz(w http.ResponseWriter, blk interfaces.ReadOnlySig
 		return
 	}
 	w.Header().Set(api.VersionHeader, version.String(blk.Version()))
-	httputil.WriteSsz(w, result, "beacon_block.ssz")
+	httputil.WriteSsz(w, result)
 }
 
 func (*Server) getBlockResponseBodySsz(blk interfaces.ReadOnlySignedBeaconBlock) ([]byte, error) {
@@ -1568,7 +1568,7 @@ func (s *Server) GetDepositSnapshot(w http.ResponseWriter, r *http.Request) {
 			httputil.HandleError(w, "Could not marshal deposit snapshot into SSZ: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszData, "deposit_snapshot.ssz")
+		httputil.WriteSsz(w, sszData)
 		return
 	}
 	httputil.WriteJson(
@@ -1646,7 +1646,7 @@ func (s *Server) GetPendingDeposits(w http.ResponseWriter, r *http.Request) {
 			httputil.HandleError(w, "Failed to serialize pending deposits: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszData, "pending_deposits.ssz")
+		httputil.WriteSsz(w, sszData)
 	} else {
 		isOptimistic, err := helpers.IsOptimistic(ctx, []byte(stateId), s.OptimisticModeFetcher, s.Stater, s.ChainInfoFetcher, s.BeaconDB)
 		if err != nil {
@@ -1702,7 +1702,7 @@ func (s *Server) GetPendingPartialWithdrawals(w http.ResponseWriter, r *http.Req
 			httputil.HandleError(w, "Failed to serialize pending partial withdrawals: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszData, "pending_partial_withdrawals.ssz")
+		httputil.WriteSsz(w, sszData)
 	} else {
 		isOptimistic, err := helpers.IsOptimistic(ctx, []byte(stateId), s.OptimisticModeFetcher, s.Stater, s.ChainInfoFetcher, s.BeaconDB)
 		if err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers_validator.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_validator.go
@@ -368,7 +368,7 @@ func (s *Server) GetValidatorIdentities(w http.ResponseWriter, r *http.Request) 
 func (s *Server) getValidatorIdentitiesSSZ(w http.ResponseWriter, st state.BeaconState, rawIds []string, ids []primitives.ValidatorIndex) {
 	// return no data if all IDs are ignored
 	if len(rawIds) > 0 && len(ids) == 0 {
-		httputil.WriteSsz(w, []byte{}, "validator_identities.ssz")
+		httputil.WriteSsz(w, []byte{})
 		return
 	}
 
@@ -406,7 +406,7 @@ func (s *Server) getValidatorIdentitiesSSZ(w http.ResponseWriter, st state.Beaco
 		}
 		copy(resp[i*sszLen:(i+1)*sszLen], ssz)
 	}
-	httputil.WriteSsz(w, resp, "validator_identities.ssz")
+	httputil.WriteSsz(w, resp)
 }
 
 func (s *Server) getValidatorIdentitiesJSON(

--- a/beacon-chain/rpc/eth/blob/handlers.go
+++ b/beacon-chain/rpc/eth/blob/handlers.go
@@ -70,7 +70,7 @@ func (s *Server) Blobs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set(api.VersionHeader, version.String(blk.Version()))
-		httputil.WriteSsz(w, sszResp, "blob_sidecars.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 

--- a/beacon-chain/rpc/eth/debug/handlers.go
+++ b/beacon-chain/rpc/eth/debug/handlers.go
@@ -134,7 +134,7 @@ func (s *Server) getBeaconStateSSZV2(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 	w.Header().Set(api.VersionHeader, version.String(st.Version()))
-	httputil.WriteSsz(w, sszState, "beacon_state.ssz")
+	httputil.WriteSsz(w, sszState)
 }
 
 // GetForkChoiceHeadsV2 retrieves the leaves of the current fork choice tree.

--- a/beacon-chain/rpc/eth/light-client/handlers.go
+++ b/beacon-chain/rpc/eth/light-client/handlers.go
@@ -58,7 +58,7 @@ func (s *Server) GetLightClientBootstrap(w http.ResponseWriter, req *http.Reques
 			httputil.HandleError(w, "Could not marshal bootstrap to SSZ: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, ssz, "light_client_bootstrap.ssz")
+		httputil.WriteSsz(w, ssz)
 	} else {
 		data, err := structs.LightClientBootstrapFromConsensus(bootstrap)
 		if err != nil {
@@ -195,7 +195,7 @@ func (s *Server) GetLightClientFinalityUpdate(w http.ResponseWriter, req *http.R
 			httputil.HandleError(w, "Could not marshal finality update to SSZ: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, ssz, "light_client_finality_update.ssz")
+		httputil.WriteSsz(w, ssz)
 	} else {
 		updateStruct, err := structs.LightClientFinalityUpdateFromConsensus(update)
 		if err != nil {
@@ -258,7 +258,7 @@ func (s *Server) GetLightClientOptimisticUpdate(w http.ResponseWriter, req *http
 			httputil.HandleError(w, "Could not marshal optimistic update to SSZ: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, ssz, "light_client_optimistic_update.ssz")
+		httputil.WriteSsz(w, ssz)
 	} else {
 		updateStruct, err := structs.LightClientOptimisticUpdateFromConsensus(update)
 		if err != nil {

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -355,7 +355,7 @@ func handleProducePhase0V3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "phase0Block.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	jsonBytes, err := json.Marshal(structs.BeaconBlockFromConsensus(blk.Phase0))
@@ -385,7 +385,7 @@ func handleProduceAltairV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "altairBlock.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	jsonBytes, err := json.Marshal(structs.BeaconBlockAltairFromConsensus(blk.Altair))
@@ -415,7 +415,7 @@ func handleProduceBellatrixV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "bellatrixBlock.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	block, err := structs.BeaconBlockBellatrixFromConsensus(blk.Bellatrix)
@@ -450,7 +450,7 @@ func handleProduceBlindedBellatrixV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "blindedBellatrixBlock.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	block, err := structs.BlindedBeaconBlockBellatrixFromConsensus(blk.BlindedBellatrix)
@@ -485,7 +485,7 @@ func handleProduceBlindedCapellaV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "blindedCapellaBlock.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	block, err := structs.BlindedBeaconBlockCapellaFromConsensus(blk.BlindedCapella)
@@ -520,7 +520,7 @@ func handleProduceCapellaV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "capellaBlock.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	block, err := structs.BeaconBlockCapellaFromConsensus(blk.Capella)
@@ -555,7 +555,7 @@ func handleProduceBlindedDenebV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "blindedDenebBlockContents.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	blindedBlock, err := structs.BlindedBeaconBlockDenebFromConsensus(blk.BlindedDeneb)
@@ -590,7 +590,7 @@ func handleProduceDenebV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "denebBlockContents.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 
@@ -626,7 +626,7 @@ func handleProduceBlindedElectraV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "blindedElectraBlockContents.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	blindedBlock, err := structs.BlindedBeaconBlockElectraFromConsensus(blk.BlindedElectra)
@@ -661,7 +661,7 @@ func handleProduceElectraV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "electraBlockContents.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 
@@ -697,7 +697,7 @@ func handleProduceBlindedFuluV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "blindedFuluBlockContents.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 	blindedBlock, err := structs.BlindedBeaconBlockFuluFromConsensus(blk.BlindedFulu)
@@ -732,7 +732,7 @@ func handleProduceFuluV3(
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		httputil.WriteSsz(w, sszResp, "fuluBlockContents.ssz")
+		httputil.WriteSsz(w, sszResp)
 		return
 	}
 

--- a/changelog/bastin_remove-content-disposition-writessz.md
+++ b/changelog/bastin_remove-content-disposition-writessz.md
@@ -1,0 +1,3 @@
+### Added
+
+- Remove the header `Content-Disposition` from the `httputil.WriteSSZ` function. No `filename` parameter is needed anymore.

--- a/changelog/bastin_remove-content-disposition-writessz.md
+++ b/changelog/bastin_remove-content-disposition-writessz.md
@@ -1,3 +1,3 @@
-### Added
+### Changed
 
 - Remove the header `Content-Disposition` from the `httputil.WriteSSZ` function. No `filename` parameter is needed anymore.

--- a/network/httputil/writer.go
+++ b/network/httputil/writer.go
@@ -40,10 +40,9 @@ func WriteJson(w http.ResponseWriter, v any) {
 }
 
 // WriteSsz writes the response message in ssz format
-func WriteSsz(w http.ResponseWriter, respSsz []byte, fileName string) {
+func WriteSsz(w http.ResponseWriter, respSsz []byte) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(respSsz)))
 	w.Header().Set("Content-Type", api.OctetStreamMediaType)
-	w.Header().Set("Content-Disposition", "attachment; filename="+fileName)
 	if _, err := io.Copy(w, io.NopCloser(bytes.NewReader(respSsz))); err != nil {
 		log.WithError(err).Error("could not write response message")
 	}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR removes the header `Content-Disposition` from the function `httputil.WriteSSZ`, and removes the `filename` parameter passed from it's usages. 
It is not needed to set this header, as SSZ requests don't typically come from a browser, and even so, most browsers handle this on their own.
As a result, there is no need to pass the `filename` parameter to the function anymore.