### PR TITLE
Fix Unmarshalling of BlobSidecarsByRoot Requests

### DIFF
--- a/beacon-chain/p2p/types/types.go
+++ b/beacon-chain/p2p/types/types.go
@@ -162,9 +162,9 @@ func (b *BlobSidecarsByRootReq) MarshalSSZ() ([]byte, error) {
 // BlobSidecarsByRootReq value.
 func (b *BlobSidecarsByRootReq) UnmarshalSSZ(buf []byte) error {
 	bufLen := len(buf)
-	maxLength := int(params.BeaconConfig().MaxRequestBlobSidecars) * blobIdSize
+	maxLength := int(params.BeaconConfig().MaxRequestBlobSidecarsElectra) * blobIdSize
 	if bufLen > maxLength {
-		return errors.Errorf("expected buffer with length of up to %d but received length %d", maxLength, bufLen)
+		return errors.Wrapf(ssz.ErrIncorrectListSize, "expected buffer with length of up to %d but received length %d", maxLength, bufLen)
 	}
 	if bufLen%blobIdSize != 0 {
 		return errors.Wrapf(ssz.ErrIncorrectByteSize, "size=%d", bufLen)

--- a/beacon-chain/p2p/types/types_test.go
+++ b/beacon-chain/p2p/types/types_test.go
@@ -44,6 +44,15 @@ func TestBlobSidecarsByRootReq_MarshalSSZ(t *testing.T) {
 			ids:  generateBlobIdentifiers(10),
 		},
 		{
+			name: "max list",
+			ids:  generateBlobIdentifiers(int(params.BeaconConfig().MaxRequestBlobSidecarsElectra)),
+		},
+		{
+			name:         "beyond max list",
+			ids:          generateBlobIdentifiers(int(params.BeaconConfig().MaxRequestBlobSidecarsElectra) + 1),
+			unmarshalErr: ssz.ErrIncorrectListSize,
+		},
+		{
 			name: "wonky unmarshal size",
 			ids:  generateBlobIdentifiers(10),
 			unmarshalMod: func(in []byte) []byte {

--- a/changelog/nisdas_fix_p2p_req_ssz.md
+++ b/changelog/nisdas_fix_p2p_req_ssz.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixes our blob sidecar by root request lists for electra.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Our unmarshalling method would reject a valid electra `BlobSidecarsByRoot` request since we use a deneb
specific parameter here. This fixes it and adds in a test.


**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
