### PR TITLE
Use latest state to pack attestation

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -112,11 +112,7 @@ func (vs *Server) packAttestations(ctx context.Context, latestState state.Beacon
 
 	var sorted proposerAtts
 	if postElectra {
-		st, err := vs.HeadFetcher.HeadStateReadOnly(ctx)
-		if err != nil {
-			return nil, err
-		}
-		sorted, err = deduped.sortOnChainAggregates(ctx, st)
+		sorted, err = deduped.sortOnChainAggregates(ctx, latestState)
 		if err != nil {
 			return nil, err
 		}

--- a/changelog/tt_3.md
+++ b/changelog/tt_3.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use latest state to pack attestation.


### PR DESCRIPTION
This PR ensures the proposer of slot `n` uses the latest head state advanced to slot `n` when packing attestations, rather than the previous head state at `n-1`. Otherwise, we might fail to include attestations from slot `n-1` because `BlockRootAtSlot(beaconState, data.Slot)` is used in `MatchingStatus` to determine `AttestationParticipationFlagIndices`