### PR TITLE
ci: bump golangci-lint-action to v8

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Is this step failing for you? 
       # Run: clang-format -i proto/**/*.proto
       # See: https://clang.llvm.org/docs/ClangFormat.html

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
           id: go
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v1.64.5
           args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number

--- a/.github/workflows/horusec.yaml
+++ b/.github/workflows/horusec.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with: # Required when commit authors is enabled
         fetch-depth: 0
         


### PR DESCRIPTION
Bumps golangci-lint-action to v8 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0