### PR TITLE
Fix payload attribute proposer calculation (Option 1)

### DIFF
--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -711,7 +711,7 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 			return ev, errors.Wrap(err, "could not get head state")
 		}
 		// double check that we need to process_slots, just in case we got here via a hot state cache miss.
-		if slots.ToEpoch(st.Slot()) == pse {
+		if slots.ToEpoch(st.Slot()) < pse {
 			start, err := slots.EpochStart(pse)
 			if err != nil {
 				return ev, errors.Wrap(err, "invalid state slot; could not compute epoch start")

--- a/changelog/tt_ramen.md
+++ b/changelog/tt_ramen.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Process slots across epoch for payload attribute event.


### PR DESCRIPTION
Previously, we only advanced the head state if its epoch exactly matched the proposal slot's epoch. I think that is an incorrect assumption, if the head state is near the end of an epoch and the proposal slot is in the next epoch, we need to process slot up to next epoch. This PR fixes the check to correctly process the state if it is *before* the target epoch.

For example, we saw the following log:
```
1. Finished applying state transition attestations=66 payloadHash=0xc0717b70f042 slot=11578015 syncBitsCount=509 txCount=70`

2. `error=Could not fill event data: failed to compute proposer index: slot 11578015 out of bounds
```

This happened because slot `11578015` is the 31st slot of an epoch, and the proposal slot is `11578015`, but the state was not properly processed forward