### PR TITLE
Proposer: change attestation sorting to reward numerator

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -75,6 +75,7 @@ type ChainService struct {
 	SyncingRoot                 [32]byte
 	Blobs                       []blocks.VerifiedROBlob
 	TargetRoot                  [32]byte
+	MockHeadSlot                *primitives.Slot
 }
 
 func (s *ChainService) Ancestor(ctx context.Context, root []byte, slot primitives.Slot) ([]byte, error) {
@@ -334,6 +335,9 @@ func (s *ChainService) ReceiveBlock(ctx context.Context, block interfaces.ReadOn
 
 // HeadSlot mocks HeadSlot method in chain service.
 func (s *ChainService) HeadSlot() primitives.Slot {
+	if s.MockHeadSlot != nil {
+		return *s.MockHeadSlot
+	}
 	if s.State == nil {
 		return 0
 	}

--- a/beacon-chain/core/altair/attestation.go
+++ b/beacon-chain/core/altair/attestation.go
@@ -165,7 +165,7 @@ func AddValidatorFlag(flag, flagPosition uint8) (uint8, error) {
 //	        if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
 //	            epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
 //	            proposer_reward_numerator += get_base_reward(state, index) * weight
-func EpochParticipation(beaconState state.BeaconState, indices []uint64, epochParticipation []byte, participatedFlags map[uint8]bool, totalBalance uint64) (uint64, []byte, error) {
+func EpochParticipation(beaconState state.ReadOnlyBeaconState, indices []uint64, epochParticipation []byte, participatedFlags map[uint8]bool, totalBalance uint64) (uint64, []byte, error) {
 	cfg := params.BeaconConfig()
 	sourceFlagIndex := cfg.TimelySourceFlagIndex
 	targetFlagIndex := cfg.TimelyTargetFlagIndex
@@ -267,7 +267,7 @@ func RewardProposer(ctx context.Context, beaconState state.BeaconState, proposer
 //	    participation_flag_indices.append(TIMELY_HEAD_FLAG_INDEX)
 //
 //	return participation_flag_indices
-func AttestationParticipationFlagIndices(beaconState state.BeaconState, data *ethpb.AttestationData, delay primitives.Slot) (map[uint8]bool, error) {
+func AttestationParticipationFlagIndices(beaconState state.ReadOnlyBeaconState, data *ethpb.AttestationData, delay primitives.Slot) (map[uint8]bool, error) {
 	currEpoch := time.CurrentEpoch(beaconState)
 	var justifiedCheckpt *ethpb.Checkpoint
 	if data.Target.Epoch == currEpoch {
@@ -312,7 +312,7 @@ func AttestationParticipationFlagIndices(beaconState state.BeaconState, data *et
 //	is_matching_source = data.source == justified_checkpoint
 //	is_matching_target = is_matching_source and data.target.root == get_block_root(state, data.target.epoch)
 //	is_matching_head = is_matching_target and data.beacon_block_root == get_block_root_at_slot(state, data.slot)
-func MatchingStatus(beaconState state.BeaconState, data *ethpb.AttestationData, cp *ethpb.Checkpoint) (matchedSrc, matchedTgt, matchedHead bool, err error) {
+func MatchingStatus(beaconState state.ReadOnlyBeaconState, data *ethpb.AttestationData, cp *ethpb.Checkpoint) (matchedSrc, matchedTgt, matchedHead bool, err error) {
 	matchedSrc = attestation.CheckPointIsEqual(data.Source, cp)
 
 	r, err := helpers.BlockRoot(beaconState, data.Target.Epoch)

--- a/beacon-chain/core/electra/BUILD.bazel
+++ b/beacon-chain/core/electra/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//monitoring/tracing/trace:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//proto/prysm/v1alpha1/attestation:go_default_library",
         "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",

--- a/beacon-chain/core/electra/BUILD.bazel
+++ b/beacon-chain/core/electra/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native:go_default_library",
+        "//beacon-chain/state/state-native/custom-types:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/core/electra/attestation.go
+++ b/beacon-chain/core/electra/attestation.go
@@ -1,7 +1,93 @@
 package electra
 
-import "github.com/prysmaticlabs/prysm/v5/beacon-chain/core/altair"
+import (
+	"context"
+	"fmt"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/time"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1/attestation"
+)
 
 var (
 	ProcessAttestationsNoVerifySignature = altair.ProcessAttestationsNoVerifySignature
 )
+
+// GetProposerRewardNumerator returns the numerator of the proposer reward for an attestation.
+func GetProposerRewardNumerator(
+	ctx context.Context,
+	st state.ReadOnlyBeaconState,
+	att ethpb.Att,
+	totalBalance uint64,
+) (uint64, error) {
+	data := att.GetData()
+
+	delay, err := st.Slot().SafeSubSlot(data.Slot)
+	if err != nil {
+		return 0, fmt.Errorf("attestation slot %d exceeds state slot %d", data.Slot, st.Slot())
+	}
+
+	flags, err := altair.AttestationParticipationFlagIndices(st, data, delay)
+	if err != nil {
+		return 0, err
+	}
+
+	committees, err := helpers.AttestationCommitteesFromState(ctx, st, att)
+	if err != nil {
+		return 0, err
+	}
+
+	indices, err := attestation.AttestingIndices(att, committees...)
+	if err != nil {
+		return 0, err
+	}
+
+	var participation []byte
+	if data.Target.Epoch == time.CurrentEpoch(st) {
+		participation, err = st.CurrentEpochParticipationNoCopy()
+	} else {
+		participation, err = st.PreviousEpochParticipationNoCopy()
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	cfg := params.BeaconConfig()
+	var rewardNumerator uint64
+	for _, index := range indices {
+		if index >= uint64(len(participation)) {
+			return 0, fmt.Errorf("index %d exceeds participation length %d", index, len(participation))
+		}
+
+		br, err := altair.BaseRewardWithTotalBalance(st, primitives.ValidatorIndex(index), totalBalance)
+		if err != nil {
+			return 0, err
+		}
+
+		for _, entry := range []struct {
+			flagIndex uint8
+			weight    uint64
+		}{
+			{cfg.TimelySourceFlagIndex, cfg.TimelySourceWeight},
+			{cfg.TimelyTargetFlagIndex, cfg.TimelyTargetWeight},
+			{cfg.TimelyHeadFlagIndex, cfg.TimelyHeadWeight},
+		} {
+			if flags[entry.flagIndex] {
+				has, err := altair.HasValidatorFlag(participation[index], entry.flagIndex)
+				if err != nil {
+					return 0, err
+				}
+				if !has {
+					rewardNumerator += br * entry.weight
+				}
+			}
+		}
+	}
+
+	return rewardNumerator, nil
+}

--- a/beacon-chain/core/electra/attestation.go
+++ b/beacon-chain/core/electra/attestation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
+	customtypes "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native/custom-types"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
@@ -47,11 +48,11 @@ func GetProposerRewardNumerator(
 		return 0, err
 	}
 
-	var participation []byte
+	var participation customtypes.ReadOnlyParticipation
 	if data.Target.Epoch == time.CurrentEpoch(st) {
-		participation, err = st.CurrentEpochParticipationNoCopy()
+		participation, err = st.CurrentEpochParticipationReadOnly()
 	} else {
-		participation, err = st.PreviousEpochParticipationNoCopy()
+		participation, err = st.PreviousEpochParticipationReadOnly()
 	}
 	if err != nil {
 		return 0, err
@@ -60,8 +61,8 @@ func GetProposerRewardNumerator(
 	cfg := params.BeaconConfig()
 	var rewardNumerator uint64
 	for _, index := range indices {
-		if index >= uint64(len(participation)) {
-			return 0, fmt.Errorf("index %d exceeds participation length %d", index, len(participation))
+		if index >= uint64(participation.Len()) {
+			return 0, fmt.Errorf("index %d exceeds participation length %d", index, participation.Len())
 		}
 
 		br, err := altair.BaseRewardWithTotalBalance(st, primitives.ValidatorIndex(index), totalBalance)
@@ -78,7 +79,7 @@ func GetProposerRewardNumerator(
 			{cfg.TimelyHeadFlagIndex, cfg.TimelyHeadWeight},
 		} {
 			if flags[entry.flagIndex] {
-				has, err := altair.HasValidatorFlag(participation[index], entry.flagIndex)
+				has, err := altair.HasValidatorFlag(participation.At(index), entry.flagIndex)
 				if err != nil {
 					return 0, err
 				}

--- a/beacon-chain/core/electra/attestation.go
+++ b/beacon-chain/core/electra/attestation.go
@@ -78,12 +78,12 @@ func GetProposerRewardNumerator(
 			{cfg.TimelyTargetFlagIndex, cfg.TimelyTargetWeight},
 			{cfg.TimelyHeadFlagIndex, cfg.TimelyHeadWeight},
 		} {
-			if flags[entry.flagIndex] {
-				has, err := altair.HasValidatorFlag(participation.At(index), entry.flagIndex)
+			if flags[entry.flagIndex] { // If set, the validator voted correctly for the attestation given flag index.
+				hasVoted, err := altair.HasValidatorFlag(participation.At(index), entry.flagIndex)
 				if err != nil {
 					return 0, err
 				}
-				if !has {
+				if !hasVoted { // If set, the validator has already voted in the beacon state so we don't double count.
 					rewardNumerator += br * entry.weight
 				}
 			}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/cache/depositsnapshot:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/electra:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/block:go_default_library",
         "//beacon-chain/core/feed/operation:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//beacon-chain/startup:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
+        "//beacon-chain/state/state-native:go_default_library",
         "//beacon-chain/sync:go_default_library",
         "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -287,18 +287,25 @@ func (a proposerAtts) sortOnChainAggregates(ctx context.Context, st state.ReadOn
 		return nil, err
 	}
 
-	// Sort attestation by proposer reward numerator
+	// Sort attestation by proposer reward numerator using a cache.
+	cache := make(map[ethpb.Att]uint64)
+
+	getCachedReward := func(att ethpb.Att) uint64 {
+		if val, ok := cache[att]; ok {
+			return val
+		}
+		r, err := electra.GetProposerRewardNumerator(ctx, st, att, totalBalance)
+		if err != nil {
+			log.WithError(err).Debug("Failed to get proposer reward numerator")
+			return 0
+		}
+		cache[att] = r
+		return r
+	}
+
 	slices.SortFunc(a, func(a, b ethpb.Att) int {
-		r1, err := electra.GetProposerRewardNumerator(ctx, st, a, totalBalance)
-		if err != nil {
-			log.WithError(err).Debug("Failed to get proposer reward numerator")
-			return 0
-		}
-		r2, err := electra.GetProposerRewardNumerator(ctx, st, b, totalBalance)
-		if err != nil {
-			log.WithError(err).Debug("Failed to get proposer reward numerator")
-			return 0
-		}
+		r1 := getCachedReward(a)
+		r2 := getCachedReward(b)
 		return cmp.Compare(r2, r1)
 	})
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/electra"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/features"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
@@ -110,7 +112,11 @@ func (vs *Server) packAttestations(ctx context.Context, latestState state.Beacon
 
 	var sorted proposerAtts
 	if postElectra {
-		sorted, err = deduped.sortOnChainAggregates()
+		st, err := vs.HeadFetcher.HeadStateReadOnly(ctx)
+		if err != nil {
+			return nil, err
+		}
+		sorted, err = deduped.sortOnChainAggregates(ctx, st)
 		if err != nil {
 			return nil, err
 		}
@@ -271,16 +277,29 @@ func (a proposerAtts) sort() (proposerAtts, error) {
 	return a.sortBySlotAndCommittee()
 }
 
-func (a proposerAtts) sortOnChainAggregates() (proposerAtts, error) {
+func (a proposerAtts) sortOnChainAggregates(ctx context.Context, st state.ReadOnlyBeaconState) (proposerAtts, error) {
 	if len(a) < 2 {
 		return a, nil
 	}
 
-	// Sort by slot first, then by bit count.
+	totalBalance, err := helpers.TotalActiveBalance(st)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort attestation by proposer reward numerator
 	slices.SortFunc(a, func(a, b ethpb.Att) int {
-		return cmp.Or(
-			-cmp.Compare(a.GetData().Slot, b.GetData().Slot),
-			-cmp.Compare(a.GetAggregationBits().Count(), b.GetAggregationBits().Count()))
+		r1, err := electra.GetProposerRewardNumerator(ctx, st, a, totalBalance)
+		if err != nil {
+			log.WithError(err).Debug("Failed to get proposer reward numerator")
+			return 0
+		}
+		r2, err := electra.GetProposerRewardNumerator(ctx, st, b, totalBalance)
+		if err != nil {
+			log.WithError(err).Debug("Failed to get proposer reward numerator")
+			return 0
+		}
+		return cmp.Compare(r2, r1)
 	})
 
 	return a, nil

--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/state",
     visibility = ["//visibility:public"],
     deps = [
+        "//beacon-chain/state/state-native/custom-types:go_default_library",
         "//config/fieldparams:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	"github.com/prysmaticlabs/go-bitfield"
+	customtypes "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native/custom-types"
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
@@ -210,8 +211,8 @@ type ReadOnlyWithdrawals interface {
 type ReadOnlyParticipation interface {
 	CurrentEpochParticipation() ([]byte, error)
 	PreviousEpochParticipation() ([]byte, error)
-	CurrentEpochParticipationNoCopy() ([]byte, error)
-	PreviousEpochParticipationNoCopy() ([]byte, error)
+	CurrentEpochParticipationReadOnly() (customtypes.ReadOnlyParticipation, error)
+	PreviousEpochParticipationReadOnly() (customtypes.ReadOnlyParticipation, error)
 }
 
 // ReadOnlyInactivity defines a struct which only has read access to inactivity methods.

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -210,6 +210,8 @@ type ReadOnlyWithdrawals interface {
 type ReadOnlyParticipation interface {
 	CurrentEpochParticipation() ([]byte, error)
 	PreviousEpochParticipation() ([]byte, error)
+	CurrentEpochParticipationNoCopy() ([]byte, error)
+	PreviousEpochParticipationNoCopy() ([]byte, error)
 }
 
 // ReadOnlyInactivity defines a struct which only has read access to inactivity methods.

--- a/beacon-chain/state/state-native/custom-types/BUILD.bazel
+++ b/beacon-chain/state/state-native/custom-types/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "block_roots.go",
         "historical_roots.go",
+        "participation.go",
         "randao_mixes.go",
         "state_roots.go",
     ],

--- a/beacon-chain/state/state-native/custom-types/participation.go
+++ b/beacon-chain/state/state-native/custom-types/participation.go
@@ -1,0 +1,17 @@
+package customtypes
+
+type ReadOnlyParticipation struct {
+	p []byte
+}
+
+func NewReadOnlyParticipation(p []byte) ReadOnlyParticipation {
+	return ReadOnlyParticipation{p}
+}
+
+func (r ReadOnlyParticipation) At(i uint64) byte {
+	return r.p[i]
+}
+
+func (r ReadOnlyParticipation) Len() int {
+	return len(r.p)
+}

--- a/beacon-chain/state/state-native/getters_participation.go
+++ b/beacon-chain/state/state-native/getters_participation.go
@@ -41,7 +41,6 @@ func (b *BeaconState) PreviousEpochParticipation() ([]byte, error) {
 }
 
 // CurrentEpochParticipationReadOnly corresponding to participation bits on the beacon chain without copying the data.
-// Modifications to the returned slice will modify the underlying data.
 func (b *BeaconState) CurrentEpochParticipationReadOnly() (customtypes.ReadOnlyParticipation, error) {
 	if b.version == version.Phase0 {
 		return customtypes.ReadOnlyParticipation{}, errNotSupported("CurrentEpochParticipation", b.version)
@@ -54,7 +53,6 @@ func (b *BeaconState) CurrentEpochParticipationReadOnly() (customtypes.ReadOnlyP
 }
 
 // PreviousEpochParticipationReadOnly corresponding to participation bits on the beacon chain without copying the data.
-// Modifications to the returned slice will modify the underlying data.
 func (b *BeaconState) PreviousEpochParticipationReadOnly() (customtypes.ReadOnlyParticipation, error) {
 	if b.version == version.Phase0 {
 		return customtypes.ReadOnlyParticipation{}, errNotSupported("PreviousEpochParticipation", b.version)

--- a/beacon-chain/state/state-native/getters_participation.go
+++ b/beacon-chain/state/state-native/getters_participation.go
@@ -39,6 +39,40 @@ func (b *BeaconState) PreviousEpochParticipation() ([]byte, error) {
 	return b.previousEpochParticipationVal(), nil
 }
 
+// CurrentEpochParticipationNoCopy corresponding to participation bits on the beacon chain without copying the data.
+// Modifications to the returned slice will modify the underlying data.
+func (b *BeaconState) CurrentEpochParticipationNoCopy() ([]byte, error) {
+	if b.version == version.Phase0 {
+		return nil, errNotSupported("CurrentEpochParticipation", b.version)
+	}
+
+	if b.currentEpochParticipation == nil {
+		return nil, nil
+	}
+
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	return b.currentEpochParticipation, nil
+}
+
+// PreviousEpochParticipationNoCopy corresponding to participation bits on the beacon chain without copying the data.
+// Modifications to the returned slice will modify the underlying data.
+func (b *BeaconState) PreviousEpochParticipationNoCopy() ([]byte, error) {
+	if b.version == version.Phase0 {
+		return nil, errNotSupported("PreviousEpochParticipation", b.version)
+	}
+
+	if b.previousEpochParticipation == nil {
+		return nil, nil
+	}
+
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	return b.previousEpochParticipation, nil
+}
+
 // UnrealizedCheckpointBalances returns the total balances: active, target attested in
 // current epoch and target attested in previous epoch. This function is used to
 // compute the "unrealized justification" that a synced Beacon Block will have.

--- a/beacon-chain/state/state-native/getters_participation.go
+++ b/beacon-chain/state/state-native/getters_participation.go
@@ -2,6 +2,7 @@ package state_native
 
 import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/time"
+	customtypes "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native/custom-types"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/v5/config/features"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
@@ -39,38 +40,30 @@ func (b *BeaconState) PreviousEpochParticipation() ([]byte, error) {
 	return b.previousEpochParticipationVal(), nil
 }
 
-// CurrentEpochParticipationNoCopy corresponding to participation bits on the beacon chain without copying the data.
+// CurrentEpochParticipationReadOnly corresponding to participation bits on the beacon chain without copying the data.
 // Modifications to the returned slice will modify the underlying data.
-func (b *BeaconState) CurrentEpochParticipationNoCopy() ([]byte, error) {
+func (b *BeaconState) CurrentEpochParticipationReadOnly() (customtypes.ReadOnlyParticipation, error) {
 	if b.version == version.Phase0 {
-		return nil, errNotSupported("CurrentEpochParticipation", b.version)
-	}
-
-	if b.currentEpochParticipation == nil {
-		return nil, nil
+		return customtypes.ReadOnlyParticipation{}, errNotSupported("CurrentEpochParticipation", b.version)
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.currentEpochParticipation, nil
+	return customtypes.NewReadOnlyParticipation(b.currentEpochParticipation), nil
 }
 
-// PreviousEpochParticipationNoCopy corresponding to participation bits on the beacon chain without copying the data.
+// PreviousEpochParticipationReadOnly corresponding to participation bits on the beacon chain without copying the data.
 // Modifications to the returned slice will modify the underlying data.
-func (b *BeaconState) PreviousEpochParticipationNoCopy() ([]byte, error) {
+func (b *BeaconState) PreviousEpochParticipationReadOnly() (customtypes.ReadOnlyParticipation, error) {
 	if b.version == version.Phase0 {
-		return nil, errNotSupported("PreviousEpochParticipation", b.version)
-	}
-
-	if b.previousEpochParticipation == nil {
-		return nil, nil
+		return customtypes.ReadOnlyParticipation{}, errNotSupported("PreviousEpochParticipation", b.version)
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.previousEpochParticipation, nil
+	return customtypes.NewReadOnlyParticipation(b.previousEpochParticipation), nil
 }
 
 // UnrealizedCheckpointBalances returns the total balances: active, target attested in

--- a/changelog/tt_propower_sort_attestation.md
+++ b/changelog/tt_propower_sort_attestation.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Sort attestations in proposer block by reward.


### PR DESCRIPTION
This PR updates the attestation sorting algorithm used by the proposer to prioritize based on the proposer reward numerator. The updated logic is reflected in the spec code below:

```python
    participation_flag_indices = get_attestation_participation_flag_indices(state, data, state.slot - data.slot)

    if data.target.epoch == get_current_epoch(state):
        epoch_participation = state.current_epoch_participation
    else:
        epoch_participation = state.previous_epoch_participation

    proposer_reward_numerator = 0
    for index in get_attesting_indices(state, attestation):
        for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
            if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
                proposer_reward_numerator += get_base_reward(state, index) * weight
```

Notes for reviewers:
- I considered reusing core functions instead of introducing a `GetProposerRewardNumerator` helper, but most core helpers mutate the state. Copying the state just to reuse them is messy, and modifying the state isn't acceptable. A clean helper was the better tradeoff.
- Technically we could use the validator's effective balance instead of `get_base_reward(state, index)` to simplify and remove one pass through on total balance. I kept the current approach since it's more accurate and the difference is minor.
- Some functions previously used full `BeaconState` but only needed a read-only version. I made minor changes to reflect this with no functional impact.
- I added `CurrentEpochParticipationReadOnly` and a custom type to avoid caller modifying the data
- I rewrote `TestPackAttestations_ElectraOnChainAggregates` to reflect sorting based on the reward numerator.