### PR TITLE
fixing field name on json response for `/eth/v2/debug/beacon/states/{state_id}`

### DIFF
--- a/api/server/structs/other.go
+++ b/api/server/structs/other.go
@@ -253,7 +253,7 @@ type PendingDeposit struct {
 }
 
 type PendingPartialWithdrawal struct {
-	Index             string `json:"index"`
+	Index             string `json:"validator_index"`
 	Amount            string `json:"amount"`
 	WithdrawableEpoch string `json:"withdrawable_epoch"`
 }

--- a/changelog/james-prysm_fix-ppw-index-alias.md
+++ b/changelog/james-prysm_fix-ppw-index-alias.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed wrong field name in pending partial withdrawals was returned on state json representation, described in https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#pendingpartialwithdrawal


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

fixing user report by correcting the json alias
```
It seems that Prysm returns one field for CL state a bit differently than required by the specification. According to specification PendingPartialWithdrawal should contain validator_index, but as far as I can see it returns index instead of it

The place in the code (not sure this is the right place tbh):
https://github.com/OffchainLabs/prysm/blob/204302a821da57632ec4e2d89126a21f00bd2817/api/server/structs/other.go#L256

Spec:

https://ethereum.github.io/beacon-APIs/#/Debug/getStateV2
"pending_partial_withdrawals": [
    {
        "validator_index": "1",
        "amount": "1",
        "withdrawable_epoch": "1"
    }
]
and also here: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#pendingpartialwithdrawal

class PendingPartialWithdrawal(Container):
    validator_index: ValidatorIndex
    amount: Gwei
    withdrawable_epoch: Epoch
```

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
