### PR TITLE
Validate parent block exists before signature

### DIFF
--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -129,6 +129,8 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 	}
 
 	// [REJECT] The proposer signature of `sidecar.signed_block_header`, is valid with respect to the `block_header.proposer_index` pubkey.
+	//          We do not strictly respect the spec ordering here. This is necessary because signature verification depends on the parent root,
+	//          which is only available if the parent block is known.
 	if err := verifier.ValidProposerSignature(ctx); err != nil {
 		return pubsub.ValidationReject, err
 	}

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -106,11 +106,6 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 		return pubsub.ValidationIgnore, err
 	}
 
-	// [REJECT] The proposer signature of `sidecar.signed_block_header`, is valid with respect to the `block_header.proposer_index` pubkey.
-	if err := verifier.ValidProposerSignature(ctx); err != nil {
-		return pubsub.ValidationReject, err
-	}
-
 	// [IGNORE] The sidecar's block's parent (defined by `block_header.parent_root`) has been seen (via gossip or non-gossip sources
 	// (a client MAY queue sidecars for processing once the parent block is retrieved).
 	if err := verifier.SidecarParentSeen(s.hasBadBlock); err != nil {
@@ -130,6 +125,11 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 
 	// [REJECT] The sidecar's block's parent (defined by `block_header.parent_root`) passes validation.
 	if err := verifier.SidecarParentValid(s.hasBadBlock); err != nil {
+		return pubsub.ValidationReject, err
+	}
+
+	// [REJECT] The proposer signature of `sidecar.signed_block_header`, is valid with respect to the `block_header.proposer_index` pubkey.
+	if err := verifier.ValidProposerSignature(ctx); err != nil {
 		return pubsub.ValidationReject, err
 	}
 


### PR DESCRIPTION
This PR updates the order of fields in the validation data from:
1. `signature`  
2. `parent_block_seen`  
3. `parent_block_bad`  

to:  
1. `parent_block_seen`  
2. `parent_block_bad`  
3. `signature`  

The change ensures we verify that the parent block is seen before attempting to validate its signature. This is necessary because signature verification depends on the parent root, which is only available if the parent block is known. This mirrors how blob sidecar validation is handled today.

Note: The beacon spec uses the original field order as it abstracts away how the pre-state for signature checks is derived.