### PR TITLE
Add support for nightly test vectors

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -256,55 +256,15 @@ filegroup(
 )
 
 consensus_spec_version = "v1.6.0-alpha.0"
-
-bls_test_version = "v0.1.1"
-
-http_archive(
-    name = "consensus_spec_tests_general",
-    build_file_content = """
-filegroup(
-    name = "test_data",
-    srcs = glob([
-        "**/*.ssz_snappy",
-        "**/*.yaml",
-    ]),
-    visibility = ["//visibility:public"],
-)
-    """,
-    integrity = "sha256-W7oKvoM0nAkyitykRxAw6kmCvjYC01IqiNJy0AmCnMM=",
-    url = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s/general.tar.gz" % consensus_spec_version,
-)
-
-http_archive(
-    name = "consensus_spec_tests_minimal",
-    build_file_content = """
-filegroup(
-    name = "test_data",
-    srcs = glob([
-        "**/*.ssz_snappy",
-        "**/*.yaml",
-    ]),
-    visibility = ["//visibility:public"],
-)
-    """,
-    integrity = "sha256-ig7/zxomjv6buBWMom4IxAJh3lFJ9+JnY44E7c8ZNP8=",
-    url = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s/minimal.tar.gz" % consensus_spec_version,
-)
-
-http_archive(
-    name = "consensus_spec_tests_mainnet",
-    build_file_content = """
-filegroup(
-    name = "test_data",
-    srcs = glob([
-        "**/*.ssz_snappy",
-        "**/*.yaml",
-    ]),
-    visibility = ["//visibility:public"],
-)
-    """,
-    integrity = "sha256-mjx+MkXtPhCNv4c4knLYLIkvIdpF7WTjx/ElvGPQzSo=",
-    url = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s/mainnet.tar.gz" % consensus_spec_version,
+load("@prysm//tools:download_spectests.bzl", "consensus_spec_tests")
+consensus_spec_tests(
+    name = "consensus_spec_tests",
+    version = consensus_spec_version,
+    flavors = {
+        "general": "sha256-W7oKvoM0nAkyitykRxAw6kmCvjYC01IqiNJy0AmCnMM=",
+        "minimal": "sha256-ig7/zxomjv6buBWMom4IxAJh3lFJ9+JnY44E7c8ZNP8=",
+        "mainnet": "sha256-mjx+MkXtPhCNv4c4knLYLIkvIdpF7WTjx/ElvGPQzSo=",
+    },
 )
 
 http_archive(
@@ -323,6 +283,7 @@ filegroup(
     url = "https://github.com/ethereum/consensus-specs/archive/refs/tags/%s.tar.gz" % consensus_spec_version,
 )
 
+bls_test_version = "v0.1.1"
 http_archive(
     name = "bls_spec_tests",
     build_file_content = """

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -256,15 +256,17 @@ filegroup(
 )
 
 consensus_spec_version = "v1.6.0-alpha.0"
+
 load("@prysm//tools:download_spectests.bzl", "consensus_spec_tests")
+
 consensus_spec_tests(
     name = "consensus_spec_tests",
-    version = consensus_spec_version,
     flavors = {
         "general": "sha256-W7oKvoM0nAkyitykRxAw6kmCvjYC01IqiNJy0AmCnMM=",
         "minimal": "sha256-ig7/zxomjv6buBWMom4IxAJh3lFJ9+JnY44E7c8ZNP8=",
         "mainnet": "sha256-mjx+MkXtPhCNv4c4knLYLIkvIdpF7WTjx/ElvGPQzSo=",
     },
+    version = consensus_spec_version,
 )
 
 http_archive(
@@ -284,6 +286,7 @@ filegroup(
 )
 
 bls_test_version = "v0.1.1"
+
 http_archive(
     name = "bls_spec_tests",
     build_file_content = """

--- a/beacon-chain/state/state-native/BUILD.bazel
+++ b/beacon-chain/state/state-native/BUILD.bazel
@@ -122,7 +122,7 @@ go_test(
         "types_test.go",
     ],
     data = glob(["testdata/**"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/changelog/jtraglia_nightly_spec_tests.md
+++ b/changelog/jtraglia_nightly_spec_tests.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add ability to download nightly test vectors.

--- a/config/params/BUILD.bazel
+++ b/config/params/BUILD.bazel
@@ -57,8 +57,7 @@ go_test(
     data = glob(["*.yaml"]) + [
         "testdata/e2e_config.yaml",
         "@consensus_spec//:spec_data",
-        "@consensus_spec_tests_mainnet//:test_data",
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
         "@eth2_networks//:configs",
         "@holesky_testnet//:configs",
         "@hoodi_testnet//:configs",

--- a/proto/testing/BUILD.bazel
+++ b/proto/testing/BUILD.bazel
@@ -46,8 +46,7 @@ go_test(
         "tags_test.go",
     ],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     embed = [":go_default_library"],
     tags = ["spectest"],

--- a/testing/spectest/general/deneb/kzg/BUILD.bazel
+++ b/testing/spectest/general/deneb/kzg/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["verify_blob_kzg_proof_batch_test.go"],
     data = [
-        "@consensus_spec_tests_general//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/altair/epoch_processing/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/altair/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/altair/fork_helper/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/fork_helper/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_altair_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/altair/fork_transition/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     timeout = "short",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/altair/fork:go_default_library"],

--- a/testing/spectest/mainnet/altair/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/altair/light_client/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/light_client/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["single_merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/operations/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/altair/random/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/altair/sanity:go_default_library"],

--- a/testing/spectest/mainnet/altair/rewards/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/altair/rewards:go_default_library"],

--- a/testing/spectest/mainnet/altair/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/altair/sanity:go_default_library"],

--- a/testing/spectest/mainnet/altair/ssz_static/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/altair/ssz_static:go_default_library"],

--- a/testing/spectest/mainnet/bellatrix/epoch_processing/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/bellatrix/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/bellatrix/fork_helper/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/fork_helper/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_altair_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/bellatrix/fork_transition/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/bellatrix/fork:go_default_library"],

--- a/testing/spectest/mainnet/bellatrix/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/bellatrix/light_client/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/light_client/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["single_merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/bellatrix/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/operations/BUILD.bazel
@@ -14,7 +14,7 @@ go_test(
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/bellatrix/random/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/bellatrix/sanity:go_default_library"],

--- a/testing/spectest/mainnet/bellatrix/rewards/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/bellatrix/rewards:go_default_library"],

--- a/testing/spectest/mainnet/bellatrix/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/bellatrix/sanity:go_default_library"],

--- a/testing/spectest/mainnet/bellatrix/ssz_static/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/bellatrix/ssz_static:go_default_library"],

--- a/testing/spectest/mainnet/capella/epoch_processing/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/capella/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 1,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/capella/fork_helper/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/fork_helper/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_capella_test.go"],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 1,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/capella/fork_transition/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["transition_test.go"],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/capella/fork:go_default_library"],

--- a/testing/spectest/mainnet/capella/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/capella/light_client/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/light_client/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["single_merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/capella/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/operations/BUILD.bazel
@@ -16,7 +16,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/capella/random/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/capella/sanity:go_default_library"],

--- a/testing/spectest/mainnet/capella/rewards/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/capella/rewards:go_default_library"],

--- a/testing/spectest/mainnet/capella/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/capella/sanity:go_default_library"],

--- a/testing/spectest/mainnet/capella/ssz_static/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/capella/ssz_static:go_default_library"],

--- a/testing/spectest/mainnet/deneb/epoch_processing/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/deneb/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/deneb/fork_helper/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/fork_helper/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_deneb_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/deneb/fork_transition/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/deneb/fork:go_default_library"],

--- a/testing/spectest/mainnet/deneb/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/deneb/light_client/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/light_client/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["single_merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/deneb/merkle_proof/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/merkle_proof/BUILD.bazel
@@ -4,7 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/deneb/merkle_proof:go_default_library"],

--- a/testing/spectest/mainnet/deneb/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/operations/BUILD.bazel
@@ -16,7 +16,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/deneb/random/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/deneb/sanity:go_default_library"],

--- a/testing/spectest/mainnet/deneb/rewards/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/deneb/rewards:go_default_library"],

--- a/testing/spectest/mainnet/deneb/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/deneb/sanity:go_default_library"],

--- a/testing/spectest/mainnet/deneb/ssz_static/BUILD.bazel
+++ b/testing/spectest/mainnet/deneb/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/deneb/ssz_static:go_default_library"],

--- a/testing/spectest/mainnet/electra/epoch_processing/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/epoch_processing/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     deps = ["//testing/spectest/shared/electra/epoch_processing:go_default_library"],
 )

--- a/testing/spectest/mainnet/electra/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/electra/fork_helper/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/fork_helper/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_electra_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/electra/fork_transition/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/electra/fork:go_default_library"],

--- a/testing/spectest/mainnet/electra/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/electra/light_client/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/light_client/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["single_merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/electra/merkle_proof/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/merkle_proof/BUILD.bazel
@@ -4,7 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/electra/merkle_proof:go_default_library"],

--- a/testing/spectest/mainnet/electra/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/operations/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     deps = ["//testing/spectest/shared/electra/operations:go_default_library"],
 )

--- a/testing/spectest/mainnet/electra/random/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/electra/sanity:go_default_library"],

--- a/testing/spectest/mainnet/electra/rewards/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/electra/rewards:go_default_library"],

--- a/testing/spectest/mainnet/electra/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/electra/sanity:go_default_library"],

--- a/testing/spectest/mainnet/electra/ssz_static/BUILD.bazel
+++ b/testing/spectest/mainnet/electra/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/electra/ssz_static:go_default_library"],

--- a/testing/spectest/mainnet/fulu/epoch_processing/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/epoch_processing/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     deps = ["//testing/spectest/shared/fulu/epoch_processing:go_default_library"],
 )

--- a/testing/spectest/mainnet/fulu/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/fulu/fork/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/fork/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_fulu_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/fulu/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = [

--- a/testing/spectest/mainnet/fulu/merkle_proof/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/merkle_proof/BUILD.bazel
@@ -4,7 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/fulu/merkle_proof:go_default_library"],

--- a/testing/spectest/mainnet/fulu/networking/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/networking/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["custody_groups_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/fulu/networking:go_default_library"],

--- a/testing/spectest/mainnet/fulu/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/operations/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     deps = ["//testing/spectest/shared/fulu/operations:go_default_library"],
 )

--- a/testing/spectest/mainnet/fulu/random/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/fulu/sanity:go_default_library"],

--- a/testing/spectest/mainnet/fulu/rewards/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/fulu/rewards:go_default_library"],

--- a/testing/spectest/mainnet/fulu/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/fulu/sanity:go_default_library"],

--- a/testing/spectest/mainnet/fulu/ssz_static/BUILD.bazel
+++ b/testing/spectest/mainnet/fulu/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/fulu/ssz_static:go_default_library"],

--- a/testing/spectest/mainnet/phase0/epoch_processing/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/phase0/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/phase0/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/operations/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     shard_count = 4,
     tags = ["spectest"],

--- a/testing/spectest/mainnet/phase0/random/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/phase0/sanity:go_default_library"],

--- a/testing/spectest/mainnet/phase0/rewards/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/phase0/rewards:go_default_library"],

--- a/testing/spectest/mainnet/phase0/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/phase0/sanity:go_default_library"],

--- a/testing/spectest/mainnet/phase0/shuffling/core/shuffle/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/shuffling/core/shuffle/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["shuffle_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/phase0/shuffling/core/shuffle:go_default_library"],

--- a/testing/spectest/mainnet/phase0/ssz_static/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_mainnet//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/phase0/ssz_static:go_default_library"],

--- a/testing/spectest/minimal/altair/epoch_processing/BUILD.bazel
+++ b/testing/spectest/minimal/altair/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/altair/finality/BUILD.bazel
+++ b/testing/spectest/minimal/altair/finality/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/altair/fork/BUILD.bazel
+++ b/testing/spectest/minimal/altair/fork/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_altair_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/altair/fork_transition/BUILD.bazel
+++ b/testing/spectest/minimal/altair/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     timeout = "short",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/altair/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/altair/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/altair/light_client/BUILD.bazel
+++ b/testing/spectest/minimal/altair/light_client/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "update_ranking_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/altair/operations/BUILD.bazel
+++ b/testing/spectest/minimal/altair/operations/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/altair/random/BUILD.bazel
+++ b/testing/spectest/minimal/altair/random/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/altair/rewards/BUILD.bazel
+++ b/testing/spectest/minimal/altair/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/altair/sanity/BUILD.bazel
+++ b/testing/spectest/minimal/altair/sanity/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/altair/ssz_static/BUILD.bazel
+++ b/testing/spectest/minimal/altair/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/bellatrix/epoch_processing/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/bellatrix/finality/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/finality/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/bellatrix/fork/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/fork/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_altair_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/bellatrix/fork_transition/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     timeout = "short",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/bellatrix/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/bellatrix/light_client/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/light_client/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "update_ranking_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/bellatrix/operations/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/operations/BUILD.bazel
@@ -14,7 +14,7 @@ go_test(
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/bellatrix/random/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/random/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/bellatrix/rewards/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/bellatrix/sanity/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/sanity/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/bellatrix/ssz_static/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/capella/epoch_processing/BUILD.bazel
+++ b/testing/spectest/minimal/capella/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/capella/finality/BUILD.bazel
+++ b/testing/spectest/minimal/capella/finality/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["finality_test.go"],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 1,

--- a/testing/spectest/minimal/capella/fork/BUILD.bazel
+++ b/testing/spectest/minimal/capella/fork/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_capella_test.go"],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 1,

--- a/testing/spectest/minimal/capella/fork_transition/BUILD.bazel
+++ b/testing/spectest/minimal/capella/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     timeout = "short",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/capella/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/capella/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/capella/light_client/BUILD.bazel
+++ b/testing/spectest/minimal/capella/light_client/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "update_ranking_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/capella/operations/BUILD.bazel
+++ b/testing/spectest/minimal/capella/operations/BUILD.bazel
@@ -16,7 +16,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/capella/random/BUILD.bazel
+++ b/testing/spectest/minimal/capella/random/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/capella/rewards/BUILD.bazel
+++ b/testing/spectest/minimal/capella/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/capella/sanity/BUILD.bazel
+++ b/testing/spectest/minimal/capella/sanity/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "slots_test.go",
     ],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/capella/ssz_static/BUILD.bazel
+++ b/testing/spectest/minimal/capella/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/epoch_processing/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/finality/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/finality/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/deneb/fork/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/fork/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_deneb_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/deneb/fork_transition/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     timeout = "short",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/deneb/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/light_client/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/light_client/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "update_ranking_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/merkle_proof/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/merkle_proof/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/operations/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/operations/BUILD.bazel
@@ -16,7 +16,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/random/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/random/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/deneb/rewards/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/sanity/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/sanity/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/deneb/ssz_static/BUILD.bazel
+++ b/testing/spectest/minimal/deneb/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/electra/epoch_processing/BUILD.bazel
+++ b/testing/spectest/minimal/electra/epoch_processing/BUILD.bazel
@@ -19,7 +19,7 @@ go_test(
         "sync_committee_updates_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     deps = ["//testing/spectest/shared/electra/epoch_processing:go_default_library"],

--- a/testing/spectest/minimal/electra/finality/BUILD.bazel
+++ b/testing/spectest/minimal/electra/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/electra/fork/BUILD.bazel
+++ b/testing/spectest/minimal/electra/fork/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_electra_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/electra/fork_transition/BUILD.bazel
+++ b/testing/spectest/minimal/electra/fork_transition/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     timeout = "short",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/electra/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/electra/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/electra/light_client/BUILD.bazel
+++ b/testing/spectest/minimal/electra/light_client/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "update_ranking_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/electra/merkle_proof/BUILD.bazel
+++ b/testing/spectest/minimal/electra/merkle_proof/BUILD.bazel
@@ -4,7 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/electra/operations/BUILD.bazel
+++ b/testing/spectest/minimal/electra/operations/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     deps = ["//testing/spectest/shared/electra/operations:go_default_library"],

--- a/testing/spectest/minimal/electra/random/BUILD.bazel
+++ b/testing/spectest/minimal/electra/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/electra/rewards/BUILD.bazel
+++ b/testing/spectest/minimal/electra/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/electra/sanity/BUILD.bazel
+++ b/testing/spectest/minimal/electra/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/electra/ssz_static/BUILD.bazel
+++ b/testing/spectest/minimal/electra/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/fulu/epoch_processing/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/epoch_processing/BUILD.bazel
@@ -19,7 +19,7 @@ go_test(
         "sync_committee_updates_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     deps = ["//testing/spectest/shared/fulu/epoch_processing:go_default_library"],

--- a/testing/spectest/minimal/fulu/finality/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/finality/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/fulu/fork/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/fork/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["upgrade_to_fulu_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/fulu/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/forkchoice/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/fulu/merkle_proof/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/merkle_proof/BUILD.bazel
@@ -4,7 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["merkle_proof_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/fulu/networking/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/networking/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["custody_columns_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/fulu/networking:go_default_library"],

--- a/testing/spectest/minimal/fulu/operations/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/operations/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
         "withdrawals_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     deps = ["//testing/spectest/shared/fulu/operations:go_default_library"],

--- a/testing/spectest/minimal/fulu/random/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/random/BUILD.bazel
@@ -6,7 +6,7 @@ go_test(
     timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/fulu/rewards/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/fulu/sanity/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/sanity/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = ["spectest"],

--- a/testing/spectest/minimal/fulu/ssz_static/BUILD.bazel
+++ b/testing/spectest/minimal/fulu/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/phase0/epoch_processing/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/epoch_processing/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "slashings_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/phase0/finality/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/finality/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     shard_count = 4,

--- a/testing/spectest/minimal/phase0/operations/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/operations/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/phase0/random/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/random/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/phase0/rewards/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/rewards/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["rewards_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/phase0/sanity/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/sanity/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "slots_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/phase0/shuffling/core/shuffle/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/shuffling/core/shuffle/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["shuffle_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/testing/spectest/minimal/phase0/ssz_static/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/ssz_static/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     size = "small",
     srcs = ["ssz_static_test.go"],
     data = glob(["*.yaml"]) + [
-        "@consensus_spec_tests_minimal//:test_data",
+        "@consensus_spec_tests//:test_data",
     ],
     eth_network = "minimal",
     tags = [

--- a/tools/download_spectests.bzl
+++ b/tools/download_spectests.bzl
@@ -22,7 +22,7 @@ def _get_redirected_url(repository_ctx, url, headers):
 
 def _impl(repository_ctx):
     version = repository_ctx.getenv("CONSENSUS_SPEC_TESTS_VERSION") or repository_ctx.attr.version
-    token   = repository_ctx.getenv("GITHUB_TOKEN") or ""
+    token = repository_ctx.getenv("GITHUB_TOKEN") or ""
 
     if version == "nightly":
         print("Downloading nightly tests")
@@ -58,7 +58,6 @@ def _impl(repository_ctx):
             name = artifact["name"]
             if name == "consensustestgen.log":
                 continue
-
             url = artifact["archive_download_url"]
             # Ugh this is the worst, bazel doesn't follow redirects...
             resolved_url = _get_redirected_url(repository_ctx, url, headers)
@@ -66,7 +65,6 @@ def _impl(repository_ctx):
             tar_gz_file = "%s.tar.gz" % name.split(" ")[0].lower()
             repository_ctx.extract(tar_gz_file)
             repository_ctx.delete(tar_gz_file)
-
     else:
         for flavor in repository_ctx.attr.flavors:
             integrity = repository_ctx.attr.flavors[flavor]

--- a/tools/download_spectests.bzl
+++ b/tools/download_spectests.bzl
@@ -1,5 +1,5 @@
 # bazel build @consensus_spec_tests//:test_data
-# bazel build @consensus_spec_tests//:test_data --repo_env=SPEC_VERSION=nightly
+# bazel build @consensus_spec_tests//:test_data --repo_env=CONSENSUS_SPEC_TESTS_VERSION=nightly
 
 def _get_redirected_url(repository_ctx, url, headers):
     if not repository_ctx.which("curl"):
@@ -21,7 +21,7 @@ def _get_redirected_url(repository_ctx, url, headers):
     return result.stdout.strip()
 
 def _impl(repository_ctx):
-    version = repository_ctx.getenv("SPEC_VERSION") or repository_ctx.attr.version
+    version = repository_ctx.getenv("CONSENSUS_SPEC_TESTS_VERSION") or repository_ctx.attr.version
     token   = repository_ctx.getenv("GITHUB_TOKEN") or ""
 
     if version == "nightly":

--- a/tools/download_spectests.bzl
+++ b/tools/download_spectests.bzl
@@ -2,16 +2,23 @@
 # bazel build @consensus_spec_tests//:test_data --repo_env=SPEC_VERSION=nightly
 
 def _get_redirected_url(repository_ctx, url, headers):
-    return repository_ctx.execute(
-        [
-            "curl", "-s", "-L", "-o", "/dev/null",
-            "-w", "%{url_effective}",
-            "-H", "Authorization: %s" % headers["Authorization"],
-            "-H", "Accept: %s" % headers["Accept"],
-            url,
-        ],
-        quiet = True,
-    ).stdout
+    if not repository_ctx.which("curl"):
+        fail("curl is required to resolve redirect URLs")
+
+    cmd = [
+        "curl",
+        "-sL",  # silent + follow redirects
+        "-o", "NUL" if repository_ctx.os.name == "windows" else "/dev/null",
+        "-w", "%{url_effective}",
+        "-H", "Authorization: %s" % headers["Authorization"],
+        "-H", "Accept: %s" % headers["Accept"],
+        url,
+    ]
+
+    result = repository_ctx.execute(cmd, quiet = True)
+    if result.return_code != 0:
+        fail("curl failed to resolve redirected URL: %s" % result.stderr)
+    return result.stdout.strip()
 
 def _impl(repository_ctx):
     version = repository_ctx.getenv("SPEC_VERSION") or repository_ctx.attr.version

--- a/tools/download_spectests.bzl
+++ b/tools/download_spectests.bzl
@@ -1,0 +1,109 @@
+# bazel build @consensus_spec_tests//:test_data
+# bazel build @consensus_spec_tests//:test_data --repo_env=SPEC_VERSION=nightly
+
+def _get_redirected_url(repository_ctx, url, headers):
+    return repository_ctx.execute(
+        [
+            "curl", "-s", "-L", "-o", "/dev/null",
+            "-w", "%{url_effective}",
+            "-H", "Authorization: %s" % headers["Authorization"],
+            "-H", "Accept: %s" % headers["Accept"],
+            url,
+        ],
+        quiet = True,
+    ).stdout
+
+def _impl(repository_ctx):
+    version = repository_ctx.getenv("SPEC_VERSION") or repository_ctx.attr.version
+    token   = repository_ctx.getenv("GITHUB_TOKEN") or ""
+
+    if version == "nightly":
+        if not token:
+            fail("Error GITHUB_TOKEN is not set")
+
+        headers = {
+            "Authorization": "token %s" % token,
+            "Accept": "application/vnd.github+json",
+        }
+
+        repository_ctx.download(
+            "https://api.github.com/repos/%s/actions/workflows/%s/runs?branch=%s&status=success&per_page=1"
+                % (repository_ctx.attr.repo, repository_ctx.attr.workflow, repository_ctx.attr.branch),
+            headers = headers,
+            output = "runs.json"
+        )
+
+        run_id = json.decode(repository_ctx.read("runs.json"))["workflow_runs"][0]["id"]
+        repository_ctx.delete("runs.json")
+
+        repository_ctx.download(
+            "https://api.github.com/repos/%s/actions/runs/%s/artifacts"
+                % (repository_ctx.attr.repo, run_id),
+            headers = headers,
+            output = "artifacts.json"
+        )
+
+        artifacts = json.decode(repository_ctx.read("artifacts.json"))["artifacts"]
+        repository_ctx.delete("artifacts.json")
+
+        for artifact in artifacts:
+            name = artifact["name"]
+            if name == "consensustestgen.log":
+                continue
+
+            url = artifact["archive_download_url"]
+            # Ugh this is the worst, bazel doesn't follow redirects...
+            resolved_url = _get_redirected_url(repository_ctx, url, headers)
+            repository_ctx.download_and_extract(resolved_url)
+            tar_gz_file = "%s.tar.gz" % name.split(" ")[0].lower()
+            repository_ctx.extract(tar_gz_file)
+            repository_ctx.delete(tar_gz_file)
+
+    else:
+        for flavor in repository_ctx.attr.flavors:
+            integrity = repository_ctx.attr.flavors[flavor]
+            url = "%s/%s.tar.gz" % (repository_ctx.attr.release_url_template % version, flavor)
+            repository_ctx.download_and_extract(url, integrity = integrity)
+
+    repository_ctx.file("BUILD.bazel", """
+filegroup(
+    name = "general_tests",
+    srcs = glob(["tests/general/**/*.yaml", "tests/general/**/*.ssz_snappy"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "mainnet_tests",
+    srcs = glob(["tests/mainnet/**/*.yaml", "tests/mainnet/**/*.ssz_snappy"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "minimal_tests",
+    srcs = glob(["tests/minimal/**/*.yaml", "tests/minimal/**/*.ssz_snappy"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "test_data",
+    srcs = [
+        ":general_tests",
+        ":mainnet_tests",
+        ":minimal_tests",
+    ],
+    visibility = ["//visibility:public"],
+)
+""")
+
+consensus_spec_tests = repository_rule(
+    implementation = _impl,
+    environ = ["CONSENSUS_SPEC_TESTS_VERSION", "GITHUB_TOKEN"],
+    attrs = {
+        "version": attr.string(mandatory = True),
+        "flavors": attr.string_dict(mandatory = True),
+        "repo": attr.string(default = "ethereum/consensus-specs"),
+        "workflow": attr.string(default = "generate_vectors.yml"),
+        "branch": attr.string(default = "dev"),
+        "release_url_template": attr.string(default = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s"),
+    },
+)

--- a/tools/download_spectests.bzl
+++ b/tools/download_spectests.bzl
@@ -25,6 +25,7 @@ def _impl(repository_ctx):
     token   = repository_ctx.getenv("GITHUB_TOKEN") or ""
 
     if version == "nightly":
+        print("Downloading nightly tests")
         if not token:
             fail("Error GITHUB_TOKEN is not set")
 


### PR DESCRIPTION

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR adds the ability to download consensus-specs' nightly test vectors. As a maintainer of the specs, I plan to use this to verify that there are no unexpected test failures prior to making a release. Also, I am planning to include Prysm on this website I am using to track test compliance: https://jtraglia.github.io/nyx/

**Which issues(s) does this PR fix?**

It allow us to easily test the latest version of the tests. 

**Other notes for review**

A GitHub token is required to download action artifacts. It can be associated with any accounts; I made a token with a burner account. Then add this to your environment variables as `GITHUB_TOKEN`.

A few examples below.

* This will download the spec tests for the version configured in `WORKSPACE`:
```
bazel build @consensus_spec_tests//:test_data
```

* This will download the spec tests for the latest [nightly test vector generation](https://github.com/ethereum/consensus-specs/actions/workflows/generate_vectors.yml):
```
bazel build @consensus_spec_tests//:test_data --repo_env=CONSENSUS_SPEC_TESTS_VERSION=nightly
```

* This will execute tests with the nightly test vectors:
```
bazel test //... --test_tag_filters=spectest --repo_env=CONSENSUS_SPEC_TESTS_VERSION=nightly
```

The only thing I am not happy with in this PR is the `_get_redirected_url` function. I really dislike needing `curl` as a dependency here. Unfortunately, this appears to be required as `repository_ctx.download()` cannot handle redirects.

<img width="779" alt="image" src="https://github.com/user-attachments/assets/7dcdd703-c14b-44b5-aa68-2b81c3775862" />

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
