### PR TITLE
extend payload attribute deadline to proposal slot

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -184,7 +184,11 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 	return payloadID, nil
 }
 
-func firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot) {
+func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot) {
+	// If we're syncing a block in the past and init-sync is still running, we shouldn't fire this event.
+	if !s.cfg.SyncChecker.Synced() {
+		return
+	}
 	// the fcu args have differing amounts of completeness based on the code path,
 	// and there is work we only want to do if a client is actually listening to the events beacon api endpoint.
 	// temporary solution: just fire a blank event and fill in the details in the api handler.

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -188,7 +188,7 @@ func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block int
 	// the fcu args have differing amounts of completeness based on the code path,
 	// and there is work we only want to do if a client is actually listening to the events beacon api endpoint.
 	// temporary solution: just fire a blank event and fill in the details in the api handler.
-	ptime, err := slots.ToTime(uint64(s.genesisTime.Unix()), nextSlot)
+	ptime, err := slots.BeginsAt(nextSlot, s.genesisTime)
 	if err != nil {
 		log.WithError(err).WithField("slot", nextSlot).Error("Could not compute time for slot")
 		return

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -184,18 +184,13 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 	return payloadID, nil
 }
 
-func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot) {
+func firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot) {
 	// the fcu args have differing amounts of completeness based on the code path,
 	// and there is work we only want to do if a client is actually listening to the events beacon api endpoint.
 	// temporary solution: just fire a blank event and fill in the details in the api handler.
-	ptime, err := slots.BeginsAt(nextSlot, s.genesisTime)
-	if err != nil {
-		log.WithError(err).WithField("slot", nextSlot).Error("Could not compute time for slot")
-		return
-	}
 	f.Send(&feed.Event{
 		Type: statefeed.PayloadAttributes,
-		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalTime: ptime, ProposalSlot: nextSlot},
+		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalSlot: nextSlot},
 	})
 }
 

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -184,13 +184,18 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 	return payloadID, nil
 }
 
-func firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot) {
+func (s *Service) firePayloadAttributesEvent(f event.SubscriberSender, block interfaces.ReadOnlySignedBeaconBlock, root [32]byte, nextSlot primitives.Slot) {
 	// the fcu args have differing amounts of completeness based on the code path,
 	// and there is work we only want to do if a client is actually listening to the events beacon api endpoint.
 	// temporary solution: just fire a blank event and fill in the details in the api handler.
+	ptime, err := slots.ToTime(uint64(s.genesisTime.Unix()), nextSlot)
+	if err != nil {
+		log.WithError(err).WithField("slot", nextSlot).Error("Could not compute time for slot")
+		return
+	}
 	f.Send(&feed.Event{
 		Type: statefeed.PayloadAttributes,
-		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalSlot: nextSlot},
+		Data: payloadattribute.EventData{HeadBlock: block, HeadRoot: root, ProposalTime: ptime, ProposalSlot: nextSlot},
 	})
 }
 

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -102,7 +102,7 @@ func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, args *fcuCo
 		log.WithError(err).Error("could not save head")
 	}
 
-	go firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), args.headBlock, args.headRoot, s.CurrentSlot()+1)
+	go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), args.headBlock, args.headRoot, s.CurrentSlot()+1)
 
 	// Only need to prune attestations from pool if the head has changed.
 	s.pruneAttsFromPool(s.ctx, args.headState, args.headBlock)

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -102,7 +102,7 @@ func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, args *fcuCo
 		log.WithError(err).Error("could not save head")
 	}
 
-	go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), args.headBlock, args.headRoot, s.CurrentSlot()+1)
+	go firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), args.headBlock, args.headRoot, s.CurrentSlot()+1)
 
 	// Only need to prune attestations from pool if the head has changed.
 	s.pruneAttsFromPool(s.ctx, args.headState, args.headBlock)

--- a/beacon-chain/blockchain/mock_test.go
+++ b/beacon-chain/blockchain/mock_test.go
@@ -20,6 +20,7 @@ func testServiceOptsWithDB(t *testing.T) []Option {
 		WithForkChoiceStore(fcs),
 		WithClockSynchronizer(cs),
 		WithStateNotifier(&mock.MockStateNotifier{RecordEvents: true}),
+		WithSyncChecker(&mock.MockSyncChecker{}),
 	}
 }
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -735,7 +735,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		}
 		// notifyForkchoiceUpdate fires the payload attribute event. But in this case, we won't
 		// call notifyForkchoiceUpdate, so the event is fired here.
-		go firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, s.CurrentSlot()+1)
+		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, s.CurrentSlot()+1)
 		return
 	}
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -735,7 +735,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		}
 		// notifyForkchoiceUpdate fires the payload attribute event. But in this case, we won't
 		// call notifyForkchoiceUpdate, so the event is fired here.
-		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, s.CurrentSlot()+1)
+		go firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, s.CurrentSlot()+1)
 		return
 	}
 

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -719,3 +719,14 @@ func (c *ChainService) ReceiveBlob(_ context.Context, b blocks.VerifiedROBlob) e
 func (c *ChainService) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
 	return c.TargetRoot, nil
 }
+
+// MockSyncChecker is a mock implementation of blockchain.Checker.
+// We can't make an assertion here that this is true because that would create a circular dependency.
+type MockSyncChecker struct {
+	synced bool
+}
+
+// Synced satisfies the blockchain.Checker interface.
+func (m *MockSyncChecker) Synced() bool {
+	return m.synced
+}

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -750,9 +750,9 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 // This event stream is intended to be used by builders and relays.
 // Parent fields are based on state at N_{current_slot}, while the rest of fields are based on state of N_{current_slot + 1}
 func (s *Server) payloadAttributesReader(ctx context.Context, ev payloadattribute.EventData) (lazyReader, error) {
-	deadline := ev.ProposalTime
+	deadline := slots.BeginsAt(ev.ProposalSlot, s.ChainInfoFetcher.GenesisTime())
 	if deadline.Before(time.Now()) {
-		log.WithField("ProposalTime", ev.ProposalTime.Unix()).Error("Payload attributes event deadline is in the past, using current time")
+		log.WithField("proposalSlotBeginsAt", deadline.Unix()).Error("Payload attributes event deadline is in the past, using current time")
 		deadline = time.Now().Add(payloadAttributeTimeout)
 	}
 	ctx, cancel := context.WithDeadline(ctx, deadline)

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -37,7 +37,6 @@ import (
 )
 
 const DefaultEventFeedDepth = 1000
-const payloadAttributeTimeout = 2 * time.Second
 
 const (
 	InvalidTopic = "__invalid__"

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -627,6 +627,7 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 }
 
 var errUnsupportedPayloadAttribute = errors.New("cannot compute payload attributes pre-Bellatrix")
+var errPayloadAttributeExpired = errors.New("skipping payload attribute event for past slot")
 
 func (s *Server) computePayloadAttributes(ctx context.Context, st state.ReadOnlyBeaconState, root [32]byte, proposer primitives.ValidatorIndex, timestamp uint64, randao []byte) (payloadattribute.Attributer, error) {
 	v := st.Version()
@@ -752,8 +753,7 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 func (s *Server) payloadAttributesReader(ctx context.Context, ev payloadattribute.EventData) (lazyReader, error) {
 	deadline := slots.BeginsAt(ev.ProposalSlot, s.ChainInfoFetcher.GenesisTime())
 	if deadline.Before(time.Now()) {
-		log.WithField("proposalSlotBeginsAt", deadline.Unix()).Error("Payload attributes event deadline is in the past, using current time")
-		deadline = time.Now().Add(payloadAttributeTimeout)
+		return nil, errors.Wrapf(errPayloadAttributeExpired, "proposal slot time %d", deadline.Unix())
 	}
 	ctx, cancel := context.WithDeadline(ctx, deadline)
 	edc := make(chan asyncPayloadAttrData)

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -750,7 +750,12 @@ func (s *Server) fillEventData(ctx context.Context, ev payloadattribute.EventDat
 // This event stream is intended to be used by builders and relays.
 // Parent fields are based on state at N_{current_slot}, while the rest of fields are based on state of N_{current_slot + 1}
 func (s *Server) payloadAttributesReader(ctx context.Context, ev payloadattribute.EventData) (lazyReader, error) {
-	ctx, cancel := context.WithTimeout(ctx, payloadAttributeTimeout)
+	deadline := ev.ProposalTime
+	if deadline.Before(time.Now()) {
+		log.WithField("ProposalTime", ev.ProposalTime.Unix()).Error("Payload attributes event deadline is in the past, using current time")
+		deadline = time.Now().Add(payloadAttributeTimeout)
+	}
+	ctx, cancel := context.WithDeadline(ctx, deadline)
 	edc := make(chan asyncPayloadAttrData)
 	go func() {
 		d := asyncPayloadAttrData{}

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -523,11 +523,14 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 				// to avoid slot processing
 				require.NoError(t, st.SetSlot(currentSlot+1))
 				b := tc.getBlock()
+				genesis := time.Now()
+				require.NoError(t, st.SetGenesisTime(uint64(genesis.Unix())))
 				mockChainService := &mockChain.ChainService{
-					Root:  make([]byte, 32),
-					State: st,
-					Block: b,
-					Slot:  &currentSlot,
+					Root:    make([]byte, 32),
+					State:   st,
+					Block:   b,
+					Slot:    &currentSlot,
+					Genesis: genesis,
 				}
 				headRoot, err := b.Block().HashTreeRoot()
 				require.NoError(t, err)
@@ -557,7 +560,7 @@ func TestStreamEvents_OperationsEvents(t *testing.T) {
 						Type: statefeed.PayloadAttributes,
 						Data: payloadattribute.EventData{
 							ProposerIndex:     0,
-							ProposalSlot:      0,
+							ProposalSlot:      mockChainService.CurrentSlot() + 1,
 							ParentBlockNumber: 0,
 							ParentBlockHash:   make([]byte, 32),
 							HeadBlock:         b,

--- a/changelog/kasey_relax-event-deadline.md
+++ b/changelog/kasey_relax-event-deadline.md
@@ -1,0 +1,2 @@
+### Fixed
+- extend the payload attribute computation deadline to the beginning of the proposal slot.

--- a/consensus-types/payload-attribute/types.go
+++ b/consensus-types/payload-attribute/types.go
@@ -1,8 +1,6 @@
 package payloadattribute
 
 import (
-	"time"
-
 	field_params "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
@@ -99,7 +97,6 @@ func initPayloadAttributeFromV3(a *enginev1.PayloadAttributesV3) (Attributer, er
 // EventData holds the values for a PayloadAttributes event.
 type EventData struct {
 	ProposerIndex     primitives.ValidatorIndex
-	ProposalTime      time.Time
 	ProposalSlot      primitives.Slot
 	ParentBlockNumber uint64
 	ParentBlockHash   []byte

--- a/consensus-types/payload-attribute/types.go
+++ b/consensus-types/payload-attribute/types.go
@@ -1,6 +1,8 @@
 package payloadattribute
 
 import (
+	"time"
+
 	field_params "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
@@ -97,6 +99,7 @@ func initPayloadAttributeFromV3(a *enginev1.PayloadAttributesV3) (Attributer, er
 // EventData holds the values for a PayloadAttributes event.
 type EventData struct {
 	ProposerIndex     primitives.ValidatorIndex
+	ProposalTime      time.Time
 	ProposalSlot      primitives.Slot
 	ParentBlockNumber uint64
 	ParentBlockHash   []byte


### PR DESCRIPTION


**What type of PR is this?**
Bug fix


**What does this PR do? Why is it needed?**

In some cases the 2 second payload attribute computation deadline is too short. This event is used by relays who would rather use resources making sure this event is computed and not skipped, so in this case we should relax the deadline and try to give them enough time to compute it (especially at the epoch boundary where we are more likely to be processing these values before they've entered the cache).

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
