### PR TITLE
BLS benchmarking for FastAggreateVerify and Eth2FastAggreateVerify

### DIFF
--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -207,7 +207,7 @@ func (s *Service) processUnaggregatedAttestation(ctx context.Context, att ethpb.
 	}
 }
 
-// processUnaggregatedAttestation logs when the beacon node observes an aggregated attestation from tracked validator.
+// processAggregatedAttestation logs when the beacon node observes an aggregated attestation from tracked validator.
 func (s *Service) processAggregatedAttestation(ctx context.Context, att ethpb.AggregateAttAndProof) {
 	s.Lock()
 	defer s.Unlock()

--- a/changelog/g1-refactor-bls-benchmark.md
+++ b/changelog/g1-refactor-bls-benchmark.md
@@ -1,0 +1,2 @@
+### Added
+- benchmarks for `FastAggregateVerify` and `Eth2FastAggregateVerify` BLS functions

--- a/crypto/bls/blst/bls_benchmark_test.go
+++ b/crypto/bls/blst/bls_benchmark_test.go
@@ -51,6 +51,90 @@ func BenchmarkSignature_AggregateVerify(b *testing.B) {
 	}
 }
 
+func BenchmarkSignature_FastAggregateVerify(b *testing.B) {
+	sigN := 128 // MAX_ATTESTATIONS per block.
+
+	msg := [32]byte{'s', 'i', 'g', 'n', 'e', 'd', 'm', 's', 'g'}
+
+	var pks []common.PublicKey
+	var sigs []common.Signature
+
+	// Gen random keys and signatures for the same message
+	for i := 0; i < sigN; i++ {
+		sk, err := blst.RandKey()
+		require.NoError(b, err)
+		sig := sk.Sign(msg[:])
+		pks = append(pks, sk.PublicKey())
+		sigs = append(sigs, sig)
+	}
+
+	aggregated := blst.AggregateSignatures(sigs)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if !aggregated.FastAggregateVerify(pks, msg) {
+			b.Fatal("could not verify fast aggregate sig")
+		}
+	}
+}
+
+func BenchmarkSignature_Eth2FastAggregateVerify(b *testing.B) {
+	sigN := 128
+
+	msg := [32]byte{'s', 'i', 'g', 'n', 'e', 'd', 'm', 's', 'g'}
+
+	var pks []common.PublicKey
+	var sigs []common.Signature
+
+	for i := 0; i < sigN; i++ {
+		sk, err := blst.RandKey()
+		require.NoError(b, err)
+		sig := sk.Sign(msg[:])
+		pks = append(pks, sk.PublicKey())
+		sigs = append(sigs, sig)
+	}
+
+	aggregated := blst.AggregateSignatures(sigs)
+
+	b.Run("Regular case with signatures", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if !aggregated.Eth2FastAggregateVerify(pks, msg) {
+				b.Fatal("could not verify eth2 fast aggregate sig")
+			}
+		}
+	})
+
+	// Special case: Empty pubkeys with infinite signature (Should pass considering as empty aggregates)
+	infiniteSig, err := blst.SignatureFromBytes(common.InfiniteSignature[:])
+	require.NoError(b, err)
+
+	b.Run("Special case: empty pubkeys with infinite signature", func(b *testing.B) {
+		emptyPks := make([]common.PublicKey, 0)
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if !infiniteSig.Eth2FastAggregateVerify(emptyPks, msg) {
+				b.Fatal("infinite signature check failed with empty pubkeys")
+			}
+		}
+	})
+
+	// Non-infinite signature with empty pubkeys (should fail)
+	b.Run("Invalid case: empty pubkeys with regular signature", func(b *testing.B) {
+		emptyPks := make([]common.PublicKey, 0)
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if aggregated.Eth2FastAggregateVerify(emptyPks, msg) {
+				b.Fatal("verification unexpectedly passed with empty pubkeys and non-infinite sig")
+			}
+		}
+	})
+}
+
 func BenchmarkSecretKey_Marshal(b *testing.B) {
 	key, err := blst.RandKey()
 	require.NoError(b, err)


### PR DESCRIPTION
<!--
Thanks for sending a PR! Before submitting:
1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR adds benchmark tests for the `FastAggregateVerify` and `Eth2FastAggregateVerify` functions in the BLS cryptography package. 

Noticed that the BLS cryptography package includes a benchmark for the deprecated AggregateVerify function, but doesn't yet have benchmarks for the actively used FastAggregateVerify and Eth2FastAggregateVerify. 

The `Eth2FastAggregateVerify` benchmark specifically tests the special case handling for empty validator sets with infinite signatures, which is a unique requirement in Ethereum 2.0's consensus protocol.

**Other notes for review**
The benchmarks follow the same pattern as the existing `BenchmarkSignature_AggregateVerify`, with adjustments for the different function signatures and behaviors.

**Acknowledgements**
- [x] I have read [[CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md)](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named changelog fragment file (g1-refactor-bls-benchmark.md) 
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.