### PR TITLE
Mainnet config copies by default

### DIFF
--- a/beacon-chain/db/kv/genesis_test.go
+++ b/beacon-chain/db/kv/genesis_test.go
@@ -145,7 +145,7 @@ func TestLoadGenesisFromFile_mismatchedForkVersion(t *testing.T) {
 func TestEnsureEmbeddedGenesis(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	// Embedded Genesis works with Mainnet config
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.SecondsPerSlot = 1
 	undo, err := params.SetActiveWithUndo(cfg)
 	require.NoError(t, err)

--- a/beacon-chain/db/kv/wss_test.go
+++ b/beacon-chain/db/kv/wss_test.go
@@ -14,7 +14,7 @@ import (
 func TestSaveOrigin(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	// Embedded Genesis works with Mainnet config
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 
 	ctx := context.Background()
 	db := setupDB(t)

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -277,7 +277,7 @@ func TestAddForkEntry_Genesis(t *testing.T) {
 	db, err := enode.OpenDB("")
 	require.NoError(t, err)
 
-	bCfg := params.MainnetConfig().Copy()
+	bCfg := params.MainnetConfig()
 	bCfg.ForkVersionSchedule = map[[4]byte]primitives.Epoch{}
 	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)] = bCfg.GenesisEpoch
 	params.OverrideBeaconConfig(bCfg)

--- a/beacon-chain/p2p/gossip_scoring_params_test.go
+++ b/beacon-chain/p2p/gossip_scoring_params_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCorrect_ActiveValidatorsCount(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.ConfigName = "test"
 
 	params.OverrideBeaconConfig(cfg)

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -1481,7 +1481,7 @@ func TestGetAttestationData(t *testing.T) {
 
 		// Ensure HistoricalRootsLimit matches scenario
 		params.SetupTestConfigCleanup(t)
-		cfg := params.MainnetConfig().Copy()
+		cfg := params.MainnetConfig()
 		cfg.HistoricalRootsLimit = 8192
 		params.OverrideBeaconConfig(cfg)
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_mainnet_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_mainnet_test.go
@@ -30,7 +30,7 @@ func TestAttestationDataAtSlot_HandlesFarAwayJustifiedEpoch(t *testing.T) {
 
 	// Ensure HistoricalRootsLimit matches scenario
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.HistoricalRootsLimit = 8192
 	params.OverrideBeaconConfig(cfg)
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_electra_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_electra_test.go
@@ -16,7 +16,7 @@ import (
 
 func Test_computeOnChainAggregate(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.MaxCommitteesPerSlot = 64
 	params.OverrideBeaconConfig(cfg)
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -844,7 +844,7 @@ func Benchmark_packAttestations_Electra(b *testing.B) {
 	ctx := context.Background()
 
 	params.SetupTestConfigCleanup(b)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.ElectraForkEpoch = 1
 	params.OverrideBeaconConfig(cfg)
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server_mainnet_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server_mainnet_test.go
@@ -24,7 +24,7 @@ import (
 func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 	// This test breaks if it doesn't use mainnet config
 	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 	ctx := context.Background()
 
 	priv1, err := bls.RandKey()

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/status_mainnet_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/status_mainnet_test.go
@@ -24,7 +24,7 @@ import (
 func TestValidatorStatus_Active(t *testing.T) {
 	// This test breaks if it doesn't use mainnet config
 	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 	ctx := context.Background()
 
 	pubkey := generatePubkey(1)

--- a/beacon-chain/sync/backfill/verify_test.go
+++ b/beacon-chain/sync/backfill/verify_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestDomainCache(t *testing.T) {
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	// This hack is needed not to have both Electra and Fulu fork epoch both set to the future max epoch.
 	// It can be removed once the Electra fork version has been set to a real value.
 	for version := range cfg.ForkVersionSchedule {

--- a/beacon-chain/sync/checkpoint/api_test.go
+++ b/beacon-chain/sync/checkpoint/api_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestDownloadFinalizedData(t *testing.T) {
 	ctx := context.Background()
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 
 	// avoid the altair zone because genesis tests are easier to set up
 	epoch := cfg.AltairForkEpoch - 1

--- a/beacon-chain/sync/checkpoint/weak-subjectivity_test.go
+++ b/beacon-chain/sync/checkpoint/weak-subjectivity_test.go
@@ -76,7 +76,7 @@ func TestFname(t *testing.T) {
 
 func TestDownloadWeakSubjectivityCheckpoint(t *testing.T) {
 	ctx := context.Background()
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 
 	epoch := cfg.AltairForkEpoch - 1
 	// set up checkpoint state, using the epoch that will be computed as the ws checkpoint state based on the head state

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.SecondsPerSlot = 1
 	params.OverrideBeaconConfig(cfg)
 

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -123,7 +123,7 @@ func TestSubscribe_UnsubscribeTopic(t *testing.T) {
 
 func TestSubscribe_ReceivesAttesterSlashing(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.SecondsPerSlot = 1
 	params.OverrideBeaconConfig(cfg)
 
@@ -428,7 +428,7 @@ func Test_wrapAndReportValidation(t *testing.T) {
 
 func TestFilterSubnetPeers(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.SecondsPerSlot = 1
 	params.OverrideBeaconConfig(cfg)
 
@@ -510,7 +510,7 @@ func TestFilterSubnetPeers(t *testing.T) {
 
 func TestSubscribeWithSyncSubnets_DynamicOK(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.SecondsPerSlot = 1
 	params.OverrideBeaconConfig(cfg)
 

--- a/changelog/tt_7.md
+++ b/changelog/tt_7.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Mainnet config returns copied config instead of assume caller to copy.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -158,7 +158,7 @@ func configureTestnet(ctx *cli.Context) error {
 		} else {
 			log.Info("Running on Ethereum Mainnet")
 		}
-		if err := params.SetActive(params.MainnetConfig().Copy()); err != nil {
+		if err := params.SetActive(params.MainnetConfig()); err != nil {
 			return err
 		}
 	}

--- a/config/params/configset_test.go
+++ b/config/params/configset_test.go
@@ -22,7 +22,7 @@ func TestConfigset_Add(t *testing.T) {
 
 func TestConfigsetReplaceMainnet(t *testing.T) {
 	r := newConfigset()
-	mainnet := MainnetConfig().Copy()
+	mainnet := MainnetConfig()
 	require.NoError(t, r.setActive(mainnet))
 	FillTestVersions(mainnet, 128)
 	require.NoError(t, r.replace(mainnet))
@@ -30,7 +30,7 @@ func TestConfigsetReplaceMainnet(t *testing.T) {
 
 func TestConfigset_Replace(t *testing.T) {
 	r := newConfigset()
-	mainnet := MainnetConfig().Copy()
+	mainnet := MainnetConfig()
 	require.NoError(t, r.add(mainnet))
 	require.NoError(t, r.setActive(mainnet))
 	require.ErrorIs(t, r.add(mainnet), errCollisionName)
@@ -66,7 +66,7 @@ func TestConfigset_Replace(t *testing.T) {
 }
 
 func testConfig(name string) *BeaconChainConfig {
-	c := MainnetConfig().Copy()
+	c := MainnetConfig()
 	FillTestVersions(c, 127)
 	c.ConfigName = name
 	return c

--- a/config/params/interop.go
+++ b/config/params/interop.go
@@ -2,7 +2,7 @@ package params
 
 // InteropConfig provides a generic config suitable for interop testing.
 func InteropConfig() *BeaconChainConfig {
-	c := MainnetConfig().Copy()
+	c := MainnetConfig()
 
 	// Prysm constants.
 	c.ConfigName = InteropName

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -35,7 +35,7 @@ func UnmarshalConfig(yamlFile []byte, conf *BeaconChainConfig) (*BeaconChainConf
 			conf = MinimalSpecConfig().Copy()
 		} else {
 			// Default to using mainnet.
-			conf = MainnetConfig().Copy()
+			conf = MainnetConfig()
 		}
 	}
 	for i, line := range lines {

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -183,7 +183,7 @@ func TestModifiedE2E(t *testing.T) {
 
 func TestLoadConfigFile(t *testing.T) {
 	t.Run("mainnet", func(t *testing.T) {
-		mn := params.MainnetConfig().Copy()
+		mn := params.MainnetConfig()
 		mainnetPresetsFiles := presetsFilePath(t, "mainnet")
 		var err error
 		for _, fp := range mainnetPresetsFiles {

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -13,7 +13,7 @@ func MainnetConfig() *BeaconChainConfig {
 	if mainnetBeaconConfig.ForkVersionSchedule == nil {
 		mainnetBeaconConfig.InitializeForkSchedule()
 	}
-	return mainnetBeaconConfig
+	return mainnetBeaconConfig.Copy()
 }
 
 const (
@@ -341,7 +341,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 // and a different fork choice schedule. This can be used in cases where we want to use config values
 // that are consistent with mainnet, but won't conflict or cause the hard-coded genesis to be loaded.
 func MainnetTestConfig() *BeaconChainConfig {
-	mn := MainnetConfig().Copy()
+	mn := MainnetConfig()
 	mn.ConfigName = MainnetTestName
 	FillTestVersions(mn, 128)
 	return mn

--- a/config/params/testnet_config_test.go
+++ b/config/params/testnet_config_test.go
@@ -20,7 +20,7 @@ func TestE2EConfigParity(t *testing.T) {
 	yamlObj := params.ConfigToYaml(params.E2EMainnetTestConfig())
 	assert.NoError(t, file.WriteFile(yamlDir, yamlObj))
 
-	require.NoError(t, params.LoadChainConfigFile(yamlDir, params.MainnetConfig().Copy()))
+	require.NoError(t, params.LoadChainConfigFile(yamlDir, params.MainnetConfig()))
 
 	// compareConfigs makes it easier to figure out exactly what changed
 	compareConfigs(t, params.BeaconConfig(), testCfg)

--- a/config/params/testnet_e2e_config.go
+++ b/config/params/testnet_e2e_config.go
@@ -65,7 +65,7 @@ func E2ETestConfig() *BeaconChainConfig {
 }
 
 func E2EMainnetTestConfig() *BeaconChainConfig {
-	e2eConfig := MainnetConfig().Copy()
+	e2eConfig := MainnetConfig()
 	e2eConfig.DepositContractAddress = "0x4242424242424242424242424242424242424242"
 	e2eConfig.Eth1FollowDistance = 8
 

--- a/config/params/testnet_holesky_config.go
+++ b/config/params/testnet_holesky_config.go
@@ -22,7 +22,7 @@ func UseHoleskyNetworkConfig() {
 
 // HoleskyConfig defines the config for the Holesky beacon chain testnet.
 func HoleskyConfig() *BeaconChainConfig {
-	cfg := MainnetConfig().Copy()
+	cfg := MainnetConfig()
 	cfg.MinGenesisTime = 1695902100
 	cfg.GenesisDelay = 300
 	cfg.ConfigName = HoleskyName

--- a/config/params/testnet_hoodi_config.go
+++ b/config/params/testnet_hoodi_config.go
@@ -21,7 +21,7 @@ func UseHoodiNetworkConfig() {
 
 // HoodiConfig defines the config for the Hoodi beacon chain testnet.
 func HoodiConfig() *BeaconChainConfig {
-	cfg := MainnetConfig().Copy()
+	cfg := MainnetConfig()
 	cfg.MinGenesisTime = 1742212800
 	cfg.GenesisDelay = 600
 	cfg.ConfigName = HoodiName

--- a/config/params/testnet_sepolia_config.go
+++ b/config/params/testnet_sepolia_config.go
@@ -26,7 +26,7 @@ func UseSepoliaNetworkConfig() {
 
 // SepoliaConfig defines the config for the Sepolia beacon chain testnet.
 func SepoliaConfig() *BeaconChainConfig {
-	cfg := MainnetConfig().Copy()
+	cfg := MainnetConfig()
 	cfg.MinGenesisTime = 1655647200
 	cfg.GenesisDelay = 86400
 	cfg.MinGenesisActiveValidatorCount = 1300

--- a/testing/spectest/utils/config.go
+++ b/testing/spectest/utils/config.go
@@ -18,7 +18,7 @@ func SetConfig(t testing.TB, config string) error {
 		params.OverrideBeaconConfig(params.MinimalSpecConfig().Copy())
 		return nil
 	case "mainnet":
-		params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+		params.OverrideBeaconConfig(params.MainnetConfig())
 		return nil
 	case "":
 		return errors.New("no config provided")

--- a/testing/util/block_test.go
+++ b/testing/util/block_test.go
@@ -32,7 +32,7 @@ func TestGenerateFullBlock_PassesStateTransition(t *testing.T) {
 
 func TestGenerateFullBlock_ThousandValidators(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 	beaconState, privs := DeterministicGenesisState(t, 1024)
 	conf := &BlockGenConfig{
 		NumAttestations: 4,
@@ -47,7 +47,7 @@ func TestGenerateFullBlock_ThousandValidators(t *testing.T) {
 
 func TestGenerateFullBlock_Passes4Epochs(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 	beaconState, privs := DeterministicGenesisState(t, 64)
 
 	conf := &BlockGenConfig{
@@ -78,7 +78,7 @@ func TestGenerateFullBlock_Passes4Epochs(t *testing.T) {
 
 func TestGenerateFullBlock_ValidProposerSlashings(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 	beaconState, privs := DeterministicGenesisState(t, 32)
 	conf := &BlockGenConfig{
 		NumProposerSlashings: 1,
@@ -99,7 +99,7 @@ func TestGenerateFullBlock_ValidProposerSlashings(t *testing.T) {
 
 func TestGenerateFullBlock_ValidAttesterSlashings(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 	beaconState, privs := DeterministicGenesisState(t, 256)
 	conf := &BlockGenConfig{
 		NumAttesterSlashings: 1,
@@ -120,7 +120,7 @@ func TestGenerateFullBlock_ValidAttesterSlashings(t *testing.T) {
 
 func TestGenerateFullBlock_ValidAttestations(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	params.OverrideBeaconConfig(params.MainnetConfig().Copy())
+	params.OverrideBeaconConfig(params.MainnetConfig())
 
 	beaconState, privs := DeterministicGenesisState(t, 256)
 	conf := &BlockGenConfig{

--- a/testing/util/helpers.go
+++ b/testing/util/helpers.go
@@ -160,7 +160,7 @@ func Random32Bytes(t *testing.T) []byte {
 // to multiplication overflow.
 // Monkey patching tests with this function is the simplest workaround in these cases.
 func HackForksMaxuint(t *testing.T, forksVersion []int) func() {
-	bc := params.MainnetConfig().Copy()
+	bc := params.MainnetConfig()
 	for _, forkVersion := range forksVersion {
 		switch forkVersion {
 		case version.Electra:

--- a/validator/client/wait_for_activation_test.go
+++ b/validator/client/wait_for_activation_test.go
@@ -52,7 +52,7 @@ func TestWaitActivation_Exiting_OK(t *testing.T) {
 
 func TestWaitForActivation_RefetchKeys(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.ConfigName = "test"
 	cfg.SecondsPerSlot = 1
 	params.OverrideBeaconConfig(cfg)
@@ -235,7 +235,7 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 
 func TestWaitForActivation_AttemptsReconnectionOnFailure(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	cfg := params.MainnetConfig().Copy()
+	cfg := params.MainnetConfig()
 	cfg.ConfigName = "test"
 	cfg.SecondsPerSlot = 1
 	params.OverrideBeaconConfig(cfg)


### PR DESCRIPTION
`params.MainnetConfig()` should just return a copied version instead of relying on the caller to copy it every time since the config is a reference and easy to accidentally mutate