### PR TITLE
Use headstate to validate canonical attestations for old targets

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -59,7 +59,7 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		return nil
 	}
 	if err := s.checkpointStateCache.AddCheckpointState(c, st); err != nil {
-		log.WithError(err).Error("could not save checkpoint state to cache")
+		log.WithError(err).Error("Could not save checkpoint state to cache")
 	}
 	return st
 }

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
 
+// The caller of this function must have a lock on forkchoice.
 func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) state.ReadOnlyBeaconState {
 	headEpoch := slots.ToEpoch(s.HeadSlot())
 	if c.Epoch < headEpoch {
@@ -27,13 +28,6 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		return nil
 	}
 	if c.Epoch == headEpoch {
-		targetSlot, err := s.cfg.ForkChoiceStore.Slot([32]byte(c.Root))
-		if err != nil {
-			return nil
-		}
-		if slots.ToEpoch(targetSlot)+1 < headEpoch {
-			return nil
-		}
 		st, err := s.HeadStateReadOnly(ctx)
 		if err != nil {
 			return nil
@@ -65,12 +59,13 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 		return nil
 	}
 	if err := s.checkpointStateCache.AddCheckpointState(c, st); err != nil {
-		return nil
+		log.WithError(err).Error("could not save checkpoint state to cache")
 	}
 	return st
 }
 
 // getAttPreState retrieves the att pre state by either from the cache or the DB.
+// The caller of this function must have a lock on forkchoice.
 func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (state.ReadOnlyBeaconState, error) {
 	// If the attestation is recent and canonical we can use the head state to compute the shuffling.
 	if st := s.getRecentPreState(ctx, c); st != nil {

--- a/changelog/potuz_use_headstate_1.md
+++ b/changelog/potuz_use_headstate_1.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use headstate to validate canonical attestations with an old target


### PR DESCRIPTION
When validating an attestation we need the target state to obtain the balances. When the target is compatible with the head state and the target epoch is the same as the head block epoch, then we can use the saved headstate regardless of the targets root slot. 