### PR TITLE
Enable the minimal config to generate a genesis state

### DIFF
--- a/beacon-chain/state/state-native/setters_block.go
+++ b/beacon-chain/state/state-native/setters_block.go
@@ -4,7 +4,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native/types"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stateutil"
 	"github.com/OffchainLabs/prysm/v6/config/features"
-	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v6/config/params"
 	consensus_types "github.com/OffchainLabs/prysm/v6/consensus-types"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/pkg/errors"
@@ -35,7 +35,7 @@ func (b *BeaconState) SetBlockRoots(val [][]byte) error {
 		b.sharedFieldReferences[types.BlockRoots].MinusRef()
 		b.sharedFieldReferences[types.BlockRoots] = stateutil.NewRef(1)
 
-		rootsArr := make([][32]byte, fieldparams.BlockRootsLength)
+		rootsArr := make([][32]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 		for i := 0; i < len(rootsArr); i++ {
 			copy(rootsArr[i][:], val[i])
 		}

--- a/beacon-chain/state/state-native/setters_randao.go
+++ b/beacon-chain/state/state-native/setters_randao.go
@@ -4,7 +4,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native/types"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stateutil"
 	"github.com/OffchainLabs/prysm/v6/config/features"
-	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v6/config/params"
 	consensus_types "github.com/OffchainLabs/prysm/v6/consensus-types"
 	"github.com/pkg/errors"
 )
@@ -24,7 +24,7 @@ func (b *BeaconState) SetRandaoMixes(val [][]byte) error {
 		b.sharedFieldReferences[types.RandaoMixes].MinusRef()
 		b.sharedFieldReferences[types.RandaoMixes] = stateutil.NewRef(1)
 
-		rootsArr := make([][32]byte, fieldparams.RandaoMixesLength)
+		rootsArr := make([][32]byte, params.BeaconConfig().EpochsPerHistoricalVector)
 		for i := 0; i < len(rootsArr); i++ {
 			copy(rootsArr[i][:], val[i])
 		}

--- a/beacon-chain/state/state-native/setters_state.go
+++ b/beacon-chain/state/state-native/setters_state.go
@@ -4,7 +4,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native/types"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stateutil"
 	"github.com/OffchainLabs/prysm/v6/config/features"
-	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v6/config/params"
 	consensus_types "github.com/OffchainLabs/prysm/v6/consensus-types"
 	"github.com/pkg/errors"
 )
@@ -24,7 +24,7 @@ func (b *BeaconState) SetStateRoots(val [][]byte) error {
 		b.sharedFieldReferences[types.StateRoots].MinusRef()
 		b.sharedFieldReferences[types.StateRoots] = stateutil.NewRef(1)
 
-		rootsArr := make([][32]byte, fieldparams.StateRootsLength)
+		rootsArr := make([][32]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 		for i := 0; i < len(rootsArr); i++ {
 			copy(rootsArr[i][:], val[i])
 		}

--- a/runtime/interop/premine-state_test.go
+++ b/runtime/interop/premine-state_test.go
@@ -22,12 +22,18 @@ func TestPremineGenesis_Electra(t *testing.T) {
 		ExcessBlobGas: &one,
 		BlobGasUsed:   &one,
 	})
-	_, err := NewPreminedGenesis(context.Background(), genesis.Time(), 10, 10, version.Electra, genesis)
+	state1, err := NewPreminedGenesis(context.Background(), genesis.Time(), 10, 10, version.Electra, genesis)
+	require.NoError(t, err)
+
+	_, err = state1.MarshalSSZ()
 	require.NoError(t, err)
 
 	// Use minimal setup
 	require.NoError(t, params.SetActive(params.MinimalSpecConfig()))
 
-	_, err = NewPreminedGenesis(context.Background(), genesis.Time(), 10, 10, version.Electra, genesis)
+	state2, err := NewPreminedGenesis(context.Background(), genesis.Time(), 10, 10, version.Electra, genesis)
+	require.NoError(t, err)
+
+	_, err = state2.MarshalSSZ()
 	require.NoError(t, err)
 }

--- a/runtime/interop/premine-state_test.go
+++ b/runtime/interop/premine-state_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/OffchainLabs/prysm/v6/time"
@@ -22,5 +23,11 @@ func TestPremineGenesis_Electra(t *testing.T) {
 		BlobGasUsed:   &one,
 	})
 	_, err := NewPreminedGenesis(context.Background(), genesis.Time(), 10, 10, version.Electra, genesis)
+	require.NoError(t, err)
+
+	// Use minimal setup
+	require.NoError(t, params.SetActive(params.MinimalSpecConfig()))
+
+	_, err = NewPreminedGenesis(context.Background(), genesis.Time(), 10, 10, version.Electra, genesis)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

This PR enables using the minimal config to generate a genesis state.

**Which issues(s) does this PR fix?**

Fixes #15282 

**Other notes for review**

There is an error because I cannot encode to SSZ since the Beacon state hardcodes the BlocksRoot field to the mainnet preset value. Do you have any insights on how to fix that?

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
