### PR TITLE
Create hopium21_fix-url-in-dependencies.md

### DIFF
--- a/changelog/hopium21_fix-url-in-dependencies.md
+++ b/changelog/hopium21_fix-url-in-dependencies.md
@@ -1,0 +1,2 @@
+### Ignored
+- Fixed URL in dependencies.md


### PR DESCRIPTION
This PR adds a changelog fragment file for the previous fix that corrected a broken URL in dependencies.md. The fragment documents the change as required by the project's contribution guidelines.
