### PR TITLE
Handle Consolidation Processing Edge Case

### DIFF
--- a/beacon-chain/core/electra/consolidations.go
+++ b/beacon-chain/core/electra/consolidations.go
@@ -211,7 +211,7 @@ func ProcessConsolidationRequests(ctx context.Context, st state.BeaconState, req
 		if npc, err := st.NumPendingConsolidations(); err != nil {
 			return fmt.Errorf("failed to fetch number of pending consolidations: %w", err) // This should never happen.
 		} else if npc >= pcLimit {
-			return nil
+			continue
 		}
 
 		activeBal, err := helpers.TotalActiveBalance(st)
@@ -220,7 +220,7 @@ func ProcessConsolidationRequests(ctx context.Context, st state.BeaconState, req
 		}
 		churnLimit := helpers.ConsolidationChurnLimit(primitives.Gwei(activeBal))
 		if churnLimit <= primitives.Gwei(params.BeaconConfig().MinActivationBalance) {
-			return nil
+			continue
 		}
 
 		srcIdx, ok := st.ValidatorIndexByPubkey(sourcePubkey)

--- a/changelog/nisdas_handle_consolidation_bug.md
+++ b/changelog/nisdas_handle_consolidation_bug.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a bug in consolidation request processing.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] In the event we have the maximum amount of consolidations included in our pending queue in the state, we will exit the consolidation processing loop. This PR makes sure that we continue processing new consolidation requests to handle new compounding consolidations.
- [x] Regression test

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
