### PR TITLE
Fix deadlines

### DIFF
--- a/changelog/potuz_pass_parent_context.md
+++ b/changelog/potuz_pass_parent_context.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Pass parent context to update duties when dependent roots change

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -91,8 +91,8 @@ func run(ctx context.Context, v iface.Validator) {
 			// epoch transition in the beacon node's state.
 			if err := v.UpdateDuties(slotCtx, slot); err != nil {
 				handleAssignmentError(err, slot)
-				cancel()
 				span.End()
+				cancel()
 				continue
 			}
 
@@ -113,8 +113,8 @@ func run(ctx context.Context, v iface.Validator) {
 			allRoles, err := v.RolesAt(slotCtx, slot)
 			if err != nil {
 				log.WithError(err).Error("Could not get validator roles")
-				cancel()
 				span.End()
+				cancel()
 				continue
 			}
 			performRoles(slotCtx, allRoles, v, slot, &wg, span)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1158,11 +1158,8 @@ func (v *validator) checkDependentRoots(ctx context.Context, head *structs.HeadE
 	if err != nil {
 		return err
 	}
-	deadline := v.SlotDeadline(slot)
-	slotCtx, cancel := context.WithDeadline(ctx, deadline)
-	defer cancel()
 	if !bytes.Equal(prevDepedentRoot, v.duties.PrevDependentRoot) {
-		if err := v.UpdateDuties(slotCtx, currEpochStart); err != nil {
+		if err := v.UpdateDuties(ctx, currEpochStart); err != nil {
 			return errors.Wrap(err, "failed to update duties")
 		}
 		log.Info("Updated duties due to previous dependent root change")
@@ -1173,7 +1170,7 @@ func (v *validator) checkDependentRoots(ctx context.Context, head *structs.HeadE
 		return errors.Wrap(err, "failed to decode current duty dependent root")
 	}
 	if !bytes.Equal(currDepedentRoot, v.duties.CurrDependentRoot) {
-		if err := v.UpdateDuties(slotCtx, currEpochStart); err != nil {
+		if err := v.UpdateDuties(ctx, currEpochStart); err != nil {
 			return errors.Wrap(err, "failed to update duties")
 		}
 		log.Info("Updated duties due to current dependent root change")

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -520,7 +520,7 @@ func (v *validator) UpdateDuties(ctx context.Context, slot primitives.Slot) erro
 		return nil
 	}
 	// Set deadline to end of epoch.
-	ss, err := slots.EpochStart(slots.ToEpoch(slot) + 1)
+	ss, err := slots.EpochStart(primitives.Epoch(slots.CurrentSlot(v.genesisTime) + 1))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
h/t @james-prysm for finding out there was something wrong with the update duties deadlines.

This PR passes the parent context instead of a slot context when the dependent roots change

It also fixes and passes the right context to this function and ends the spans correctly
