### PR TITLE
Beacon node: Instantiate custody info.

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/cache/depositsnapshot:go_default_library",
         "//beacon-chain/core/light-client:go_default_library",
+        "//beacon-chain/core/peerdas:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/filesystem:go_default_library",
         "//beacon-chain/db/kv:go_default_library",

--- a/changelog/manu-peerdas-node.md
+++ b/changelog/manu-peerdas-node.md
@@ -1,0 +1,2 @@
+### Added 
+- PeerDAS: Add `CustodyInfo` in `BeaconNode`.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Previously, running `develop` when the Fulu fork epoch was defined lead to a panic.
This PR fixes this panic.

![image](https://github.com/user-attachments/assets/9429438d-5802-4879-8bf0-adcac8a19d69)

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
