### PR TITLE
chore: Address TODO to use ROBlock 

### DIFF
--- a/beacon-chain/sync/backfill/verify.go
+++ b/beacon-chain/sync/backfill/verify.go
@@ -59,7 +59,7 @@ type verifier struct {
 
 func (vr verifier) verify(blks []blocks.ROBlock) (verifiedROBlocks, error) {
 	var err error
-	result := blks // Use the input directly
+	result := blks
 	sigSet := bls.NewSet()
 	for i := range result {
 		if i > 0 && result[i-1].Root() != result[i].Block().ParentRoot() {

--- a/beacon-chain/sync/backfill/verify.go
+++ b/beacon-chain/sync/backfill/verify.go
@@ -62,7 +62,6 @@ func (vr verifier) verify(blks []blocks.ROBlock) (verifiedROBlocks, error) {
 	result := blks // Use the input directly
 	sigSet := bls.NewSet()
 	for i := range result {
-		// Conversion loop removed
 		if i > 0 && result[i-1].Root() != result[i].Block().ParentRoot() {
 			p, b := result[i-1], result[i]
 			return nil, errors.Wrapf(errInvalidBatchChain,

--- a/beacon-chain/sync/backfill/verify.go
+++ b/beacon-chain/sync/backfill/verify.go
@@ -58,15 +58,12 @@ type verifier struct {
 }
 
 // TODO: rewrite this to use ROBlock.
-func (vr verifier) verify(blks []interfaces.ReadOnlySignedBeaconBlock) (verifiedROBlocks, error) {
+func (vr verifier) verify(blks []blocks.ROBlock) (verifiedROBlocks, error) {
 	var err error
-	result := make([]blocks.ROBlock, len(blks))
+	result := blks // Use the input directly
 	sigSet := bls.NewSet()
-	for i := range blks {
-		result[i], err = blocks.NewROBlock(blks[i])
-		if err != nil {
-			return nil, err
-		}
+	for i := range result {
+		// Conversion loop removed
 		if i > 0 && result[i-1].Root() != result[i].Block().ParentRoot() {
 			p, b := result[i-1], result[i]
 			return nil, errors.Wrapf(errInvalidBatchChain,

--- a/beacon-chain/sync/backfill/verify.go
+++ b/beacon-chain/sync/backfill/verify.go
@@ -57,7 +57,6 @@ type verifier struct {
 	domain *domainCache
 }
 
-// TODO: rewrite this to use ROBlock.
 func (vr verifier) verify(blks []blocks.ROBlock) (verifiedROBlocks, error) {
 	var err error
 	result := blks // Use the input directly

--- a/beacon-chain/sync/backfill/verify_test.go
+++ b/beacon-chain/sync/backfill/verify_test.go
@@ -72,12 +72,7 @@ func TestVerify(t *testing.T) {
 	}
 	v, err := newBackfillVerifier(vr, pubkeys)
 	require.NoError(t, err)
-	notrob := make([]interfaces.ReadOnlySignedBeaconBlock, len(blks))
-	// We have to unwrap the ROBlocks for this code because that's what it expects (for now).
-	for i := range blks {
-		notrob[i] = blks[i].ReadOnlySignedBeaconBlock
-	}
-	vbs, err := v.verify(notrob)
+	vbs, err := v.verify(blks)
 	require.NoError(t, err)
 	require.Equal(t, len(blks), len(vbs))
 }

--- a/beacon-chain/sync/backfill/worker.go
+++ b/beacon-chain/sync/backfill/worker.go
@@ -58,7 +58,6 @@ func (w *p2pWorker) handleBlocks(ctx context.Context, b batch) batch {
 		log.WithError(err).WithFields(b.logFields()).Debug("Batch requesting failed")
 		return b.withRetryableError(err)
 	}
-	// Convert to ROBlock slice before verification
 	roBlocks, err := blocks.NewROBlockSlice(results)
 	if err != nil {
 		log.WithError(err).WithFields(b.logFields()).Error("Failed to convert blocks to ROBlock format")

--- a/beacon-chain/sync/backfill/worker.go
+++ b/beacon-chain/sync/backfill/worker.go
@@ -58,7 +58,13 @@ func (w *p2pWorker) handleBlocks(ctx context.Context, b batch) batch {
 		log.WithError(err).WithFields(b.logFields()).Debug("Batch requesting failed")
 		return b.withRetryableError(err)
 	}
-	vb, err := w.v.verify(results)
+	// Convert to ROBlock slice before verification
+	roBlocks, err := blocks.NewROBlockSlice(results)
+	if err != nil {
+		log.WithError(err).WithFields(b.logFields()).Error("Failed to convert blocks to ROBlock format")
+		return b.withRetryableError(err) // Or handle error appropriately
+	}
+	vb, err := w.v.verify(roBlocks)
 	backfillBatchTimeVerifying.Observe(float64(time.Since(dlt).Milliseconds()))
 	if err != nil {
 		log.WithError(err).WithFields(b.logFields()).Debug("Batch validation failed")

--- a/beacon-chain/sync/backfill/worker.go
+++ b/beacon-chain/sync/backfill/worker.go
@@ -61,7 +61,7 @@ func (w *p2pWorker) handleBlocks(ctx context.Context, b batch) batch {
 	roBlocks, err := blocks.NewROBlockSlice(results)
 	if err != nil {
 		log.WithError(err).WithFields(b.logFields()).Error("Failed to convert blocks to ROBlock format")
-		return b.withRetryableError(err) // Or handle error appropriately
+		return b.withRetryableError(err)
 	}
 	vb, err := w.v.verify(roBlocks)
 	backfillBatchTimeVerifying.Observe(float64(time.Since(dlt).Milliseconds()))

--- a/changelog/gap-editor_Address_TODO_to_use_ROBlock.md
+++ b/changelog/gap-editor_Address_TODO_to_use_ROBlock.md
@@ -1,0 +1,2 @@
+### Changed
+- Refactored code to utilize `ROBlock` as per existing TODO comment. [#15193](https://github.com/OffchainLabs/prysm/pull/15193)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR refactors the `backfill.verifier.verify` function to accept `[]blocks.ROBlock` directly, addressing an existing `TODO` comment. This simplifies the verification logic by removing the internal conversion from `interfaces.ReadOnlySignedBeaconBlock` to `blocks.ROBlock` and leverages the cached root within `ROBlock`.

**Which issues(s) does this PR fix?**

Fixes # (Addresses inline `TODO` in `beacon-chain/sync/backfill/verify.go`)

**Other notes for review**

This change primarily involves updating the function signature and adjusting the call sites in `worker.go` and `verify_test.go`. No functional changes are intended. A user-facing changelog entry is likely not required as this is internal refactoring.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd). (Likely not needed for this change)
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.