### PR TITLE
Increase sepolia gas limit to 60m

### DIFF
--- a/changelog/tt_rice.md
+++ b/changelog/tt_rice.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Increase sepolia gas limit to 60M.

--- a/config/params/testnet_sepolia_config.go
+++ b/config/params/testnet_sepolia_config.go
@@ -50,6 +50,7 @@ func SepoliaConfig() *BeaconChainConfig {
 	cfg.FuluForkVersion = []byte{0x90, 0x00, 0x00, 0x75} // TODO: Define sepolia fork version for fulu. This is a placeholder value.
 	cfg.TerminalTotalDifficulty = "17000000000000000"
 	cfg.DepositContractAddress = "0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"
+	cfg.DefaultBuilderGasLimit = uint64(60000000)
 	cfg.InitializeForkSchedule()
 	return cfg
 }


### PR DESCRIPTION
Per meeting minutes, the Sepolia gas limit will be raised to 60M: [https://github.com/ethereum/pm/issues/1227#issuecomment-2590936062](https://github.com/ethereum/pm/issues/1227#issuecomment-2590936062)
