### PR TITLE
Added prysm build data to otel tracing spans

### DIFF
--- a/changelog/pvl-build.md
+++ b/changelog/pvl-build.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added Prysm build data to otel tracing spans.

--- a/monitoring/tracing/BUILD.bazel
+++ b/monitoring/tracing/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//monitoring/tracing/trace:go_default_library",
+        "//runtime/version:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opentelemetry_go_otel//:go_default_library",
         "@io_opentelemetry_go_otel//attribute:go_default_library",

--- a/monitoring/tracing/tracer.go
+++ b/monitoring/tracing/tracer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	prysmTrace "github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
+	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -51,6 +52,7 @@ func Setup(ctx context.Context, serviceName, processName, endpoint string, sampl
 				semconv.SchemaURL,
 				semconv.ServiceNameKey.String(serviceName),
 				attribute.String("process_name", processName),
+				attribute.String("build", version.BuildData()),
 			),
 		),
 	)


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

As title describes, this adds metadata to all spans showing the prysm build data (i.e. the version string and git commit) for better aggregation/filtering of spans.

**Which issues(s) does this PR fix?**

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
