### PR TITLE
Use forkchoice dependent root helper

### DIFF
--- a/changelog/potuz_use_fc_dependent_root.md
+++ b/changelog/potuz_use_fc_dependent_root.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use forkchoice dependent root helper in new head event feed. 


### PR DESCRIPTION
In the event feed, this PR replaces lookups to blockroots by slot to the cached root from forkchoice. 

Needs #15136 