### PR TITLE
beacon-chain/rpc: Fix invalid `ParentBeaconBlockRoot` in Payload Attributes

### DIFF
--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -710,15 +710,10 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 	pr := ev.HeadBlock.Block().ParentRoot()
 	ev.ParentBlockRoot = pr[:]
 
-	hsr, err := ev.HeadState.LatestBlockHeader().HashTreeRoot()
-	if err != nil {
-		return ev, errors.Wrap(err, "could not compute latest block header root")
-	}
-
 	pse := slots.ToEpoch(ev.ProposalSlot)
 	st := ev.HeadState
 	if slots.ToEpoch(st.Slot()) != pse {
-		st, err = transition.ProcessSlotsUsingNextSlotCache(ctx, st, hsr[:], ev.ProposalSlot)
+		st, err = transition.ProcessSlotsUsingNextSlotCache(ctx, st, ev.HeadRoot[:], ev.ProposalSlot)
 		if err != nil {
 			return ev, errors.Wrap(err, "could not run process blocks on head state into the proposal slot epoch")
 		}
@@ -743,7 +738,7 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 	if err != nil {
 		return ev, errors.Wrap(err, "could not get head state slot time")
 	}
-	ev.Attributer, err = s.computePayloadAttributes(ctx, st, hsr, ev.ProposerIndex, uint64(t.Unix()), randao)
+	ev.Attributer, err = s.computePayloadAttributes(ctx, st, ev.HeadRoot, ev.ProposerIndex, uint64(t.Unix()), randao)
 	return ev, err
 }
 

--- a/changelog/ngotchac_fix-payload-attributes.md
+++ b/changelog/ngotchac_fix-payload-attributes.md
@@ -1,0 +1,2 @@
+### Fixed
+- Use root from head block instead of state.latest_block_header in payload attributes and process_slots.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

We were passing the root hash of the latest state, instead of the latest header. This lead to the `parent_beacon_block_root` in payload attributes being entirely wrong.

To test:
```bash
curl 'http://localhost:3500/eth/v1/events?topics=payload_attributes' -H 'accept: text/event-stream'
```

Before this PR, it would send these kind of payloads:
```
{"version":"deneb","data":{"proposer_index":"1046648","proposal_slot":"11500761","parent_block_number":"22283764","parent_block_root":"0x4a5476c85c744e32aefe4ee76b3f4ff9531214df20e880ba438048228dffa045","parent_block_hash":"0x403b5f27d4bcf0340e7affa74a4deb9ed8e725a93b6f60147b9d814e7e1e6ddd","payload_attributes":{"timestamp":"1744833155","prev_randao":"0x2da7d38f071d35f77d97497222a3ed4499c26d6e96f68d09eb3ee149de6001cf","suggested_fee_recipient":"0x99351746fc2bddc37e694a9529be9b401b7b0370","withdrawals":[...],"parent_beacon_block_root":"0x9739c73caa8ca1289943fa390fabf1aad3f91c76b645048a2fcf0e7956193a6d"}}}
```

Checking https://beaconcha.in/slot/11500761, the parent root should be 0xc3c56d59833bdc68871db7fce8ae08a86d261cba40b41bd464d018367810222f

With this PR:
```
{"version":"deneb","data":{"proposer_index":"1750223","proposal_slot":"11501043","parent_block_number":"22284045","parent_block_root":"0xa7d9fe7116e25dac0973687ced708fe0a99b651ad3234ed247e9bbc41ab2aaaf","parent_block_hash":"0x80b8459064630e3e8d3f2f4c8f56a1d2385c43ae737b8bb31efd8801d9385d64","payload_attributes":{"timestamp":"1744836539","prev_randao":"0x4f12e909ef92e3da9e8bc797e03f2eaf6be5bd89902d45028b718beb79974f1a","suggested_fee_recipient":"0x99351746fc2bddc37e694a9529be9b401b7b0370","withdrawals":[...],"parent_beacon_block_root":"0x78729dbb8c6aedfb2b80998c12f7a6ddf000a2207146515ddd75b3c941505c5a"}}}
```

Which matches the value in https://beaconcha.in/slot/11501043

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
