### PR TITLE
Use independent context when updating domain data

### DIFF
--- a/changelog/potuz_domain_data_context.md
+++ b/changelog/potuz_domain_data_context.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use independent context for domain data calculation. 

--- a/testing/endtoend/evaluators/fee_recipient.go
+++ b/testing/endtoend/evaluators/fee_recipient.go
@@ -72,7 +72,11 @@ func feeRecipientIsPresent(_ *types.EvaluationContext, conns ...*grpc.ClientConn
 	if err != nil {
 		return errors.Wrap(err, "failed to get chain head")
 	}
-	req := &ethpb.ListBlocksRequest{QueryFilter: &ethpb.ListBlocksRequest_Epoch{Epoch: chainHead.HeadEpoch.Sub(1)}}
+	epoch := chainHead.HeadEpoch
+	if epoch > 0 {
+		epoch--
+	}
+	req := &ethpb.ListBlocksRequest{QueryFilter: &ethpb.ListBlocksRequest_Epoch{Epoch: epoch}}
 	blks, err := client.ListBeaconBlocks(context.Background(), req)
 	if err != nil {
 		return errors.Wrap(err, "failed to list blocks")

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -119,9 +119,8 @@ func run(ctx context.Context, v iface.Validator) {
 
 			// Start fetching domain data for the next epoch.
 			if slots.IsEpochEnd(slot) {
-				domainCtx, domainCancel := context.WithDeadline(ctx, deadline)
+				domainCtx, _ := context.WithDeadline(ctx, deadline)
 				go v.UpdateDomainDataCaches(domainCtx, slot+1)
-				domainCancel()
 			}
 
 			var wg sync.WaitGroup

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -119,7 +119,9 @@ func run(ctx context.Context, v iface.Validator) {
 
 			// Start fetching domain data for the next epoch.
 			if slots.IsEpochEnd(slot) {
-				go v.UpdateDomainDataCaches(slotCtx, slot+1)
+				domainCtx, domainCancel := context.WithDeadline(ctx, deadline)
+				go v.UpdateDomainDataCaches(domainCtx, slot+1)
+				domainCancel()
 			}
 
 			var wg sync.WaitGroup
@@ -132,6 +134,8 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 			performRoles(slotCtx, allRoles, v, slot, &wg, span)
+			span.End()
+			cancel()
 		case isHealthyAgain := <-healthTracker.HealthUpdates():
 			if isHealthyAgain {
 				headSlot, err = initializeValidatorAndGetHeadSlot(ctx, v)

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -132,9 +132,10 @@ func run(ctx context.Context, v iface.Validator) {
 				cancel()
 				continue
 			}
-			// performRoles calls span.End()
-			performRoles(slotCtx, allRoles, v, slot, &wg, span)
 			cancel()
+			// performRoles calls span.End()
+			rolesCtx, _ := context.WithDeadline(ctx, deadline)
+			performRoles(rolesCtx, allRoles, v, slot, &wg, span)
 		case isHealthyAgain := <-healthTracker.HealthUpdates():
 			if isHealthyAgain {
 				headSlot, err = initializeValidatorAndGetHeadSlot(ctx, v)

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -133,8 +133,8 @@ func run(ctx context.Context, v iface.Validator) {
 				cancel()
 				continue
 			}
+			// performRoles calls span.End()
 			performRoles(slotCtx, allRoles, v, slot, &wg, span)
-			span.End()
 			cancel()
 		case isHealthyAgain := <-healthTracker.HealthUpdates():
 			if isHealthyAgain {


### PR DESCRIPTION
We currently call `UpdataDomainDataCaches`  at end of epoch with a slot context but in a goroutine. If later this context is cancelled upon completion of the swtich case, the cache may not have updated. 