### PR TITLE
Use finalized state for validator custody instead of head state.

### DIFF
--- a/beacon-chain/core/peerdas/validator.go
+++ b/beacon-chain/core/peerdas/validator.go
@@ -9,7 +9,7 @@ import (
 
 // ValidatorsCustodyRequirement returns the number of custody groups regarding the validator indices attached to the beacon node.
 // https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.5/specs/fulu/validator.md#validator-custody
-func ValidatorsCustodyRequirement(state beaconState.ReadOnlyBeaconState, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
+func ValidatorsCustodyRequirement(state beaconState.BeaconState, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
 	totalNodeBalance := uint64(0)
 	for index := range validatorsIndex {
 		balance, err := state.BalanceAtIndex(index)

--- a/beacon-chain/core/peerdas/validator.go
+++ b/beacon-chain/core/peerdas/validator.go
@@ -9,7 +9,7 @@ import (
 
 // ValidatorsCustodyRequirement returns the number of custody groups regarding the validator indices attached to the beacon node.
 // https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.5/specs/fulu/validator.md#validator-custody
-func ValidatorsCustodyRequirement(state beaconState.BeaconState, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
+func ValidatorsCustodyRequirement(state beaconState.ReadOnlyBeaconState, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
 	totalNodeBalance := uint64(0)
 	for index := range validatorsIndex {
 		balance, err := state.BalanceAtIndex(index)

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -259,7 +259,7 @@ func (s *State) latestAncestor(ctx context.Context, blockRoot [32]byte) (state.B
 	defer span.End()
 
 	if s.isFinalizedRoot(blockRoot) {
-		finalizedState := s.finalizedState()
+		finalizedState := s.FinalizedState()
 		if finalizedState != nil {
 			return finalizedState, nil
 		}
@@ -297,7 +297,7 @@ func (s *State) latestAncestor(ctx context.Context, blockRoot [32]byte) (state.B
 
 		// Does the state exist in finalized info cache.
 		if s.isFinalizedRoot(parentRoot) {
-			return s.finalizedState(), nil
+			return s.FinalizedState(), nil
 		}
 
 		// Does the state exist in epoch boundary cache.

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -196,7 +196,7 @@ func (s *State) isFinalizedRoot(r [32]byte) bool {
 }
 
 // Returns the cached and copied finalized state.
-func (s *State) finalizedState() state.BeaconState {
+func (s *State) FinalizedState() state.BeaconState {
 	s.finalizedInfo.lock.RLock()
 	defer s.finalizedInfo.lock.RUnlock()
 	return s.finalizedInfo.state.Copy()

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -33,5 +33,5 @@ func TestResume(t *testing.T) {
 	require.DeepSSZEqual(t, beaconState.ToProtoUnsafe(), resumeState.ToProtoUnsafe())
 	assert.Equal(t, params.BeaconConfig().SlotsPerEpoch, service.finalizedInfo.slot, "Did not get watned slot")
 	assert.Equal(t, service.finalizedInfo.root, root, "Did not get wanted root")
-	assert.NotNil(t, service.finalizedState(), "Wanted a non nil finalized state")
+	assert.NotNil(t, service.FinalizedState(), "Wanted a non nil finalized state")
 }

--- a/beacon-chain/sync/validators_custody.go
+++ b/beacon-chain/sync/validators_custody.go
@@ -35,14 +35,14 @@ func (s *Service) setTargetValidatorsCustodyRequirement() {
 	}
 
 	// Retrieve the head state.
-	headState, err := s.cfg.chain.HeadStateReadOnly(s.ctx)
-	if err != nil || headState == nil {
-		log.WithError(err).Error("Failed to get head state")
+	finalizedState := s.cfg.stateGen.FinalizedState()
+	if finalizedState == nil || finalizedState.IsNil() {
+		log.Error("Finalized state is nil")
 		return
 	}
 
 	// Get the validators custody requirement.
-	validatorsCustodyRequirement, err := peerdas.ValidatorsCustodyRequirement(headState, indices)
+	validatorsCustodyRequirement, err := peerdas.ValidatorsCustodyRequirement(finalizedState, indices)
 	if err != nil {
 		log.WithError(err).Error("Failed to get validators custody requirement")
 		return

--- a/beacon-chain/sync/validators_custody_test.go
+++ b/beacon-chain/sync/validators_custody_test.go
@@ -1,10 +1,8 @@
 package sync
 
 import (
-	"context"
 	"testing"
 
-	mock "github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/cache"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	testDB "github.com/OffchainLabs/prysm/v6/beacon-chain/db/testing"
@@ -102,21 +100,18 @@ func TestSetTargetValidatorsCustodyRequirement(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
 			beaconDB := testDB.SetupDB(t)
 			stateGen := stategen.New(beaconDB, doublylinkedtree.New())
 			state, _ := util.DeterministicGenesisState(t, 32)
 			err := state.SetBalances(tc.validatorsBalance)
 			require.NoError(t, err)
-			err = stateGen.SaveState(ctx, [32]byte{}, state)
-			require.NoError(t, err)
+
+			stateGen.SaveFinalizedState(0, [32]byte{}, state)
 
 			service := &Service{
 				trackedValidatorsCache: cache.NewTrackedValidatorsCache(),
 				cfg: &config{
-					chain: &mock.ChainService{
-						State: state,
-					},
+					stateGen:    stateGen,
 					custodyInfo: &peerdas.CustodyInfo{},
 				},
 			}


### PR DESCRIPTION
**Please read commit by commit.**

Use finalized state instead of head state for validator custody.
[Specification](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#validator-custody)

(Previously, the specification stated to use the head state.)