### PR TITLE
Guard against no attesters within committee in `VerifyAttestationNoVerifySignature`

### DIFF
--- a/beacon-chain/core/blocks/attestation_test.go
+++ b/beacon-chain/core/blocks/attestation_test.go
@@ -296,6 +296,22 @@ func TestVerifyAttestationNoVerifySignature_Electra(t *testing.T) {
 		err = blocks.VerifyAttestationNoVerifySignature(context.TODO(), beaconState, att)
 		assert.ErrorContains(t, "aggregation bits count 123 is different than participant count 3", err)
 	})
+	t.Run("no attester in committee", func(t *testing.T) {
+		aggBits := bitfield.NewBitlist(3)
+		committeeBits := bitfield.NewBitvector64()
+		committeeBits.SetBitAt(0, true)
+		att := &ethpb.AttestationElectra{
+			Data: &ethpb.AttestationData{
+				Source: &ethpb.Checkpoint{Epoch: 0, Root: mockRoot[:]},
+				Target: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+			},
+			AggregationBits: aggBits,
+			CommitteeBits:   committeeBits,
+		}
+		att.Signature = zeroSig[:]
+		err = blocks.VerifyAttestationNoVerifySignature(context.TODO(), beaconState, att)
+		assert.ErrorContains(t, "no attesting indices found for committee index 0", err)
+	})
 }
 
 func TestConvertToIndexed_OK(t *testing.T) {

--- a/changelog/radek_electra-committee-assertion.md
+++ b/changelog/radek_electra-committee-assertion.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Guard against no attesters within committee in `VerifyAttestationNoVerifySignature`.

--- a/proto/prysm/v1alpha1/attestation/attestation_utils.go
+++ b/proto/prysm/v1alpha1/attestation/attestation_utils.go
@@ -111,7 +111,7 @@ func AttestingIndices(att ethpb.Att, committees ...[]primitives.ValidatorIndex) 
 
 	attesters := make([]uint64, 0, aggBits.Count())
 	committeeOffset := 0
-	for _, c := range committees {
+	for ci, c := range committees {
 		committeeAttesters := make([]uint64, 0, len(c))
 		for i, vi := range c {
 			if aggBits.BitAt(uint64(committeeOffset + i)) {
@@ -119,7 +119,7 @@ func AttestingIndices(att ethpb.Att, committees ...[]primitives.ValidatorIndex) 
 			}
 		}
 		if len(committeeAttesters) == 0 {
-			return nil, fmt.Errorf("no attesting indices found in committee %v", c)
+			return nil, fmt.Errorf("no attesting indices found for committee index %d", ci)
 		}
 		attesters = append(attesters, committeeAttesters...)
 		committeeOffset += len(c)

--- a/proto/prysm/v1alpha1/attestation/attestation_utils_test.go
+++ b/proto/prysm/v1alpha1/attestation/attestation_utils_test.go
@@ -81,6 +81,14 @@ func TestAttestingIndices(t *testing.T) {
 			},
 			want: []uint64{0, 1},
 		},
+		{
+			name: "Electra - No attester in committee",
+			args: args{
+				att:        &eth.AttestationElectra{AggregationBits: bitfield.Bitlist{0b11100}},
+				committees: [][]primitives.ValidatorIndex{{0, 1}, {0, 1}},
+			},
+			err: "no attesting indices found for committee index 0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

- Adds missing assertion from the spec: `assert len(committee_attesters) > 0` in https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-process_attestation
- Modifies the error message in `AttestingIndices` because the current message outputs the full committee which is not useful, and it is more useful to know the committee index.
- Adds a test case for `AttestingIndices`

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
