### PR TITLE
Fix Operations Length Check For Attestations

### DIFF
--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -415,11 +415,15 @@ func VerifyOperationLengths(_ context.Context, state state.BeaconState, b interf
 		)
 	}
 
-	if uint64(len(body.Attestations())) > params.BeaconConfig().MaxAttestations {
+	maxAttestations := params.BeaconConfig().MaxAttestations
+	if body.Version() >= version.Electra {
+		maxAttestations = params.BeaconConfig().MaxAttestationsElectra
+	}
+	if uint64(len(body.Attestations())) > maxAttestations {
 		return nil, fmt.Errorf(
 			"number of attestations (%d) in block body exceeds allowed threshold of %d",
 			len(body.Attestations()),
-			params.BeaconConfig().MaxAttestations,
+			maxAttestations,
 		)
 	}
 

--- a/beacon-chain/core/transition/transition_test.go
+++ b/beacon-chain/core/transition/transition_test.go
@@ -474,6 +474,24 @@ func TestProcessBlock_OverMaxAttestations(t *testing.T) {
 	assert.ErrorContains(t, want, err)
 }
 
+func TestProcessBlock_OverMaxAttestationsElectra(t *testing.T) {
+	b := &ethpb.SignedBeaconBlockElectra{
+		Block: &ethpb.BeaconBlockElectra{
+			Body: &ethpb.BeaconBlockBodyElectra{
+				Attestations: make([]*ethpb.AttestationElectra, params.BeaconConfig().MaxAttestationsElectra+1),
+			},
+		},
+	}
+	want := fmt.Sprintf("number of attestations (%d) in block body exceeds allowed threshold of %d",
+		len(b.Block.Body.Attestations), params.BeaconConfig().MaxAttestationsElectra)
+	s, err := state_native.InitializeFromProtoUnsafeElectra(&ethpb.BeaconStateElectra{})
+	require.NoError(t, err)
+	wsb, err := consensusblocks.NewSignedBeaconBlock(b)
+	require.NoError(t, err)
+	_, err = transition.VerifyOperationLengths(context.Background(), s, wsb.Block())
+	assert.ErrorContains(t, want, err)
+}
+
 func TestProcessBlock_OverMaxVoluntaryExits(t *testing.T) {
 	maxExits := params.BeaconConfig().MaxVoluntaryExits
 	b := &ethpb.SignedBeaconBlock{

--- a/changelog/nisdas_fix_operations_check_bug.md
+++ b/changelog/nisdas_fix_operations_check_bug.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a bug in checking for attestation lengths in our block.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

This uses the correct length check for attestations in an Electra block. Also adds in the regression test to make sure
we do reject the block.

**Which issues(s) does this PR fix?**



**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
