### PR TITLE
PeerDAS: Downscore peers that request too many data columns via RPC

### DIFF
--- a/beacon-chain/p2p/peers/peerdata/store.go
+++ b/beacon-chain/p2p/peers/peerdata/store.go
@@ -66,7 +66,8 @@ type PeerData struct {
 	GossipScore      float64
 	BehaviourPenalty float64
 	// Data Column RPC request tracking
-	DataColumnRequestCount uint64
+	DataColumnRequestCount       uint64
+	DataColumnRPCLastRequestTime time.Time
 }
 
 // NewStore creates new peer data store.

--- a/beacon-chain/p2p/peers/peerdata/store.go
+++ b/beacon-chain/p2p/peers/peerdata/store.go
@@ -65,6 +65,8 @@ type PeerData struct {
 	TopicScores      map[string]*ethpb.TopicScoreSnapshot
 	GossipScore      float64
 	BehaviourPenalty float64
+	// Data Column RPC request tracking
+	DataColumnRequestCount uint64
 }
 
 // NewStore creates new peer data store.

--- a/beacon-chain/p2p/peers/scorers/BUILD.bazel
+++ b/beacon-chain/p2p/peers/scorers/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bad_responses.go",
         "block_providers.go",
+        "data_column_rpc_request_scorer.go",
         "gossip_scorer.go",
         "peer_status.go",
         "service.go",
@@ -29,6 +30,7 @@ go_test(
     srcs = [
         "bad_responses_test.go",
         "block_providers_test.go",
+        "data_column_rpc_request_scorer_test.go",
         "gossip_scorer_test.go",
         "peer_status_test.go",
         "scorers_test.go",
@@ -50,5 +52,6 @@ go_test(
         "@com_github_libp2p_go_libp2p//core/network:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
@@ -1,13 +1,13 @@
 package scorers
 
 import (
+	"fmt"
 	"math"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/peerdata"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/pkg/errors"
 )
 
 var _ Scorer = (*DataColumnRPCRequestScorer)(nil)
@@ -113,7 +113,7 @@ func (s *DataColumnRPCRequestScorer) IsBadPeer(pid peer.ID) error {
 // isBadPeerNoLock is a lock-free version of IsBadPeer.
 func (s *DataColumnRPCRequestScorer) isBadPeerNoLock(pid peer.ID) error {
 	if peerData, ok := s.store.PeerData(pid); ok && peerData.DataColumnRequestCount >= s.config.Threshold {
-		return errors.New("exceeded data column request threshold")
+		return fmt.Errorf("bad peer %s: request count %d exceeds threshold %d", pid, peerData.DataColumnRequestCount, s.config.Threshold)
 	}
 	return nil
 }

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
@@ -22,6 +22,9 @@ const (
 	DefaultDataColumnRPCRequestThreshold = uint64(100)
 	// DefaultDataColumnRPCRequestPenaltyFactor defines the penalty factor applied to request count.
 	DefaultDataColumnRPCRequestPenaltyFactor = float64(0.02)
+	// DefaultDataColumnMaxGossipAgeSlots defines the maximum age in slots for a requested column
+	// to trigger downscoring. Defaults to half an epoch on mainnet.
+	DefaultDataColumnMaxGossipAgeSlots = uint64(16)
 )
 
 // DataColumnRPCRequestScorer represents scoring service for tracking data column RPC requests.
@@ -40,16 +43,21 @@ type DataColumnRPCRequestScorerConfig struct {
 	Threshold uint64
 	// PenaltyFactor defines multiplier applied to request count when calculating score.
 	PenaltyFactor float64
+	// MaxGossipAgeSlots defines the maximum age in slots for a requested column
+	// to trigger downscoring. Columns requested for slots older than
+	// current_slot - MaxGossipAgeSlots will not be penalized.
+	MaxGossipAgeSlots uint64
 }
 
 // newDataColumnRPCRequestScorer creates new scoring service for data column RPC requests.
 func newDataColumnRPCRequestScorer(store *peerdata.Store, config *DataColumnRPCRequestScorerConfig) *DataColumnRPCRequestScorer {
 	// Create a new config with default values
 	cfg := &DataColumnRPCRequestScorerConfig{
-		DecayInterval: DefaultDataColumnRPCRequestDecayInterval,
-		Decay:         DefaultDataColumnRPCRequestDecay,
-		Threshold:     DefaultDataColumnRPCRequestThreshold,
-		PenaltyFactor: DefaultDataColumnRPCRequestPenaltyFactor,
+		DecayInterval:     DefaultDataColumnRPCRequestDecayInterval,
+		Decay:             DefaultDataColumnRPCRequestDecay,
+		Threshold:         DefaultDataColumnRPCRequestThreshold,
+		PenaltyFactor:     DefaultDataColumnRPCRequestPenaltyFactor,
+		MaxGossipAgeSlots: DefaultDataColumnMaxGossipAgeSlots,
 	}
 
 	// Override with provided config values if present
@@ -65,6 +73,9 @@ func newDataColumnRPCRequestScorer(store *peerdata.Store, config *DataColumnRPCR
 		}
 		if config.PenaltyFactor != 0 {
 			cfg.PenaltyFactor = config.PenaltyFactor
+		}
+		if config.MaxGossipAgeSlots != 0 {
+			cfg.MaxGossipAgeSlots = config.MaxGossipAgeSlots
 		}
 	}
 
@@ -120,16 +131,23 @@ func (s *DataColumnRPCRequestScorer) BadPeers() []peer.ID {
 	return badPeers
 }
 
-// RecordRequest records a data column RPC request for a peer.
-func (s *DataColumnRPCRequestScorer) RecordRequest(pid peer.ID, numColumns int) {
-	if pid == "" || numColumns <= 0 {
+// RecordRequest records a potentially downscorable data column RPC request for a peer.
+// Downscoring only occurs if the requested columnSlot is recent enough compared to the currentSlot.
+func (s *DataColumnRPCRequestScorer) RecordRequest(pid peer.ID, currentSlot, columnSlot uint64) {
+	if pid == "" {
 		return
 	}
+	// Check if the column is recent enough to warrant downscoring.
+	// A peer shouldn't be penalized for requesting old columns it might have missed.
+	if columnSlot+s.config.MaxGossipAgeSlots < currentSlot {
+		return
+	}
+
 	s.store.Lock()
 	defer s.store.Unlock()
 
 	peerData := s.store.PeerDataGetOrCreate(pid)
-	peerData.DataColumnRequestCount += uint64(numColumns)
+	peerData.DataColumnRequestCount++ // Increment count for each recent column requested
 	peerData.DataColumnRPCLastRequestTime = time.Now()
 }
 

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/peerdata"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 )
@@ -133,13 +134,13 @@ func (s *DataColumnRPCRequestScorer) BadPeers() []peer.ID {
 
 // RecordRequest records a potentially downscorable data column RPC request for a peer.
 // Downscoring only occurs if the requested columnSlot is recent enough compared to the currentSlot.
-func (s *DataColumnRPCRequestScorer) RecordRequest(pid peer.ID, currentSlot, columnSlot uint64) {
+func (s *DataColumnRPCRequestScorer) RecordRequest(pid peer.ID, currentSlot, columnSlot primitives.Slot) {
 	if pid == "" {
 		return
 	}
 	// Check if the column is recent enough to warrant downscoring.
 	// A peer shouldn't be penalized for requesting old columns it might have missed.
-	if columnSlot+s.config.MaxGossipAgeSlots < currentSlot {
+	if uint64(columnSlot)+s.config.MaxGossipAgeSlots < uint64(currentSlot) {
 		return
 	}
 

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
@@ -44,26 +44,34 @@ type DataColumnRPCRequestScorerConfig struct {
 
 // newDataColumnRPCRequestScorer creates new scoring service for data column RPC requests.
 func newDataColumnRPCRequestScorer(store *peerdata.Store, config *DataColumnRPCRequestScorerConfig) *DataColumnRPCRequestScorer {
-	if config == nil {
-		config = &DataColumnRPCRequestScorerConfig{}
+	// Create a new config with default values
+	cfg := &DataColumnRPCRequestScorerConfig{
+		DecayInterval: DefaultDataColumnRPCRequestDecayInterval,
+		Decay:         DefaultDataColumnRPCRequestDecay,
+		Threshold:     DefaultDataColumnRPCRequestThreshold,
+		PenaltyFactor: DefaultDataColumnRPCRequestPenaltyFactor,
 	}
-	scorer := &DataColumnRPCRequestScorer{
-		config: config,
+
+	// Override with provided config values if present
+	if config != nil {
+		if config.DecayInterval != 0 {
+			cfg.DecayInterval = config.DecayInterval
+		}
+		if config.Decay != 0 {
+			cfg.Decay = config.Decay
+		}
+		if config.Threshold != 0 {
+			cfg.Threshold = config.Threshold
+		}
+		if config.PenaltyFactor != 0 {
+			cfg.PenaltyFactor = config.PenaltyFactor
+		}
+	}
+
+	return &DataColumnRPCRequestScorer{
+		config: cfg,
 		store:  store,
 	}
-	if scorer.config.DecayInterval == 0 {
-		scorer.config.DecayInterval = DefaultDataColumnRPCRequestDecayInterval
-	}
-	if scorer.config.Decay == 0 {
-		scorer.config.Decay = DefaultDataColumnRPCRequestDecay
-	}
-	if scorer.config.Threshold == 0 {
-		scorer.config.Threshold = DefaultDataColumnRPCRequestThreshold
-	}
-	if scorer.config.PenaltyFactor == 0 {
-		scorer.config.PenaltyFactor = DefaultDataColumnRPCRequestPenaltyFactor
-	}
-	return scorer
 }
 
 // Score returns calculated peer score.

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
@@ -122,6 +122,7 @@ func (s *DataColumnRPCRequestScorer) RecordRequest(pid peer.ID, numColumns int) 
 
 	peerData := s.store.PeerDataGetOrCreate(pid)
 	peerData.DataColumnRequestCount += uint64(numColumns)
+	peerData.DataColumnRPCLastRequestTime = time.Now()
 }
 
 // Decay implements periodic decay of request counts.

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer.go
@@ -1,0 +1,144 @@
+package scorers
+
+import (
+	"math"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/peerdata"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/pkg/errors"
+)
+
+var _ Scorer = (*DataColumnRPCRequestScorer)(nil)
+
+const (
+	// DefaultDataColumnRPCRequestDecayInterval defines how often the decaying routine is called.
+	DefaultDataColumnRPCRequestDecayInterval = 30 * time.Second
+	// DefaultDataColumnRPCRequestDecay defines default number of requests that are to be subtracted
+	// from stats on each decay interval.
+	DefaultDataColumnRPCRequestDecay = uint64(10)
+	// DefaultDataColumnRPCRequestThreshold defines the maximum number of requests a peer can make
+	// before being considered bad.
+	DefaultDataColumnRPCRequestThreshold = uint64(100)
+	// DefaultDataColumnRPCRequestPenaltyFactor defines the penalty factor applied to request count.
+	DefaultDataColumnRPCRequestPenaltyFactor = float64(0.02)
+)
+
+// DataColumnRPCRequestScorer represents scoring service for tracking data column RPC requests.
+type DataColumnRPCRequestScorer struct {
+	config *DataColumnRPCRequestScorerConfig
+	store  *peerdata.Store
+}
+
+// DataColumnRPCRequestScorerConfig holds configuration parameters for data column RPC request scoring service.
+type DataColumnRPCRequestScorerConfig struct {
+	// DecayInterval defines how often stats should be decayed.
+	DecayInterval time.Duration
+	// Decay specifies number of requests subtracted from stats on each decay step.
+	Decay uint64
+	// Threshold defines maximum number of requests before peer is considered bad.
+	Threshold uint64
+	// PenaltyFactor defines multiplier applied to request count when calculating score.
+	PenaltyFactor float64
+}
+
+// newDataColumnRPCRequestScorer creates new scoring service for data column RPC requests.
+func newDataColumnRPCRequestScorer(store *peerdata.Store, config *DataColumnRPCRequestScorerConfig) *DataColumnRPCRequestScorer {
+	if config == nil {
+		config = &DataColumnRPCRequestScorerConfig{}
+	}
+	scorer := &DataColumnRPCRequestScorer{
+		config: config,
+		store:  store,
+	}
+	if scorer.config.DecayInterval == 0 {
+		scorer.config.DecayInterval = DefaultDataColumnRPCRequestDecayInterval
+	}
+	if scorer.config.Decay == 0 {
+		scorer.config.Decay = DefaultDataColumnRPCRequestDecay
+	}
+	if scorer.config.Threshold == 0 {
+		scorer.config.Threshold = DefaultDataColumnRPCRequestThreshold
+	}
+	if scorer.config.PenaltyFactor == 0 {
+		scorer.config.PenaltyFactor = DefaultDataColumnRPCRequestPenaltyFactor
+	}
+	return scorer
+}
+
+// Score returns calculated peer score.
+func (s *DataColumnRPCRequestScorer) Score(pid peer.ID) float64 {
+	s.store.RLock()
+	defer s.store.RUnlock()
+	return s.scoreNoLock(pid)
+}
+
+// scoreNoLock is a lock-free version of Score.
+func (s *DataColumnRPCRequestScorer) scoreNoLock(pid peer.ID) float64 {
+	if peerData, ok := s.store.PeerData(pid); ok {
+		// Apply penalty based on request count
+		score := -1 * float64(peerData.DataColumnRequestCount) * s.config.PenaltyFactor
+		return math.Round(score*ScoreRoundingFactor) / ScoreRoundingFactor
+	}
+	return 0
+}
+
+// IsBadPeer implements Scorer interface.
+func (s *DataColumnRPCRequestScorer) IsBadPeer(pid peer.ID) error {
+	s.store.RLock()
+	defer s.store.RUnlock()
+	return s.isBadPeerNoLock(pid)
+}
+
+// isBadPeerNoLock is a lock-free version of IsBadPeer.
+func (s *DataColumnRPCRequestScorer) isBadPeerNoLock(pid peer.ID) error {
+	if peerData, ok := s.store.PeerData(pid); ok && peerData.DataColumnRequestCount >= s.config.Threshold {
+		return errors.New("exceeded data column request threshold")
+	}
+	return nil
+}
+
+// BadPeers returns the peers that are considered bad by the scorer.
+func (s *DataColumnRPCRequestScorer) BadPeers() []peer.ID {
+	s.store.RLock()
+	defer s.store.RUnlock()
+
+	badPeers := make([]peer.ID, 0)
+	for pid := range s.store.Peers() {
+		if s.isBadPeerNoLock(pid) != nil {
+			badPeers = append(badPeers, pid)
+		}
+	}
+	return badPeers
+}
+
+// RecordRequest records a data column RPC request for a peer.
+func (s *DataColumnRPCRequestScorer) RecordRequest(pid peer.ID, numColumns int) {
+	if pid == "" || numColumns <= 0 {
+		return
+	}
+	s.store.Lock()
+	defer s.store.Unlock()
+
+	peerData := s.store.PeerDataGetOrCreate(pid)
+	peerData.DataColumnRequestCount += uint64(numColumns)
+}
+
+// Decay implements periodic decay of request counts.
+func (s *DataColumnRPCRequestScorer) Decay() {
+	s.store.Lock()
+	defer s.store.Unlock()
+
+	for _, peerData := range s.store.Peers() {
+		if peerData.DataColumnRequestCount > s.config.Decay {
+			peerData.DataColumnRequestCount -= s.config.Decay
+		} else {
+			peerData.DataColumnRequestCount = 0
+		}
+	}
+}
+
+// Params exposes scorer's parameters.
+func (s *DataColumnRPCRequestScorer) Params() *DataColumnRPCRequestScorerConfig {
+	return s.config
+}

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
@@ -494,3 +494,123 @@ func TestScorers_DataColumnRPCRequest_Decay(t *testing.T) {
 			"Wrong score after decay with custom decay value")
 	})
 }
+
+func TestScorers_DataColumnRPCRequest_BadPeer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+		ScorerParams: &scorers.Config{},
+	})
+	scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+
+	// Test transition from good to bad
+	t.Run("good to bad transition", func(t *testing.T) {
+		pid := peer.ID("peer1")
+
+		// Start with requests below threshold
+		requestsBelow := int(scorers.DefaultDataColumnRPCRequestThreshold - 10)
+		scorer.RecordRequest(pid, requestsBelow)
+		assert.NoError(t, scorer.IsBadPeer(pid), "Peer should not be bad when below threshold")
+		assert.Equal(t, 0, len(scorer.BadPeers()), "Should have no bad peers")
+
+		// Add more requests to exceed threshold
+		scorer.RecordRequest(pid, 15)
+		assert.NotNil(t, scorer.IsBadPeer(pid), "Peer should be bad after exceeding threshold")
+		assert.Equal(t, 1, len(scorer.BadPeers()), "Should have one bad peer")
+		assert.Equal(t, pid, scorer.BadPeers()[0], "Bad peer should match test peer")
+	})
+
+	// Test peer remaining bad after decay
+	t.Run("remain bad after decay", func(t *testing.T) {
+		pid := peer.ID("peer2")
+
+		// Push well over threshold
+		scorer.RecordRequest(pid, int(scorers.DefaultDataColumnRPCRequestThreshold*2))
+		assert.NotNil(t, scorer.IsBadPeer(pid), "Peer should be bad when significantly over threshold")
+
+		// Apply decay
+		scorer.Decay()
+		assert.NotNil(t, scorer.IsBadPeer(pid),
+			"Peer should remain bad after decay if still above threshold")
+	})
+
+	// Test peer recovery through decay
+	t.Run("recovery through decay", func(t *testing.T) {
+		pid := peer.ID("peer3")
+
+		// Set just over threshold
+		scorer.RecordRequest(pid, int(scorers.DefaultDataColumnRPCRequestThreshold+1))
+		assert.NotNil(t, scorer.IsBadPeer(pid), "Peer should be bad when just over threshold")
+
+		// Apply multiple decays until peer recovers
+		decaysNeeded := (scorers.DefaultDataColumnRPCRequestThreshold+1)/
+			scorers.DefaultDataColumnRPCRequestDecay + 1
+		for i := uint64(0); i < decaysNeeded; i++ {
+			scorer.Decay()
+		}
+		assert.NoError(t, scorer.IsBadPeer(pid),
+			"Peer should recover after sufficient decay cycles")
+	})
+
+	// Test multiple peers with different statuses
+	t.Run("multiple peer statuses", func(t *testing.T) {
+		// Create peers with different request counts
+		goodPeer1 := peer.ID("good1")
+		goodPeer2 := peer.ID("good2")
+		badPeer1 := peer.ID("bad1")
+		badPeer2 := peer.ID("bad2")
+
+		// Set request counts
+		scorer.RecordRequest(goodPeer1, 1)                                                   // Well below threshold
+		scorer.RecordRequest(goodPeer2, int(scorers.DefaultDataColumnRPCRequestThreshold-1)) // Just below
+		scorer.RecordRequest(badPeer1, int(scorers.DefaultDataColumnRPCRequestThreshold+1))  // Just above
+		scorer.RecordRequest(badPeer2, int(scorers.DefaultDataColumnRPCRequestThreshold*2))  // Well above
+
+		// Verify individual statuses
+		assert.NoError(t, scorer.IsBadPeer(goodPeer1), "goodPeer1 should not be bad")
+		assert.NoError(t, scorer.IsBadPeer(goodPeer2), "goodPeer2 should not be bad")
+		assert.NotNil(t, scorer.IsBadPeer(badPeer1), "badPeer1 should be bad")
+		assert.NotNil(t, scorer.IsBadPeer(badPeer2), "badPeer2 should be bad")
+
+		// Verify bad peers list
+		badPeers := scorer.BadPeers()
+		assert.Equal(t, 2, len(badPeers), "Should have exactly two bad peers")
+		assert.Equal(t, true, containsPeer(badPeers, badPeer1), "badPeer1 should be in bad peers list")
+		assert.Equal(t, true, containsPeer(badPeers, badPeer2), "badPeer2 should be in bad peers list")
+	})
+
+	// Test with custom threshold
+	t.Run("custom threshold", func(t *testing.T) {
+		customConfig := &scorers.DataColumnRPCRequestScorerConfig{
+			Threshold: 50, // Lower threshold
+		}
+		peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+			ScorerParams: &scorers.Config{
+				DataColumnRPCRequestScorerConfig: customConfig,
+			},
+		})
+		customScorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+
+		pid := peer.ID("peer4")
+
+		// Test with custom threshold
+		customScorer.RecordRequest(pid, 40)
+		assert.NoError(t, customScorer.IsBadPeer(pid),
+			"Peer should not be bad when below custom threshold")
+
+		customScorer.RecordRequest(pid, 11)
+		assert.NotNil(t, customScorer.IsBadPeer(pid),
+			"Peer should be bad when above custom threshold")
+	})
+}
+
+// containsPeer is a helper function to check if a peer ID is in a list
+func containsPeer(peers []peer.ID, pid peer.ID) bool {
+	for _, p := range peers {
+		if p == pid {
+			return true
+		}
+	}
+	return false
+}

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
@@ -8,16 +8,17 @@ import (
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/scorers"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/testing/assert"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // Use a fixed current slot for deterministic testing.
-const currentSlot uint64 = 1000
+const currentSlot primitives.Slot = 1000
 
 // Define MaxGossipAgeSlots based on default or ensure it's accessible if customized.
-const maxGossipAgeSlots = scorers.DefaultDataColumnMaxGossipAgeSlots
+const maxGossipAgeSlots = primitives.Slot(scorers.DefaultDataColumnMaxGossipAgeSlots)
 
 // Helper to create a new scorer for isolated sub-tests
 func newDataColumnScorer(ctx context.Context, cfg *scorers.DataColumnRPCRequestScorerConfig) *scorers.DataColumnRPCRequestScorer {
@@ -78,7 +79,8 @@ func TestScorers_DataColumnRPCRequest_Score(t *testing.T) {
 			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
 				// Make 10 requests for recent slots (currentSlot - columnSlot < maxGossipAgeSlots)
 				for i := range 10 {
-					scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-uint64(i%int(maxGossipAgeSlots))) // Vary recent slots
+					columnSlot := currentSlot - primitives.Slot(i%int(maxGossipAgeSlots))
+					scorer.RecordRequest(peer.ID("peer1"), currentSlot, columnSlot) // Vary recent slots
 				}
 			},
 			check: func(scorer *scorers.DataColumnRPCRequestScorer) {

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
@@ -1,0 +1,147 @@
+package scorers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/scorers"
+	"github.com/OffchainLabs/prysm/v6/testing/assert"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func TestScorers_DataColumnRPCRequest_Score(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name   string
+		update func(scorer *scorers.DataColumnRPCRequestScorer)
+		check  func(scorer *scorers.DataColumnRPCRequestScorer)
+	}{
+		{
+			name: "nonexistent peer",
+			update: func(*scorers.DataColumnRPCRequestScorer) {
+			},
+			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				assert.Equal(t, 0.0, scorer.Score("peer1"), "Unexpected score")
+			},
+		},
+		{
+			name: "peer with no requests",
+			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				scorer.RecordRequest("peer1", 0)
+			},
+			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				assert.Equal(t, 0.0, scorer.Score("peer1"), "Unexpected score")
+				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status")
+			},
+		},
+		{
+			name: "peer with requests below threshold",
+			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				scorer.RecordRequest("peer1", 10)
+			},
+			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Expected score: -10 * DefaultDataColumnRPCRequestPenaltyFactor
+				expectedScore := -10.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
+				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status")
+			},
+		},
+		{
+			name: "peer at threshold",
+			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Set requests to exactly the threshold
+				for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10); i++ {
+					scorer.RecordRequest("peer1", 10)
+				}
+			},
+			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Expected score: -threshold * DefaultDataColumnRPCRequestPenaltyFactor
+				expectedScore := -float64(scorers.DefaultDataColumnRPCRequestThreshold) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
+				assert.NotNil(t, scorer.IsBadPeer("peer1"), "Expected peer to be marked as bad")
+			},
+		},
+		{
+			name: "peer above threshold",
+			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Set requests above the threshold
+				for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10)+1; i++ {
+					scorer.RecordRequest("peer1", 10)
+				}
+			},
+			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Expected score: -(threshold+10) * DefaultDataColumnRPCRequestPenaltyFactor
+				expectedScore := -float64(scorers.DefaultDataColumnRPCRequestThreshold+10) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
+				assert.NotNil(t, scorer.IsBadPeer("peer1"), "Expected peer to be marked as bad")
+			},
+		},
+		{
+			name: "peer with decay",
+			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Set initial requests
+				scorer.RecordRequest("peer1", 50)
+				// Trigger decay
+				scorer.Decay()
+			},
+			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// After decay, count should be (50 - DefaultDataColumnRPCRequestDecay)
+				expectedCount := uint64(50 - scorers.DefaultDataColumnRPCRequestDecay)
+				expectedScore := -float64(expectedCount) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score after decay")
+				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status after decay")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+				ScorerParams: &scorers.Config{},
+			})
+			scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+			if tt.update != nil {
+				tt.update(scorer)
+			}
+			tt.check(scorer)
+		})
+	}
+}
+
+func TestScorers_DataColumnRPCRequest_BadPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+		ScorerParams: &scorers.Config{},
+	})
+	scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+
+	// Add three peers with different request counts
+	pid1 := peer.ID("peer1")
+	pid2 := peer.ID("peer2")
+	pid3 := peer.ID("peer3")
+
+	// Peer1: Below threshold
+	scorer.RecordRequest(pid1, 10)
+	// Peer2: At threshold
+	for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10); i++ {
+		scorer.RecordRequest(pid2, 10)
+	}
+	// Peer3: Above threshold
+	for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10)+1; i++ {
+		scorer.RecordRequest(pid3, 10)
+	}
+
+	// Check bad peers list
+	badPeers := scorer.BadPeers()
+	assert.Equal(t, 2, len(badPeers), "Unexpected number of bad peers")
+
+	// Verify specific peers
+	assert.NoError(t, scorer.IsBadPeer(pid1), "Peer1 should not be bad")
+	assert.NotNil(t, scorer.IsBadPeer(pid2), "Peer2 should be bad")
+	assert.NotNil(t, scorer.IsBadPeer(pid3), "Peer3 should be bad")
+}

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
@@ -13,6 +13,22 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+// Use a fixed current slot for deterministic testing.
+const currentSlot uint64 = 1000
+
+// Define MaxGossipAgeSlots based on default or ensure it's accessible if customized.
+const maxGossipAgeSlots = scorers.DefaultDataColumnMaxGossipAgeSlots
+
+// Helper to create a new scorer for isolated sub-tests
+func newDataColumnScorer(ctx context.Context, cfg *scorers.DataColumnRPCRequestScorerConfig) *scorers.DataColumnRPCRequestScorer {
+	peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+		ScorerParams: &scorers.Config{
+			DataColumnRPCRequestScorerConfig: cfg,
+		},
+	})
+	return peerStatuses.Scorers().DataColumnRPCRequestScorer()
+}
+
 func TestScorers_DataColumnRPCRequest_Score(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -31,62 +47,86 @@ func TestScorers_DataColumnRPCRequest_Score(t *testing.T) {
 			},
 		},
 		{
-			name: "peer with no requests",
+			name: "peer with request exactly MaxGossipAgeSlots old",
 			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				scorer.RecordRequest("peer1", 0)
+				// Request a slot that is exactly MaxGossipAgeSlots old
+				// Based on current logic `columnSlot+MaxGossipAgeSlots < currentSlot` (false),
+				// this request *is* penalized.
+				scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-maxGossipAgeSlots)
 			},
 			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				assert.Equal(t, 0.0, scorer.Score("peer1"), "Unexpected score")
-				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status")
+				// Expected count = 1, score = -1 * PenaltyFactor
+				expectedScore := -1.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+				assertFloatEqual(t, expectedScore, scorer.Score("peer1"), "Unexpected score for request exactly MaxGossipAgeSlots old")
+				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status for request exactly MaxGossipAgeSlots old")
 			},
 		},
 		{
-			name: "peer with requests below threshold",
+			name: "peer with no penalized requests",
 			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				scorer.RecordRequest("peer1", 10)
+				// Request a slot that is older than MaxGossipAgeSlots (currentSlot - columnSlot > maxGossipAgeSlots)
+				// This should not be penalized.
+				scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-maxGossipAgeSlots-1)
 			},
 			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				// Expected score: -10 * DefaultDataColumnRPCRequestPenaltyFactor
+				assert.Equal(t, 0.0, scorer.Score("peer1"), "Unexpected score for old request")
+				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status for old request")
+			},
+		},
+		{
+			name: "peer with penalized requests below threshold",
+			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Make 10 requests for recent slots (currentSlot - columnSlot < maxGossipAgeSlots)
+				for i := range 10 {
+					scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-uint64(i%int(maxGossipAgeSlots))) // Vary recent slots
+				}
+			},
+			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
+				// Expected count = 10
 				expectedScore := -10.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor
-				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
+				assertFloatEqual(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
 				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status")
 			},
 		},
 		{
 			name: "peer at threshold",
 			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				// Set requests to exactly the threshold
-				for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10); i++ {
-					scorer.RecordRequest("peer1", 10)
+				// Make requests equal to the threshold
+				requests := int(scorers.DefaultDataColumnRPCRequestThreshold)
+				for range requests {
+					scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-1) // Request recent slot
 				}
 			},
 			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				// Expected score: -threshold * DefaultDataColumnRPCRequestPenaltyFactor
+				// Expected count = threshold
 				expectedScore := -float64(scorers.DefaultDataColumnRPCRequestThreshold) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
-				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
+				assertFloatEqual(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
 				assert.NotNil(t, scorer.IsBadPeer("peer1"), "Expected peer to be marked as bad")
 			},
 		},
 		{
 			name: "peer above threshold",
 			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				// Set requests above the threshold
-				for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10)+1; i++ {
-					scorer.RecordRequest("peer1", 10)
+				// Make requests above the threshold
+				requests := int(scorers.DefaultDataColumnRPCRequestThreshold + 10)
+				for range requests {
+					scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-1) // Request recent slot
 				}
 			},
 			check: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				// Expected score: -(threshold+10) * DefaultDataColumnRPCRequestPenaltyFactor
+				// Expected count = threshold + 10
 				expectedScore := -float64(scorers.DefaultDataColumnRPCRequestThreshold+10) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
-				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
+				assertFloatEqual(t, expectedScore, scorer.Score("peer1"), "Unexpected score")
 				assert.NotNil(t, scorer.IsBadPeer("peer1"), "Expected peer to be marked as bad")
 			},
 		},
 		{
 			name: "peer with decay",
 			update: func(scorer *scorers.DataColumnRPCRequestScorer) {
-				// Set initial requests
-				scorer.RecordRequest("peer1", 50)
+				// Set initial request count to 50 by making 50 valid requests
+				for range 50 {
+					scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-1)
+				}
 				// Trigger decay
 				scorer.Decay()
 			},
@@ -94,7 +134,7 @@ func TestScorers_DataColumnRPCRequest_Score(t *testing.T) {
 				// After decay, count should be (50 - DefaultDataColumnRPCRequestDecay)
 				expectedCount := uint64(50 - scorers.DefaultDataColumnRPCRequestDecay)
 				expectedScore := -float64(expectedCount) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
-				assert.Equal(t, expectedScore, scorer.Score("peer1"), "Unexpected score after decay")
+				assertFloatEqual(t, expectedScore, scorer.Score("peer1"), "Unexpected score after decay")
 				assert.NoError(t, scorer.IsBadPeer("peer1"), "Unexpected bad peer status after decay")
 			},
 		},
@@ -128,15 +168,19 @@ func TestScorers_DataColumnRPCRequest_BadPeers(t *testing.T) {
 	pid2 := peer.ID("peer2")
 	pid3 := peer.ID("peer3")
 
-	// Peer1: Below threshold
-	scorer.RecordRequest(pid1, 10)
-	// Peer2: At threshold
-	for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10); i++ {
-		scorer.RecordRequest(pid2, 10)
+	// Peer1: Below threshold (make 10 valid requests)
+	for range 10 {
+		scorer.RecordRequest(pid1, currentSlot, currentSlot-1)
 	}
-	// Peer3: Above threshold
-	for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10)+1; i++ {
-		scorer.RecordRequest(pid3, 10)
+	// Peer2: At threshold (make DefaultDataColumnRPCRequestThreshold valid requests)
+	requestsAtThreshold := int(scorers.DefaultDataColumnRPCRequestThreshold)
+	for range requestsAtThreshold {
+		scorer.RecordRequest(pid2, currentSlot, currentSlot-1)
+	}
+	// Peer3: Above threshold (make DefaultDataColumnRPCRequestThreshold + 1 valid requests)
+	requestsAboveThreshold := int(scorers.DefaultDataColumnRPCRequestThreshold + 1)
+	for range requestsAboveThreshold {
+		scorer.RecordRequest(pid3, currentSlot, currentSlot-1)
 	}
 
 	// Check bad peers list
@@ -189,14 +233,19 @@ func TestScorers_DataColumnRPCRequest_Params(t *testing.T) {
 		assert.Equal(t, customConfig.PenaltyFactor, params.PenaltyFactor, "Wrong custom penalty factor")
 
 		// Verify the config affects scoring
-		scorer.RecordRequest("peer1", 150)
+		// Make 150 valid requests
+		for range 150 {
+			scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-1)
+		}
 		expectedScore := -150.0 * customConfig.PenaltyFactor
-		assert.Equal(t, expectedScore, scorer.Score("peer1"), "Wrong score with custom penalty factor")
-		assert.NoError(t, scorer.IsBadPeer("peer1"), "Peer should not be bad yet")
+		assertFloatEqual(t, expectedScore, scorer.Score("peer1"), "Wrong score with custom penalty factor")
+		assert.NoError(t, scorer.IsBadPeer("peer1"), "Peer should not be bad yet (150 < threshold 200)")
 
-		// Push peer over custom threshold
-		scorer.RecordRequest("peer1", 51)
-		assert.NotNil(t, scorer.IsBadPeer("peer1"), "Peer should be bad after exceeding custom threshold")
+		// Push peer over custom threshold (make 51 more valid requests, total 201)
+		for range 51 {
+			scorer.RecordRequest(peer.ID("peer1"), currentSlot, currentSlot-1)
+		}
+		assert.NotNil(t, scorer.IsBadPeer("peer1"), "Peer should be bad after exceeding custom threshold (201 > 200)")
 	})
 
 	// Test partial config (some values specified, others default)
@@ -266,8 +315,10 @@ func TestScorers_DataColumnRPCRequest_Count(t *testing.T) {
 		_, err := peerStatuses.ConnectionState(pid)
 		assert.ErrorContains(t, "peer unknown", err, "Peer should not exist")
 
-		// Record request for unknown peer
-		scorer.RecordRequest(pid, 5)
+		// Record 5 valid requests for unknown peer
+		for range 5 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 
 		// Verify peer data after request
 		state, err := peerStatuses.ConnectionState(pid)
@@ -280,86 +331,80 @@ func TestScorers_DataColumnRPCRequest_Count(t *testing.T) {
 	t.Run("request accumulation", func(t *testing.T) {
 		pid := peer.ID("peer2")
 
-		// Record series of requests
-		scorer.RecordRequest(pid, 10)
-		assert.Equal(t, float64(-0.2), scorer.Score(pid), "Wrong score after first request")
+		// Record series of requests, check cumulative count
+		// 10 requests
+		for range 10 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
+		assertFloatEqual(t, -10.0*scorers.DefaultDataColumnRPCRequestPenaltyFactor, scorer.Score(pid), "Wrong score after 10 requests")
 
-		scorer.RecordRequest(pid, 15)
-		assert.Equal(t, float64(-0.5), scorer.Score(pid), "Wrong score after second request")
+		// +15 requests (total 25)
+		for range 15 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
+		assertFloatEqual(t, -25.0*scorers.DefaultDataColumnRPCRequestPenaltyFactor, scorer.Score(pid), "Wrong score after 25 requests")
 
-		scorer.RecordRequest(pid, 20)
-		assert.Equal(t, float64(-0.9), scorer.Score(pid), "Wrong score after third request")
+		// +20 requests (total 45)
+		for range 20 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
+		assertFloatEqual(t, -45.0*scorers.DefaultDataColumnRPCRequestPenaltyFactor, scorer.Score(pid), "Wrong score after 45 requests")
 	})
 
-	// Test invalid requests
+	// Test invalid requests (only invalid peer ID should be ignored now)
+	// Requesting old slots is also ignored but tested separately.
 	t.Run("invalid requests", func(t *testing.T) {
 		pid := peer.ID("peer3")
 
-		// Record initial valid request
-		scorer.RecordRequest(pid, 10)
+		// Record initial valid request (count = 1)
+		scorer.RecordRequest(pid, currentSlot, currentSlot-1)
 		initialScore := scorer.Score(pid)
+		require.Equal(t, -1.0*scorers.DefaultDataColumnRPCRequestPenaltyFactor, initialScore, "Check initial score setup")
 
 		// Try invalid requests
-		scorer.RecordRequest(pid, 0)  // Zero columns
-		scorer.RecordRequest(pid, -1) // Negative columns
-		scorer.RecordRequest("", 5)   // Empty peer ID
+		scorer.RecordRequest("", currentSlot, currentSlot-1) // Empty peer ID
 
-		// Verify score unchanged
-		assert.Equal(t, initialScore, scorer.Score(pid), "Score should not change for invalid requests")
+		// Verify score unchanged for the valid peer
+		assert.Equal(t, initialScore, scorer.Score(pid), "Score should not change for invalid peer ID requests")
 	})
 
-	// Test request timing
+	// Test request timing (score accumulation is based on count, not timing between calls)
 	t.Run("request timing", func(t *testing.T) {
 		pid := peer.ID("peer4")
 
-		// Record first request
-		scorer.RecordRequest(pid, 5)
+		// Record first request (count = 1)
+		scorer.RecordRequest(pid, currentSlot, currentSlot-1)
 		time.Sleep(time.Millisecond)
-		firstScore := scorer.Score(pid)
 
-		// Record second request
-		scorer.RecordRequest(pid, 5)
+		// Record second request (count = 2)
+		scorer.RecordRequest(pid, currentSlot, currentSlot-1)
 		secondScore := scorer.Score(pid)
 
-		// Verify scores reflect accumulation
-		assert.Equal(t, 2*firstScore, secondScore, "Second score should be double the first")
+		// Verify scores reflect accumulation based on count
+		expectedSecondScore := -2.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, expectedSecondScore, secondScore, "Second score should reflect count=2")
 	})
 
 	// Test concurrent requests
 	t.Run("concurrent requests", func(t *testing.T) {
 		pid := peer.ID("peer5")
 		const numRequests = 100
-		const columnsPerRequest = 5
 
 		// Launch multiple goroutines to record requests concurrently
 		var wg sync.WaitGroup
-		for i := 0; i < numRequests; i++ {
+		for range numRequests {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				scorer.RecordRequest(pid, columnsPerRequest)
+				// Record a valid request
+				scorer.RecordRequest(pid, currentSlot, currentSlot-1)
 			}()
 		}
 		wg.Wait()
 
-		// Verify final score
-		expectedScore := -float64(numRequests*columnsPerRequest) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
-		assert.Equal(t, expectedScore, scorer.Score(pid), "Wrong score after concurrent requests")
-	})
-
-	// Test ByRange requests with count multiplier
-	t.Run("byrange requests", func(t *testing.T) {
-		pid := peer.ID("peer6")
-
-		// Record a ByRange request with count=3 and 2 columns
-		scorer.RecordRequest(pid, 6) // 3 * 2 columns
-		expectedScore := -float64(6) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
-		assert.Equal(t, expectedScore, scorer.Score(pid), "Wrong score for ByRange request")
-
-		// Record another ByRange request with count=2 and 3 columns
-		scorer.RecordRequest(pid, 6) // 2 * 3 columns
-		expectedScore = -float64(12) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
-		assert.Equal(t, expectedScore, scorer.Score(pid), "Wrong score after multiple ByRange requests")
+		// Verify final score (count should be numRequests)
+		expectedScore := -float64(numRequests) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, expectedScore, scorer.Score(pid), "Wrong score after concurrent requests")
 	})
 }
 
@@ -385,7 +430,10 @@ func TestScorers_DataColumnRPCRequest_Decay(t *testing.T) {
 	// Test basic decay
 	t.Run("basic decay", func(t *testing.T) {
 		pid := peer.ID("peer1")
-		scorer.RecordRequest(pid, 50)
+		// Set initial count to 50
+		for range 50 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 
 		// Trigger decay
 		scorer.Decay()
@@ -399,10 +447,13 @@ func TestScorers_DataColumnRPCRequest_Decay(t *testing.T) {
 	// Test multiple decay cycles
 	t.Run("multiple decay cycles", func(t *testing.T) {
 		pid := peer.ID("peer2")
-		scorer.RecordRequest(pid, 100)
+		// Set initial count to 100
+		for range 100 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 
 		// Apply decay multiple times
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			scorer.Decay()
 		}
 
@@ -415,16 +466,24 @@ func TestScorers_DataColumnRPCRequest_Decay(t *testing.T) {
 	// Test decay to zero
 	t.Run("decay to zero", func(t *testing.T) {
 		pid := peer.ID("peer3")
-		// Use a small value that will decay to zero
-		scorer.RecordRequest(pid, 10)
+		// Use a small initial count (e.g., 10)
+		for range 10 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 
-		// Single decay should bring count to 0
+		// Single decay might bring count to 0 if Decay >= 10
 		scorer.Decay()
-		assertFloatEqual(t, float64(0), scorer.Score(pid), "Score should be zero after decay")
+		// Calculate expected count after decay
+		expectedCount := uint64(0)
+		if 10 > scorers.DefaultDataColumnRPCRequestDecay {
+			expectedCount = 10 - scorers.DefaultDataColumnRPCRequestDecay
+		}
+		expectedScore := -float64(expectedCount) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, expectedScore, scorer.Score(pid), "Score should be correct after first decay")
 
-		// Additional decay should not make score positive
+		// Additional decay should not make score positive (should keep it at 0 if it reached 0)
 		scorer.Decay()
-		assertFloatEqual(t, float64(0), scorer.Score(pid), "Score should remain zero after additional decay")
+		assertFloatEqual(t, 0.0, scorer.Score(pid), "Score should remain zero or decay further towards zero")
 	})
 
 	// Test decay with multiple peers
@@ -433,29 +492,28 @@ func TestScorers_DataColumnRPCRequest_Decay(t *testing.T) {
 		pid2 := peer.ID("peer5")
 		pid3 := peer.ID("peer6")
 
-		// Set different initial counts
-		scorer.RecordRequest(pid1, 30)  // Will decay but remain > 0
-		scorer.RecordRequest(pid2, 10)  // Will decay to 0
-		scorer.RecordRequest(pid3, 100) // Will decay but remain well above 0
+		// Set different initial counts via valid requests
+		counts := map[peer.ID]int{pid1: 30, pid2: 10, pid3: 100}
+		for pid, count := range counts {
+			for range count {
+				scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+			}
+		}
 
 		// Record initial scores
-		scores := make(map[peer.ID]float64)
-		scores[pid1] = scorer.Score(pid1)
-		scores[pid2] = scorer.Score(pid2)
-		scores[pid3] = scorer.Score(pid3)
+		initialScores := make(map[peer.ID]float64)
+		for pid, count := range counts {
+			initialScores[pid] = -float64(count) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		}
 
 		// Apply decay
 		scorer.Decay()
 
 		// Verify each peer's decay
-		for _, pid := range []peer.ID{pid1, pid2, pid3} {
-			initialScore := scores[pid]
+		for pid, initialScore := range initialScores {
 			newScore := scorer.Score(pid)
-
-			// New score should be less negative (closer to 0) than initial score
 			assert.Equal(t, true, newScore > initialScore || newScore == 0,
 				"Score should either increase towards 0 or remain at 0 after decay")
-			// Score should never become positive
 			assert.Equal(t, true, newScore <= 0,
 				"Score should never become positive after decay")
 		}
@@ -483,12 +541,20 @@ func TestScorers_DataColumnRPCRequest_Decay(t *testing.T) {
 		customScorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
 
 		pid := peer.ID("peer7")
-		customScorer.RecordRequest(pid, 100)
+		// Set initial count to 100
+		for range 100 {
+			customScorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 
 		// Apply decay with custom value
 		customScorer.Decay()
 
-		expectedCount := uint64(100 - customConfig.Decay)
+		// Calculate expected count after custom decay
+		expectedCount := uint64(0)
+		if 100 > customConfig.Decay {
+			expectedCount = 100 - customConfig.Decay
+		}
+		// Use the default penalty factor since it wasn't overridden in this partial config
 		expectedScore := -float64(expectedCount) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
 		assertFloatEqual(t, expectedScore, customScorer.Score(pid),
 			"Wrong score after decay with custom decay value")
@@ -499,23 +565,25 @@ func TestScorers_DataColumnRPCRequest_BadPeer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
-		ScorerParams: &scorers.Config{},
-	})
-	scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+	// Note: Each sub-test now creates its own scorer for isolation.
 
 	// Test transition from good to bad
 	t.Run("good to bad transition", func(t *testing.T) {
+		scorer := newDataColumnScorer(ctx, nil) // Use default config
 		pid := peer.ID("peer1")
 
-		// Start with requests below threshold
+		// Start with requests count below threshold
 		requestsBelow := int(scorers.DefaultDataColumnRPCRequestThreshold - 10)
-		scorer.RecordRequest(pid, requestsBelow)
+		for range requestsBelow {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 		assert.NoError(t, scorer.IsBadPeer(pid), "Peer should not be bad when below threshold")
 		assert.Equal(t, 0, len(scorer.BadPeers()), "Should have no bad peers")
 
-		// Add more requests to exceed threshold
-		scorer.RecordRequest(pid, 15)
+		// Add more requests to exceed threshold (15 more, total = threshold + 5)
+		for range 15 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 		assert.NotNil(t, scorer.IsBadPeer(pid), "Peer should be bad after exceeding threshold")
 		assert.Equal(t, 1, len(scorer.BadPeers()), "Should have one bad peer")
 		assert.Equal(t, pid, scorer.BadPeers()[0], "Bad peer should match test peer")
@@ -523,49 +591,76 @@ func TestScorers_DataColumnRPCRequest_BadPeer(t *testing.T) {
 
 	// Test peer remaining bad after decay
 	t.Run("remain bad after decay", func(t *testing.T) {
+		scorer := newDataColumnScorer(ctx, nil) // Use default config
 		pid := peer.ID("peer2")
 
-		// Push well over threshold
-		scorer.RecordRequest(pid, int(scorers.DefaultDataColumnRPCRequestThreshold*2))
+		// Push well over threshold (e.g., threshold * 2). Using defaults (100), this is 200.
+		requestsOver := int(scorers.DefaultDataColumnRPCRequestThreshold * 2)
+		for range requestsOver {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 		assert.NotNil(t, scorer.IsBadPeer(pid), "Peer should be bad when significantly over threshold")
 
-		// Apply decay
+		// Apply decay once. With defaults (decay=10), count becomes 190, still >= 100.
 		scorer.Decay()
+
+		// Assert peer is still bad after one decay cycle.
 		assert.NotNil(t, scorer.IsBadPeer(pid),
-			"Peer should remain bad after decay if still above threshold")
+			"Peer should remain bad after decay as count (190) is still >= threshold (100)")
 	})
 
 	// Test peer recovery through decay
 	t.Run("recovery through decay", func(t *testing.T) {
+		scorer := newDataColumnScorer(ctx, nil) // Use default config
 		pid := peer.ID("peer3")
 
-		// Set just over threshold
-		scorer.RecordRequest(pid, int(scorers.DefaultDataColumnRPCRequestThreshold+1))
+		// Set just over threshold (threshold + 1). Using defaults, this is 101.
+		requestsJustOver := int(scorers.DefaultDataColumnRPCRequestThreshold + 1)
+		for range requestsJustOver {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
 		assert.NotNil(t, scorer.IsBadPeer(pid), "Peer should be bad when just over threshold")
 
-		// Apply multiple decays until peer recovers
-		decaysNeeded := (scorers.DefaultDataColumnRPCRequestThreshold+1)/
-			scorers.DefaultDataColumnRPCRequestDecay + 1
-		for i := uint64(0); i < decaysNeeded; i++ {
+		// Apply decay repeatedly until the scorer no longer considers the peer bad.
+		const maxDecays = 1000 // Safety break
+		decaysApplied := 0
+		for scorer.IsBadPeer(pid) != nil {
+			if decaysApplied >= maxDecays {
+				t.Fatalf("Peer did not recover after %d decay cycles", maxDecays)
+			}
 			scorer.Decay()
+			decaysApplied++
 		}
+
+		// Assert the peer is no longer bad.
 		assert.NoError(t, scorer.IsBadPeer(pid),
-			"Peer should recover after sufficient decay cycles")
+			"Peer should recover after %d decay cycles", decaysApplied)
 	})
 
 	// Test multiple peers with different statuses
 	t.Run("multiple peer statuses", func(t *testing.T) {
-		// Create peers with different request counts
+		scorer := newDataColumnScorer(ctx, nil) // Use default config
+		// Create peers
 		goodPeer1 := peer.ID("good1")
 		goodPeer2 := peer.ID("good2")
 		badPeer1 := peer.ID("bad1")
 		badPeer2 := peer.ID("bad2")
 
-		// Set request counts
-		scorer.RecordRequest(goodPeer1, 1)                                                   // Well below threshold
-		scorer.RecordRequest(goodPeer2, int(scorers.DefaultDataColumnRPCRequestThreshold-1)) // Just below
-		scorer.RecordRequest(badPeer1, int(scorers.DefaultDataColumnRPCRequestThreshold+1))  // Just above
-		scorer.RecordRequest(badPeer2, int(scorers.DefaultDataColumnRPCRequestThreshold*2))  // Well above
+		// Set request counts via valid requests
+		// goodPeer1: 1 request
+		scorer.RecordRequest(goodPeer1, currentSlot, currentSlot-1)
+		// goodPeer2: threshold - 1 requests
+		for range int(scorers.DefaultDataColumnRPCRequestThreshold - 1) {
+			scorer.RecordRequest(goodPeer2, currentSlot, currentSlot-1)
+		}
+		// badPeer1: threshold + 1 requests
+		for range int(scorers.DefaultDataColumnRPCRequestThreshold + 1) {
+			scorer.RecordRequest(badPeer1, currentSlot, currentSlot-1)
+		}
+		// badPeer2: threshold * 2 requests
+		for range int(scorers.DefaultDataColumnRPCRequestThreshold * 2) {
+			scorer.RecordRequest(badPeer2, currentSlot, currentSlot-1)
+		}
 
 		// Verify individual statuses
 		assert.NoError(t, scorer.IsBadPeer(goodPeer1), "goodPeer1 should not be bad")
@@ -585,22 +680,24 @@ func TestScorers_DataColumnRPCRequest_BadPeer(t *testing.T) {
 		customConfig := &scorers.DataColumnRPCRequestScorerConfig{
 			Threshold: 50, // Lower threshold
 		}
-		peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
-			ScorerParams: &scorers.Config{
-				DataColumnRPCRequestScorerConfig: customConfig,
-			},
-		})
-		customScorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+		// Create scorer with custom config
+		scorer := newDataColumnScorer(ctx, customConfig)
 
 		pid := peer.ID("peer4")
 
 		// Test with custom threshold
-		customScorer.RecordRequest(pid, 40)
-		assert.NoError(t, customScorer.IsBadPeer(pid),
+		// Make 40 valid requests (below custom threshold 50)
+		for range 40 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
+		assert.NoError(t, scorer.IsBadPeer(pid),
 			"Peer should not be bad when below custom threshold")
 
-		customScorer.RecordRequest(pid, 11)
-		assert.NotNil(t, customScorer.IsBadPeer(pid),
+		// Make 11 more valid requests (total 51, above custom threshold 50)
+		for range 11 {
+			scorer.RecordRequest(pid, currentSlot, currentSlot-1)
+		}
+		assert.NotNil(t, scorer.IsBadPeer(pid),
 			"Peer should be bad when above custom threshold")
 	})
 }

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
@@ -2,12 +2,14 @@ package scorers_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/scorers"
 	"github.com/OffchainLabs/prysm/v6/testing/assert"
+	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
@@ -245,5 +247,118 @@ func TestScorers_DataColumnRPCRequest_Params(t *testing.T) {
 		assert.Equal(t, uint64(20), params.Decay, "Config should be immutable")
 		assert.Equal(t, uint64(200), params.Threshold, "Config should be immutable")
 		assert.Equal(t, 0.05, params.PenaltyFactor, "Config should be immutable")
+	})
+}
+
+func TestScorers_DataColumnRPCRequest_Count(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+		ScorerParams: &scorers.Config{},
+	})
+	scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+
+	// Test unknown peer
+	t.Run("unknown peer", func(t *testing.T) {
+		pid := peer.ID("peer1")
+		// Verify peer is unknown initially
+		_, err := peerStatuses.ConnectionState(pid)
+		assert.ErrorContains(t, "peer unknown", err, "Peer should not exist")
+
+		// Record request for unknown peer
+		scorer.RecordRequest(pid, 5)
+
+		// Verify peer data after request
+		state, err := peerStatuses.ConnectionState(pid)
+		require.NoError(t, err, "Peer should exist")
+		assert.Equal(t, peers.Disconnected, state, "Wrong connection state")
+		assert.Equal(t, float64(-0.1), scorer.Score(pid), "Wrong score for request count of 5")
+	})
+
+	// Test multiple requests accumulation
+	t.Run("request accumulation", func(t *testing.T) {
+		pid := peer.ID("peer2")
+
+		// Record series of requests
+		scorer.RecordRequest(pid, 10)
+		assert.Equal(t, float64(-0.2), scorer.Score(pid), "Wrong score after first request")
+
+		scorer.RecordRequest(pid, 15)
+		assert.Equal(t, float64(-0.5), scorer.Score(pid), "Wrong score after second request")
+
+		scorer.RecordRequest(pid, 20)
+		assert.Equal(t, float64(-0.9), scorer.Score(pid), "Wrong score after third request")
+	})
+
+	// Test invalid requests
+	t.Run("invalid requests", func(t *testing.T) {
+		pid := peer.ID("peer3")
+
+		// Record initial valid request
+		scorer.RecordRequest(pid, 10)
+		initialScore := scorer.Score(pid)
+
+		// Try invalid requests
+		scorer.RecordRequest(pid, 0)  // Zero columns
+		scorer.RecordRequest(pid, -1) // Negative columns
+		scorer.RecordRequest("", 5)   // Empty peer ID
+
+		// Verify score unchanged
+		assert.Equal(t, initialScore, scorer.Score(pid), "Score should not change for invalid requests")
+	})
+
+	// Test request timing
+	t.Run("request timing", func(t *testing.T) {
+		pid := peer.ID("peer4")
+
+		// Record first request
+		scorer.RecordRequest(pid, 5)
+		time.Sleep(time.Millisecond)
+		firstScore := scorer.Score(pid)
+
+		// Record second request
+		scorer.RecordRequest(pid, 5)
+		secondScore := scorer.Score(pid)
+
+		// Verify scores reflect accumulation
+		assert.Equal(t, 2*firstScore, secondScore, "Second score should be double the first")
+	})
+
+	// Test concurrent requests
+	t.Run("concurrent requests", func(t *testing.T) {
+		pid := peer.ID("peer5")
+		const numRequests = 100
+		const columnsPerRequest = 5
+
+		// Launch multiple goroutines to record requests concurrently
+		var wg sync.WaitGroup
+		for i := 0; i < numRequests; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				scorer.RecordRequest(pid, columnsPerRequest)
+			}()
+		}
+		wg.Wait()
+
+		// Verify final score
+		expectedScore := -float64(numRequests*columnsPerRequest) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assert.Equal(t, expectedScore, scorer.Score(pid), "Wrong score after concurrent requests")
+	})
+
+	// Test ByRange requests with count multiplier
+	t.Run("byrange requests", func(t *testing.T) {
+		pid := peer.ID("peer6")
+
+		// Record a ByRange request with count=3 and 2 columns
+		scorer.RecordRequest(pid, 6) // 3 * 2 columns
+		expectedScore := -float64(6) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assert.Equal(t, expectedScore, scorer.Score(pid), "Wrong score for ByRange request")
+
+		// Record another ByRange request with count=2 and 3 columns
+		scorer.RecordRequest(pid, 6) // 2 * 3 columns
+		expectedScore = -float64(12) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assert.Equal(t, expectedScore, scorer.Score(pid), "Wrong score after multiple ByRange requests")
 	})
 }

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
@@ -362,3 +362,135 @@ func TestScorers_DataColumnRPCRequest_Count(t *testing.T) {
 		assert.Equal(t, expectedScore, scorer.Score(pid), "Wrong score after multiple ByRange requests")
 	})
 }
+
+// assertFloatEqual is a helper function to compare floating point values with a small epsilon
+func assertFloatEqual(t *testing.T, expected, actual float64, msg string) {
+	t.Helper()
+	epsilon := 1e-10
+	diff := expected - actual
+	if diff < -epsilon || diff > epsilon {
+		t.Errorf("%s, want: %f, got: %f", msg, expected, actual)
+	}
+}
+
+func TestScorers_DataColumnRPCRequest_Decay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+		ScorerParams: &scorers.Config{},
+	})
+	scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+
+	// Test basic decay
+	t.Run("basic decay", func(t *testing.T) {
+		pid := peer.ID("peer1")
+		scorer.RecordRequest(pid, 50)
+
+		// Trigger decay
+		scorer.Decay()
+
+		// After decay, count should be (50 - DefaultDataColumnRPCRequestDecay)
+		expectedCount := uint64(50 - scorers.DefaultDataColumnRPCRequestDecay)
+		expectedScore := -float64(expectedCount) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, expectedScore, scorer.Score(pid), "Wrong score after decay")
+	})
+
+	// Test multiple decay cycles
+	t.Run("multiple decay cycles", func(t *testing.T) {
+		pid := peer.ID("peer2")
+		scorer.RecordRequest(pid, 100)
+
+		// Apply decay multiple times
+		for i := 0; i < 3; i++ {
+			scorer.Decay()
+		}
+
+		// After 3 decays, count should be (100 - 3*DefaultDataColumnRPCRequestDecay)
+		expectedCount := uint64(100 - 3*scorers.DefaultDataColumnRPCRequestDecay)
+		expectedScore := -float64(expectedCount) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, expectedScore, scorer.Score(pid), "Wrong score after multiple decays")
+	})
+
+	// Test decay to zero
+	t.Run("decay to zero", func(t *testing.T) {
+		pid := peer.ID("peer3")
+		// Use a small value that will decay to zero
+		scorer.RecordRequest(pid, 10)
+
+		// Single decay should bring count to 0
+		scorer.Decay()
+		assertFloatEqual(t, float64(0), scorer.Score(pid), "Score should be zero after decay")
+
+		// Additional decay should not make score positive
+		scorer.Decay()
+		assertFloatEqual(t, float64(0), scorer.Score(pid), "Score should remain zero after additional decay")
+	})
+
+	// Test decay with multiple peers
+	t.Run("multiple peers decay", func(t *testing.T) {
+		pid1 := peer.ID("peer4")
+		pid2 := peer.ID("peer5")
+		pid3 := peer.ID("peer6")
+
+		// Set different initial counts
+		scorer.RecordRequest(pid1, 30)  // Will decay but remain > 0
+		scorer.RecordRequest(pid2, 10)  // Will decay to 0
+		scorer.RecordRequest(pid3, 100) // Will decay but remain well above 0
+
+		// Record initial scores
+		scores := make(map[peer.ID]float64)
+		scores[pid1] = scorer.Score(pid1)
+		scores[pid2] = scorer.Score(pid2)
+		scores[pid3] = scorer.Score(pid3)
+
+		// Apply decay
+		scorer.Decay()
+
+		// Verify each peer's decay
+		for _, pid := range []peer.ID{pid1, pid2, pid3} {
+			initialScore := scores[pid]
+			newScore := scorer.Score(pid)
+
+			// New score should be less negative (closer to 0) than initial score
+			assert.Equal(t, true, newScore > initialScore || newScore == 0,
+				"Score should either increase towards 0 or remain at 0 after decay")
+			// Score should never become positive
+			assert.Equal(t, true, newScore <= 0,
+				"Score should never become positive after decay")
+		}
+
+		// Specific checks for each peer
+		decayedScore1 := -float64(30-scorers.DefaultDataColumnRPCRequestDecay) *
+			scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, decayedScore1, scorer.Score(pid1), "Wrong score for peer1 after decay")
+		assertFloatEqual(t, float64(0), scorer.Score(pid2), "Score for peer2 should be 0 after decay")
+		decayedScore3 := -float64(100-scorers.DefaultDataColumnRPCRequestDecay) *
+			scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, decayedScore3, scorer.Score(pid3), "Wrong score for peer3 after decay")
+	})
+
+	// Test decay with custom decay value
+	t.Run("custom decay value", func(t *testing.T) {
+		customConfig := &scorers.DataColumnRPCRequestScorerConfig{
+			Decay: 30,
+		}
+		peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+			ScorerParams: &scorers.Config{
+				DataColumnRPCRequestScorerConfig: customConfig,
+			},
+		})
+		customScorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+
+		pid := peer.ID("peer7")
+		customScorer.RecordRequest(pid, 100)
+
+		// Apply decay with custom value
+		customScorer.Decay()
+
+		expectedCount := uint64(100 - customConfig.Decay)
+		expectedScore := -float64(expectedCount) * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		assertFloatEqual(t, expectedScore, customScorer.Score(pid),
+			"Wrong score after decay with custom decay value")
+	})
+}

--- a/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
+++ b/beacon-chain/p2p/peers/scorers/data_column_rpc_request_scorer_test.go
@@ -3,6 +3,7 @@ package scorers_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/scorers"
@@ -144,4 +145,105 @@ func TestScorers_DataColumnRPCRequest_BadPeers(t *testing.T) {
 	assert.NoError(t, scorer.IsBadPeer(pid1), "Peer1 should not be bad")
 	assert.NotNil(t, scorer.IsBadPeer(pid2), "Peer2 should be bad")
 	assert.NotNil(t, scorer.IsBadPeer(pid3), "Peer3 should be bad")
+}
+
+func TestScorers_DataColumnRPCRequest_Params(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Test with default config (nil config)
+	t.Run("default config", func(t *testing.T) {
+		peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+			ScorerParams: &scorers.Config{},
+		})
+		scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+		params := scorer.Params()
+
+		assert.Equal(t, scorers.DefaultDataColumnRPCRequestDecayInterval, params.DecayInterval, "Wrong default decay interval")
+		assert.Equal(t, scorers.DefaultDataColumnRPCRequestDecay, params.Decay, "Wrong default decay value")
+		assert.Equal(t, scorers.DefaultDataColumnRPCRequestThreshold, params.Threshold, "Wrong default threshold")
+		assert.Equal(t, scorers.DefaultDataColumnRPCRequestPenaltyFactor, params.PenaltyFactor, "Wrong default penalty factor")
+	})
+
+	// Test with custom config
+	t.Run("custom config", func(t *testing.T) {
+		customConfig := &scorers.DataColumnRPCRequestScorerConfig{
+			DecayInterval: time.Minute,
+			Decay:         20,
+			Threshold:     200,
+			PenaltyFactor: 0.05,
+		}
+		peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+			ScorerParams: &scorers.Config{
+				DataColumnRPCRequestScorerConfig: customConfig,
+			},
+		})
+		scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+		params := scorer.Params()
+
+		assert.Equal(t, customConfig.DecayInterval, params.DecayInterval, "Wrong custom decay interval")
+		assert.Equal(t, customConfig.Decay, params.Decay, "Wrong custom decay value")
+		assert.Equal(t, customConfig.Threshold, params.Threshold, "Wrong custom threshold")
+		assert.Equal(t, customConfig.PenaltyFactor, params.PenaltyFactor, "Wrong custom penalty factor")
+
+		// Verify the config affects scoring
+		scorer.RecordRequest("peer1", 150)
+		expectedScore := -150.0 * customConfig.PenaltyFactor
+		assert.Equal(t, expectedScore, scorer.Score("peer1"), "Wrong score with custom penalty factor")
+		assert.NoError(t, scorer.IsBadPeer("peer1"), "Peer should not be bad yet")
+
+		// Push peer over custom threshold
+		scorer.RecordRequest("peer1", 51)
+		assert.NotNil(t, scorer.IsBadPeer("peer1"), "Peer should be bad after exceeding custom threshold")
+	})
+
+	// Test partial config (some values specified, others default)
+	t.Run("partial config", func(t *testing.T) {
+		partialConfig := &scorers.DataColumnRPCRequestScorerConfig{
+			DecayInterval: time.Minute,
+			Threshold:     200,
+		}
+		peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+			ScorerParams: &scorers.Config{
+				DataColumnRPCRequestScorerConfig: partialConfig,
+			},
+		})
+		scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+		params := scorer.Params()
+
+		assert.Equal(t, partialConfig.DecayInterval, params.DecayInterval, "Wrong decay interval")
+		assert.Equal(t, partialConfig.Threshold, params.Threshold, "Wrong threshold")
+		// Unspecified values should use defaults
+		assert.Equal(t, scorers.DefaultDataColumnRPCRequestDecay, params.Decay, "Should use default decay")
+		assert.Equal(t, scorers.DefaultDataColumnRPCRequestPenaltyFactor, params.PenaltyFactor, "Should use default penalty factor")
+	})
+
+	// Test config immutability
+	t.Run("config immutability", func(t *testing.T) {
+		customConfig := &scorers.DataColumnRPCRequestScorerConfig{
+			DecayInterval: time.Minute,
+			Decay:         20,
+			Threshold:     200,
+			PenaltyFactor: 0.05,
+		}
+		peerStatuses := peers.NewStatus(ctx, &peers.StatusConfig{
+			ScorerParams: &scorers.Config{
+				DataColumnRPCRequestScorerConfig: customConfig,
+			},
+		})
+		scorer := peerStatuses.Scorers().DataColumnRPCRequestScorer()
+
+		// Modify original config
+		customConfig.DecayInterval = time.Hour
+		customConfig.Decay = 50
+		customConfig.Threshold = 500
+		customConfig.PenaltyFactor = 0.1
+
+		// Verify scorer's config is unchanged
+		params := scorer.Params()
+		assert.Equal(t, time.Minute, params.DecayInterval, "Config should be immutable")
+		assert.Equal(t, uint64(20), params.Decay, "Config should be immutable")
+		assert.Equal(t, uint64(200), params.Threshold, "Config should be immutable")
+		assert.Equal(t, 0.05, params.PenaltyFactor, "Config should be immutable")
+	})
 }

--- a/beacon-chain/p2p/peers/scorers/service.go
+++ b/beacon-chain/p2p/peers/scorers/service.go
@@ -33,10 +33,11 @@ type Scorer interface {
 type Service struct {
 	store   *peerdata.Store
 	scorers struct {
-		badResponsesScorer  *BadResponsesScorer
-		blockProviderScorer *BlockProviderScorer
-		peerStatusScorer    *PeerStatusScorer
-		gossipScorer        *GossipScorer
+		badResponsesScorer         *BadResponsesScorer
+		blockProviderScorer        *BlockProviderScorer
+		peerStatusScorer           *PeerStatusScorer
+		gossipScorer               *GossipScorer
+		dataColumnRPCRequestScorer *DataColumnRPCRequestScorer
 	}
 	weights     map[Scorer]float64
 	totalWeight float64
@@ -44,10 +45,11 @@ type Service struct {
 
 // Config holds configuration parameters for scoring service.
 type Config struct {
-	BadResponsesScorerConfig  *BadResponsesScorerConfig
-	BlockProviderScorerConfig *BlockProviderScorerConfig
-	PeerStatusScorerConfig    *PeerStatusScorerConfig
-	GossipScorerConfig        *GossipScorerConfig
+	BadResponsesScorerConfig         *BadResponsesScorerConfig
+	BlockProviderScorerConfig        *BlockProviderScorerConfig
+	PeerStatusScorerConfig           *PeerStatusScorerConfig
+	GossipScorerConfig               *GossipScorerConfig
+	DataColumnRPCRequestScorerConfig *DataColumnRPCRequestScorerConfig
 }
 
 // NewService provides fully initialized peer scoring service.
@@ -59,13 +61,15 @@ func NewService(ctx context.Context, store *peerdata.Store, config *Config) *Ser
 
 	// Register scorers.
 	s.scorers.badResponsesScorer = newBadResponsesScorer(store, config.BadResponsesScorerConfig)
-	s.setScorerWeight(s.scorers.badResponsesScorer, 0.3)
+	s.setScorerWeight(s.scorers.badResponsesScorer, 0.25)
 	s.scorers.blockProviderScorer = newBlockProviderScorer(store, config.BlockProviderScorerConfig)
 	s.setScorerWeight(s.scorers.blockProviderScorer, 0.0)
 	s.scorers.peerStatusScorer = newPeerStatusScorer(store, config.PeerStatusScorerConfig)
-	s.setScorerWeight(s.scorers.peerStatusScorer, 0.3)
+	s.setScorerWeight(s.scorers.peerStatusScorer, 0.25)
 	s.scorers.gossipScorer = newGossipScorer(store, config.GossipScorerConfig)
-	s.setScorerWeight(s.scorers.gossipScorer, 0.4)
+	s.setScorerWeight(s.scorers.gossipScorer, 0.35)
+	s.scorers.dataColumnRPCRequestScorer = newDataColumnRPCRequestScorer(store, config.DataColumnRPCRequestScorerConfig)
+	s.setScorerWeight(s.scorers.dataColumnRPCRequestScorer, 0.15)
 
 	// Start background tasks.
 	go s.loop(ctx)
@@ -91,6 +95,11 @@ func (s *Service) PeerStatusScorer() *PeerStatusScorer {
 // GossipScorer exposes the peer's gossip scoring service.
 func (s *Service) GossipScorer() *GossipScorer {
 	return s.scorers.gossipScorer
+}
+
+// DataColumnRPCRequestScorer exposes data column RPC request scoring service.
+func (s *Service) DataColumnRPCRequestScorer() *DataColumnRPCRequestScorer {
+	return s.scorers.dataColumnRPCRequestScorer
 }
 
 // ActiveScorersCount returns number of scorers that can affect score (have non-zero weight).
@@ -121,6 +130,7 @@ func (s *Service) ScoreNoLock(pid peer.ID) float64 {
 	score += s.scorers.blockProviderScorer.scoreNoLock(pid) * s.scorerWeight(s.scorers.blockProviderScorer)
 	score += s.scorers.peerStatusScorer.scoreNoLock(pid) * s.scorerWeight(s.scorers.peerStatusScorer)
 	score += s.scorers.gossipScorer.scoreNoLock(pid) * s.scorerWeight(s.scorers.gossipScorer)
+	score += s.scorers.dataColumnRPCRequestScorer.scoreNoLock(pid) * s.scorerWeight(s.scorers.dataColumnRPCRequestScorer)
 	return math.Round(score*ScoreRoundingFactor) / ScoreRoundingFactor
 }
 
@@ -144,6 +154,9 @@ func (s *Service) IsBadPeerNoLock(pid peer.ID) error {
 	if features.Get().EnablePeerScorer {
 		if err := s.scorers.gossipScorer.isBadPeerNoLock(pid); err != nil {
 			return errors.Wrap(err, "gossip scorer")
+		}
+		if err := s.scorers.dataColumnRPCRequestScorer.isBadPeerNoLock(pid); err != nil {
+			return errors.Wrap(err, "data column RPC request scorer")
 		}
 	}
 
@@ -183,6 +196,8 @@ func (s *Service) loop(ctx context.Context) {
 	defer decayBadResponsesStats.Stop()
 	decayBlockProviderStats := time.NewTicker(s.scorers.blockProviderScorer.Params().DecayInterval)
 	defer decayBlockProviderStats.Stop()
+	decayDataColumnRPCRequestStats := time.NewTicker(s.scorers.dataColumnRPCRequestScorer.Params().DecayInterval)
+	defer decayDataColumnRPCRequestStats.Stop()
 
 	for {
 		select {
@@ -198,6 +213,12 @@ func (s *Service) loop(ctx context.Context) {
 				return
 			}
 			s.scorers.blockProviderScorer.Decay()
+		case <-decayDataColumnRPCRequestStats.C:
+			// Exit early if context is canceled.
+			if ctx.Err() != nil {
+				return
+			}
+			s.scorers.dataColumnRPCRequestScorer.Decay()
 		case <-ctx.Done():
 			return
 		}

--- a/beacon-chain/p2p/peers/scorers/service.go
+++ b/beacon-chain/p2p/peers/scorers/service.go
@@ -61,13 +61,13 @@ func NewService(ctx context.Context, store *peerdata.Store, config *Config) *Ser
 
 	// Register scorers.
 	s.scorers.badResponsesScorer = newBadResponsesScorer(store, config.BadResponsesScorerConfig)
-	s.setScorerWeight(s.scorers.badResponsesScorer, 0.25)
+	s.setScorerWeight(s.scorers.badResponsesScorer, 0.3)
 	s.scorers.blockProviderScorer = newBlockProviderScorer(store, config.BlockProviderScorerConfig)
 	s.setScorerWeight(s.scorers.blockProviderScorer, 0.0)
 	s.scorers.peerStatusScorer = newPeerStatusScorer(store, config.PeerStatusScorerConfig)
-	s.setScorerWeight(s.scorers.peerStatusScorer, 0.25)
+	s.setScorerWeight(s.scorers.peerStatusScorer, 0.3)
 	s.scorers.gossipScorer = newGossipScorer(store, config.GossipScorerConfig)
-	s.setScorerWeight(s.scorers.gossipScorer, 0.35)
+	s.setScorerWeight(s.scorers.gossipScorer, 0.4)
 	s.scorers.dataColumnRPCRequestScorer = newDataColumnRPCRequestScorer(store, config.DataColumnRPCRequestScorerConfig)
 	s.setScorerWeight(s.scorers.dataColumnRPCRequestScorer, 0.15)
 

--- a/beacon-chain/p2p/peers/scorers/service_test.go
+++ b/beacon-chain/p2p/peers/scorers/service_test.go
@@ -219,8 +219,16 @@ func TestScorers_Service_Score(t *testing.T) {
 
 		// Record some requests
 		pid := peer.ID("peer1")
-		s1.RecordRequest(pid, 10)
-		expectedScore := -10.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor * 0.15
+		currentSlot := uint64(100)
+		recentColumnSlot := uint64(90) // Within MaxGossipAgeSlots (default 16)
+		oldColumnSlot := uint64(50)    // Older than MaxGossipAgeSlots
+		// Record a request for a recent column (should be penalized)
+		s1.RecordRequest(pid, currentSlot, recentColumnSlot)
+		// Record a request for an old column (should NOT be penalized)
+		s1.RecordRequest(pid, currentSlot, oldColumnSlot)
+
+		// Only the recent column request should count towards the score.
+		expectedScore := -1.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor * 0.15
 		expectedScore = math.Round(expectedScore*scorers.ScoreRoundingFactor) / scorers.ScoreRoundingFactor
 		assert.Equal(t, roundScore(expectedScore), s.Score(pid), "Wrong weighted score")
 
@@ -232,8 +240,8 @@ func TestScorers_Service_Score(t *testing.T) {
 		require.LessOrEqual(t, decayedScore, float64(0), "Score should not become positive after decay")
 
 		// Test bad peer detection
-		for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10)+1; i++ {
-			s1.RecordRequest(pid, 10)
+		for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold); i++ {
+			s1.RecordRequest(pid, currentSlot, recentColumnSlot) // Record enough recent requests
 		}
 		require.NotNil(t, s.IsBadPeer(pid), "Peer should be marked as bad")
 		require.Contains(t, s.BadPeers(), pid, "Bad peer should be in service's bad peers list")

--- a/beacon-chain/p2p/peers/scorers/service_test.go
+++ b/beacon-chain/p2p/peers/scorers/service_test.go
@@ -2,6 +2,7 @@ package scorers_test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/testing/assert"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScorers_Service_Init(t *testing.T) {
@@ -209,6 +211,32 @@ func TestScorers_Service_Score(t *testing.T) {
 		// If peer continues to misbehave, score becomes negative.
 		s2.Increment("peer1")
 		assert.Equal(t, roundScore(3*penalty), s.Score("peer1"), "Unexpected overall score")
+	})
+
+	t.Run("data column RPC request score", func(t *testing.T) {
+		s, _ := setupScorer()
+		s1 := s.DataColumnRPCRequestScorer()
+
+		// Record some requests
+		pid := peer.ID("peer1")
+		s1.RecordRequest(pid, 10)
+		expectedScore := -10.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor * 0.15
+		expectedScore = math.Round(expectedScore*scorers.ScoreRoundingFactor) / scorers.ScoreRoundingFactor
+		assert.Equal(t, roundScore(expectedScore), s.Score(pid), "Wrong weighted score")
+
+		// Test decay
+		initialScore := s.Score(pid)
+		s1.Decay()
+		decayedScore := s.Score(pid)
+		require.Greater(t, decayedScore, initialScore, "Score should increase after decay")
+		require.LessOrEqual(t, decayedScore, float64(0), "Score should not become positive after decay")
+
+		// Test bad peer detection
+		for i := 0; i < int(scorers.DefaultDataColumnRPCRequestThreshold/10)+1; i++ {
+			s1.RecordRequest(pid, 10)
+		}
+		require.NotNil(t, s.IsBadPeer(pid), "Peer should be marked as bad")
+		require.Contains(t, s.BadPeers(), pid, "Bad peer should be in service's bad peers list")
 	})
 }
 

--- a/beacon-chain/p2p/peers/scorers/service_test.go
+++ b/beacon-chain/p2p/peers/scorers/service_test.go
@@ -15,6 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	// Define scorer weights as used in service.go
+	badResponsesScorerWeight         = 0.3
+	blockProviderScorerWeight        = 0.0 // Note: This scorer's weight is 0 in the default config used by setupScorer.
+	peerStatusScorerWeight           = 0.3
+	gossipScorerWeight               = 0.4
+	dataColumnRPCRequestScorerWeight = 0.15
+
+	// Calculate total weight
+	totalWeight = badResponsesScorerWeight + peerStatusScorerWeight + gossipScorerWeight + dataColumnRPCRequestScorerWeight
+
+	// Calculate relative weights
+	badResponsesRelativeWeight         = badResponsesScorerWeight / totalWeight
+	dataColumnRPCRequestRelativeWeight = dataColumnRPCRequestScorerWeight / totalWeight
+)
+
 func TestScorers_Service_Init(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -145,7 +161,10 @@ func TestScorers_Service_Score(t *testing.T) {
 		s, pids := setupScorer()
 		// Peers start with boosted start score (new peers are boosted by block provider).
 		startScore := float64(0)
-		penalty := (-10 / float64(s.BadResponsesScorer().Params().Threshold)) * 0.3
+		// Calculate the raw penalty without weighting.
+		rawPenalty := -10 / float64(s.BadResponsesScorer().Params().Threshold)
+		// Apply the scorer's relative weight to the penalty.
+		penalty := rawPenalty * badResponsesRelativeWeight
 
 		// Update peers' stats and test the effect on peer order.
 		s.BadResponsesScorer().Increment("peer2")
@@ -199,7 +218,10 @@ func TestScorers_Service_Score(t *testing.T) {
 		s, _ := setupScorer()
 		s1 := s.BlockProviderScorer()
 		s2 := s.BadResponsesScorer()
-		penalty := (-10 / float64(s.BadResponsesScorer().Params().Threshold)) * 0.3
+		// Calculate the raw penalty without weighting.
+		rawPenalty := -10 / float64(s.BadResponsesScorer().Params().Threshold)
+		// Apply the scorer's relative weight to the penalty.
+		penalty := rawPenalty * badResponsesRelativeWeight
 
 		// Full score, no penalty.
 		s1.IncrementProcessedBlocks("peer1", batchSize*5)
@@ -228,7 +250,10 @@ func TestScorers_Service_Score(t *testing.T) {
 		s1.RecordRequest(pid, currentSlot, oldColumnSlot)
 
 		// Only the recent column request should count towards the score.
-		expectedScore := -1.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor * 0.15
+		// Calculate the raw penalty.
+		rawPenalty := -1.0 * scorers.DefaultDataColumnRPCRequestPenaltyFactor
+		// Apply the scorer's relative weight to the penalty.
+		expectedScore := rawPenalty * dataColumnRPCRequestRelativeWeight
 		expectedScore = math.Round(expectedScore*scorers.ScoreRoundingFactor) / scorers.ScoreRoundingFactor
 		assert.Equal(t, roundScore(expectedScore), s.Score(pid), "Wrong weighted score")
 

--- a/beacon-chain/p2p/peers/scorers/service_test.go
+++ b/beacon-chain/p2p/peers/scorers/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/scorers"
 	"github.com/OffchainLabs/prysm/v6/cmd/beacon-chain/flags"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/testing/assert"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -241,9 +242,9 @@ func TestScorers_Service_Score(t *testing.T) {
 
 		// Record some requests
 		pid := peer.ID("peer1")
-		currentSlot := uint64(100)
-		recentColumnSlot := uint64(90) // Within MaxGossipAgeSlots (default 16)
-		oldColumnSlot := uint64(50)    // Older than MaxGossipAgeSlots
+		currentSlot := primitives.Slot(100)
+		recentColumnSlot := primitives.Slot(90) // Within MaxGossipAgeSlots (default 16)
+		oldColumnSlot := primitives.Slot(50)    // Older than MaxGossipAgeSlots
 		// Record a request for a recent column (should be penalized)
 		s1.RecordRequest(pid, currentSlot, recentColumnSlot)
 		// Record a request for an old column (should NOT be penalized)

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
@@ -111,6 +111,18 @@ func (s *Service) dataColumnSidecarsByRangeRPCHandler(ctx context.Context, msg i
 		return err
 	}
 
+	// Record the request with the DataColumnRPCRequestScorer
+	if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
+		totalColumns := int(r.Count) * len(r.Columns)
+		scorer.RecordRequest(stream.Conn().RemotePeer(), totalColumns)
+		log.WithFields(logrus.Fields{
+			"peer":           stream.Conn().RemotePeer(),
+			"requestedCount": totalColumns,
+			"rangeCount":     r.Count,
+			"columnCount":    len(r.Columns),
+		}).Debug("Recorded data column RPC request")
+	}
+
 	// Ticker to stagger out large requests.
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
@@ -43,7 +43,7 @@ func (s *Service) streamDataColumnBatch(ctx context.Context, batch blockBatch, w
 		for _, verifiedRODataColumn := range verifiedRODataColumns {
 			// Record the request for scoring if the column is recent enough.
 			if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
-				scorer.RecordRequest(stream.Conn().RemotePeer(), uint64(currentSlot), uint64(verifiedRODataColumn.SignedBlockHeader.Header.Slot))
+				scorer.RecordRequest(stream.Conn().RemotePeer(), currentSlot, verifiedRODataColumn.SignedBlockHeader.Header.Slot)
 			}
 
 			SetStreamWriteDeadline(stream, defaultWriteDuration)

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
@@ -28,6 +28,8 @@ func (s *Service) streamDataColumnBatch(ctx context.Context, batch blockBatch, w
 		return 0, nil
 	}
 
+	currentSlot := s.cfg.chain.CurrentSlot()
+
 	for _, block := range batch.canonical() {
 		// Get the block blockRoot.
 		blockRoot := block.Root()
@@ -39,6 +41,11 @@ func (s *Service) streamDataColumnBatch(ctx context.Context, batch blockBatch, w
 		}
 
 		for _, verifiedRODataColumn := range verifiedRODataColumns {
+			// Record the request for scoring if the column is recent enough.
+			if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
+				scorer.RecordRequest(stream.Conn().RemotePeer(), uint64(currentSlot), uint64(verifiedRODataColumn.SignedBlockHeader.Header.Slot))
+			}
+
 			SetStreamWriteDeadline(stream, defaultWriteDuration)
 			if chunkErr := WriteDataColumnSidecarChunk(stream, s.cfg.chain, s.cfg.p2p.Encoding(), verifiedRODataColumn.DataColumnSidecar); chunkErr != nil {
 				log.WithError(chunkErr).Debug("Could not send a chunked response")
@@ -109,18 +116,6 @@ func (s *Service) dataColumnSidecarsByRangeRPCHandler(ctx context.Context, msg i
 		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
 		tracing.AnnotateError(span, err)
 		return err
-	}
-
-	// Record the request with the DataColumnRPCRequestScorer
-	if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
-		totalColumns := int(r.Count) * len(r.Columns)
-		scorer.RecordRequest(stream.Conn().RemotePeer(), totalColumns)
-		log.WithFields(logrus.Fields{
-			"peer":           stream.Conn().RemotePeer(),
-			"requestedCount": totalColumns,
-			"rangeCount":     r.Count,
-			"columnCount":    len(r.Columns),
-		}).Debug("Recorded data column RPC request")
 	}
 
 	// Ticker to stagger out large requests.

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -143,7 +143,7 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 
 			// Record the request for scoring if the column is recent enough.
 			if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
-				scorer.RecordRequest(stream.Conn().RemotePeer(), uint64(cs), uint64(verifiedRODataColumn.SignedBlockHeader.Header.Slot))
+				scorer.RecordRequest(stream.Conn().RemotePeer(), cs, verifiedRODataColumn.SignedBlockHeader.Header.Slot)
 			}
 
 			SetStreamWriteDeadline(stream, defaultWriteDuration)

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -57,6 +57,15 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		return errors.Wrap(err, "validate data columns by root request")
 	}
 
+	// Record the request with the DataColumnRPCRequestScorer
+	if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
+		scorer.RecordRequest(stream.Conn().RemotePeer(), int(len(requestedColumnIdents)))
+		log.WithFields(logrus.Fields{
+			"peer":           stream.Conn().RemotePeer(),
+			"requestedCount": len(requestedColumnIdents),
+		}).Debug("Recorded data column RPC request")
+	}
+
 	// Sort the identifiers so that requests for the same data columns root will be adjacent, minimizing db lookups.
 	sort.Sort(&requestedColumnIdents)
 

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -57,15 +57,6 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		return errors.Wrap(err, "validate data columns by root request")
 	}
 
-	// Record the request with the DataColumnRPCRequestScorer
-	if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
-		scorer.RecordRequest(stream.Conn().RemotePeer(), int(len(requestedColumnIdents)))
-		log.WithFields(logrus.Fields{
-			"peer":           stream.Conn().RemotePeer(),
-			"requestedCount": len(requestedColumnIdents),
-		}).Debug("Recorded data column RPC request")
-	}
-
 	// Sort the identifiers so that requests for the same data columns root will be adjacent, minimizing db lookups.
 	sort.Sort(&requestedColumnIdents)
 
@@ -148,6 +139,11 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 		for _, verifiedRODataColumn := range verifiedRODataColumns {
 			if verifiedRODataColumn.SignedBlockHeader.Header.Slot < minReqSlot {
 				continue
+			}
+
+			// Record the request for scoring if the column is recent enough.
+			if scorer := s.cfg.p2p.Peers().Scorers().DataColumnRPCRequestScorer(); scorer != nil {
+				scorer.RecordRequest(stream.Conn().RemotePeer(), uint64(cs), uint64(verifiedRODataColumn.SignedBlockHeader.Header.Slot))
 			}
 
 			SetStreamWriteDeadline(stream, defaultWriteDuration)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**
Downscores peers that request too many data columns via RPC to manage upload bandwidth for nodes.

**Which issues(s) does this PR fix?**
Part of #14129.

**Other notes for review**

**Acknowledgements**

- [X] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [X] I have added a description to this PR with sufficient context for reviewers to understand this PR.
