### PR TITLE
Add `increaseFinalizedSlotBy` to LC test util functions

### DIFF
--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2653,7 +2653,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 
 	t.Run("Altair", func(t *testing.T) {
 		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+			l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2699,7 +2699,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+			l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2751,7 +2751,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestAltair(0, false)
+			l := util.NewTestLightClient(t).SetupTestAltair(0, 0, false)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2812,7 +2812,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 
 	t.Run("Capella", func(t *testing.T) {
 		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2857,7 +2857,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2909,7 +2909,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, false)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, false)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -2970,7 +2970,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 
 	t.Run("Deneb", func(t *testing.T) {
 		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3015,7 +3015,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3067,7 +3067,7 @@ func TestSaveLightClientUpdate(t *testing.T) {
 		})
 
 		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, false)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, false)
 
 			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3138,7 +3138,7 @@ func TestSaveLightClientBootstrap(t *testing.T) {
 	ctx := tr.ctx
 
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3173,7 +3173,7 @@ func TestSaveLightClientBootstrap(t *testing.T) {
 	})
 
 	t.Run("Capella", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 
 		s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
@@ -3208,7 +3208,7 @@ func TestSaveLightClientBootstrap(t *testing.T) {
 	})
 
 	t.Run("Deneb", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true)
 
 		s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 

--- a/beacon-chain/core/light-client/lightclient_test.go
+++ b/beacon-chain/core/light-client/lightclient_test.go
@@ -32,7 +32,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	})
 
 	t.Run("Capella", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	})
 
 	t.Run("Deneb", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	})
 
 	t.Run("Electra", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true)
+		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, 0, true)
 
 		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
@@ -131,7 +131,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 	t.Run("Capella", func(t *testing.T) {
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
@@ -238,7 +238,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 	t.Run("Deneb", func(t *testing.T) {
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true)
 
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
@@ -390,7 +390,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 
 	t.Run("Electra", func(t *testing.T) {
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestElectra(false, 0, 0, true)
 
 			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
@@ -542,7 +542,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 
 func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	t.Run("Altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -565,7 +565,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	})
 
 	t.Run("Bellatrix", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestBellatrix(0, true)
+		l := util.NewTestLightClient(t).SetupTestBellatrix(0, 0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -589,7 +589,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Capella", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -650,7 +650,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(true, 0, true)
+			l := util.NewTestLightClient(t).SetupTestCapella(true, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -713,7 +713,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Deneb", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -782,7 +782,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestDeneb(true, 0, true)
+			l := util.NewTestLightClient(t).SetupTestDeneb(true, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -853,7 +853,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Electra", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestElectra(false, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(l.Ctx, l.State.Slot(), l.Block)
 			require.NoError(t, err)
@@ -918,7 +918,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestElectra(true, 0, true)
+			l := util.NewTestLightClient(t).SetupTestElectra(true, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(l.Ctx, l.State.Slot(), l.Block)
 			require.NoError(t, err)
@@ -984,7 +984,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	})
 
 	t.Run("Capella fork with Altair block", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -1006,7 +1006,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 	})
 
 	t.Run("Deneb fork with Altair block", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		header, err := lightClient.BlockToLightClientHeader(
 			l.Ctx,
@@ -1029,7 +1029,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 
 	t.Run("Deneb fork with Capella block", func(t *testing.T) {
 		t.Run("Non-Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+			l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,
@@ -1089,7 +1089,7 @@ func TestLightClient_BlockToLightClientHeader(t *testing.T) {
 		})
 
 		t.Run("Blinded Beacon Block", func(t *testing.T) {
-			l := util.NewTestLightClient(t).SetupTestCapella(true, 0, true)
+			l := util.NewTestLightClient(t).SetupTestCapella(true, 0, 0, true)
 
 			header, err := lightClient.BlockToLightClientHeader(
 				l.Ctx,

--- a/beacon-chain/core/light-client/store_test.go
+++ b/beacon-chain/core/light-client/store_test.go
@@ -23,7 +23,7 @@ func TestLightClientStore(t *testing.T) {
 	lcStore := &lightClient.Store{}
 
 	// Create test light client updates for Capella and Deneb
-	lCapella := util.NewTestLightClient(t).SetupTestCapella(false, 0, true)
+	lCapella := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true)
 	opUpdateCapella, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lCapella.Ctx, lCapella.State.Slot(), lCapella.State, lCapella.Block, lCapella.AttestedState, lCapella.AttestedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, opUpdateCapella, "OptimisticUpdateCapella is nil")
@@ -31,7 +31,7 @@ func TestLightClientStore(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, finUpdateCapella, "FinalityUpdateCapella is nil")
 
-	lDeneb := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true)
+	lDeneb := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true)
 	opUpdateDeneb, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lDeneb.Ctx, lDeneb.State.Slot(), lDeneb.State, lDeneb.Block, lDeneb.AttestedState, lDeneb.AttestedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, opUpdateDeneb, "OptimisticUpdateDeneb is nil")

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -51,7 +51,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	t.Run("altair", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().AltairForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -93,7 +93,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("altairSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().AltairForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -127,7 +127,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("altair - no bootstrap found", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestAltair(0, true)
+		l := util.NewTestLightClient(t).SetupTestAltair(0, 0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().AltairForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -153,7 +153,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, writer.Code)
 	})
 	t.Run("bellatrix", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestBellatrix(0, true)
+		l := util.NewTestLightClient(t).SetupTestBellatrix(0, 0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -194,7 +194,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("bellatrixSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestBellatrix(0, true)
+		l := util.NewTestLightClient(t).SetupTestBellatrix(0, 0, true)
 
 		slot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -228,7 +228,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("capella", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -269,7 +269,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("capellaSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, true) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestCapella(false, 0, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -303,7 +303,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("deneb", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -344,7 +344,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("denebSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, true) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestDeneb(false, 0, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -378,7 +378,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.CurrentSyncCommitteeBranch)
 	})
 	t.Run("electra", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()
@@ -419,7 +419,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 	})
 	t.Run("electraSSZ", func(t *testing.T) {
-		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, true) // result is same for true and false
+		l := util.NewTestLightClient(t).SetupTestElectra(false, 0, 0, true) // result is same for true and false
 
 		slot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 		blockRoot, err := l.Block.Block().HashTreeRoot()

--- a/changelog/bastin_add-parameters-to-lc-testutils.md
+++ b/changelog/bastin_add-parameters-to-lc-testutils.md
@@ -1,3 +1,4 @@
 ### Ignored
 
-- add two parameters `increaseAttestedSlotBy` and `supermajority` to the lc test utils.
+- add parameters `increaseAttestedSlotBy` and `supermajority` to the lc test utils.
+- add `increaseFinalizedSlotBy` to the lc test utils.

--- a/testing/util/lightclient.go
+++ b/testing/util/lightclient.go
@@ -17,6 +17,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
+	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )
 
 type TestLightClient struct {
@@ -33,12 +34,16 @@ func NewTestLightClient(t *testing.T) *TestLightClient {
 	return &TestLightClient{T: t}
 }
 
-func (l *TestLightClient) SetupTestCapella(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestCapella(blinded bool, increaseAttestedSlotBy int, increaseFinalizedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
-
-	slot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	finalizedSlot := primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
+	slot := finalizedSlot.Add(1)
 	if increaseAttestedSlotBy > 0 {
 		slot = slot.Add(uint64(increaseAttestedSlotBy))
+	}
+	if increaseFinalizedSlotBy > 0 {
+		finalizedSlot = finalizedSlot.Add(uint64(increaseFinalizedSlotBy))
+		slot = slot.Add(uint64(increaseFinalizedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateCapella()
@@ -48,14 +53,14 @@ func (l *TestLightClient) SetupTestCapella(blinded bool, increaseAttestedSlotBy 
 
 	finalizedBlock, err := blocks.NewSignedBeaconBlock(NewBeaconBlockCapella())
 	require.NoError(l.T, err)
-	finalizedBlock.SetSlot(primitives.Slot(params.BeaconConfig().CapellaForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)))
+	finalizedBlock.SetSlot(finalizedSlot)
 	finalizedHeader, err := finalizedBlock.Header()
 	require.NoError(l.T, err)
 	finalizedRoot, err := finalizedHeader.Header.HashTreeRoot()
 	require.NoError(l.T, err)
 
 	require.NoError(l.T, attestedState.SetFinalizedCheckpoint(&ethpb.Checkpoint{
-		Epoch: params.BeaconConfig().CapellaForkEpoch,
+		Epoch: slots.ToEpoch(finalizedSlot),
 		Root:  finalizedRoot[:],
 	}))
 
@@ -95,7 +100,7 @@ func (l *TestLightClient) SetupTestCapella(blinded bool, increaseAttestedSlotBy 
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) / 3 * 2) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}
@@ -125,7 +130,7 @@ func (l *TestLightClient) SetupTestCapella(blinded bool, increaseAttestedSlotBy 
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) / 3 * 2) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}
@@ -272,12 +277,17 @@ func (l *TestLightClient) SetupTestCapellaFinalizedBlockAltair(blinded bool) *Te
 	return l
 }
 
-func (l *TestLightClient) SetupTestAltair(increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestAltair(increaseAttestedSlotBy int, increaseFinalizedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
-	slot := primitives.Slot(uint64(params.BeaconConfig().AltairForkEpoch) * uint64(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	finalizedSlot := primitives.Slot(params.BeaconConfig().AltairForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
+	slot := finalizedSlot.Add(1)
 	if increaseAttestedSlotBy > 0 {
 		slot = slot.Add(uint64(increaseAttestedSlotBy))
+	}
+	if increaseFinalizedSlotBy > 0 {
+		finalizedSlot = finalizedSlot.Add(uint64(increaseFinalizedSlotBy))
+		slot = slot.Add(uint64(increaseFinalizedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateAltair()
@@ -287,13 +297,13 @@ func (l *TestLightClient) SetupTestAltair(increaseAttestedSlotBy int, supermajor
 
 	finalizedState, err := NewBeaconStateAltair()
 	require.NoError(l.T, err)
-	err = finalizedState.SetSlot(1)
+	err = finalizedState.SetSlot(finalizedSlot)
 	require.NoError(l.T, err)
 	finalizedStateRoot, err := finalizedState.HashTreeRoot(ctx)
 	require.NoError(l.T, err)
 	SignedFinalizedBlock, err := blocks.NewSignedBeaconBlock(NewBeaconBlockAltair())
 	require.NoError(l.T, err)
-	SignedFinalizedBlock.SetSlot(1)
+	SignedFinalizedBlock.SetSlot(finalizedSlot)
 	SignedFinalizedBlock.SetStateRoot(finalizedStateRoot[:])
 	finalizedHeader, err := SignedFinalizedBlock.Header()
 	require.NoError(l.T, err)
@@ -301,7 +311,7 @@ func (l *TestLightClient) SetupTestAltair(increaseAttestedSlotBy int, supermajor
 	require.NoError(l.T, err)
 
 	finalizedCheckpoint := &ethpb.Checkpoint{
-		Epoch: params.BeaconConfig().AltairForkEpoch - 10,
+		Epoch: slots.ToEpoch(finalizedSlot),
 		Root:  finalizedRoot[:],
 	}
 	require.NoError(l.T, attestedState.SetFinalizedCheckpoint(finalizedCheckpoint))
@@ -340,7 +350,7 @@ func (l *TestLightClient) SetupTestAltair(increaseAttestedSlotBy int, supermajor
 
 	var trueBitNum uint64
 	if supermajority {
-		trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+		trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) / 3 * 2) + 1)
 	} else {
 		trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 	}
@@ -374,12 +384,17 @@ func (l *TestLightClient) SetupTestAltair(increaseAttestedSlotBy int, supermajor
 	return l
 }
 
-func (l *TestLightClient) SetupTestBellatrix(increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestBellatrix(increaseAttestedSlotBy int, increaseFinalizedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
-	slot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	finalizedSlot := primitives.Slot(params.BeaconConfig().BellatrixForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
+	slot := finalizedSlot.Add(1)
 	if increaseAttestedSlotBy > 0 {
 		slot = slot.Add(uint64(increaseAttestedSlotBy))
+	}
+	if increaseFinalizedSlotBy > 0 {
+		finalizedSlot = finalizedSlot.Add(uint64(increaseFinalizedSlotBy))
+		slot = slot.Add(uint64(increaseFinalizedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateBellatrix()
@@ -389,14 +404,14 @@ func (l *TestLightClient) SetupTestBellatrix(increaseAttestedSlotBy int, superma
 
 	finalizedBlock, err := blocks.NewSignedBeaconBlock(NewBeaconBlockBellatrix())
 	require.NoError(l.T, err)
-	finalizedBlock.SetSlot(1)
+	finalizedBlock.SetSlot(finalizedSlot)
 	finalizedHeader, err := finalizedBlock.Header()
 	require.NoError(l.T, err)
 	finalizedRoot, err := finalizedHeader.Header.HashTreeRoot()
 	require.NoError(l.T, err)
 
 	require.NoError(l.T, attestedState.SetFinalizedCheckpoint(&ethpb.Checkpoint{
-		Epoch: params.BeaconConfig().BellatrixForkEpoch - 10,
+		Epoch: slots.ToEpoch(finalizedSlot),
 		Root:  finalizedRoot[:],
 	}))
 
@@ -434,7 +449,7 @@ func (l *TestLightClient) SetupTestBellatrix(increaseAttestedSlotBy int, superma
 
 	var trueBitNum uint64
 	if supermajority {
-		trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+		trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) * 2.0 / 3.0) + 1)
 	} else {
 		trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 	}
@@ -468,12 +483,17 @@ func (l *TestLightClient) SetupTestBellatrix(increaseAttestedSlotBy int, superma
 	return l
 }
 
-func (l *TestLightClient) SetupTestDeneb(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestDeneb(blinded bool, increaseAttestedSlotBy int, increaseFinalizedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
-	slot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	finalizedSlot := primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
+	slot := finalizedSlot.Add(1)
 	if increaseAttestedSlotBy > 0 {
 		slot = slot.Add(uint64(increaseAttestedSlotBy))
+	}
+	if increaseFinalizedSlotBy > 0 {
+		finalizedSlot = finalizedSlot.Add(uint64(increaseFinalizedSlotBy))
+		slot = slot.Add(uint64(increaseFinalizedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateDeneb()
@@ -483,14 +503,14 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool, increaseAttestedSlotBy in
 
 	finalizedBlock, err := blocks.NewSignedBeaconBlock(NewBeaconBlockDeneb())
 	require.NoError(l.T, err)
-	finalizedBlock.SetSlot(primitives.Slot(params.BeaconConfig().DenebForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)))
+	finalizedBlock.SetSlot(finalizedSlot)
 	finalizedHeader, err := finalizedBlock.Header()
 	require.NoError(l.T, err)
 	finalizedRoot, err := finalizedHeader.Header.HashTreeRoot()
 	require.NoError(l.T, err)
 
 	require.NoError(l.T, attestedState.SetFinalizedCheckpoint(&ethpb.Checkpoint{
-		Epoch: params.BeaconConfig().DenebForkEpoch,
+		Epoch: slots.ToEpoch(finalizedSlot),
 		Root:  finalizedRoot[:],
 	}))
 
@@ -530,7 +550,7 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool, increaseAttestedSlotBy in
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) * 2.0 / 3.0) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}
@@ -560,7 +580,7 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool, increaseAttestedSlotBy in
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) * 2.0 / 3.0) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}
@@ -595,14 +615,18 @@ func (l *TestLightClient) SetupTestDeneb(blinded bool, increaseAttestedSlotBy in
 	return l
 }
 
-func (l *TestLightClient) SetupTestElectra(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestElectra(blinded bool, increaseAttestedSlotBy int, increaseFinalizedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
-	slot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	finalizedSlot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
+	slot := finalizedSlot.Add(1)
 	if increaseAttestedSlotBy > 0 {
 		slot = slot.Add(uint64(increaseAttestedSlotBy))
 	}
-	finalizedBlockSlot := primitives.Slot(params.BeaconConfig().ElectraForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
+	if increaseFinalizedSlotBy > 0 {
+		finalizedSlot = finalizedSlot.Add(uint64(increaseFinalizedSlotBy))
+		slot = slot.Add(uint64(increaseFinalizedSlotBy))
+	}
 
 	attestedState, err := NewBeaconStateElectra()
 	require.NoError(l.T, err)
@@ -611,14 +635,14 @@ func (l *TestLightClient) SetupTestElectra(blinded bool, increaseAttestedSlotBy 
 
 	finalizedBlock, err := blocks.NewSignedBeaconBlock(NewBeaconBlockDeneb())
 	require.NoError(l.T, err)
-	finalizedBlock.SetSlot(finalizedBlockSlot)
+	finalizedBlock.SetSlot(finalizedSlot)
 	finalizedHeader, err := finalizedBlock.Header()
 	require.NoError(l.T, err)
 	finalizedRoot, err := finalizedHeader.Header.HashTreeRoot()
 	require.NoError(l.T, err)
 
 	require.NoError(l.T, attestedState.SetFinalizedCheckpoint(&ethpb.Checkpoint{
-		Epoch: params.BeaconConfig().ElectraForkEpoch,
+		Epoch: slots.ToEpoch(finalizedSlot),
 		Root:  finalizedRoot[:],
 	}))
 
@@ -658,7 +682,7 @@ func (l *TestLightClient) SetupTestElectra(blinded bool, increaseAttestedSlotBy 
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) * 2.0 / 3.0) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}
@@ -688,7 +712,7 @@ func (l *TestLightClient) SetupTestElectra(blinded bool, increaseAttestedSlotBy 
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) * 2.0 / 3.0) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}
@@ -723,12 +747,17 @@ func (l *TestLightClient) SetupTestElectra(blinded bool, increaseAttestedSlotBy 
 	return l
 }
 
-func (l *TestLightClient) SetupTestFulu(blinded bool, increaseAttestedSlotBy int, supermajority bool) *TestLightClient {
+func (l *TestLightClient) SetupTestFulu(blinded bool, increaseAttestedSlotBy int, increaseFinalizedSlotBy int, supermajority bool) *TestLightClient {
 	ctx := context.Background()
 
-	slot := primitives.Slot(params.BeaconConfig().FuluForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+	finalizedSlot := primitives.Slot(params.BeaconConfig().FuluForkEpoch * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch))
+	slot := finalizedSlot.Add(1)
 	if increaseAttestedSlotBy > 0 {
 		slot = slot.Add(uint64(increaseAttestedSlotBy))
+	}
+	if increaseFinalizedSlotBy > 0 {
+		finalizedSlot = finalizedSlot.Add(uint64(increaseFinalizedSlotBy))
+		slot = slot.Add(uint64(increaseFinalizedSlotBy))
 	}
 
 	attestedState, err := NewBeaconStateFulu()
@@ -738,14 +767,14 @@ func (l *TestLightClient) SetupTestFulu(blinded bool, increaseAttestedSlotBy int
 
 	finalizedBlock, err := blocks.NewSignedBeaconBlock(NewBeaconBlockFulu())
 	require.NoError(l.T, err)
-	finalizedBlock.SetSlot(1)
+	finalizedBlock.SetSlot(finalizedSlot)
 	finalizedHeader, err := finalizedBlock.Header()
 	require.NoError(l.T, err)
 	finalizedRoot, err := finalizedHeader.Header.HashTreeRoot()
 	require.NoError(l.T, err)
 
 	require.NoError(l.T, attestedState.SetFinalizedCheckpoint(&ethpb.Checkpoint{
-		Epoch: params.BeaconConfig().FuluForkEpoch - 10,
+		Epoch: slots.ToEpoch(finalizedSlot),
 		Root:  finalizedRoot[:],
 	}))
 
@@ -785,7 +814,7 @@ func (l *TestLightClient) SetupTestFulu(blinded bool, increaseAttestedSlotBy int
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) * 2.0 / 3.0) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}
@@ -815,7 +844,7 @@ func (l *TestLightClient) SetupTestFulu(blinded bool, increaseAttestedSlotBy int
 
 		var trueBitNum uint64
 		if supermajority {
-			trueBitNum = (params.BeaconConfig().SyncCommitteeSize / 3 * 2) + 1
+			trueBitNum = uint64((float64(params.BeaconConfig().SyncCommitteeSize) * 2.0 / 3.0) + 1)
 		} else {
 			trueBitNum = params.BeaconConfig().MinSyncCommitteeParticipants
 		}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR adds a parameter `increaseFinalizedSlotBy` to the light client testing util functions, in order to manipulate the slot of the finalized block.

**Which issues(s) does this PR fix?**
Part of #12991 