### PR TITLE
Fixed URL in dependencies.md

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 Prysm is go project with many complicated dependencies, including some c++ based libraries. There
 are two parts to Prysm's dependency management. Go modules and bazel managed dependencies. Be sure 
-to read [Why Bazel?](https://github.com/OffchainLabs/documentation/issues/138) to fully
+to read [Why Bazel?](https://github.com/OffchainLabs/prysm-documentation/issues/138) to fully
 understand the reasoning behind an additional layer of build tooling via Bazel rather than a pure
 "go build" project.
 


### PR DESCRIPTION
The old link to the Bazel explanation (https://github.com/OffchainLabs/documentation/issues/138) was broken.
It has been updated to the correct working path:
https://github.com/OffchainLabs/prysm-documentation/issues/138.