### PR TITLE
Add column sidecar inclusion proof cache

### DIFF
--- a/beacon-chain/sync/data_columns_test.go
+++ b/beacon-chain/sync/data_columns_test.go
@@ -585,7 +585,11 @@ func TestRequestDataColumnSidecarsByRoot(t *testing.T) {
 
 			ctxMap := map[[4]byte]int{{245, 165, 253, 66}: version.Fulu}
 			verifier := func(cols []blocks.RODataColumn, reqs []verification.Requirement) verification.DataColumnsVerifier {
-				initializer := &verification.Initializer{}
+				clockSync := startup.NewClockSynchronizer()
+				require.NoError(t, clockSync.SetClock(clock))
+				w := verification.NewInitializerWaiter(clockSync, nil, nil)
+				initializer, err := w.WaitForInitializer(context.Background())
+				require.NoError(t, err)
 				return initializer.NewDataColumnsVerifier(cols, reqs)
 			}
 

--- a/beacon-chain/verification/cache.go
+++ b/beacon-chain/verification/cache.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	DefaultSignatureCacheSize = 256
+	DefaultSignatureCacheSize      = 256
+	DefaultInclusionProofCacheSize = 2
 )
 
 // ValidatorAtIndexer defines the method needed to retrieve a validator by its index.
@@ -71,6 +72,14 @@ type sigCache struct {
 	*lru.Cache
 	valRoot []byte
 	getFork forkLookup
+}
+
+type inclusionProofCache struct {
+	*lru.Cache
+}
+
+func newInclusionProofCache(size int) *inclusionProofCache {
+	return &inclusionProofCache{Cache: lruwrpr.New(size)}
 }
 
 // VerifySignature verifies the given signature data against the key obtained via ValidatorAtIndexer.

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -1,7 +1,9 @@
 package verification
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"time"
@@ -372,8 +374,21 @@ func (dv *RODataColumnsVerifier) SidecarInclusionProven() (err error) {
 	startTime := time.Now()
 
 	for _, dataColumn := range dv.dataColumns {
+		k, keyErr := inclusionProofKey(dataColumn)
+		if keyErr == nil {
+			if _, ok := dv.ic.Get(k); ok {
+				continue
+			}
+		} else {
+			log.WithError(keyErr).Error("Failed to get inclusion proof key")
+		}
+
 		if err = peerdas.VerifyDataColumnSidecarInclusionProof(dataColumn); err != nil {
 			return columnErrBuilder(ErrSidecarInclusionProofInvalid)
+		}
+
+		if keyErr == nil {
+			dv.ic.Add(k, struct{}{})
 		}
 	}
 
@@ -468,4 +483,24 @@ func columnToSignatureData(d blocks.RODataColumn) SignatureData {
 
 func columnErrBuilder(baseErr error) error {
 	return errors.Wrap(baseErr, errColumnsInvalid.Error())
+}
+
+func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
+	var buf bytes.Buffer
+
+	r, err := c.SignedBlockHeader.HashTreeRoot()
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash tree root")
+	}
+	buf.Write(r[:])
+
+	for _, proof := range c.KzgCommitmentsInclusionProof {
+		buf.Write(proof)
+	}
+
+	for _, commitment := range c.KzgCommitments {
+		buf.Write(commitment)
+	}
+
+	return sha256.Sum256(buf.Bytes()), nil
 }

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -699,7 +699,9 @@ func TestDataColumnsSidecarInclusionProven(t *testing.T) {
 				firstColumn.SignedBlockHeader.Header.BodyRoot[0] = byte0 ^ 255
 			}
 
-			initializer := Initializer{}
+			initializer := Initializer{
+				shared: &sharedResources{ic: newInclusionProofCache(1)},
+			}
 			verifier := initializer.NewDataColumnsVerifier(columns, GossipDataColumnSidecarRequirements)
 			err := verifier.SidecarInclusionProven()
 			require.Equal(t, true, verifier.results.executed(RequireSidecarInclusionProven))

--- a/beacon-chain/verification/initializer.go
+++ b/beacon-chain/verification/initializer.go
@@ -39,6 +39,7 @@ type sharedResources struct {
 	sc    SignatureCache
 	pc    ProposerCache
 	sr    StateByRooter
+	ic    *inclusionProofCache
 }
 
 // Initializer is used to create different Verifiers.
@@ -97,6 +98,7 @@ func NewInitializerWaiter(cw startup.ClockWaiter, fc Forkchoicer, sr StateByRoot
 		fc: fc,
 		pc: pc,
 		sr: sr,
+		ic: newInclusionProofCache(DefaultInclusionProofCacheSize),
 	}
 	iw := &InitializerWaiter{cw: cw, ini: &Initializer{shared: shared}}
 	for _, o := range opts {
@@ -118,6 +120,7 @@ func (w *InitializerWaiter) WaitForInitializer(ctx context.Context) (*Initialize
 	vr := w.ini.shared.clock.GenesisValidatorsRoot()
 	sc := newSigCache(vr[:], DefaultSignatureCacheSize, w.getFork)
 	w.ini.shared.sc = sc
+	w.ini.shared.ic = newInclusionProofCache(DefaultInclusionProofCacheSize)
 	return w.ini, nil
 }
 


### PR DESCRIPTION
### Summary
This PR introduces an `InclusionProofCache` to improve performance when verifying sidecar inclusion proofs. By caching the inclusion proof computation, we reduce redundant work

### Key Changes

- **New cache**: Added `InclusionProofCache` backed by `lru.Cache` to store computed inclusion proof keys.
- **Initializer**: Extended the shared `Initializer` to support inclusion proof caching.
- **Usage**:
  - `SidecarInclusionProven()` now attempts to use cached keys before computing them.
  - Fails gracefully on key generation errors and continues verification instead of aborting early.
- **Key generation**: `inclusionProofKey()` generates a hash-based inclusion proof key from a data column.