### PR TITLE
Use current slot helper whenever possible

### DIFF
--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -187,9 +187,7 @@ func ValidateAttestationTime(attSlot primitives.Slot, genesisTime time.Time, clo
 // VerifyCheckpointEpoch is within current epoch and previous epoch
 // with respect to current time. Returns true if it's within, false if it's not.
 func VerifyCheckpointEpoch(c *ethpb.Checkpoint, genesis time.Time) bool {
-	now := uint64(prysmTime.Now().Unix())
-	genesisTime := uint64(genesis.Unix())
-	currentSlot := primitives.Slot((now - genesisTime) / params.BeaconConfig().SecondsPerSlot)
+	currentSlot := slots.CurrentSlot(uint64(genesis.Unix()))
 	currentEpoch := slots.ToEpoch(currentSlot)
 
 	var prevEpoch primitives.Epoch

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -267,7 +267,7 @@ func (f *ForkChoice) HighestReceivedBlockSlot() primitives.Slot {
 	return f.store.highestReceivedNode.slot
 }
 
-// HighestReceivedBlockSlotDelay returns the number of slots that the highest
+// HighestReceivedBlockDelay returns the number of slots that the highest
 // received block was late when receiving it
 func (f *ForkChoice) HighestReceivedBlockDelay() primitives.Slot {
 	n := f.store.highestReceivedNode

--- a/changelog/tt_toro.md
+++ b/changelog/tt_toro.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use current slot helper whenever possible

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -21,7 +21,6 @@ import (
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	validatorpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1/validator-client"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
-	prysmTime "github.com/OffchainLabs/prysm/v6/time"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	"github.com/OffchainLabs/prysm/v6/validator/client/iface"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -320,8 +319,7 @@ func ProposeExit(
 }
 
 func CurrentEpoch(genesisTime *timestamp.Timestamp) (primitives.Epoch, error) {
-	totalSecondsPassed := prysmTime.Now().Unix() - genesisTime.Seconds
-	currentSlot := primitives.Slot((uint64(totalSecondsPassed)) / params.BeaconConfig().SecondsPerSlot)
+	currentSlot := slots.CurrentSlot(uint64(genesisTime.Seconds))
 	currentEpoch := slots.ToEpoch(currentSlot)
 	return currentEpoch, nil
 }


### PR DESCRIPTION
Found multiple places using `/ params.BeaconConfig().SecondsPerSlot` which is just replicating the `CurrentSlot` helper. We should replace these with the helper directly. This also makes it easier to evaluate shorter slot durations if we ever pursue that