### PR TITLE
Use fieldparams.RootLength instead of local variable in p2p types.go

### DIFF
--- a/beacon-chain/p2p/types/BUILD.bazel
+++ b/beacon-chain/p2p/types/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//validator/client:__pkg__",
     ],
     deps = [
+        "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",

--- a/beacon-chain/p2p/types/types.go
+++ b/beacon-chain/p2p/types/types.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/pkg/errors"
 	ssz "github.com/prysmaticlabs/fastssz"
+	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 )
-
-const rootLength = 32
 
 const maxErrorLength = 256
 
@@ -34,7 +33,7 @@ func (b *SSZBytes) HashTreeRootWith(hh *ssz.Hasher) error {
 }
 
 // BeaconBlockByRootsReq specifies the block by roots request type.
-type BeaconBlockByRootsReq [][rootLength]byte
+type BeaconBlockByRootsReq [][fieldparams.RootLength]byte
 
 // MarshalSSZTo marshals the block by roots request with the provided byte slice.
 func (r *BeaconBlockByRootsReq) MarshalSSZTo(dst []byte) ([]byte, error) {
@@ -59,25 +58,25 @@ func (r *BeaconBlockByRootsReq) MarshalSSZ() ([]byte, error) {
 
 // SizeSSZ returns the size of the serialized representation.
 func (r *BeaconBlockByRootsReq) SizeSSZ() int {
-	return len(*r) * rootLength
+	return len(*r) * fieldparams.RootLength
 }
 
 // UnmarshalSSZ unmarshals the provided bytes buffer into the
 // block by roots request object.
 func (r *BeaconBlockByRootsReq) UnmarshalSSZ(buf []byte) error {
 	bufLen := len(buf)
-	maxLength := int(params.BeaconConfig().MaxRequestBlocks * rootLength)
+	maxLength := int(params.BeaconConfig().MaxRequestBlocks * fieldparams.RootLength)
 	if bufLen > maxLength {
 		return errors.Errorf("expected buffer with length of up to %d but received length %d", maxLength, bufLen)
 	}
-	if bufLen%rootLength != 0 {
+	if bufLen%fieldparams.RootLength != 0 {
 		return ssz.ErrIncorrectByteSize
 	}
-	numOfRoots := bufLen / rootLength
-	roots := make([][rootLength]byte, 0, numOfRoots)
+	numOfRoots := bufLen / fieldparams.RootLength
+	roots := make([][fieldparams.RootLength]byte, 0, numOfRoots)
 	for i := 0; i < numOfRoots; i++ {
-		var rt [rootLength]byte
-		copy(rt[:], buf[i*rootLength:(i+1)*rootLength])
+		var rt [fieldparams.RootLength]byte
+		copy(rt[:], buf[i*fieldparams.RootLength:(i+1)*fieldparams.RootLength])
 		roots = append(roots, rt)
 	}
 	*r = roots


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR refactors the `p2p/types/types.go` file to use `fieldparams.RootLength = 32` instead of the locally defined `rootLength = 32`.