### PR TITLE
Fix deadlines

### DIFF
--- a/changelog/potuz_vc_deadlines.md
+++ b/changelog/potuz_vc_deadlines.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed deadlines in update duties.

--- a/testing/endtoend/evaluators/fee_recipient.go
+++ b/testing/endtoend/evaluators/fee_recipient.go
@@ -72,6 +72,9 @@ func feeRecipientIsPresent(_ *types.EvaluationContext, conns ...*grpc.ClientConn
 	if err != nil {
 		return errors.Wrap(err, "failed to get chain head")
 	}
+	if chainHead.HeadEpoch == 0 {
+		return nil
+	}
 	req := &ethpb.ListBlocksRequest{QueryFilter: &ethpb.ListBlocksRequest_Epoch{Epoch: chainHead.HeadEpoch.Sub(1)}}
 	blks, err := client.ListBeaconBlocks(context.Background(), req)
 	if err != nil {

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -25,6 +25,9 @@ import (
 // Time to wait before trying to reconnect with beacon node.
 var backOffPeriod = 10 * time.Second
 
+// dutiesDeadline is the deadline we give to update duties
+const dutiesDeadline = primitives.Slot(5)
+
 // Run the main validator routine. This routine exits if the context is
 // canceled.
 //
@@ -43,7 +46,10 @@ func run(ctx context.Context, v iface.Validator) {
 	if err != nil {
 		return // Exit if context is canceled.
 	}
-	if err := v.UpdateDuties(ctx, headSlot); err != nil {
+	deadline := v.SlotDeadline(headSlot + dutiesDeadline)
+	dutiesCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	if err := v.UpdateDuties(dutiesCtx, headSlot); err != nil {
 		handleAssignmentError(err, headSlot)
 	}
 	eventsChan := make(chan *event.Event, 1)
@@ -77,7 +83,7 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 
-			deadline := v.SlotDeadline(slot)
+			deadline := v.SlotDeadline(slot + dutiesDeadline)
 			slotCtx, cancel := context.WithDeadline(ctx, deadline)
 
 			var span trace.Span
@@ -91,8 +97,8 @@ func run(ctx context.Context, v iface.Validator) {
 			// epoch transition in the beacon node's state.
 			if err := v.UpdateDuties(slotCtx, slot); err != nil {
 				handleAssignmentError(err, slot)
-				cancel()
 				span.End()
+				cancel()
 				continue
 			}
 
@@ -113,11 +119,13 @@ func run(ctx context.Context, v iface.Validator) {
 			allRoles, err := v.RolesAt(slotCtx, slot)
 			if err != nil {
 				log.WithError(err).Error("Could not get validator roles")
-				cancel()
 				span.End()
+				cancel()
 				continue
 			}
 			performRoles(slotCtx, allRoles, v, slot, &wg, span)
+			span.End()
+			cancel()
 		case isHealthyAgain := <-healthTracker.HealthUpdates():
 			if isHealthyAgain {
 				headSlot, err = initializeValidatorAndGetHeadSlot(ctx, v)
@@ -125,10 +133,13 @@ func run(ctx context.Context, v iface.Validator) {
 					log.WithError(err).Error("Failed to re initialize validator and get head slot")
 					continue
 				}
-				if err := v.UpdateDuties(ctx, headSlot); err != nil {
+				dutiesCtx, cancel := context.WithDeadline(ctx, v.SlotDeadline(headSlot+dutiesDeadline))
+				if err := v.UpdateDuties(dutiesCtx, headSlot); err != nil {
 					handleAssignmentError(err, headSlot)
+					cancel()
 					continue
 				}
+				cancel()
 			}
 		case e := <-eventsChan:
 			v.ProcessEvent(ctx, e)

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -84,10 +84,10 @@ func run(ctx context.Context, v iface.Validator) {
 			}
 
 			deadline := v.SlotDeadline(slot + dutiesDeadline)
-			slotCtx, cancel := context.WithDeadline(ctx, deadline)
+			dutiesCtx, cancel := context.WithDeadline(ctx, deadline)
 
 			var span trace.Span
-			slotCtx, span = prysmTrace.StartSpan(slotCtx, "validator.processSlot")
+			dutiesCtx, span = prysmTrace.StartSpan(dutiesCtx, "validator.processSlot.updateDuties")
 			span.SetAttributes(prysmTrace.Int64Attribute("slot", int64(slot))) // lint:ignore uintcast -- This conversion is OK for tracing.
 
 			log := log.WithField("slot", slot)
@@ -95,12 +95,19 @@ func run(ctx context.Context, v iface.Validator) {
 
 			// Keep trying to update assignments if they are nil or if we are past an
 			// epoch transition in the beacon node's state.
-			if err := v.UpdateDuties(slotCtx, slot); err != nil {
+			if err := v.UpdateDuties(dutiesCtx, slot); err != nil {
 				handleAssignmentError(err, slot)
 				span.End()
 				cancel()
 				continue
 			}
+			span.End()
+			cancel()
+
+			deadline = v.SlotDeadline(slot)
+			slotCtx, cancel := context.WithDeadline(ctx, deadline)
+			slotCtx, span = prysmTrace.StartSpan(slotCtx, "validator.processSlot.performRoles")
+			span.SetAttributes(prysmTrace.Int64Attribute("slot", int64(slot))) // lint:ignore uintcast -- This conversion is OK for tracing.
 
 			// call push proposer settings often to account for the following edge cases:
 			// proposer is activated at the start of epoch and tries to propose immediately

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -90,9 +90,6 @@ func run(ctx context.Context, v iface.Validator) {
 			dutiesCtx, span = prysmTrace.StartSpan(dutiesCtx, "validator.processSlot.updateDuties")
 			span.SetAttributes(prysmTrace.Int64Attribute("slot", int64(slot))) // lint:ignore uintcast -- This conversion is OK for tracing.
 
-			log := log.WithField("slot", slot)
-			log.WithField("deadline", deadline).Debug("Set deadline for proposals and attestations")
-
 			// Keep trying to update assignments if they are nil or if we are past an
 			// epoch transition in the beacon node's state.
 			if err := v.UpdateDuties(dutiesCtx, slot); err != nil {
@@ -108,6 +105,8 @@ func run(ctx context.Context, v iface.Validator) {
 			slotCtx, cancel := context.WithDeadline(ctx, deadline)
 			slotCtx, span = prysmTrace.StartSpan(slotCtx, "validator.processSlot.performRoles")
 			span.SetAttributes(prysmTrace.Int64Attribute("slot", int64(slot))) // lint:ignore uintcast -- This conversion is OK for tracing.
+			log := log.WithField("slot", slot)
+			log.WithField("deadline", deadline).Debug("Set deadline for proposals and attestations")
 
 			// call push proposer settings often to account for the following edge cases:
 			// proposer is activated at the start of epoch and tries to propose immediately

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -25,9 +25,6 @@ import (
 // Time to wait before trying to reconnect with beacon node.
 var backOffPeriod = 10 * time.Second
 
-// dutiesDeadline is the deadline we give to update duties
-const dutiesDeadline = primitives.Slot(5)
-
 // Run the main validator routine. This routine exits if the context is
 // canceled.
 //
@@ -46,7 +43,12 @@ func run(ctx context.Context, v iface.Validator) {
 	if err != nil {
 		return // Exit if context is canceled.
 	}
-	deadline := v.SlotDeadline(headSlot + dutiesDeadline)
+	endEpoch, err := slots.EpochEnd(slots.ToEpoch(headSlot))
+	if err != nil {
+		log.WithError(err).Error("Could not get current epoch")
+		return
+	}
+	deadline := v.SlotDeadline(endEpoch)
 	dutiesCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 	if err := v.UpdateDuties(dutiesCtx, headSlot); err != nil {
@@ -83,7 +85,12 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 
-			deadline := v.SlotDeadline(slot + dutiesDeadline)
+			endEpoch, err := slots.EpochEnd(slots.ToEpoch(slot))
+			if err != nil {
+				log.WithError(err).Error("Could not get current epoch")
+				continue
+			}
+			deadline := v.SlotDeadline(endEpoch)
 			dutiesCtx, cancel := context.WithDeadline(ctx, deadline)
 
 			var span trace.Span
@@ -139,7 +146,12 @@ func run(ctx context.Context, v iface.Validator) {
 					log.WithError(err).Error("Failed to re initialize validator and get head slot")
 					continue
 				}
-				dutiesCtx, cancel := context.WithDeadline(ctx, v.SlotDeadline(headSlot+dutiesDeadline))
+				endEpoch, err := slots.EpochEnd(slots.ToEpoch(headSlot))
+				if err != nil {
+					log.WithError(err).Error("Could not get current epoch")
+					continue
+				}
+				dutiesCtx, cancel := context.WithDeadline(ctx, v.SlotDeadline(endEpoch))
 				if err := v.UpdateDuties(dutiesCtx, headSlot); err != nil {
 					handleAssignmentError(err, headSlot)
 					cancel()

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -511,27 +511,11 @@ func retrieveLatestRecord(recs []*dbCommon.AttestationRecord) *dbCommon.Attestat
 	return chosenRec
 }
 
-// UpdateDuties checks the slot number to determine if the validator's
-// list of upcoming assignments needs to be updated. For example, at the
-// beginning of a new epoch.
-func (v *validator) UpdateDuties(ctx context.Context, slot primitives.Slot) error {
-	if !slots.IsEpochStart(slot) && v.duties != nil {
-		// Do nothing if not epoch start AND assignments already exist.
-		return nil
-	}
-	// Set deadline to end of epoch.
-	ss, err := slots.EpochStart(slots.ToEpoch(slot) + 1)
-	if err != nil {
-		return err
-	}
-	ctx, cancel := context.WithDeadline(ctx, v.SlotDeadline(ss))
-	defer cancel()
-	ctx, span := trace.StartSpan(ctx, "validator.UpdateDuties")
-	defer span.End()
-
+// getFilteredKeys returns the list of keys that are not slashable.
+func (v *validator) getFilteredKeys(ctx context.Context) ([][fieldparams.BLSPubkeyLength]byte, error) {
 	validatingKeys, err := v.km.FetchValidatingPublicKeys(ctx)
 	if err != nil {
-		return err
+		return nil, errors.Wrap(err, "could not fetch validating public keys")
 	}
 
 	// Filter out the slashable public keys from the duties request.
@@ -548,6 +532,23 @@ func (v *validator) UpdateDuties(ctx context.Context, slot primitives.Slot) erro
 		}
 	}
 	v.blacklistedPubkeysLock.RUnlock()
+	return filteredKeys, nil
+}
+
+// UpdateDuties checks the slot number to determine if the validator's
+// list of upcoming assignments needs to be updated. For example, at the
+// beginning of a new epoch.
+func (v *validator) UpdateDuties(ctx context.Context, slot primitives.Slot) error {
+	if !slots.IsEpochStart(slot) && v.duties != nil {
+		// Do nothing if not epoch start AND assignments already exist.
+		return nil
+	}
+	ctx, span := trace.StartSpan(ctx, "validator.UpdateDuties")
+	defer span.End()
+	filteredKeys, err := v.getFilteredKeys(ctx)
+	if err != nil {
+		return errors.Wrap(err, "could not get filtered keys")
+	}
 
 	req := &ethpb.DutiesRequest{
 		Epoch:      primitives.Epoch(slot / params.BeaconConfig().SlotsPerEpoch),
@@ -1148,21 +1149,17 @@ func (v *validator) checkDependentRoots(ctx context.Context, head *structs.HeadE
 	if err != nil {
 		return errors.Wrap(err, "failed to decode previous duty dependent root")
 	}
-	uintSlot, err := strconv.ParseUint(head.Slot, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "Failed to parse slot")
-	}
-
-	slot := primitives.Slot(uintSlot)
+	slot := slots.CurrentSlot(v.genesisTime)
 	currEpochStart, err := slots.EpochStart(slots.ToEpoch(slot))
 	if err != nil {
 		return err
 	}
-	deadline := v.SlotDeadline(slot)
-	slotCtx, cancel := context.WithDeadline(ctx, deadline)
+	// set deadline for next epoch instead of dutiesDeadline
+	deadline := v.SlotDeadline(currEpochStart + params.BeaconConfig().SlotsPerEpoch)
+	dutiesCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 	if !bytes.Equal(prevDepedentRoot, v.duties.PrevDependentRoot) {
-		if err := v.UpdateDuties(slotCtx, currEpochStart); err != nil {
+		if err := v.UpdateDuties(dutiesCtx, currEpochStart); err != nil {
 			return errors.Wrap(err, "failed to update duties")
 		}
 		log.Info("Updated duties due to previous dependent root change")
@@ -1173,7 +1170,7 @@ func (v *validator) checkDependentRoots(ctx context.Context, head *structs.HeadE
 		return errors.Wrap(err, "failed to decode current duty dependent root")
 	}
 	if !bytes.Equal(currDepedentRoot, v.duties.CurrDependentRoot) {
-		if err := v.UpdateDuties(slotCtx, currEpochStart); err != nil {
+		if err := v.UpdateDuties(dutiesCtx, currEpochStart); err != nil {
 			return errors.Wrap(err, "failed to update duties")
 		}
 		log.Info("Updated duties due to current dependent root change")


### PR DESCRIPTION
h/t @james-prysm for finding out there was something wrong with the update duties deadlines. 

This PR moves the deadline from `UpdateDuties`  to the caller. We call with different deadlines at different places. 

It also fixes and passes the right context to this function and ends the spans correctly
