### PR TITLE
fixing attester slashing v2 endpoint

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -751,9 +751,9 @@ func (s *Server) GetAttesterSlashingsV2(w http.ResponseWriter, r *http.Request) 
 		httputil.HandleError(w, "Could not get head state: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	var attStructs []interface{}
-	sourceSlashings := s.SlashingsPool.PendingAttesterSlashings(ctx, headState, true /* return unlimited slashings */)
 
+	sourceSlashings := s.SlashingsPool.PendingAttesterSlashings(ctx, headState, true /* return unlimited slashings */)
+	attStructs := make([]interface{}, 0, len(sourceSlashings))
 	for _, slashing := range sourceSlashings {
 		var attStruct interface{}
 		if v >= version.Electra && slashing.Version() >= version.Electra {

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -1858,6 +1858,7 @@ func TestGetAttesterSlashings(t *testing.T) {
 			// Unmarshal resp.Data into a slice of slashings
 			var slashings []*structs.AttesterSlashingElectra
 			require.NoError(t, json.Unmarshal(resp.Data, &slashings))
+			require.NotNil(t, slashings)
 			require.Equal(t, 0, len(slashings))
 		})
 	})

--- a/changelog/james-prysm_consistent-slashingv2-api.md
+++ b/changelog/james-prysm_consistent-slashingv2-api.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed /eth/v2/beacon/pool/attester_slashings no slashings returns empty array instead of nil.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
 
fixes consistency with other client teams when there are no slashing we should return an empty array instead of nil for  /eth/v2/beacon/pool/attester_slashings endpoint

**Which issues(s) does this PR fix?**

Fixes #15267

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
