### PR TITLE
Optimize by pre allocate slices to avoid `Runtime.Growslice`

### DIFF
--- a/beacon-chain/core/helpers/randao.go
+++ b/beacon-chain/core/helpers/randao.go
@@ -29,10 +29,13 @@ func Seed(state state.ReadOnlyBeaconState, epoch primitives.Epoch, domain [bls.D
 	if err != nil {
 		return [32]byte{}, err
 	}
-	seed := append(domain[:], bytesutil.Bytes8(uint64(epoch))...)
-	seed = append(seed, randaoMix...)
 
-	seed32 := hash.Hash(seed)
+	var seed [bls.DomainByteLength + 8 + 32]byte
+	copy(seed[0:], domain[:])
+	copy(seed[bls.DomainByteLength:], bytesutil.Bytes8(uint64(epoch)))
+	copy(seed[bls.DomainByteLength+8:], randaoMix)
+
+	seed32 := hash.Hash(seed[:])
 
 	return seed32, nil
 }

--- a/beacon-chain/core/signing/signing_root.go
+++ b/beacon-chain/core/signing/signing_root.go
@@ -247,9 +247,9 @@ func ComputeDomain(domainType [DomainByteLength]byte, forkVersion, genesisValida
 
 // This returns the bls domain given by the domain type and fork data root.
 func domain(domainType [DomainByteLength]byte, forkDataRoot []byte) []byte {
-	b := make([]byte, 32)
-	copy(b[0:4], domainType[:4])
-	copy(b[4:], forkDataRoot[:28])
+	b := make([]byte, 0, 32)
+	b = append(b, domainType[:4]...)
+	b = append(b, forkDataRoot[:28]...)
 	return b
 }
 

--- a/beacon-chain/core/signing/signing_root.go
+++ b/beacon-chain/core/signing/signing_root.go
@@ -247,9 +247,9 @@ func ComputeDomain(domainType [DomainByteLength]byte, forkVersion, genesisValida
 
 // This returns the bls domain given by the domain type and fork data root.
 func domain(domainType [DomainByteLength]byte, forkDataRoot []byte) []byte {
-	var b []byte
-	b = append(b, domainType[:4]...)
-	b = append(b, forkDataRoot[:28]...)
+	b := make([]byte, 32)
+	copy(b[0:4], domainType[:4])
+	copy(b[4:], forkDataRoot[:28])
 	return b
 }
 

--- a/beacon-chain/state/stateutil/participation_bit_root.go
+++ b/beacon-chain/state/stateutil/participation_bit_root.go
@@ -32,7 +32,7 @@ func ParticipationBitsRoot(bits []byte) ([32]byte, error) {
 // it does not have length bytes per chunk.
 func packParticipationBits(bytes []byte) ([][32]byte, error) {
 	numItems := len(bytes)
-	chunks := make([][32]byte, 0, numItems/32)
+	chunks := make([][32]byte, 0, (numItems+31)/32)
 	for i := 0; i < numItems; i += 32 {
 		j := i + 32
 		// We create our upper bound index of the chunk, if it is greater than numItems,

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
@@ -265,9 +266,10 @@ func (s *Service) hasSeenAggregatorIndexEpoch(epoch primitives.Epoch, aggregator
 func (s *Service) setAggregatorIndexEpochSeen(epoch primitives.Epoch, aggregatorIndex primitives.ValidatorIndex) {
 	s.seenAggregatedAttestationLock.Lock()
 	defer s.seenAggregatedAttestationLock.Unlock()
+
 	b := make([]byte, 64)
-	copy(b[0:32], bytesutil.Bytes32(uint64(epoch)))
-	copy(b[32:], bytesutil.Bytes32(uint64(aggregatorIndex)))
+	binary.BigEndian.PutUint64(b[24:], uint64(epoch))
+	binary.BigEndian.PutUint64(b[56:], uint64(aggregatorIndex))
 	s.seenAggregatedAttestationCache.Add(string(b), true)
 }
 

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -265,7 +265,9 @@ func (s *Service) hasSeenAggregatorIndexEpoch(epoch primitives.Epoch, aggregator
 func (s *Service) setAggregatorIndexEpochSeen(epoch primitives.Epoch, aggregatorIndex primitives.ValidatorIndex) {
 	s.seenAggregatedAttestationLock.Lock()
 	defer s.seenAggregatedAttestationLock.Unlock()
-	b := append(bytesutil.Bytes32(uint64(epoch)), bytesutil.Bytes32(uint64(aggregatorIndex))...)
+	b := make([]byte, 64)
+	copy(b[0:32], bytesutil.Bytes32(uint64(epoch)))
+	copy(b[32:], bytesutil.Bytes32(uint64(aggregatorIndex)))
 	s.seenAggregatedAttestationCache.Add(string(b), true)
 }
 

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -268,8 +268,8 @@ func (s *Service) setAggregatorIndexEpochSeen(epoch primitives.Epoch, aggregator
 	defer s.seenAggregatedAttestationLock.Unlock()
 
 	b := make([]byte, 64)
-	binary.BigEndian.PutUint64(b[24:], uint64(epoch))
-	binary.BigEndian.PutUint64(b[56:], uint64(aggregatorIndex))
+	binary.LittleEndian.PutUint64(b, uint64(epoch))
+	binary.LittleEndian.PutUint64(b[32:], uint64(aggregatorIndex))
 	s.seenAggregatedAttestationCache.Add(string(b), true)
 }
 

--- a/changelog/tt_bread.md
+++ b/changelog/tt_bread.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Pre allocate slices if we can to avoid grow slice.

--- a/crypto/bls/signature_batch.go
+++ b/crypto/bls/signature_batch.go
@@ -32,16 +32,18 @@ func NewSet() *SignatureBatch {
 
 // Join merges the provided signature batch to out current one.
 func (s *SignatureBatch) Join(set *SignatureBatch) *SignatureBatch {
-	if cap(s.Signatures)-len(s.Signatures) < len(set.Signatures) &&
-		cap(set.Signatures)-len(set.Signatures) >= len(s.Signatures) {
-		return set.Join(s)
+	if cap(s.Signatures)-len(s.Signatures) < cap(set.Signatures)-len(set.Signatures) {
+		set.Signatures = append(set.Signatures, s.Signatures...)
+		set.PublicKeys = append(set.PublicKeys, s.PublicKeys...)
+		set.Messages = append(set.Messages, s.Messages...)
+		set.Descriptions = append(set.Descriptions, s.Descriptions...)
+		return set
 	}
 
 	s.Signatures = append(s.Signatures, set.Signatures...)
 	s.PublicKeys = append(s.PublicKeys, set.PublicKeys...)
 	s.Messages = append(s.Messages, set.Messages...)
 	s.Descriptions = append(s.Descriptions, set.Descriptions...)
-
 	return s
 }
 

--- a/crypto/bls/signature_batch.go
+++ b/crypto/bls/signature_batch.go
@@ -32,6 +32,30 @@ func NewSet() *SignatureBatch {
 
 // Join merges the provided signature batch to out current one.
 func (s *SignatureBatch) Join(set *SignatureBatch) *SignatureBatch {
+	total := len(s.Signatures) + len(set.Signatures)
+
+	// Preallocate capacity if needed
+	if cap(s.Signatures) < total {
+		newSigs := make([][]byte, len(s.Signatures), total)
+		copy(newSigs, s.Signatures)
+		s.Signatures = newSigs
+	}
+	if cap(s.PublicKeys) < total {
+		newPKs := make([]PublicKey, len(s.PublicKeys), total)
+		copy(newPKs, s.PublicKeys)
+		s.PublicKeys = newPKs
+	}
+	if cap(s.Messages) < total {
+		newMsgs := make([][32]byte, len(s.Messages), total)
+		copy(newMsgs, s.Messages)
+		s.Messages = newMsgs
+	}
+	if cap(s.Descriptions) < total {
+		newDescs := make([]string, len(s.Descriptions), total)
+		copy(newDescs, s.Descriptions)
+		s.Descriptions = newDescs
+	}
+
 	s.Signatures = append(s.Signatures, set.Signatures...)
 	s.PublicKeys = append(s.PublicKeys, set.PublicKeys...)
 	s.Messages = append(s.Messages, set.Messages...)

--- a/crypto/bls/signature_batch.go
+++ b/crypto/bls/signature_batch.go
@@ -32,9 +32,13 @@ func NewSet() *SignatureBatch {
 
 // Join merges the provided signature batch to out current one.
 func (s *SignatureBatch) Join(set *SignatureBatch) *SignatureBatch {
+	if cap(s.Signatures)-len(s.Signatures) < len(set.Signatures) &&
+		cap(set.Signatures)-len(set.Signatures) >= len(s.Signatures) {
+		return set.Join(s)
+	}
+
 	total := len(s.Signatures) + len(set.Signatures)
 
-	// Preallocate capacity if needed
 	if cap(s.Signatures) < total {
 		newSigs := make([][]byte, len(s.Signatures), total)
 		copy(newSigs, s.Signatures)
@@ -60,6 +64,7 @@ func (s *SignatureBatch) Join(set *SignatureBatch) *SignatureBatch {
 	s.PublicKeys = append(s.PublicKeys, set.PublicKeys...)
 	s.Messages = append(s.Messages, set.Messages...)
 	s.Descriptions = append(s.Descriptions, set.Descriptions...)
+
 	return s
 }
 

--- a/crypto/bls/signature_batch.go
+++ b/crypto/bls/signature_batch.go
@@ -37,29 +37,6 @@ func (s *SignatureBatch) Join(set *SignatureBatch) *SignatureBatch {
 		return set.Join(s)
 	}
 
-	total := len(s.Signatures) + len(set.Signatures)
-
-	if cap(s.Signatures) < total {
-		newSigs := make([][]byte, len(s.Signatures), total)
-		copy(newSigs, s.Signatures)
-		s.Signatures = newSigs
-	}
-	if cap(s.PublicKeys) < total {
-		newPKs := make([]PublicKey, len(s.PublicKeys), total)
-		copy(newPKs, s.PublicKeys)
-		s.PublicKeys = newPKs
-	}
-	if cap(s.Messages) < total {
-		newMsgs := make([][32]byte, len(s.Messages), total)
-		copy(newMsgs, s.Messages)
-		s.Messages = newMsgs
-	}
-	if cap(s.Descriptions) < total {
-		newDescs := make([]string, len(s.Descriptions), total)
-		copy(newDescs, s.Descriptions)
-		s.Descriptions = newDescs
-	}
-
 	s.Signatures = append(s.Signatures, set.Signatures...)
 	s.PublicKeys = append(s.PublicKeys, set.PublicKeys...)
 	s.Messages = append(s.Messages, set.Messages...)


### PR DESCRIPTION
I've fixed the top 5 offenders given the following profile.
`(s *SignatureBatch) Join` is the worst one.
![Screenshot 2025-05-09 at 11 03 56 AM](https://github.com/user-attachments/assets/75487621-dc0b-47a5-b276-f62185463c51)
