### PR TITLE
Add blob schedule support

### DIFF
--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -532,7 +532,7 @@ func TestClient_GetHeader(t *testing.T) {
 				require.Equal(t, expectedPath, r.URL.Path)
 				epr := &ExecHeaderResponseElectra{}
 				require.NoError(t, json.Unmarshal([]byte(testExampleHeaderResponseElectra), epr))
-				pro, err := epr.ToProto()
+				pro, err := epr.ToProto(100)
 				require.NoError(t, err)
 				ssz, err := pro.MarshalSSZ()
 				require.NoError(t, err)

--- a/api/client/builder/types.go
+++ b/api/client/builder/types.go
@@ -1284,8 +1284,8 @@ type ExecHeaderResponseElectra struct {
 }
 
 // ToProto creates a SignedBuilderBidElectra Proto from ExecHeaderResponseElectra.
-func (ehr *ExecHeaderResponseElectra) ToProto() (*eth.SignedBuilderBidElectra, error) {
-	bb, err := ehr.Data.Message.ToProto()
+func (ehr *ExecHeaderResponseElectra) ToProto(slot types.Slot) (*eth.SignedBuilderBidElectra, error) {
+	bb, err := ehr.Data.Message.ToProto(slot)
 	if err != nil {
 		return nil, err
 	}
@@ -1296,13 +1296,13 @@ func (ehr *ExecHeaderResponseElectra) ToProto() (*eth.SignedBuilderBidElectra, e
 }
 
 // ToProto creates a BuilderBidElectra Proto from BuilderBidElectra.
-func (bb *BuilderBidElectra) ToProto() (*eth.BuilderBidElectra, error) {
+func (bb *BuilderBidElectra) ToProto(slot types.Slot) (*eth.BuilderBidElectra, error) {
 	header, err := bb.Header.ToProto()
 	if err != nil {
 		return nil, err
 	}
-	if len(bb.BlobKzgCommitments) > params.BeaconConfig().MaxBlobsPerBlockByVersion(version.Electra) {
-		return nil, fmt.Errorf("blob commitment count %d exceeds the maximum %d", len(bb.BlobKzgCommitments), params.BeaconConfig().MaxBlobsPerBlockByVersion(version.Electra))
+	if len(bb.BlobKzgCommitments) > params.BeaconConfig().MaxBlobsPerBlock(slot) {
+		return nil, fmt.Errorf("blob commitment count %d exceeds the maximum %d", len(bb.BlobKzgCommitments), params.BeaconConfig().MaxBlobsPerBlock(slot))
 	}
 	kzgCommitments := make([][]byte, len(bb.BlobKzgCommitments))
 	for i, commit := range bb.BlobKzgCommitments {

--- a/api/client/builder/types.go
+++ b/api/client/builder/types.go
@@ -1301,8 +1301,9 @@ func (bb *BuilderBidElectra) ToProto(slot types.Slot) (*eth.BuilderBidElectra, e
 	if err != nil {
 		return nil, err
 	}
-	if len(bb.BlobKzgCommitments) > params.BeaconConfig().MaxBlobsPerBlock(slot) {
-		return nil, fmt.Errorf("blob commitment count %d exceeds the maximum %d", len(bb.BlobKzgCommitments), params.BeaconConfig().MaxBlobsPerBlock(slot))
+	maxBlobsPerBlock := params.BeaconConfig().MaxBlobsPerBlock(slot)
+	if len(bb.BlobKzgCommitments) > maxBlobsPerBlock {
+		return nil, fmt.Errorf("blob commitment count %d exceeds the maximum %d", len(bb.BlobKzgCommitments), maxBlobsPerBlock)
 	}
 	kzgCommitments := make([][]byte, len(bb.BlobKzgCommitments))
 	for i, commit := range bb.BlobKzgCommitments {

--- a/beacon-chain/core/transition/BUILD.bazel
+++ b/beacon-chain/core/transition/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//runtime/version:go_default_library",
+        "//time/slots:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/beacon-chain/rpc/eth/blob/handlers_test.go
+++ b/beacon-chain/rpc/eth/blob/handlers_test.go
@@ -412,6 +412,10 @@ func TestBlobs_Electra(t *testing.T) {
 	cfg := params.BeaconConfig().Copy()
 	cfg.DenebForkEpoch = 0
 	cfg.ElectraForkEpoch = 1
+	cfg.BlobSchedule = []params.BlobScheduleEntry{
+		{Epoch: 0, MaxBlobsPerBlock: 6},
+		{Epoch: 1, MaxBlobsPerBlock: 9},
+	}
 	params.OverrideBeaconConfig(cfg)
 
 	db := testDB.SetupDB(t)

--- a/beacon-chain/rpc/eth/blob/handlers_test.go
+++ b/beacon-chain/rpc/eth/blob/handlers_test.go
@@ -265,7 +265,7 @@ func TestBlobs(t *testing.T) {
 		require.Equal(t, false, resp.Finalized)
 	})
 	t.Run("blob index over max", func(t *testing.T) {
-		overLimit := params.BeaconConfig().MaxBlobsPerBlockByVersion(version.Deneb)
+		overLimit := maxBlobsPerBlockByVersion(version.Deneb)
 		u := fmt.Sprintf("http://foo.example/123?indices=%d", overLimit)
 		request := httptest.NewRequest("GET", u, nil)
 		writer := httptest.NewRecorder()
@@ -415,7 +415,7 @@ func TestBlobs_Electra(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	db := testDB.SetupDB(t)
-	electraBlock, blobs := util.GenerateTestElectraBlockWithSidecar(t, [32]byte{}, 123, params.BeaconConfig().MaxBlobsPerBlockByVersion(version.Electra))
+	electraBlock, blobs := util.GenerateTestElectraBlockWithSidecar(t, [32]byte{}, 123, maxBlobsPerBlockByVersion(version.Electra))
 	require.NoError(t, db.SaveBlock(context.Background(), electraBlock))
 	bs := filesystem.NewEphemeralBlobStorage(t)
 	testSidecars := verification.FakeVerifySliceForTest(t, blobs)
@@ -451,7 +451,7 @@ func TestBlobs_Electra(t *testing.T) {
 		assert.Equal(t, http.StatusOK, writer.Code)
 		resp := &structs.SidecarsResponse{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-		require.Equal(t, params.BeaconConfig().MaxBlobsPerBlockByVersion(version.Electra), len(resp.Data))
+		require.Equal(t, maxBlobsPerBlockByVersion(version.Electra), len(resp.Data))
 		sidecar := resp.Data[0]
 		require.NotNil(t, sidecar)
 		assert.Equal(t, "0", sidecar.Index)
@@ -464,7 +464,7 @@ func TestBlobs_Electra(t *testing.T) {
 		require.Equal(t, false, resp.Finalized)
 	})
 	t.Run("requested blob index at max", func(t *testing.T) {
-		limit := params.BeaconConfig().MaxBlobsPerBlockByVersion(version.Electra) - 1
+		limit := maxBlobsPerBlockByVersion(version.Electra) - 1
 		u := fmt.Sprintf("http://foo.example/123?indices=%d", limit)
 		request := httptest.NewRequest("GET", u, nil)
 		writer := httptest.NewRecorder()
@@ -496,7 +496,7 @@ func TestBlobs_Electra(t *testing.T) {
 		require.Equal(t, false, resp.Finalized)
 	})
 	t.Run("blob index over max", func(t *testing.T) {
-		overLimit := params.BeaconConfig().MaxBlobsPerBlockByVersion(version.Electra)
+		overLimit := maxBlobsPerBlockByVersion(version.Electra)
 		u := fmt.Sprintf("http://foo.example/123?indices=%d", overLimit)
 		request := httptest.NewRequest("GET", u, nil)
 		writer := httptest.NewRecorder()
@@ -553,4 +553,12 @@ func Test_parseIndices(t *testing.T) {
 			}
 		})
 	}
+}
+
+func maxBlobsPerBlockByVersion(v int) int {
+	if v >= version.Electra {
+		return params.BeaconConfig().DeprecatedMaxBlobsPerBlockElectra
+	}
+
+	return params.BeaconConfig().DeprecatedMaxBlobsPerBlock
 }

--- a/changelog/tt_corn.md
+++ b/changelog/tt_corn.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add blob schedule support from https://github.com/ethereum/consensus-specs/pull/4277

--- a/config/params/BUILD.bazel
+++ b/config/params/BUILD.bazel
@@ -73,7 +73,6 @@ go_test(
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//io/file:go_default_library",
-        "//runtime/version:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -3,6 +3,7 @@ package params
 
 import (
 	"math"
+	"slices"
 	"time"
 
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
@@ -410,7 +411,14 @@ func (b *BeaconChainConfig) MaxBlobsPerBlock(slot primitives.Slot) int {
 	epoch := primitives.Epoch(slot.DivSlot(b.SlotsPerEpoch))
 
 	if len(b.BlobSchedule) > 0 {
-		// Assume BlobSchedule is already sorted ascending by Epoch
+		if !slices.IsSortedFunc(b.BlobSchedule, func(a, b BlobScheduleEntry) int {
+			return int(a.Epoch - b.Epoch)
+		}) {
+			slices.SortFunc(b.BlobSchedule, func(a, b BlobScheduleEntry) int {
+				return int(a.Epoch - b.Epoch)
+			})
+		}
+
 		for i := len(b.BlobSchedule) - 1; i >= 0; i-- {
 			if epoch >= b.BlobSchedule[i].Epoch {
 				return int(b.BlobSchedule[i].MaxBlobsPerBlock)
@@ -418,18 +426,23 @@ func (b *BeaconChainConfig) MaxBlobsPerBlock(slot primitives.Slot) int {
 		}
 	}
 
-	// If the blob schedule is empty, we fall back to the deprecated value.
 	if epoch >= b.ElectraForkEpoch {
 		return b.DeprecatedMaxBlobsPerBlockElectra
 	}
-
 	return b.DeprecatedMaxBlobsPerBlock
 }
 
 // MaxBlobsPerBlockAtEpoch returns the maximum number of blobs per block for the given epoch
 func (b *BeaconChainConfig) MaxBlobsPerBlockAtEpoch(epoch primitives.Epoch) int {
 	if len(b.BlobSchedule) > 0 {
-		// Assume BlobSchedule is already sorted ascending by Epoch
+		if !slices.IsSortedFunc(b.BlobSchedule, func(a, b BlobScheduleEntry) int {
+			return int(a.Epoch - b.Epoch)
+		}) {
+			slices.SortFunc(b.BlobSchedule, func(a, b BlobScheduleEntry) int {
+				return int(a.Epoch - b.Epoch)
+			})
+		}
+
 		for i := len(b.BlobSchedule) - 1; i >= 0; i-- {
 			if epoch >= b.BlobSchedule[i].Epoch {
 				return int(b.BlobSchedule[i].MaxBlobsPerBlock)
@@ -437,11 +450,9 @@ func (b *BeaconChainConfig) MaxBlobsPerBlockAtEpoch(epoch primitives.Epoch) int 
 		}
 	}
 
-	// If the blob schedule is empty, we fall back to the deprecated value.
 	if epoch >= b.ElectraForkEpoch {
 		return b.DeprecatedMaxBlobsPerBlockElectra
 	}
-
 	return b.DeprecatedMaxBlobsPerBlock
 }
 

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -417,15 +417,7 @@ func (b *BeaconChainConfig) MaxBlobsPerBlock(slot primitives.Slot) int {
 			}
 		}
 	}
-
-	switch {
-	case epoch >= b.FuluForkEpoch:
-		return b.DeprecatedMaxBlobsPerBlockFulu
-	case epoch >= b.ElectraForkEpoch:
-		return b.DeprecatedMaxBlobsPerBlockElectra
-	default:
-		return b.DeprecatedMaxBlobsPerBlock
-	}
+	return b.DeprecatedMaxBlobsPerBlock
 }
 
 // MaxBlobsPerBlockAtEpoch returns the maximum number of blobs per block for the given epoch
@@ -438,15 +430,7 @@ func (b *BeaconChainConfig) MaxBlobsPerBlockAtEpoch(epoch primitives.Epoch) int 
 			}
 		}
 	}
-
-	switch {
-	case epoch >= b.FuluForkEpoch:
-		return b.DeprecatedMaxBlobsPerBlockFulu
-	case epoch >= b.ElectraForkEpoch:
-		return b.DeprecatedMaxBlobsPerBlockElectra
-	default:
-		return b.DeprecatedMaxBlobsPerBlock
-	}
+	return b.DeprecatedMaxBlobsPerBlock
 }
 
 // DenebEnabled centralizes the check to determine if code paths

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -417,6 +417,12 @@ func (b *BeaconChainConfig) MaxBlobsPerBlock(slot primitives.Slot) int {
 			}
 		}
 	}
+
+	// If the blob schedule is empty, we fall back to the deprecated value.
+	if epoch >= b.ElectraForkEpoch {
+		return b.DeprecatedMaxBlobsPerBlockElectra
+	}
+
 	return b.DeprecatedMaxBlobsPerBlock
 }
 
@@ -430,6 +436,12 @@ func (b *BeaconChainConfig) MaxBlobsPerBlockAtEpoch(epoch primitives.Epoch) int 
 			}
 		}
 	}
+
+	// If the blob schedule is empty, we fall back to the deprecated value.
+	if epoch >= b.ElectraForkEpoch {
+		return b.DeprecatedMaxBlobsPerBlockElectra
+	}
+
 	return b.DeprecatedMaxBlobsPerBlock
 }
 

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -295,6 +295,7 @@ type BeaconChainConfig struct {
 	NodeIdBits                      uint64          `yaml:"NODE_ID_BITS" spec:"true"`                       // NodeIdBits defines the bit length of a node id.
 
 	// Blobs Values
+	BlobSchedule []BlobScheduleEntry `yaml:"BLOB_SCHEDULE"`
 
 	// Deprecated_MaxBlobsPerBlock defines the max blobs that could exist in a block.
 	// Deprecated: This field is no longer supported. Avoid using it.
@@ -311,6 +312,11 @@ type BeaconChainConfig struct {
 	// DeprecatedMaxBlobsPerBlockFulu defines the max blobs that could exist in a block post Fulu hard fork.
 	// Deprecated: This field is no longer supported. Avoid using it.
 	DeprecatedMaxBlobsPerBlockFulu int `yaml:"MAX_BLOBS_PER_BLOCK_FULU" spec:"true"`
+}
+
+type BlobScheduleEntry struct {
+	Epoch            primitives.Epoch `yaml:"EPOCH"`
+	MaxBlobsPerBlock uint64           `yaml:"MAX_BLOBS_PER_BLOCK"`
 }
 
 // InitializeForkSchedule initializes the schedules forks baked into the config.
@@ -400,46 +406,47 @@ func (b *BeaconChainConfig) TargetBlobsPerBlock(slot primitives.Slot) int {
 	return b.DeprecatedMaxBlobsPerBlock / 2
 }
 
-// MaxBlobsPerBlock returns the maximum number of blobs per block for the given slot.
 func (b *BeaconChainConfig) MaxBlobsPerBlock(slot primitives.Slot) int {
 	epoch := primitives.Epoch(slot.DivSlot(b.SlotsPerEpoch))
 
-	if epoch >= b.FuluForkEpoch {
+	if len(b.BlobSchedule) > 0 {
+		// Assume BlobSchedule is already sorted ascending by Epoch
+		for i := len(b.BlobSchedule) - 1; i >= 0; i-- {
+			if epoch >= b.BlobSchedule[i].Epoch {
+				return int(b.BlobSchedule[i].MaxBlobsPerBlock)
+			}
+		}
+	}
+
+	switch {
+	case epoch >= b.FuluForkEpoch:
 		return b.DeprecatedMaxBlobsPerBlockFulu
-	}
-
-	if epoch >= b.ElectraForkEpoch {
+	case epoch >= b.ElectraForkEpoch:
 		return b.DeprecatedMaxBlobsPerBlockElectra
+	default:
+		return b.DeprecatedMaxBlobsPerBlock
 	}
-
-	return b.DeprecatedMaxBlobsPerBlock
 }
 
-// MaxBlobsPerBlockByVersion returns the maximum number of blobs per block for the given fork version
-func (b *BeaconChainConfig) MaxBlobsPerBlockByVersion(v int) int {
-	if v >= version.Fulu {
-		return b.DeprecatedMaxBlobsPerBlockFulu
-	}
-
-	if v >= version.Electra {
-		return b.DeprecatedMaxBlobsPerBlockElectra
-	}
-
-	return b.DeprecatedMaxBlobsPerBlock
-}
-
-// MaxBlobsPerBlockByEpoch returns the maximum number of blobs per block for the given epoch,
-// adjusting for the Electra fork.
+// MaxBlobsPerBlockAtEpoch returns the maximum number of blobs per block for the given epoch
 func (b *BeaconChainConfig) MaxBlobsPerBlockAtEpoch(epoch primitives.Epoch) int {
-	if epoch >= b.FuluForkEpoch {
+	if len(b.BlobSchedule) > 0 {
+		// Assume BlobSchedule is already sorted ascending by Epoch
+		for i := len(b.BlobSchedule) - 1; i >= 0; i-- {
+			if epoch >= b.BlobSchedule[i].Epoch {
+				return int(b.BlobSchedule[i].MaxBlobsPerBlock)
+			}
+		}
+	}
+
+	switch {
+	case epoch >= b.FuluForkEpoch:
 		return b.DeprecatedMaxBlobsPerBlockFulu
-	}
-
-	if epoch >= b.ElectraForkEpoch {
+	case epoch >= b.ElectraForkEpoch:
 		return b.DeprecatedMaxBlobsPerBlockElectra
+	default:
+		return b.DeprecatedMaxBlobsPerBlock
 	}
-
-	return b.DeprecatedMaxBlobsPerBlock
 }
 
 // DenebEnabled centralizes the check to determine if code paths

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/genesis"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
-	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 )
 
@@ -108,12 +107,61 @@ func TestConfigGenesisValidatorRoot(t *testing.T) {
 	}
 }
 
-func Test_MaxBlobCount(t *testing.T) {
-	cfg := params.MainnetConfig()
-	cfg.ElectraForkEpoch = 10
-	require.Equal(t, cfg.MaxBlobsPerBlock(primitives.Slot(cfg.ElectraForkEpoch)*cfg.SlotsPerEpoch-1), 6)
-	require.Equal(t, cfg.MaxBlobsPerBlock(primitives.Slot(cfg.ElectraForkEpoch)*cfg.SlotsPerEpoch), 9)
-	cfg.ElectraForkEpoch = math.MaxUint64
+func TestMaxBlobsPerBlock(t *testing.T) {
+	t.Run("Before all forks and no BlobSchedule", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.BlobSchedule = nil
+		cfg.ElectraForkEpoch = 100
+		cfg.FuluForkEpoch = 200
+		require.Equal(t, cfg.MaxBlobsPerBlock(0), cfg.DeprecatedMaxBlobsPerBlock)
+	})
+
+	t.Run("After ElectraForkEpoch but before FuluForkEpoch", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.BlobSchedule = nil
+		cfg.ElectraForkEpoch = 10
+		cfg.FuluForkEpoch = 20
+		slot := primitives.Slot(cfg.ElectraForkEpoch * 32)
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), cfg.DeprecatedMaxBlobsPerBlockElectra)
+	})
+
+	t.Run("After FuluForkEpoch", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.BlobSchedule = nil
+		cfg.FuluForkEpoch = 15
+		slot := primitives.Slot(cfg.FuluForkEpoch * 32)
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), cfg.DeprecatedMaxBlobsPerBlockFulu)
+	})
+
+	t.Run("Uses latest matching BlobSchedule entry", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.BlobSchedule = []params.BlobScheduleEntry{
+			{Epoch: 5, MaxBlobsPerBlock: 7},
+			{Epoch: 10, MaxBlobsPerBlock: 11},
+		}
+		slot := primitives.Slot(11 * cfg.SlotsPerEpoch)
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), 11)
+	})
+
+	t.Run("Uses earlier matching BlobSchedule entry", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.BlobSchedule = []params.BlobScheduleEntry{
+			{Epoch: 5, MaxBlobsPerBlock: 7},
+			{Epoch: 10, MaxBlobsPerBlock: 11},
+		}
+		slot := primitives.Slot(6 * cfg.SlotsPerEpoch)
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), 7)
+	})
+
+	t.Run("Before first BlobSchedule entry falls back to fork logic", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.FuluForkEpoch = 1
+		cfg.BlobSchedule = []params.BlobScheduleEntry{
+			{Epoch: 5, MaxBlobsPerBlock: 7},
+		}
+		slot := primitives.Slot(2) // Epoch 0
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), cfg.DeprecatedMaxBlobsPerBlock)
+	})
 }
 
 func Test_TargetBlobCount(t *testing.T) {
@@ -122,42 +170,4 @@ func Test_TargetBlobCount(t *testing.T) {
 	require.Equal(t, cfg.TargetBlobsPerBlock(primitives.Slot(cfg.ElectraForkEpoch)*cfg.SlotsPerEpoch-1), 3)
 	require.Equal(t, cfg.TargetBlobsPerBlock(primitives.Slot(cfg.ElectraForkEpoch)*cfg.SlotsPerEpoch), 6)
 	cfg.ElectraForkEpoch = math.MaxUint64
-}
-
-func TestMaxBlobsPerBlockByVersion(t *testing.T) {
-	tests := []struct {
-		name string
-		v    int
-		want int
-	}{
-		{
-			name: "Version below Electra",
-			v:    version.Electra - 1,
-			want: params.BeaconConfig().DeprecatedMaxBlobsPerBlock,
-		},
-		{
-			name: "Version equal to Electra",
-			v:    version.Electra,
-			want: params.BeaconConfig().DeprecatedMaxBlobsPerBlockElectra,
-		},
-		{
-			name: "Version equal to Fulu",
-			v:    version.Fulu,
-			want: params.BeaconConfig().DeprecatedMaxBlobsPerBlockFulu,
-		},
-		{
-			name: "Version above Fulu",
-			v:    version.Fulu + 1,
-			want: params.BeaconConfig().DeprecatedMaxBlobsPerBlockFulu,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := params.BeaconConfig().MaxBlobsPerBlockByVersion(tt.v)
-			if got != tt.want {
-				t.Errorf("MaxBlobsPerBlockByVersion(%d) = %d, want %d", tt.v, got, tt.want)
-			}
-		})
-	}
 }

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -116,30 +116,13 @@ func TestMaxBlobsPerBlock(t *testing.T) {
 		require.Equal(t, cfg.MaxBlobsPerBlock(0), cfg.DeprecatedMaxBlobsPerBlock)
 	})
 
-	t.Run("After ElectraForkEpoch but before FuluForkEpoch", func(t *testing.T) {
-		cfg := params.MainnetConfig()
-		cfg.BlobSchedule = nil
-		cfg.ElectraForkEpoch = 10
-		cfg.FuluForkEpoch = 20
-		slot := primitives.Slot(cfg.ElectraForkEpoch * 32)
-		require.Equal(t, cfg.MaxBlobsPerBlock(slot), cfg.DeprecatedMaxBlobsPerBlockElectra)
-	})
-
-	t.Run("After FuluForkEpoch", func(t *testing.T) {
-		cfg := params.MainnetConfig()
-		cfg.BlobSchedule = nil
-		cfg.FuluForkEpoch = 15
-		slot := primitives.Slot(cfg.FuluForkEpoch * 32)
-		require.Equal(t, cfg.MaxBlobsPerBlock(slot), cfg.DeprecatedMaxBlobsPerBlockFulu)
-	})
-
 	t.Run("Uses latest matching BlobSchedule entry", func(t *testing.T) {
 		cfg := params.MainnetConfig()
 		cfg.BlobSchedule = []params.BlobScheduleEntry{
 			{Epoch: 5, MaxBlobsPerBlock: 7},
 			{Epoch: 10, MaxBlobsPerBlock: 11},
 		}
-		slot := primitives.Slot(11 * cfg.SlotsPerEpoch)
+		slot := 11 * cfg.SlotsPerEpoch
 		require.Equal(t, cfg.MaxBlobsPerBlock(slot), 11)
 	})
 
@@ -149,7 +132,7 @@ func TestMaxBlobsPerBlock(t *testing.T) {
 			{Epoch: 5, MaxBlobsPerBlock: 7},
 			{Epoch: 10, MaxBlobsPerBlock: 11},
 		}
-		slot := primitives.Slot(6 * cfg.SlotsPerEpoch)
+		slot := 6 * cfg.SlotsPerEpoch
 		require.Equal(t, cfg.MaxBlobsPerBlock(slot), 7)
 	})
 

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -145,6 +145,37 @@ func TestMaxBlobsPerBlock(t *testing.T) {
 		slot := primitives.Slot(2) // Epoch 0
 		require.Equal(t, cfg.MaxBlobsPerBlock(slot), cfg.DeprecatedMaxBlobsPerBlock)
 	})
+
+	t.Run("Unsorted BlobSchedule still picks latest matching entry", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.BlobSchedule = []params.BlobScheduleEntry{
+			{Epoch: 10, MaxBlobsPerBlock: 11},
+			{Epoch: 5, MaxBlobsPerBlock: 7},
+		}
+		slot := 11 * cfg.SlotsPerEpoch
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), 11)
+	})
+
+	t.Run("Unsorted BlobSchedule picks earlier matching entry correctly", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.BlobSchedule = []params.BlobScheduleEntry{
+			{Epoch: 10, MaxBlobsPerBlock: 11},
+			{Epoch: 5, MaxBlobsPerBlock: 7},
+		}
+		slot := 6 * cfg.SlotsPerEpoch
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), 7)
+	})
+
+	t.Run("Unsorted BlobSchedule falls back to fork logic when epoch is before all entries", func(t *testing.T) {
+		cfg := params.MainnetConfig()
+		cfg.ElectraForkEpoch = 2
+		cfg.BlobSchedule = []params.BlobScheduleEntry{
+			{Epoch: 10, MaxBlobsPerBlock: 11},
+			{Epoch: 5, MaxBlobsPerBlock: 7},
+		}
+		slot := primitives.Slot(1) // Epoch 0
+		require.Equal(t, cfg.MaxBlobsPerBlock(slot), cfg.DeprecatedMaxBlobsPerBlock)
+	})
 }
 
 func Test_TargetBlobCount(t *testing.T) {

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
@@ -242,6 +243,16 @@ func ConfigToYaml(cfg *BeaconChainConfig) []byte {
 		fmt.Sprintf("MAX_BLOBS_PER_BLOCK: %d", cfg.DeprecatedMaxBlobsPerBlock),
 		fmt.Sprintf("MAX_BLOBS_PER_BLOCK_ELECTRA: %d", cfg.DeprecatedMaxBlobsPerBlockElectra),
 		fmt.Sprintf("MAX_BLOBS_PER_BLOCK_FULU: %d", cfg.DeprecatedMaxBlobsPerBlockFulu),
+	}
+
+	if len(cfg.BlobSchedule) > 0 {
+		lines = append(lines, "BLOB_SCHEDULE:")
+		for _, entry := range cfg.BlobSchedule {
+			lines = append(lines,
+				"  - EPOCH: "+strconv.FormatUint(uint64(entry.Epoch), 10),
+				"    MAX_BLOBS_PER_BLOCK: "+strconv.FormatUint(entry.MaxBlobsPerBlock, 10),
+			)
+		}
 	}
 
 	yamlFile := []byte(strings.Join(lines, "\n"))

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -25,7 +25,6 @@ import (
 // IMPORTANT: Use one field per line and sort these alphabetically to reduce conflicts.
 var placeholderFields = []string{
 	"ATTESTATION_DEADLINE",
-	"BLOB_SCHEDULE",
 	"BLOB_SIDECAR_SUBNET_COUNT_FULU",
 	"EIP6110_FORK_EPOCH",
 	"EIP6110_FORK_VERSION",

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -339,6 +339,11 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	AttestationSubnetPrefixBits:     6,
 	SubnetsPerNode:                  2,
 	NodeIdBits:                      256,
+
+	BlobSchedule: []BlobScheduleEntry{
+		{Epoch: 269568, MaxBlobsPerBlock: 6},
+		{Epoch: 364032, MaxBlobsPerBlock: 9},
+	},
 }
 
 // MainnetTestConfig provides a version of the mainnet config that has a different name

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -127,6 +127,11 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.ConfigName = MinimalName
 	minimalConfig.PresetBase = "minimal"
 
+	minimalConfig.BlobSchedule = []BlobScheduleEntry{
+		{Epoch: 18446744073709551615, MaxBlobsPerBlock: 6},
+		{Epoch: 18446744073709551615, MaxBlobsPerBlock: 9},
+	}
+
 	minimalConfig.InitializeForkSchedule()
 	return minimalConfig
 }

--- a/config/params/testdata/e2e_config.yaml
+++ b/config/params/testdata/e2e_config.yaml
@@ -124,4 +124,13 @@ SLOTS_PER_EPOCH: 6
 EPOCHS_PER_ETH1_VOTING_PERIOD: 2
 MAX_SEED_LOOKAHEAD: 1
 
+# Blob Scheduling
+# ---------------------------------------------------------------
 
+BLOB_SCHEDULE:
+  # Deneb
+  - EPOCH: 12
+    MAX_BLOBS_PER_BLOCK: 6
+  # Electra
+  - EPOCH: 14
+    MAX_BLOBS_PER_BLOCK: 9

--- a/config/params/testnet_e2e_config.go
+++ b/config/params/testnet_e2e_config.go
@@ -60,6 +60,11 @@ func E2ETestConfig() *BeaconChainConfig {
 	e2eConfig.ElectraForkVersion = []byte{5, 0, 0, 253}
 	e2eConfig.FuluForkVersion = []byte{6, 0, 0, 253}
 
+	e2eConfig.BlobSchedule = []BlobScheduleEntry{
+		{Epoch: 12, MaxBlobsPerBlock: 6},
+		{Epoch: 14, MaxBlobsPerBlock: 9},
+	}
+
 	e2eConfig.InitializeForkSchedule()
 	return e2eConfig
 }
@@ -108,6 +113,11 @@ func E2EMainnetTestConfig() *BeaconChainConfig {
 
 	// Deneb changes.
 	e2eConfig.MinPerEpochChurnLimit = 2
+
+	e2eConfig.BlobSchedule = []BlobScheduleEntry{
+		{Epoch: 12, MaxBlobsPerBlock: 6},
+		{Epoch: 14, MaxBlobsPerBlock: 9},
+	}
 
 	e2eConfig.InitializeForkSchedule()
 	return e2eConfig

--- a/config/params/testnet_holesky_config.go
+++ b/config/params/testnet_holesky_config.go
@@ -46,6 +46,10 @@ func HoleskyConfig() *BeaconChainConfig {
 	cfg.TerminalTotalDifficulty = "0"
 	cfg.DepositContractAddress = "0x4242424242424242424242424242424242424242"
 	cfg.EjectionBalance = 28000000000
+	cfg.BlobSchedule = []BlobScheduleEntry{
+		{Epoch: 29696, MaxBlobsPerBlock: 6},
+		{Epoch: 115968, MaxBlobsPerBlock: 9},
+	}
 	cfg.InitializeForkSchedule()
 	return cfg
 }

--- a/config/params/testnet_hoodi_config.go
+++ b/config/params/testnet_hoodi_config.go
@@ -53,6 +53,10 @@ func HoodiConfig() *BeaconChainConfig {
 	cfg.FuluForkVersion = []byte{0x70, 0x00, 0x09, 0x10}
 	cfg.TerminalTotalDifficulty = "0"
 	cfg.DepositContractAddress = "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+	cfg.BlobSchedule = []BlobScheduleEntry{
+		{Epoch: 0, MaxBlobsPerBlock: 6},
+		{Epoch: 2048, MaxBlobsPerBlock: 9},
+	}
 	cfg.InitializeForkSchedule()
 	return cfg
 }

--- a/config/params/testnet_sepolia_config.go
+++ b/config/params/testnet_sepolia_config.go
@@ -51,6 +51,10 @@ func SepoliaConfig() *BeaconChainConfig {
 	cfg.TerminalTotalDifficulty = "17000000000000000"
 	cfg.DepositContractAddress = "0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"
 	cfg.DefaultBuilderGasLimit = uint64(60000000)
+	cfg.BlobSchedule = []BlobScheduleEntry{
+		{Epoch: 132608, MaxBlobsPerBlock: 6},
+		{Epoch: 222464, MaxBlobsPerBlock: 9},
+	}
 	cfg.InitializeForkSchedule()
 	return cfg
 }

--- a/testing/endtoend/components/web3remotesigner.go
+++ b/testing/endtoend/components/web3remotesigner.go
@@ -256,7 +256,13 @@ func (w *Web3RemoteSigner) UnderlyingProcess() *os.Process {
 func createTestnetDir() (string, error) {
 	testNetDir := e2e.TestParams.TestPath + "/web3signer-testnet"
 	configPath := filepath.Join(testNetDir, "config.yaml")
-	rawYaml := params.ConfigToYaml(params.BeaconConfig())
+
+	// TODO: add blob schedule back in as soon as web3signer supports it!
+	configCopy := params.BeaconConfig().Copy()
+	configCopy.BlobSchedule = nil
+	// ---
+
+	rawYaml := params.ConfigToYaml(configCopy)
 
 	// Add in deposit contract in yaml
 	depContractStr := fmt.Sprintf("\nDEPOSIT_CONTRACT_ADDRESS: %s\n", params.BeaconConfig().DepositContractAddress)

--- a/testing/spectest/shared/electra/sanity/block_processing.go
+++ b/testing/spectest/shared/electra/sanity/block_processing.go
@@ -38,7 +38,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 		t.Run(folder.Name(), func(t *testing.T) {
 			params.SetupTestConfigCleanup(t)
 			cfg := params.BeaconConfig().Copy()
-			cfg.ElectraForkEpoch = 0
+			cfg.BlobSchedule = []params.BlobScheduleEntry{{MaxBlobsPerBlock: 9}}
 			params.OverrideBeaconConfig(cfg)
 
 			helpers.ClearCache()


### PR DESCRIPTION
This PR adds blob schedule support from https://github.com/ethereum/consensus-specs/pull/4277

Note to the reviewer:
`MaxBlobsPerBlockByVersion` is no longer safe to use after BPO, so it's better to remove it. Its only usage is in mev-boost to check that the number of blobs doesn't exceed the limit, and in that case, we can just pass the slot directly into the function.
