### PR TITLE
Add flag to subscribe to all blob column subnets

### DIFF
--- a/beacon-chain/core/peerdas/info.go
+++ b/beacon-chain/core/peerdas/info.go
@@ -111,7 +111,7 @@ func (custodyInfo *CustodyInfo) ActualGroupCount() uint64 {
 // CustodyGroupCount returns the number of groups we should participate in for custody.
 func (tcgc *targetCustodyGroupCount) Get() uint64 {
 	// If subscribed to all subnets, return the number of custody groups.
-	if flags.Get().SubscribeAllColumnSubnets {
+	if flags.Get().SubscribeAllDataSubnetsubnets {
 		return params.BeaconConfig().NumberOfCustodyGroups
 	}
 
@@ -138,7 +138,7 @@ func (tcgc *targetCustodyGroupCount) SetValidatorsCustodyRequirement(value uint6
 // Get returns the to advertise custody group count.
 func (tacgc *toAdverstiseCustodyGroupCount) Get() uint64 {
 	// If subscribed to all subnets, return the number of custody groups.
-	if flags.Get().SubscribeAllColumnSubnets {
+	if flags.Get().SubscribeAllDataSubnetsubnets {
 		return params.BeaconConfig().NumberOfCustodyGroups
 	}
 

--- a/beacon-chain/core/peerdas/info.go
+++ b/beacon-chain/core/peerdas/info.go
@@ -111,7 +111,7 @@ func (custodyInfo *CustodyInfo) ActualGroupCount() uint64 {
 // CustodyGroupCount returns the number of groups we should participate in for custody.
 func (tcgc *targetCustodyGroupCount) Get() uint64 {
 	// If subscribed to all subnets, return the number of custody groups.
-	if flags.Get().SubscribeToAllSubnets {
+	if flags.Get().SubscribeAllColumnSubnets {
 		return params.BeaconConfig().NumberOfCustodyGroups
 	}
 
@@ -138,7 +138,7 @@ func (tcgc *targetCustodyGroupCount) SetValidatorsCustodyRequirement(value uint6
 // Get returns the to advertise custody group count.
 func (tacgc *toAdverstiseCustodyGroupCount) Get() uint64 {
 	// If subscribed to all subnets, return the number of custody groups.
-	if flags.Get().SubscribeToAllSubnets {
+	if flags.Get().SubscribeAllColumnSubnets {
 		return params.BeaconConfig().NumberOfCustodyGroups
 	}
 

--- a/beacon-chain/core/peerdas/info_test.go
+++ b/beacon-chain/core/peerdas/info_test.go
@@ -60,7 +60,7 @@ func TestTargetCustodyGroupCount(t *testing.T) {
 			if tc.subscribeToAllColumns {
 				resetFlags := flags.Get()
 				gFlags := new(flags.GlobalFlags)
-				gFlags.SubscribeAllColumnSubnets = true
+				gFlags.SubscribeAllDataSubnetsubnets = true
 				flags.Init(gFlags)
 				defer flags.Init(resetFlags)
 			}
@@ -112,7 +112,7 @@ func TestToAdvertiseCustodyGroupCount(t *testing.T) {
 			if tc.subscribeToAllColumns {
 				resetFlags := flags.Get()
 				gFlags := new(flags.GlobalFlags)
-				gFlags.SubscribeAllColumnSubnets = true
+				gFlags.SubscribeAllDataSubnetsubnets = true
 				flags.Init(gFlags)
 				defer flags.Init(resetFlags)
 			}

--- a/beacon-chain/core/peerdas/info_test.go
+++ b/beacon-chain/core/peerdas/info_test.go
@@ -60,7 +60,7 @@ func TestTargetCustodyGroupCount(t *testing.T) {
 			if tc.subscribeToAllColumns {
 				resetFlags := flags.Get()
 				gFlags := new(flags.GlobalFlags)
-				gFlags.SubscribeToAllSubnets = true
+				gFlags.SubscribeAllColumnSubnets = true
 				flags.Init(gFlags)
 				defer flags.Init(resetFlags)
 			}

--- a/beacon-chain/core/peerdas/info_test.go
+++ b/beacon-chain/core/peerdas/info_test.go
@@ -30,25 +30,25 @@ func TestInfo(t *testing.T) {
 func TestTargetCustodyGroupCount(t *testing.T) {
 	testCases := []struct {
 		name                         string
-		subscribeToAllSubnets        bool
+		subscribeToAllColumns        bool
 		validatorsCustodyRequirement uint64
 		expected                     uint64
 	}{
 		{
 			name:                         "subscribed to all subnets",
-			subscribeToAllSubnets:        true,
+			subscribeToAllColumns:        true,
 			validatorsCustodyRequirement: 100,
 			expected:                     128,
 		},
 		{
 			name:                         "no validators attached",
-			subscribeToAllSubnets:        false,
+			subscribeToAllColumns:        false,
 			validatorsCustodyRequirement: 0,
 			expected:                     4,
 		},
 		{
 			name:                         "some validators attached",
-			subscribeToAllSubnets:        false,
+			subscribeToAllColumns:        false,
 			validatorsCustodyRequirement: 100,
 			expected:                     100,
 		},
@@ -57,7 +57,7 @@ func TestTargetCustodyGroupCount(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Subscribe to all subnets if needed.
-			if tc.subscribeToAllSubnets {
+			if tc.subscribeToAllColumns {
 				resetFlags := flags.Get()
 				gFlags := new(flags.GlobalFlags)
 				gFlags.SubscribeToAllSubnets = true
@@ -82,25 +82,25 @@ func TestTargetCustodyGroupCount(t *testing.T) {
 func TestToAdvertiseCustodyGroupCount(t *testing.T) {
 	testCases := []struct {
 		name                         string
-		subscribeToAllSubnets        bool
+		subscribeToAllColumns        bool
 		toAdvertiseCustodyGroupCount uint64
 		expected                     uint64
 	}{
 		{
 			name:                         "subscribed to all subnets",
-			subscribeToAllSubnets:        true,
+			subscribeToAllColumns:        true,
 			toAdvertiseCustodyGroupCount: 100,
 			expected:                     128,
 		},
 		{
 			name:                         "higher than custody requirement",
-			subscribeToAllSubnets:        false,
+			subscribeToAllColumns:        false,
 			toAdvertiseCustodyGroupCount: 100,
 			expected:                     100,
 		},
 		{
 			name:                         "lower than custody requirement",
-			subscribeToAllSubnets:        false,
+			subscribeToAllColumns:        false,
 			toAdvertiseCustodyGroupCount: 1,
 			expected:                     4,
 		},
@@ -109,10 +109,10 @@ func TestToAdvertiseCustodyGroupCount(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Subscribe to all subnets if needed.
-			if tc.subscribeToAllSubnets {
+			if tc.subscribeToAllColumns {
 				resetFlags := flags.Get()
 				gFlags := new(flags.GlobalFlags)
-				gFlags.SubscribeToAllSubnets = true
+				gFlags.SubscribeAllColumnSubnets = true
 				flags.Init(gFlags)
 				defer flags.Init(resetFlags)
 			}

--- a/beacon-chain/das/availability_columns_test.go
+++ b/beacon-chain/das/availability_columns_test.go
@@ -228,7 +228,7 @@ func TestFullCommitmentsToCheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resetFlags := flags.Get()
 			gFlags := new(flags.GlobalFlags)
-			gFlags.SubscribeAllColumnSubnets = true
+			gFlags.SubscribeAllDataSubnetsubnets = true
 			flags.Init(gFlags)
 			defer flags.Init(resetFlags)
 

--- a/beacon-chain/das/availability_columns_test.go
+++ b/beacon-chain/das/availability_columns_test.go
@@ -228,7 +228,7 @@ func TestFullCommitmentsToCheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resetFlags := flags.Get()
 			gFlags := new(flags.GlobalFlags)
-			gFlags.SubscribeToAllSubnets = true
+			gFlags.SubscribeAllColumnSubnets = true
 			flags.Init(gFlags)
 			defer flags.Init(resetFlags)
 

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -331,7 +331,7 @@ func (p *BeaconDbBlocker) blobsFromStoredDataColumns(indices map[uint64]bool, ro
 	if !canReconstruct {
 		// There is no way to reconstruct the data columns.
 		return nil, &core.RpcError{
-			Err:    errors.Errorf("the node does not custody enough data columns to reconstruct blobs. Please start the beacon node with the `--%s` flag to ensure this call to success, or retry later if it already the case.", flags.SubscribeAllColumns.Name),
+			Err:    errors.Errorf("the node does not custody enough data columns to reconstruct blobs. Please start the beacon node with the `--%s` flag to ensure this call to success, or retry later if it already the case.", flags.SubscribeAllDataSubnets.Name),
 			Reason: core.NotFound,
 		}
 	}

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -331,7 +331,7 @@ func (p *BeaconDbBlocker) blobsFromStoredDataColumns(indices map[uint64]bool, ro
 	if !canReconstruct {
 		// There is no way to reconstruct the data columns.
 		return nil, &core.RpcError{
-			Err:    errors.Errorf("the node does not custody enough data columns to reconstruct blobs. Please start the beacon node with the `--%s` flag to ensure this call to success, or retry later if it already the case.", flags.SubscribeToAllSubnets.Name),
+			Err:    errors.Errorf("the node does not custody enough data columns to reconstruct blobs. Please start the beacon node with the `--%s` flag to ensure this call to success, or retry later if it already the case.", flags.SubscribeAllColumns.Name),
 			Reason: core.NotFound,
 		}
 	}

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -337,6 +337,6 @@ var (
 	// SubscribeAllDataSubnets enables subscription to all data subnets.
 	SubscribeAllDataSubnets = &cli.BoolFlag{
 		Name:  "subscribe-all-data-subnets",
-		Usage: "Enable subscription to all data subnets",
+		Usage: "Enable subscription to all data subnets.",
 	}
 )

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -334,9 +334,9 @@ var (
 		Usage: "Specifies the retention period for the pruner service in terms of epochs. " +
 			"If this value is less than MIN_EPOCHS_FOR_BLOCK_REQUESTS, it will be ignored.",
 	}
-	// SubscribeAllColumns enables subscription to all blob columns.
-	SubscribeAllColumns = &cli.BoolFlag{
-		Name:  "subscribe-all-columns",
-		Usage: "Enable subscription to all blob columns",
+	// SubscribeAllDataSubnets enables subscription to all data subnets.
+	SubscribeAllDataSubnets = &cli.BoolFlag{
+		Name:  "subscribe-data-subnets",
+		Usage: "Enable subscription to all data subnets",
 	}
 )

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -336,7 +336,7 @@ var (
 	}
 	// SubscribeAllDataSubnets enables subscription to all data subnets.
 	SubscribeAllDataSubnets = &cli.BoolFlag{
-		Name:  "subscribe-data-subnets",
+		Name:  "subscribe-all-data-subnets",
 		Usage: "Enable subscription to all data subnets",
 	}
 )

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -334,4 +334,9 @@ var (
 		Usage: "Specifies the retention period for the pruner service in terms of epochs. " +
 			"If this value is less than MIN_EPOCHS_FOR_BLOCK_REQUESTS, it will be ignored.",
 	}
+	// SubscribeAllColumns enables subscription to all blob columns.
+	SubscribeAllColumns = &cli.BoolFlag{
+		Name:  "subscribe-all-columns",
+		Usage: "Enable subscription to all blob columns",
+	}
 )

--- a/cmd/beacon-chain/flags/config.go
+++ b/cmd/beacon-chain/flags/config.go
@@ -53,7 +53,7 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg.MinimumPeersPerSubnet = ctx.Int(MinPeersPerSubnet.Name)
 	cfg.MaxConcurrentDials = ctx.Int(MaxConcurrentDials.Name)
 	if ctx.Bool(SubscribeAllDataSubnets.Name) {
-		log.Warn("Subscribing to all data column subnets")
+		log.Warning("Subscribing to all data subnets")
 		cfg.SubscribeAllDataSubnetsubnets = true
 	}
 	configureMinimumPeers(ctx, cfg)

--- a/cmd/beacon-chain/flags/config.go
+++ b/cmd/beacon-chain/flags/config.go
@@ -9,7 +9,7 @@ import (
 // beacon node.
 type GlobalFlags struct {
 	SubscribeToAllSubnets           bool
-	SubscribeAllColumnSubnets       bool
+	SubscribeAllDataSubnetsubnets   bool
 	MinimumSyncPeers                int
 	MinimumPeersPerSubnet           int
 	MaxConcurrentDials              int
@@ -52,9 +52,9 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg.DataColumnBatchLimitBurstFactor = ctx.Int(DataColumnBatchLimitBurstFactor.Name)
 	cfg.MinimumPeersPerSubnet = ctx.Int(MinPeersPerSubnet.Name)
 	cfg.MaxConcurrentDials = ctx.Int(MaxConcurrentDials.Name)
-	if ctx.Bool(SubscribeAllColumns.Name) {
+	if ctx.Bool(SubscribeAllDataSubnets.Name) {
 		log.Warn("Subscribing to all data column subnets")
-		cfg.SubscribeAllColumnSubnets = true
+		cfg.SubscribeAllDataSubnetsubnets = true
 	}
 	configureMinimumPeers(ctx, cfg)
 

--- a/cmd/beacon-chain/flags/config.go
+++ b/cmd/beacon-chain/flags/config.go
@@ -9,6 +9,7 @@ import (
 // beacon node.
 type GlobalFlags struct {
 	SubscribeToAllSubnets           bool
+	SubscribeAllColumnSubnets       bool
 	MinimumSyncPeers                int
 	MinimumPeersPerSubnet           int
 	MaxConcurrentDials              int
@@ -51,6 +52,10 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg.DataColumnBatchLimitBurstFactor = ctx.Int(DataColumnBatchLimitBurstFactor.Name)
 	cfg.MinimumPeersPerSubnet = ctx.Int(MinPeersPerSubnet.Name)
 	cfg.MaxConcurrentDials = ctx.Int(MaxConcurrentDials.Name)
+	if ctx.Bool(SubscribeAllColumns.Name) {
+		log.Warn("Subscribing to all data column subnets")
+		cfg.SubscribeAllColumnSubnets = true
+	}
 	configureMinimumPeers(ctx, cfg)
 
 	Init(cfg)

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -65,7 +65,7 @@ var appFlags = []cli.Flag{
 	flags.SlotsPerArchivedPoint,
 	flags.DisableDebugRPCEndpoints,
 	flags.SubscribeToAllSubnets,
-	flags.SubscribeAllColumns,
+	flags.SubscribeAllDataSubnets,
 	flags.HistoricalSlasherNode,
 	flags.ChainID,
 	flags.NetworkID,

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -65,6 +65,7 @@ var appFlags = []cli.Flag{
 	flags.SlotsPerArchivedPoint,
 	flags.DisableDebugRPCEndpoints,
 	flags.SubscribeToAllSubnets,
+	flags.SubscribeAllColumns,
 	flags.HistoricalSlasherNode,
 	flags.ChainID,
 	flags.NetworkID,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -106,7 +106,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.MinPeersPerSubnet,
 			flags.MinSyncPeers,
 			flags.SubscribeToAllSubnets,
-			flags.SubscribeAllColumns,
+			flags.SubscribeAllDataSubnets,
 		},
 	},
 	{ // Flags relevant to storing data on disk and configuring the beacon chain database.

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -106,6 +106,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.MinPeersPerSubnet,
 			flags.MinSyncPeers,
 			flags.SubscribeToAllSubnets,
+			flags.SubscribeAllColumns,
 		},
 	},
 	{ // Flags relevant to storing data on disk and configuring the beacon chain database.


### PR DESCRIPTION
**Description:**  
This PR introduces a new CLI flag `--subscribe-all-columns` that enables clients to subscribe to all blob column subnets. This is useful for nodes running in a PeerDAS super node configuration or other setups that require full blob data visibility.
Previously, nodes wanting full blob data had to use the `--subscribe-all-subnets` flag, which also subscribed them to all attestation and sync committee subnets. This approach was bandwidth and compute heavy

Changes include:
- Added `SubscribeAllColumns` flag in the CLI
- Updated `peer_das` and `validator` services to respect the flag
- Included warning logs when the flag is active
