### PR TITLE
Validator: Remove early context cancellation

### DIFF
--- a/changelog/pvl-rm-ctx-rm.md
+++ b/changelog/pvl-rm-ctx-rm.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Removed eager validator context cancellation that was causing validator builder registrations to fail occasionally.

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -123,7 +123,6 @@ func run(ctx context.Context, v iface.Validator) {
 				cancel()
 				continue
 			}
-			cancel()
 			// performRoles calls span.End()
 			rolesCtx, _ := context.WithDeadline(ctx, deadline)
 			performRoles(rolesCtx, allRoles, v, slot, &wg, span)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The context, which was being cancelled early, is used in non-blocking go routines such as 

https://github.com/OffchainLabs/prysm/blob/472c5da49e2162b6dcf91aff601a884cd23a3882/validator/client/validator.go#L1143-L1147

**Which issues(s) does this PR fix?**

This is causing issues where submitting validator registrations and proposer settings were failing about 50% of the time in testing.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
