### PR TITLE
code cleanup: moving event channel initialization

### DIFF
--- a/changelog/james-prysm_move-event-channel.md
+++ b/changelog/james-prysm_move-event-channel.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- code cleanup moving event channel into the validator struct for function cleanups.

--- a/validator/client/grpc-api/grpc_validator_client.go
+++ b/validator/client/grpc-api/grpc_validator_client.go
@@ -257,7 +257,6 @@ func (c *grpcValidatorClient) StartEventStream(ctx context.Context, topics []str
 		select {
 		case <-ctx.Done():
 			log.Info("Context canceled, stopping event stream")
-			close(eventsChannel)
 			c.isEventStreamRunning = false
 			return
 		default:

--- a/validator/client/iface/validator.go
+++ b/validator/client/iface/validator.go
@@ -36,6 +36,7 @@ const (
 // Validator interface defines the primary methods of a validator client.
 type Validator interface {
 	Done()
+	EventsChan() <-chan *event.Event
 	AccountsChangedChan() <-chan [][fieldparams.BLSPubkeyLength]byte
 	WaitForChainStart(ctx context.Context) error
 	WaitForSync(ctx context.Context) error
@@ -60,7 +61,7 @@ type Validator interface {
 	CheckDoppelGanger(ctx context.Context) error
 	PushProposerSettings(ctx context.Context, slot primitives.Slot, forceFullPush bool) error
 	SignValidatorRegistrationRequest(ctx context.Context, signer SigningFunc, newValidatorRegistration *ethpb.ValidatorRegistrationV1) (*ethpb.SignedValidatorRegistrationV1, bool /* isCached */, error)
-	StartEventStream(ctx context.Context, topics []string, eventsChan chan<- *event.Event)
+	StartEventStream(ctx context.Context, topics []string)
 	EventStreamIsRunning() bool
 	ProcessEvent(ctx context.Context, event *event.Event)
 	ProposerSettings() *proposer.Settings

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	eventClient "github.com/OffchainLabs/prysm/v6/api/client/event"
 	grpcutil "github.com/OffchainLabs/prysm/v6/api/grpc"
 	"github.com/OffchainLabs/prysm/v6/async/event"
 	lruwrpr "github.com/OffchainLabs/prysm/v6/cache/lru"
@@ -223,6 +224,7 @@ func (v *ValidatorService) Start() {
 		distributed:                    v.distributed,
 		disableDutiesPolling:           v.disableDutiesPolling,
 		accountsChangedChannel:         make(chan [][fieldparams.BLSPubkeyLength]byte, 1),
+		eventsChannel:                  make(chan *eventClient.Event, 1),
 	}
 
 	v.validator = valStruct

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -75,6 +75,10 @@ func (fv *FakeValidator) Done() {
 	fv.DoneCalled = true
 }
 
+func (fv *FakeValidator) EventsChan() <-chan *event.Event {
+	return fv.EventsChannel
+}
+
 func (fv *FakeValidator) AccountsChangedChan() <-chan [][fieldparams.BLSPubkeyLength]byte {
 	return fv.AccountsChannel
 }
@@ -323,7 +327,7 @@ func (fv *FakeValidator) DeleteGraffiti(_ context.Context, _ [fieldparams.BLSPub
 	return nil
 }
 
-func (*FakeValidator) StartEventStream(_ context.Context, _ []string, _ chan<- *event.Event) {
+func (*FakeValidator) StartEventStream(_ context.Context, _ []string) {
 
 }
 

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -114,6 +114,7 @@ type validator struct {
 	dutiesLock                         sync.RWMutex
 	disableDutiesPolling               bool
 	accountsChangedChannel             chan [][fieldparams.BLSPubkeyLength]byte
+	eventsChannel                      chan *eventClient.Event
 	accountChangedSub                  event.Subscription
 }
 
@@ -136,6 +137,10 @@ func (v *validator) Done() {
 	if v.ticker != nil {
 		v.ticker.Done()
 	}
+}
+
+func (v *validator) EventsChan() <-chan *eventClient.Event {
+	return v.eventsChannel
 }
 
 func (v *validator) AccountsChangedChan() <-chan [][fieldparams.BLSPubkeyLength]byte {
@@ -1145,9 +1150,9 @@ func (v *validator) PushProposerSettings(ctx context.Context, slot primitives.Sl
 	return nil
 }
 
-func (v *validator) StartEventStream(ctx context.Context, topics []string, eventsChannel chan<- *eventClient.Event) {
+func (v *validator) StartEventStream(ctx context.Context, topics []string) {
 	log.WithField("topics", topics).Info("Starting event stream")
-	v.validatorClient.StartEventStream(ctx, topics, eventsChannel)
+	v.validatorClient.StartEventStream(ctx, topics, v.eventsChannel)
 }
 
 func (v *validator) checkDependentRoots(ctx context.Context, head *structs.HeadEvent) error {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Other

**What does this PR do? Why is it needed?**

Much like the account changes channel, we should initialize the channel with the validator struct so it can be used in different places. 

**Which issues(s) does this PR fix?**

removes close channel on context done to prevent panics as the channel isn't reinitialized anywhere else and there might be other subscribers

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
