### PR TITLE
Data columns by range: Use all possible peers then filter them.

### DIFF
--- a/beacon-chain/sync/data_columns.go
+++ b/beacon-chain/sync/data_columns.go
@@ -204,7 +204,6 @@ func RequestMissingDataColumnsByRange(
 	rateLimiter *leakybucket.Collector,
 	groupCount uint64,
 	dataColumnsStorage filesystem.DataColumnStorageSummarizer,
-	peers []peer.ID,
 	blks []blocks.ROBlock,
 	batchSize int,
 ) (map[[fieldparams.RootLength]byte][]blocks.RODataColumn, error) {
@@ -285,7 +284,7 @@ func RequestMissingDataColumnsByRange(
 		// Requests data column sidecars from peers.
 		retrievedDataColumnsByRoot := make(map[[fieldparams.RootLength]byte][]blocks.RODataColumn)
 		for _, request := range requests {
-			roDataColumns, err := fetchDataColumnsFromPeers(ctx, clock, p2p, rateLimiter, ctxMap, peers, request)
+			roDataColumns, err := fetchDataColumnsFromPeers(ctx, clock, p2p, rateLimiter, ctxMap, request)
 			if err != nil {
 				return nil, errors.Wrap(err, "fetch data columns from peers")
 			}
@@ -720,7 +719,6 @@ func fetchDataColumnsFromPeers(
 	p2p p2p.P2P,
 	rateLimiter *leakybucket.Collector,
 	ctxMap ContextByteVersions,
-	peers []peer.ID,
 	targetRequest *eth.DataColumnSidecarsByRangeRequest,
 ) ([]blocks.RODataColumn, error) {
 	// Filter out requests with no data columns.
@@ -729,7 +727,7 @@ func fetchDataColumnsFromPeers(
 	}
 
 	// Get all admissible peers with the data columns they custody.
-	dataColumnsByAdmissiblePeer, err := waitForPeersForDataColumns(p2p, rateLimiter, peers, targetRequest)
+	dataColumnsByAdmissiblePeer, err := waitForPeersForDataColumns(p2p, rateLimiter, targetRequest)
 	if err != nil {
 		return nil, errors.Wrap(err, "wait for peers for data columns")
 	}
@@ -766,7 +764,7 @@ func fetchDataColumnsFromPeers(
 // - synced up to `lastSlot`, and
 // - have bandwidth to serve `blockCount` blocks.
 // It waits until at least one peer per data column is available.
-func waitForPeersForDataColumns(p2p p2p.P2P, rateLimiter *leakybucket.Collector, peers []peer.ID, request *eth.DataColumnSidecarsByRangeRequest) (map[peer.ID]map[uint64]bool, error) {
+func waitForPeersForDataColumns(p2p p2p.P2P, rateLimiter *leakybucket.Collector, request *eth.DataColumnSidecarsByRangeRequest) (map[peer.ID]map[uint64]bool, error) {
 	const delay = 5 * time.Second
 
 	numberOfColumns := params.BeaconConfig().NumberOfColumns
@@ -788,7 +786,7 @@ func waitForPeersForDataColumns(p2p p2p.P2P, rateLimiter *leakybucket.Collector,
 
 	// Keep only peers with head epoch greater than or equal to the epoch corresponding to the target slot, and
 	// keep only peers with enough bandwidth.
-	filteredPeers, descriptions, err := filterPeersByTargetSlotAndBandwidth(p2p, rateLimiter, peers, lastSlot, request.Count)
+	filteredPeers, descriptions, err := filterPeersByTargetSlotAndBandwidth(p2p, rateLimiter, lastSlot, request.Count)
 	if err != nil {
 		return nil, errors.Wrap(err, "filter eers by target slot and bandwidth")
 	}
@@ -834,7 +832,7 @@ func waitForPeersForDataColumns(p2p p2p.P2P, rateLimiter *leakybucket.Collector,
 		time.Sleep(delay)
 
 		// Filter for peers with head epoch greater than or equal to our target epoch for ByRange requests.
-		filteredPeers, descriptions, err = filterPeersByTargetSlotAndBandwidth(p2p, rateLimiter, peers, lastSlot, request.Count)
+		filteredPeers, descriptions, err = filterPeersByTargetSlotAndBandwidth(p2p, rateLimiter, lastSlot, request.Count)
 		if err != nil {
 			return nil, errors.Wrap(err, "filter peers by target slot and bandwidth")
 		}
@@ -855,10 +853,8 @@ func waitForPeersForDataColumns(p2p p2p.P2P, rateLimiter *leakybucket.Collector,
 }
 
 // Filter peers to ensure they are synced to the target slot and have sufficient bandwidth to serve the request.
-func filterPeersByTargetSlotAndBandwidth(p2p p2p.P2P, rateLimiter *leakybucket.Collector, peers []peer.ID, lastSlot primitives.Slot, blockCount uint64) ([]peer.ID, []string, error) {
-	if len(peers) == 0 {
-		peers = p2p.Peers().Connected()
-	}
+func filterPeersByTargetSlotAndBandwidth(p2p p2p.P2P, rateLimiter *leakybucket.Collector, lastSlot primitives.Slot, blockCount uint64) ([]peer.ID, []string, error) {
+	peers := p2p.Peers().Connected()
 
 	slotPeers, descriptions, err := filterPeersByTargetSlot(p2p, peers, lastSlot)
 	if err != nil {

--- a/beacon-chain/sync/data_columns_test.go
+++ b/beacon-chain/sync/data_columns_test.go
@@ -1476,7 +1476,7 @@ func TestFetchDataColumnsFromPeers(t *testing.T) {
 			rateLimiter := leakybucket.NewCollector(1_000, 1_000, 1*time.Hour, false)
 
 			// Fetch the data columns from the peers.
-			fetchedRoDataColumnsByRoot, err := RequestMissingDataColumnsByRange(ctx, clock, ctxMap, p2pSvc, rateLimiter, 4, dataColumnStorageSummarizer, peersID, roBlocks, tc.batchSize)
+			fetchedRoDataColumnsByRoot, err := RequestMissingDataColumnsByRange(ctx, clock, ctxMap, p2pSvc, rateLimiter, 4, dataColumnStorageSummarizer, roBlocks, tc.batchSize)
 			if !tc.isError {
 				require.NoError(t, err)
 			} else {

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -396,7 +396,7 @@ func (f *blocksFetcher) fetchSidecars(ctx context.Context, pid peer.ID, peers []
 
 	// Fetch data column sidecars.
 	actualGroupCount := f.custodyInfo.ActualGroupCount()
-	fetchedDataColumnsByRoot, err := prysmsync.RequestMissingDataColumnsByRange(ctx, f.clock, f.ctxMap, f.p2p, f.rateLimiter, actualGroupCount, f.dcs, peers, dataColumnBlocks, batchSize)
+	fetchedDataColumnsByRoot, err := prysmsync.RequestMissingDataColumnsByRange(ctx, f.clock, f.ctxMap, f.p2p, f.rateLimiter, actualGroupCount, f.dcs, dataColumnBlocks, batchSize)
 	if err != nil {
 		return blobsPid, errors.Wrap(err, "fetch missing data columns from peers")
 	}


### PR DESCRIPTION
In `RequestMissingDataColumnsByRange`, we let the full responsibility of the choice of peers to the function.
Before, a pre-filtering was done in the calling function (or one of the parent of the calling function), and given in the `peers` argument.

This lead to some situation where `RequestMissingDataColumnsByRange` had a very small choices of peers, leading to stalled initial sync.

**Genesis of this PR:**
In "normal" situation, when no peers (for any reason) are available for requesting data columns by range, this kind of logs are displayed: 

![image](https://github.com/user-attachments/assets/dff603ea-9525-4039-8f65-958599fe3709)

- A global message says no peers are available, then
- For each peer, the reason of unavailability  is displayed.

However, on the sunnyside devnet, we saw:
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/b92fbd37-3ccc-4de6-b864-8f9b040e4444" />

Meaning that only one peer was considered (and, on this log, this peer had not enough bandwidth).

More especially, the number of peers was constrained, **in the best case**,  by `params.BeaconConfig().MaxPeersToSync`, which by default set to 15. 

This PR fixes this issue.