### PR TITLE
Proposer cancel validator main run loop

### DIFF
--- a/changelog/tt_bamboo.md
+++ b/changelog/tt_bamboo.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Proper cancel() main validator run loop.

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -132,6 +132,7 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 			performRoles(slotCtx, allRoles, v, slot, &wg, span)
+			cancel()
 		case isHealthyAgain := <-healthTracker.HealthUpdates():
 			if isHealthyAgain {
 				headSlot, err = initializeValidatorAndGetHeadSlot(ctx, v)


### PR DESCRIPTION
In validator's main loop, it doesn't look like we `cancel` properly for `slotCtx, cancel := context.WithDeadline(ctx, deadline)` after `performRoles(slotCtx, allRoles, v, slot, &wg, span)`