### PR TITLE
Refactor LC Test Utils

### DIFF
--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2653,7 +2653,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 
 	t.Run("Altair", func(t *testing.T) {
 		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestAltair()
+			l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2699,7 +2699,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestAltair()
+			l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2751,7 +2751,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestAltair()
+			l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2812,7 +2812,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 
 	t.Run("Capella", func(t *testing.T) {
 		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2857,7 +2857,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2909,7 +2909,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2970,7 +2970,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 
 	t.Run("Deneb", func(t *testing.T) {
 		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3015,7 +3015,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3067,7 +3067,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3138,7 +3138,7 @@ func TestSaveLightClientBootstrap(t *testing.T) {
 	ctx := tr.ctx
 
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3173,7 +3173,7 @@ func TestSaveLightClientBootstrap(t *testing.T) {
 	})
 
 	t.Run("Capella", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false)
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 
 		s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3208,7 +3208,7 @@ func TestSaveLightClientBootstrap(t *testing.T) {
 	})
 
 	t.Run("Deneb", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false)
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 
 		s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 

--- a/beacon-chain/core/light-client/lightclient_test.go
+++ b/beacon-chain/core/light-client/lightclient_test.go
@@ -32,7 +32,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	})
 
 	t.Run("Capella", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false)
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	})
 
 	t.Run("Deneb", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false)
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	})
 
 	t.Run("Electra", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestElectra(false)
+		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
@@ -131,7 +131,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 	t.Run("Capella", func(t *testing.T) {
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
@@ -238,7 +238,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 	t.Run("Deneb", func(t *testing.T) {
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
@@ -390,7 +390,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 
 	t.Run("Electra", func(t *testing.T) {
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestElectra(false)
+			l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true)
 
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
@@ -542,7 +542,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 
 func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -565,7 +565,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	})
 
 	t.Run("Bellatrix", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestBellatrix()
+		l := util.NewTestLightClient(t).SetupTestBellatrix(0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -589,7 +589,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Capella", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -650,7 +650,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(true)
+			l := util.NewTestLightClient(t).SetupTestCapella(true, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -713,7 +713,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Deneb", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -782,7 +782,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(true)
+			l := util.NewTestLightClient(t).SetupTestDeneb(true, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -853,7 +853,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Electra", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestElectra(false)
+			l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(l.Ctx, l.State.Slot(), l.Block)
 			require.NoError(t, err)
@@ -918,7 +918,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestElectra(true)
+			l := util.NewTestLightClient(t).SetupTestElectra(true, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(l.Ctx, l.State.Slot(), l.Block)
 			require.NoError(t, err)
@@ -984,7 +984,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	})
 
 	t.Run("Capella fork with Altair block", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -1006,7 +1006,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	})
 
 	t.Run("Deneb fork with Altair block", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -1029,7 +1029,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Deneb fork with Capella block", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -1089,7 +1089,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(true)
+			l := util.NewTestLightClient(t).SetupTestCapella(true, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,

--- a/beacon-chain/core/light-client/store_test.go
+++ b/beacon-chain/core/light-client/store_test.go
@@ -23,7 +23,7 @@ func TestLightClientStore(t *testing.T) {
 	lcStore := &lightClient.Store{}
 
 	// Create test light client updates for Capella and Deneb
-	lCapella := util.NewTestLightClient(t).SetupTestCapella(false)
+	lCapella := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
 	opUpdateCapella, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lCapella.Ctx, lCapella.State.Slot(), lCapella.State, lCapella.Block, lCapella.AttestedState, lCapella.AttestedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, opUpdateCapella, "OptimisticUpdateCapella is nil")
@@ -31,7 +31,7 @@ func TestLightClientStore(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, finUpdateCapella, "FinalityUpdateCapella is nil")
 
-	lDeneb := util.NewTestLightClient(t).SetupTestDeneb(false)
+	lDeneb := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
 	opUpdateDeneb, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lDeneb.Ctx, lDeneb.State.Slot(), lDeneb.State, lDeneb.Block, lDeneb.AttestedState, lDeneb.AttestedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, opUpdateDeneb, "OptimisticUpdateDeneb is nil")

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -51,7 +51,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().AltairForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -93,7 +93,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("altairSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().AltairForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -127,7 +127,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("altair - no bootstrap found", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair()
+		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().AltairForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -153,7 +153,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, writer.Code)
 	})
 	t.Run("bellatrix", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestBellatrix()
+		l := util.NewTestLightClient(t).SetupTestBellatrix(0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -194,7 +194,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("bellatrixSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestBellatrix()
+		l := util.NewTestLightClient(t).SetupTestBellatrix(0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -228,7 +228,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("capella", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -269,7 +269,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("capellaSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -303,7 +303,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("deneb", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -344,7 +344,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("denebSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -378,7 +378,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("electra", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestElectra(false) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -419,7 +419,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("electraSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestElectra(false) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()

--- a/testing/util/lightclient.go
+++ b/testing/util/lightclient.go
@@ -33,10 +33,13 @@ func NewTestLightClient(t *testing.T) *TestLightClient {
 	return &TestLightClient{T: t}
 }
 
-func (l *TestLightClient) SetupTestCapella(blinded bool) *TestLightClient {
+func (l *TestLightClient) SetupTestCapella(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	if newerSlotBy > 0 {
+		slot = slot.Add(uint64(newerSlotBy))
+	}
 
 	attestedState, err := NewBeaconStateCapella()
 	require.NoError(l.T, err)
@@ -91,7 +94,7 @@ func (l *TestLightClient) SetupTestCapella(blinded bool) *TestLightClient {
 		block.Block.ParentRoot = parentRoot[:]
 
 		for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 		}
 
 		signedBlock, err = blocks.NewSignedBeaconBlock(block)
@@ -257,10 +260,13 @@ func (l *TestLightClient) SetupTestCapellaFinalizedBlockAltair(blinded bool) *Te
 	return l
 }
 
-func (l *TestLightClient) SetupTestAltair() *TestLightClient {
+func (l *TestLightClient) SetupTestAltair(newerSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(uint64(params.BeaconConfig().AltairForkEpoch) * uint64(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	if newerSlotBy > 0 {
+		slot = slot.Add(uint64(newerSlotBy))
+	}
 
 	attestedState, err := NewBeaconStateAltair()
 	require.NoError(l.T, err)
@@ -321,7 +327,7 @@ func (l *TestLightClient) SetupTestAltair() *TestLightClient {
 	block.Block.ParentRoot = parentRoot[:]
 
 	for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-		block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+		block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 	}
 
 	signedBlock, err := blocks.NewSignedBeaconBlock(block)
@@ -350,10 +356,13 @@ func (l *TestLightClient) SetupTestAltair() *TestLightClient {
 	return l
 }
 
-func (l *TestLightClient) SetupTestBellatrix() *TestLightClient {
+func (l *TestLightClient) SetupTestBellatrix(newerSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	if newerSlotBy > 0 {
+		slot = slot.Add(uint64(newerSlotBy))
+	}
 
 	attestedState, err := NewBeaconStateBellatrix()
 	require.NoError(l.T, err)
@@ -406,7 +415,7 @@ func (l *TestLightClient) SetupTestBellatrix() *TestLightClient {
 	block.Block.ParentRoot = parentRoot[:]
 
 	for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-		block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+		block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 	}
 
 	signedBlock, err := blocks.NewSignedBeaconBlock(block)
@@ -435,10 +444,13 @@ func (l *TestLightClient) SetupTestBellatrix() *TestLightClient {
 	return l
 }
 
-func (l *TestLightClient) SetupTestDeneb(blinded bool) *TestLightClient {
+func (l *TestLightClient) SetupTestDeneb(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	if newerSlotBy > 0 {
+		slot = slot.Add(uint64(newerSlotBy))
+	}
 
 	attestedState, err := NewBeaconStateDeneb()
 	require.NoError(l.T, err)
@@ -493,7 +505,7 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool) *TestLightClient {
 		block.Message.ParentRoot = parentRoot[:]
 
 		for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-			block.Message.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+			block.Message.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 		}
 
 		signedBlock, err = blocks.NewSignedBeaconBlock(block)
@@ -517,7 +529,7 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool) *TestLightClient {
 		block.Block.ParentRoot = parentRoot[:]
 
 		for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 		}
 
 		signedBlock, err = blocks.NewSignedBeaconBlock(block)
@@ -547,10 +559,13 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool) *TestLightClient {
 	return l
 }
 
-func (l *TestLightClient) SetupTestElectra(blinded bool) *TestLightClient {
+func (l *TestLightClient) SetupTestElectra(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	if newerSlotBy > 0 {
+		slot = slot.Add(uint64(newerSlotBy))
+	}
 	finalizedBlockSlot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
 
 	attestedState, err := NewBeaconStateElectra()
@@ -606,7 +621,7 @@ func (l *TestLightClient) SetupTestElectra(blinded bool) *TestLightClient {
 		block.Message.ParentRoot = parentRoot[:]
 
 		for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-			block.Message.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+			block.Message.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 		}
 
 		signedBlock, err = blocks.NewSignedBeaconBlock(block)
@@ -630,7 +645,7 @@ func (l *TestLightClient) SetupTestElectra(blinded bool) *TestLightClient {
 		block.Block.ParentRoot = parentRoot[:]
 
 		for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 		}
 
 		signedBlock, err = blocks.NewSignedBeaconBlock(block)
@@ -660,10 +675,13 @@ func (l *TestLightClient) SetupTestElectra(blinded bool) *TestLightClient {
 	return l
 }
 
-func (l *TestLightClient) SetupTestFulu(blinded bool) *TestLightClient {
+func (l *TestLightClient) SetupTestFulu(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().FuluForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	if newerSlotBy > 0 {
+		slot = slot.Add(uint64(newerSlotBy))
+	}
 
 	attestedState, err := NewBeaconStateFulu()
 	require.NoError(l.T, err)
@@ -718,7 +736,7 @@ func (l *TestLightClient) SetupTestFulu(blinded bool) *TestLightClient {
 		block.Message.ParentRoot = parentRoot[:]
 
 		for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-			block.Message.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+			block.Message.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 		}
 
 		signedBlock, err = blocks.NewSignedBeaconBlock(block)
@@ -742,7 +760,7 @@ func (l *TestLightClient) SetupTestFulu(blinded bool) *TestLightClient {
 		block.Block.ParentRoot = parentRoot[:]
 
 		for i := uint64(0); i < params.BeaconConfig().MinSyncCommitteeParticipants; i++ {
-			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, true)
+			block.Block.Body.SyncAggregate.SyncCommitteeBits.SetBitAt(i, supermajority)
 		}
 
 		signedBlock, err = blocks.NewSignedBeaconBlock(block)

--- a/testing/util/lightclient.go
+++ b/testing/util/lightclient.go
@@ -33,12 +33,12 @@ func NewTestLightClient(t *testing.T) *TestLightClient {
 	return &TestLightClient{T: t}
 }
 
-func (l *TestLightClient) SetupTestCapella(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestCapella(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
-	if newerSlotBy > 0 {
-		slot = slot.Add(uint64(newerSlotBy))
+	if increaseAttestedSlotBy > 0 {
+		slot = slot.Add(uint64(increaseAttestedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateCapella()
@@ -260,12 +260,12 @@ func (l *TestLightClient) SetupTestCapellaFinalizedBlockAltair(blinded bool) *Te
 	return l
 }
 
-func (l *TestLightClient) SetupTestAltair(newerSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestAltair(increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(uint64(params.BeaconConfig().AltairForkEpoch) * uint64(params.BeaconConfig().SlotsPerEpoch)).Add(1)
-	if newerSlotBy > 0 {
-		slot = slot.Add(uint64(newerSlotBy))
+	if increaseAttestedSlotBy > 0 {
+		slot = slot.Add(uint64(increaseAttestedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateAltair()
@@ -356,12 +356,12 @@ func (l *TestLightClient) SetupTestAltair(newerSlotBy int, supermajority bool) *
 	return l
 }
 
-func (l *TestLightClient) SetupTestBellatrix(newerSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestBellatrix(increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
-	if newerSlotBy > 0 {
-		slot = slot.Add(uint64(newerSlotBy))
+	if increaseAttestedSlotBy > 0 {
+		slot = slot.Add(uint64(increaseAttestedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateBellatrix()
@@ -444,12 +444,12 @@ func (l *TestLightClient) SetupTestBellatrix(newerSlotBy int, supermajority bool
 	return l
 }
 
-func (l *TestLightClient) SetupTestDeneb(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestDeneb(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
-	if newerSlotBy > 0 {
-		slot = slot.Add(uint64(newerSlotBy))
+	if increaseAttestedSlotBy > 0 {
+		slot = slot.Add(uint64(increaseAttestedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateDeneb()
@@ -559,12 +559,12 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool, newerSlotBy int, supermaj
 	return l
 }
 
-func (l *TestLightClient) SetupTestElectra(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestElectra(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
-	if newerSlotBy > 0 {
-		slot = slot.Add(uint64(newerSlotBy))
+	if increaseAttestedSlotBy > 0 {
+		slot = slot.Add(uint64(increaseAttestedSlotBy))
 	}
 	finalizedBlockSlot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
 
@@ -675,12 +675,12 @@ func (l *TestLightClient) SetupTestElectra(blinded bool, newerSlotBy int, superm
 	return l
 }
 
-func (l *TestLightClient) SetupTestFulu(blinded bool, newerSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestFulu(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
 	slot := primitives.Slot(params.BeaconConfig().FuluForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
-	if newerSlotBy > 0 {
-		slot = slot.Add(uint64(newerSlotBy))
+	if increaseAttestedSlotBy > 0 {
+		slot = slot.Add(uint64(increaseAttestedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateFulu()


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR refactors the light client test util functions, and adds two new parameters:
- `newerSlotBy`: sets up the data with a bigger slot by `newerSlotBy` slots.
- `supermajority`: sets the sync committee participation for that block based on the passed `supermajority`.

**Which issues(s) does this PR fix?**
Part of #12991 