### PR TITLE
Remove deneb and electra entries from blob schedule

### DIFF
--- a/changelog/tt_fugu_.md
+++ b/changelog/tt_fugu_.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Deneb and electra entries from blob schedule.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -340,10 +340,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	SubnetsPerNode:                  2,
 	NodeIdBits:                      256,
 
-	BlobSchedule: []BlobScheduleEntry{
-		{Epoch: 269568, MaxBlobsPerBlock: 6},
-		{Epoch: 364032, MaxBlobsPerBlock: 9},
-	},
+	BlobSchedule: []BlobScheduleEntry{},
 }
 
 // MainnetTestConfig provides a version of the mainnet config that has a different name

--- a/config/params/testnet_holesky_config.go
+++ b/config/params/testnet_holesky_config.go
@@ -46,10 +46,7 @@ func HoleskyConfig() *BeaconChainConfig {
 	cfg.TerminalTotalDifficulty = "0"
 	cfg.DepositContractAddress = "0x4242424242424242424242424242424242424242"
 	cfg.EjectionBalance = 28000000000
-	cfg.BlobSchedule = []BlobScheduleEntry{
-		{Epoch: 29696, MaxBlobsPerBlock: 6},
-		{Epoch: 115968, MaxBlobsPerBlock: 9},
-	}
+	cfg.BlobSchedule = []BlobScheduleEntry{}
 	cfg.InitializeForkSchedule()
 	return cfg
 }

--- a/config/params/testnet_hoodi_config.go
+++ b/config/params/testnet_hoodi_config.go
@@ -53,10 +53,7 @@ func HoodiConfig() *BeaconChainConfig {
 	cfg.FuluForkVersion = []byte{0x70, 0x00, 0x09, 0x10}
 	cfg.TerminalTotalDifficulty = "0"
 	cfg.DepositContractAddress = "0x00000000219ab540356cBB839Cbe05303d7705Fa"
-	cfg.BlobSchedule = []BlobScheduleEntry{
-		{Epoch: 0, MaxBlobsPerBlock: 6},
-		{Epoch: 2048, MaxBlobsPerBlock: 9},
-	}
+	cfg.BlobSchedule = []BlobScheduleEntry{}
 	cfg.DefaultBuilderGasLimit = uint64(60000000)
 	cfg.InitializeForkSchedule()
 	return cfg

--- a/config/params/testnet_sepolia_config.go
+++ b/config/params/testnet_sepolia_config.go
@@ -51,10 +51,7 @@ func SepoliaConfig() *BeaconChainConfig {
 	cfg.TerminalTotalDifficulty = "17000000000000000"
 	cfg.DepositContractAddress = "0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"
 	cfg.DefaultBuilderGasLimit = uint64(60000000)
-	cfg.BlobSchedule = []BlobScheduleEntry{
-		{Epoch: 132608, MaxBlobsPerBlock: 6},
-		{Epoch: 222464, MaxBlobsPerBlock: 9},
-	}
+	cfg.BlobSchedule = []BlobScheduleEntry{}
 	cfg.InitializeForkSchedule()
 	return cfg
 }


### PR DESCRIPTION
This PR removes deneb and electra entries from blob schedule to align with: https://github.com/ethereum/consensus-specs/pull/4341
This is important to align on fork digest calculation pre-fusaka to avoid network split

Note to the reviewer: the current config spec test will fail until we update the consensus spec version in `WORKSPACE` which is scheduled be release next week