### PR TITLE
chore(ci): update actions/checkout from v2 to v4

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Is this step failing for you? 
       # Run: clang-format -i proto/**/*.proto
       # See: https://clang.llvm.org/docs/ClangFormat.html

--- a/.github/workflows/horusec.yaml
+++ b/.github/workflows/horusec.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with: # Required when commit authors is enabled
         fetch-depth: 0
         


### PR DESCRIPTION
### Description
Updated `actions/checkout` from `v2` to the latest stable version `v4` to ensure compatibility with the latest GitHub Actions runner features and improvements.

Reference: [actions/checkout v4 release](https://github.com/actions/checkout/releases/tag/v4)

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
