### PR TITLE
Prefer Prysm peers

### DIFF
--- a/beacon-chain/p2p/peers/scorers/gossip_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/gossip_scorer.go
@@ -15,6 +15,7 @@ var badPeerAgents = map[peer.ID]struct{}{
 	"Lodestar":   {},
 	"Caplin":     {},
 	"Nimbus":     {},
+	"Grandinet":  {},
 }
 
 const (

--- a/beacon-chain/p2p/peers/scorers/gossip_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/gossip_scorer.go
@@ -9,6 +9,14 @@ import (
 
 var _ Scorer = (*GossipScorer)(nil)
 
+var badPeerAgents = map[peer.ID]struct{}{
+	"LightHouse": {},
+	"Teku":       {}, // TODO: should we keep this? I kinda like these guys, they implemented ePBS
+	"Lodestar":   {},
+	"Caplin":     {},
+	"Nimbus":     {},
+}
+
 const (
 	// The boundary till which a peer's gossip score is acceptable.
 	gossipThreshold = -100.0
@@ -65,7 +73,13 @@ func (s *GossipScorer) isBadPeerNoLock(pid peer.ID) error {
 		return nil
 	}
 
-	if peerData.GossipScore < gossipThreshold {
+	_, ok = badPeerAgents[pid]
+	badPeerBoost := 0.0
+	if ok {
+		badPeerBoost = 100.0
+	}
+
+	if peerData.GossipScore < gossipThreshold+badPeerBoost {
 		return errors.Errorf("gossip score below threshold: got %f - threshold %f", peerData.GossipScore, gossipThreshold)
 	}
 

--- a/changelog/potuz_favor_prysm.md
+++ b/changelog/potuz_favor_prysm.md
@@ -1,0 +1,3 @@
+### Added
+
+- Favor Prysm and downscore faster other CLs identified by the agent string. 


### PR DESCRIPTION
One of the untold problems of client diversity is the lack of accountability for spamming the network with invalid or useless messages. After evaluating numerous complains on our Discord server regarding the spamming of our logs with invalid messages, this PR attempts to address this by adding a boost to downscore peers from a list of bad CL clients. These are identified by user agent strings, which can be gamed, but overall most nodes maintain their sane defaults. 