### PR TITLE
Fix typos and improve code comments

### DIFF
--- a/beacon-chain/builder/service_test.go
+++ b/beacon-chain/builder/service_test.go
@@ -54,7 +54,7 @@ func Test_RegisterValidator_WithCache(t *testing.T) {
 	require.DeepEqual(t, reg, registration)
 }
 
-func Test_BuilderMethodsWithouClient(t *testing.T) {
+func Test_BuilderMethodsWithoutClient(t *testing.T) {
 	s, err := NewService(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, false, s.Configured())

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -43,7 +43,7 @@ func (s *Store) getBlock(ctx context.Context, blockRoot [32]byte, tx *bolt.Tx) (
 		return v.(interfaces.ReadOnlySignedBeaconBlock), nil
 	}
 	// This method allows the caller to pass in its tx if one is already open.
-	// Or if a nil value is used, a transaction will be managed intenally.
+	// Or if a nil value is used, a transaction will be managed internally.
 	if tx == nil {
 		var err error
 		tx, err = s.db.Begin(false)

--- a/beacon-chain/sync/backfill/service_test.go
+++ b/beacon-chain/sync/backfill/service_test.go
@@ -26,10 +26,10 @@ func (m mockMinimumSlotter) minimumSlot(_ primitives.Slot) primitives.Slot {
 	return m.min
 }
 
-type mockInitalizerWaiter struct {
+type mockInitializerWaiter struct {
 }
 
-func (*mockInitalizerWaiter) WaitForInitializer(_ context.Context) (*verification.Initializer, error) {
+func (*mockInitializerWaiter) WaitForInitializer(_ context.Context) (*verification.Initializer, error) {
 	return &verification.Initializer{}, nil
 }
 
@@ -58,7 +58,7 @@ func TestServiceInit(t *testing.T) {
 	p2pt := p2ptest.NewTestP2P(t)
 	bfs := filesystem.NewEphemeralBlobStorage(t)
 	srv, err := NewService(ctx, su, bfs, cw, p2pt, &mockAssigner{},
-		WithBatchSize(batchSize), WithWorkerCount(nWorkers), WithEnableBackfill(true), WithVerifierWaiter(&mockInitalizerWaiter{}))
+		WithBatchSize(batchSize), WithWorkerCount(nWorkers), WithEnableBackfill(true), WithVerifierWaiter(&mockInitializerWaiter{}))
 	require.NoError(t, err)
 	srv.ms = mockMinimumSlotter{min: primitives.Slot(high - batchSize*uint64(nBatches))}.minimumSlot
 	srv.pool = pool


### PR DESCRIPTION
This pull request addresses several minor issues:

1. Fixed a typo in `beacon-chain/db/kv/blocks.go` where `intenally` was corrected to `internally`
2. Corrected struct definition formatting in `beacon-chain/sync/backfill/service_test.go`
3. Improved code readability in `Test_BuilderMethodsWithoutClient` function

These changes are purely cosmetic and do not affect functionality.