### PR TITLE
Clean up verification package

### DIFF
--- a/beacon-chain/verification/batch.go
+++ b/beacon-chain/verification/batch.go
@@ -42,12 +42,12 @@ func (batch *BlobBatchVerifier) VerifiedROBlobs(_ context.Context, blk blocks.RO
 	for i := range scs {
 		blobSig := bytesutil.ToBytes96(scs[i].SignedBlockHeader.Signature)
 		if blkSig != blobSig {
-			return nil, ErrBatchSignatureMismatch
+			return nil, errBatchSignatureMismatch
 		}
 		// Extra defensive check to make sure the roots match. This should be unnecessary in practice since the root from
 		// the block should be used as the lookup key into the cache of sidecars.
 		if blk.Root() != scs[i].BlockRoot() {
-			return nil, ErrBatchBlockRootMismatch
+			return nil, errBatchBlockRootMismatch
 		}
 	}
 	// Verify commitments for all blobs at once. verifyOneBlob assumes it is only called once this check succeeds.

--- a/beacon-chain/verification/batch_test.go
+++ b/beacon-chain/verification/batch_test.go
@@ -104,7 +104,7 @@ func TestBatchVerifier(t *testing.T) {
 				blbs[0].SignedBlockHeader.Signature = []byte("wrong")
 				return blk, blbs
 			},
-			err:    ErrBatchSignatureMismatch,
+			err:    errBatchSignatureMismatch,
 			nblobs: 2,
 		},
 		{
@@ -124,7 +124,7 @@ func TestBatchVerifier(t *testing.T) {
 				blbs[0] = wr
 				return blk, blbs
 			},
-			err:    ErrBatchBlockRootMismatch,
+			err:    errBatchBlockRootMismatch,
 			nblobs: 1,
 		},
 		{

--- a/beacon-chain/verification/cache_test.go
+++ b/beacon-chain/verification/cache_test.go
@@ -90,12 +90,12 @@ type mockValidatorAtIndexer struct {
 	cb func(idx primitives.ValidatorIndex) (*eth.Validator, error)
 }
 
-// ValidatorAtIndex implements ValidatorAtIndexer.
+// ValidatorAtIndex implements validatorAtIndexer.
 func (m *mockValidatorAtIndexer) ValidatorAtIndex(idx primitives.ValidatorIndex) (*eth.Validator, error) {
 	return m.cb(idx)
 }
 
-var _ ValidatorAtIndexer = &mockValidatorAtIndexer{}
+var _ validatorAtIndexer = &mockValidatorAtIndexer{}
 
 func TestProposerCache(t *testing.T) {
 	ctx := context.Background()

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -167,7 +167,7 @@ func (dv *RODataColumnsVerifier) NotFromFutureSlot() (err error) {
 
 		// If the system time is still before earliestStart, we consider the column from a future slot and return an error.
 		if now.Before(earliestStart) {
-			return columnErrBuilder(ErrFromFutureSlot)
+			return columnErrBuilder(errFromFutureSlot)
 		}
 	}
 
@@ -196,7 +196,7 @@ func (dv *RODataColumnsVerifier) SlotAboveFinalized() (err error) {
 
 		// Check if the data column slot is after first slot of the epoch corresponding to the finalized checkpoint.
 		if dataColumnSlot <= startSlot {
-			return columnErrBuilder(ErrSlotNotAfterFinalized)
+			return columnErrBuilder(errSlotNotAfterFinalized)
 		}
 	}
 
@@ -267,7 +267,7 @@ func (dv *RODataColumnsVerifier) SidecarParentSeen(parentSeen func([fieldparams.
 		}
 
 		if !dv.fc.HasNode(parentRoot) {
-			return columnErrBuilder(ErrSidecarParentNotSeen)
+			return columnErrBuilder(errSidecarParentNotSeen)
 		}
 	}
 
@@ -286,7 +286,7 @@ func (dv *RODataColumnsVerifier) SidecarParentValid(badParent func([fieldparams.
 		parentRoot := dataColumn.ParentRoot()
 
 		if badParent != nil && badParent(parentRoot) {
-			return columnErrBuilder(ErrSidecarParentInvalid)
+			return columnErrBuilder(errSidecarParentInvalid)
 		}
 	}
 
@@ -315,7 +315,7 @@ func (dv *RODataColumnsVerifier) SidecarParentSlotLower() (err error) {
 
 		// Check if the data column slot is after the parent slot.
 		if parentSlot >= dataColumnSlot {
-			return ErrSlotNotAfterParent
+			return errSlotNotAfterParent
 		}
 	}
 
@@ -334,7 +334,7 @@ func (dv *RODataColumnsVerifier) SidecarDescendsFromFinalized() (err error) {
 		parentRoot := dataColumn.ParentRoot()
 
 		if !dv.fc.HasNode(parentRoot) {
-			return columnErrBuilder(ErrSidecarNotFinalizedDescendent)
+			return columnErrBuilder(errSidecarNotFinalizedDescendent)
 		}
 	}
 
@@ -470,7 +470,7 @@ func (dv *RODataColumnsVerifier) SidecarProposerExpected(ctx context.Context) (e
 		}
 
 		if idx != dataColumn.ProposerIndex() {
-			return columnErrBuilder(ErrSidecarUnexpectedProposer)
+			return columnErrBuilder(errSidecarUnexpectedProposer)
 		}
 	}
 
@@ -498,8 +498,8 @@ func (dv *RODataColumnsVerifier) parentState(ctx context.Context, dataColumn blo
 	return st, nil
 }
 
-func columnToSignatureData(d blocks.RODataColumn) SignatureData {
-	return SignatureData{
+func columnToSignatureData(d blocks.RODataColumn) signatureData {
+	return signatureData{
 		Root:      d.BlockRoot(),
 		Parent:    d.ParentRoot(),
 		Signature: bytesutil.ToBytes96(d.SignedBlockHeader.Signature),

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -198,7 +198,7 @@ func TestNotFromFutureSlot(t *testing.T) {
 			require.Equal(t, true, verifier.results.executed(RequireNotFromFutureSlot))
 
 			if tc.isError {
-				require.ErrorIs(t, err, ErrFromFutureSlot)
+				require.ErrorIs(t, err, errFromFutureSlot)
 				require.NotNil(t, verifier.results.result(RequireNotFromFutureSlot))
 				return
 			}
@@ -267,7 +267,7 @@ func TestColumnSlotAboveFinalized(t *testing.T) {
 			require.Equal(t, true, v.results.executed(RequireSlotAboveFinalized))
 
 			if tc.isErr {
-				require.ErrorIs(t, err, ErrSlotNotAfterFinalized)
+				require.ErrorIs(t, err, errSlotNotAfterFinalized)
 				require.NotNil(t, v.results.result(RequireSlotAboveFinalized))
 				return
 			}
@@ -355,13 +355,13 @@ func TestValidProposerSignature(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			signatureCache := &mockSignatureCache{
-				svcb: func(signatureData SignatureData) (bool, error) {
+				svcb: func(signatureData signatureData) (bool, error) {
 					if signatureData != expectedSignatureData {
 						t.Error("Did not see expected SignatureData")
 					}
 					return tc.svcbReturn, tc.svcbError
 				},
-				vscb: func(signatureData SignatureData, _ ValidatorAtIndexer) (err error) {
+				vscb: func(signatureData signatureData, _ validatorAtIndexer) (err error) {
 					if tc.vscbShouldError {
 						t.Error("VerifySignature should not be called if the result is cached")
 						return nil
@@ -472,7 +472,7 @@ func TestDataColumnsSidecarParentSeen(t *testing.T) {
 			require.Equal(t, true, verifier.results.executed(RequireSidecarParentSeen))
 
 			if tc.isError {
-				require.ErrorIs(t, err, ErrSidecarParentNotSeen)
+				require.ErrorIs(t, err, errSidecarParentNotSeen)
 				require.NotNil(t, verifier.results.result(RequireSidecarParentSeen))
 				return
 			}
@@ -522,7 +522,7 @@ func TestDataColumnsSidecarParentValid(t *testing.T) {
 			require.Equal(t, true, verifier.results.executed(RequireSidecarParentValid))
 
 			if tc.isError {
-				require.ErrorIs(t, err, ErrSidecarParentInvalid)
+				require.ErrorIs(t, err, errSidecarParentInvalid)
 				require.NotNil(t, verifier.results.result(RequireSidecarParentValid))
 				return
 			}
@@ -549,7 +549,7 @@ func TestColumnSidecarParentSlotLower(t *testing.T) {
 		{
 			name:            "Not in forkchoice",
 			forkChoiceError: errors.New("not in forkchoice"),
-			err:             ErrSlotNotAfterParent,
+			err:             errSlotNotAfterParent,
 		},
 		{
 			name:           "In forkchoice, slot lower",
@@ -558,13 +558,13 @@ func TestColumnSidecarParentSlotLower(t *testing.T) {
 		{
 			name:           "In forkchoice, slot equal",
 			forkChoiceSlot: firstColumn.Slot(),
-			err:            ErrSlotNotAfterParent,
+			err:            errSlotNotAfterParent,
 			errCheckValue:  true,
 		},
 		{
 			name:           "In forkchoice, slot higher",
 			forkChoiceSlot: firstColumn.Slot() + 1,
-			err:            ErrSlotNotAfterParent,
+			err:            errSlotNotAfterParent,
 			errCheckValue:  true,
 		},
 	}
@@ -656,7 +656,7 @@ func TestDataColumnsSidecarDescendsFromFinalized(t *testing.T) {
 			require.Equal(t, true, verifier.results.executed(RequireSidecarDescendsFromFinalized))
 
 			if tc.isError {
-				require.ErrorIs(t, err, ErrSidecarNotFinalizedDescendent)
+				require.ErrorIs(t, err, errSidecarNotFinalizedDescendent)
 				require.NotNil(t, verifier.results.result(RequireSidecarDescendsFromFinalized))
 				return
 			}
@@ -810,7 +810,7 @@ func TestDataColumnsSidecarProposerExpected(t *testing.T) {
 	testCases := []struct {
 		name          string
 		stateByRooter StateByRooter
-		proposerCache ProposerCache
+		proposerCache proposerCache
 		columns       []blocks.RODataColumn
 		error         string
 	}{
@@ -829,7 +829,7 @@ func TestDataColumnsSidecarProposerExpected(t *testing.T) {
 				ProposerCB: pcReturnsIdx(firstColumn.ProposerIndex() + 1),
 			},
 			columns: columns,
-			error:   ErrSidecarUnexpectedProposer.Error(),
+			error:   errSidecarUnexpectedProposer.Error(),
 		},
 		{
 			name:          "Not cached, state lookup failure",
@@ -883,7 +883,7 @@ func TestDataColumnsSidecarProposerExpected(t *testing.T) {
 				},
 			},
 			columns: columns,
-			error:   ErrSidecarUnexpectedProposer.Error(),
+			error:   errSidecarUnexpectedProposer.Error(),
 		},
 		{
 			name:          "Not cached, ComputeProposer fails",

--- a/beacon-chain/verification/error.go
+++ b/beacon-chain/verification/error.go
@@ -10,7 +10,7 @@ import (
 // a verification failure that should impact peer scoring.
 var ErrInvalid = errors.New("verification failure")
 
-// AsVerification joins the given error with the base ErrVerificationFailure error
+// AsVerificationFailure joins the given error with the base ErrVerificationFailure error
 // so that it can be tested with errors.Is()
 func AsVerificationFailure(err error) error {
 	return errors.Join(ErrInvalid, err)
@@ -29,26 +29,26 @@ var (
 	// ErrBlobIndexInvalid means RequireBlobIndexInBounds failed.
 	ErrBlobIndexInvalid = errors.Join(ErrBlobInvalid, errors.New("incorrect blob sidecar index"))
 
-	// ErrFromFutureSlot means RequireSlotNotTooEarly failed.
-	ErrFromFutureSlot = errors.Join(ErrBlobInvalid, errors.New("slot is too far in the future"))
+	// errFromFutureSlot means RequireSlotNotTooEarly failed.
+	errFromFutureSlot = errors.Join(ErrBlobInvalid, errors.New("slot is too far in the future"))
 
-	// ErrSlotNotAfterFinalized means RequireSlotAboveFinalized failed.
-	ErrSlotNotAfterFinalized = errors.Join(ErrBlobInvalid, errors.New("slot <= finalized checkpoint"))
+	// errSlotNotAfterFinalized means RequireSlotAboveFinalized failed.
+	errSlotNotAfterFinalized = errors.Join(ErrBlobInvalid, errors.New("slot <= finalized checkpoint"))
 
 	// ErrInvalidProposerSignature means RequireValidProposerSignature failed.
 	ErrInvalidProposerSignature = errors.Join(ErrBlobInvalid, errors.New("proposer signature could not be verified"))
 
-	// ErrSidecarParentNotSeen means RequireSidecarParentSeen failed.
-	ErrSidecarParentNotSeen = errors.Join(ErrBlobInvalid, errors.New("parent root has not been seen"))
+	// errSidecarParentNotSeen means RequireSidecarParentSeen failed.
+	errSidecarParentNotSeen = errors.Join(ErrBlobInvalid, errors.New("parent root has not been seen"))
 
-	// ErrSidecarParentInvalid means RequireSidecarParentValid failed.
-	ErrSidecarParentInvalid = errors.Join(ErrBlobInvalid, errors.New("parent block is not valid"))
+	// errSidecarParentInvalid means RequireSidecarParentValid failed.
+	errSidecarParentInvalid = errors.Join(ErrBlobInvalid, errors.New("parent block is not valid"))
 
-	// ErrSlotNotAfterParent means RequireSidecarParentSlotLower failed.
-	ErrSlotNotAfterParent = errors.Join(ErrBlobInvalid, errors.New("slot <= slot"))
+	// errSlotNotAfterParent means RequireSidecarParentSlotLower failed.
+	errSlotNotAfterParent = errors.Join(ErrBlobInvalid, errors.New("slot <= slot"))
 
-	// ErrSidecarNotFinalizedDescendent means RequireSidecarDescendsFromFinalized failed.
-	ErrSidecarNotFinalizedDescendent = errors.Join(ErrBlobInvalid, errors.New("parent is not descended from the finalized block"))
+	// errSidecarNotFinalizedDescendent means RequireSidecarDescendsFromFinalized failed.
+	errSidecarNotFinalizedDescendent = errors.Join(ErrBlobInvalid, errors.New("parent is not descended from the finalized block"))
 
 	// ErrSidecarInclusionProofInvalid means RequireSidecarInclusionProven failed.
 	ErrSidecarInclusionProofInvalid = errors.Join(ErrBlobInvalid, errors.New("sidecar inclusion proof verification failed"))
@@ -56,23 +56,24 @@ var (
 	// ErrSidecarKzgProofInvalid means RequireSidecarKzgProofVerified failed.
 	ErrSidecarKzgProofInvalid = errors.Join(ErrBlobInvalid, errors.New("sidecar kzg commitment proof verification failed"))
 
-	// ErrSidecarUnexpectedProposer means RequireSidecarProposerExpected failed.
-	ErrSidecarUnexpectedProposer = errors.Join(ErrBlobInvalid, errors.New("sidecar was not proposed by the expected proposer_index"))
+	// errSidecarUnexpectedProposer means RequireSidecarProposerExpected failed.
+	errSidecarUnexpectedProposer = errors.Join(ErrBlobInvalid, errors.New("sidecar was not proposed by the expected proposer_index"))
 
 	// ErrMissingVerification indicates that the given verification function was never performed on the value.
 	ErrMissingVerification = errors.Join(ErrBlobInvalid, errors.New("verification was not performed for requirement"))
 
-	// ErrBatchSignatureMismatch is returned by VerifiedROBlobs when any of the blobs in the batch have a signature
+	// errBatchSignatureMismatch is returned by VerifiedROBlobs when any of the blobs in the batch have a signature
 	// which does not match the signature for the block with a corresponding root.
-	ErrBatchSignatureMismatch = errors.Join(ErrBlobInvalid, errors.New("Sidecar block header signature does not match signed block"))
-	// ErrBatchBlockRootMismatch is returned by VerifiedROBlobs in the scenario where the root of the given signed block
+	errBatchSignatureMismatch = errors.Join(ErrBlobInvalid, errors.New("sidecar block header signature does not match signed block"))
+
+	// errBatchBlockRootMismatch is returned by VerifiedROBlobs in the scenario where the root of the given signed block
 	// does not match the block header in one of the corresponding sidecars.
-	ErrBatchBlockRootMismatch = errors.Join(ErrBlobInvalid, errors.New("Sidecar block header root does not match signed block"))
+	errBatchBlockRootMismatch = errors.Join(ErrBlobInvalid, errors.New("sidecar block header root does not match signed block"))
 )
 
 // errVerificationImplementationFault indicates that a code path yielding VerifiedROBlobs has an implementation
 // error, leading it to call VerifiedROBlobError with a nil error.
-var errVerificationImplementationFault = errors.New("could not verify blob data or create a valid VerifiedROBlob.")
+var errVerificationImplementationFault = errors.New("could not verify blob data or create a valid VerifiedROBlob")
 
 // VerificationMultiError is a custom error that can be used to access individual verification failures.
 type VerificationMultiError struct {

--- a/beacon-chain/verification/filesystem.go
+++ b/beacon-chain/verification/filesystem.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// VerifiedROBlobError creates a verified read-only blob sidecar from an error.
+// VerifiedROBlobFromDisk creates a verified read-only blob sidecar from an error.
 func VerifiedROBlobFromDisk(fs afero.Fs, root [32]byte, path string) (blocks.VerifiedROBlob, error) {
 	encoded, err := afero.ReadFile(fs, path)
 	if err != nil {

--- a/beacon-chain/verification/initializer.go
+++ b/beacon-chain/verification/initializer.go
@@ -37,8 +37,8 @@ type StateByRooter interface {
 type sharedResources struct {
 	clock *startup.Clock
 	fc    Forkchoicer
-	sc    SignatureCache
-	pc    ProposerCache
+	sc    signatureCache
+	pc    proposerCache
 	sr    StateByRooter
 	ic    *inclusionProofCache
 }
@@ -101,7 +101,7 @@ func NewInitializerWaiter(cw startup.ClockWaiter, fc Forkchoicer, sr StateByRoot
 		fc: fc,
 		pc: pc,
 		sr: sr,
-		ic: newInclusionProofCache(DefaultInclusionProofCacheSize),
+		ic: newInclusionProofCache(defaultInclusionProofCacheSize),
 	}
 	iw := &InitializerWaiter{cw: cw, ini: &Initializer{shared: shared}}
 	for _, o := range opts {
@@ -121,9 +121,9 @@ func (w *InitializerWaiter) WaitForInitializer(ctx context.Context) (*Initialize
 	}
 	// We wait until this point to initialize the signature cache because here we have access to the genesis validator root.
 	vr := w.ini.shared.clock.GenesisValidatorsRoot()
-	sc := newSigCache(vr[:], DefaultSignatureCacheSize, w.getFork)
+	sc := newSigCache(vr[:], defaultSignatureCacheSize, w.getFork)
 	w.ini.shared.sc = sc
-	w.ini.shared.ic = newInclusionProofCache(DefaultInclusionProofCacheSize)
+	w.ini.shared.ic = newInclusionProofCache(defaultInclusionProofCacheSize)
 	return w.ini, nil
 }
 

--- a/beacon-chain/verification/mock.go
+++ b/beacon-chain/verification/mock.go
@@ -7,8 +7,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 )
 
-// Blob sidecars
-// -------------
+// MockBlobVerifier is a mock implementation of the BlobVerifier interface.
 type MockBlobVerifier struct {
 	ErrBlobIndexInBounds            error
 	ErrSlotTooEarly                 error

--- a/changelog/tt_curry.md
+++ b/changelog/tt_curry.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Clean up verification package


### PR DESCRIPTION
Make internal errors unexported and fix comments on exported identifiers in the verification package. No functional changes