### PR TITLE
added-feature ssz-flag

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -168,6 +168,7 @@ func (c *Client) do(ctx context.Context, method string, path string, body io.Rea
 	if err != nil {
 		return
 	}
+	client.ApplyEncodingHeader(req)
 	req.Header.Add("User-Agent", version.BuildData())
 	for _, o := range opts {
 		o(req)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+	"github.com/OffchainLabs/prysm/v6/config/params"
+	"github.com/OffchainLabs/prysm/v6/config/features"
 )
 
 const (
@@ -81,6 +83,7 @@ func (c *Client) NodeURL() string {
 func (c *Client) Get(ctx context.Context, path string, opts ...ReqOption) ([]byte, error) {
 	u := c.baseURL.ResolveReference(&url.URL{Path: path})
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+	ApplyEncodingHeader(req)
 	if err != nil {
 		return nil, err
 	}
@@ -102,4 +105,18 @@ func (c *Client) Get(ctx context.Context, path string, opts ...ReqOption) ([]byt
 		return nil, errors.Wrap(err, "error reading http response body")
 	}
 	return b, nil
+}
+
+// ApplyEncodingHeader sets the request’s Accept header to advertise JSON, SSZ, or both, based on the global --http-encoding flag.
+func ApplyEncodingHeader(req *http.Request) {
+switch features.Get().HTTPEncoding {
+case params.EncodingSSZ:
+	req.Header.Set("Accept", "application/octet-stream")
+case params.EncodingJSON:
+	req.Header.Set("Accept", "application/json")
+case params.EncodingAuto:
+	req.Header.Set("Accept", "application/json, application/octet-stream")
+default:	
+	req.Header.Set("Accept", "application/json")
+}
 }

--- a/api/roundtrip_flag_test.go
+++ b/api/roundtrip_flag_test.go
@@ -1,0 +1,147 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"context"
+	"encoding/json"
+	"testing"
+"fmt"
+// ssz "github.com/prysmaticlabs/fastssz"
+	"github.com/OffchainLabs/prysm/v6/api"
+	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
+	"github.com/OffchainLabs/prysm/v6/config/params"
+	// "github.com/OffchainLabs/prysm/v6/encoding/ssz"
+	"github.com/OffchainLabs/prysm/v6/network/httputil"
+	"github.com/OffchainLabs/prysm/v6/config/features"
+	"github.com/stretchr/testify/require"
+
+	beaconcli "github.com/OffchainLabs/prysm/v6/api/client/beacon"
+	// "github.com/OffchainLabs/prysm/v6/api"
+	// "github.com/OffchainLabs/prysm/v6/config/params"
+	//  "github.com/OffchainLabs/prysm/v6/encoding/ssz"
+ "encoding/binary"
+)
+
+type payload struct{ Value uint64 }
+func (p *payload) SizeSSZ() int { return 8 }
+
+func (p *payload) MarshalSSZTo(buf []byte) ([]byte, error) {
+	if len(buf) < 8 {
+		buf = make([]byte, 8)
+	}
+	binary.LittleEndian.PutUint64(buf, p.Value)
+	return buf[:8], nil
+}
+
+func (p *payload) MarshalSSZ() ([]byte, error) {
+	out := make([]byte, 8)
+	return p.MarshalSSZTo(out)
+}
+func (p *payload) UnmarshalSSZ(data []byte) error {
+	if len(data) != 8 {
+		return fmt.Errorf("payload SSZ: expected 8 bytes, got %d", len(data))
+	}
+	p.Value = binary.LittleEndian.Uint64(data)
+	return nil
+}
+func handler(w http.ResponseWriter, r *http.Request) {
+	resp:= payload{Value: 0xBEEF}
+		if middleware.PreferSSZ(r) {
+		// Encode SSZ; if it fails, reply 500.
+    if middleware.PreferSSZ(r) {
+        // One-liner: sets the header and writes SSZ.
+       data, err := resp.MarshalSSZ()        // or ssz.MarshalSSZ(&resp)
+		if err != nil {
+			http.Error(w, "SSZ marshal failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// 2) Stream bytes & set headers
+		httputil.WriteSsz(w, data)            // header + body, no returned error
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	
+}
+}
+
+func makeBeaconServer(enc params.HTTPEncoding) *httptest.Server {
+	features.Init(&features.Flags{HTTPEncoding: enc})
+
+	h := middleware.AcceptHeaderHandler(
+		[]string{api.JsonMediaType, api.OctetStreamMediaType},
+	)(
+		middleware.Negotiator(http.HandlerFunc(handler)),
+	)
+	return httptest.NewServer(h)
+}
+func TestRealBeacon_Client(t *testing.T){
+	type pair struct {
+		srv params.HTTPEncoding
+		cli params.HTTPEncoding
+		okssz bool
+
+	}
+		cases := []pair{
+		{params.EncodingJSON,  params.EncodingSSZ,  false},
+		{params.EncodingAuto,  params.EncodingSSZ,  true},
+		{params.EncodingSSZ,   params.EncodingJSON, true},
+	}
+	for _, tc  := range cases {
+		 	 	name := tc.srv.String() + "_srv__" + tc.cli.String() + "_cli"
+		t.Run(name, func(t *testing.T) {
+			/* --- spin server with its flag --- */
+			srv := makeBeaconServer(tc.srv)
+			defer srv.Close()
+
+			/* --- build *real* Beacon client with its flag --- */
+			features.Init(&features.Flags{HTTPEncoding: tc.cli})
+			bc, err := beaconcli.NewClient(srv.URL, http.DefaultClient) // real constructor
+			require.NoError(t, err)
+
+			/* --- call the endpoint -------------------------- */
+			var got payload
+			// we use the generic GET helper of the beacon client
+			// _, err = bc.Get(context.Background(), "/data", &got)
+			// require.NoError(t, err)
+			// require.Equal(t, uint64(0xBEEF), got.Value)
+
+			// /* --- confirm encoding by inspecting the last response --- */
+			// lastHdr := bc.LastResponseHeader() // method exposed by client
+			// if tc.okSsz {
+			// 	require.Equal(t, api.OctetStreamMediaType,
+			// 		lastHdr.Get("Content-Type"))
+			// } else {
+			// 	require.Equal(t, api.JsonMediaType,
+			// 		lastHdr.Get("Content-Type"))
+			// }
+
+			// /* --- decode once more directly to ensure header matched body --- */
+			// if tc.okSsz {
+			// 	var tmp payload
+			// 	require.NoError(t, UnmarshalSSZ(bc.LastResponseBody(), &tmp))
+			// 	require.Equal(t, got, tmp)
+			// } else {
+			// 	var tmp payload
+			// 	require.NoError(t, json.Unmarshal(bc.LastResponseBody(), &tmp))
+			// 	require.Equal(t, got, tmp)
+			// }
+			body, err := bc.Get(context.Background(), "/")
+			require.NoError(t, err)
+
+			/* --- decode body to verify negotiated codec ----------- */
+			// var got payload
+			if tc.okssz { // expecting SSZ
+				require.NoError(t, got.UnmarshalSSZ(body))
+			} else { // expecting JSON
+				require.NoError(t, json.Unmarshal(body, &got))
+			}
+			require.Equal(t, uint64(0xdeadbeef), got.Value)
+		})
+	
+	}
+}

--- a/api/server/middleware/middleware.go
+++ b/api/server/middleware/middleware.go
@@ -1,14 +1,52 @@
 package middleware
 
 import (
+	"context"   
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/rs/cors"
+	"github.com/OffchainLabs/prysm/v6/config/params"
+	"github.com/OffchainLabs/prysm/v6/config/features"
 )
 
 type Middleware func(http.Handler) http.Handler
+type ctxKey int
+const preferSSZKey ctxKey = iota
+
+// PreferSSZ reports whether a previous middleware decided this request should be served in SSZ.
+func PreferSSZ(r *http.Request) bool {
+	v, ok := r.Context().Value(preferSSZKey).(bool)
+	return ok && v
+}
+
+// Negotiator inspects the global --http-encoding flag + the client’s Accept header;
+// if SSZ is mutually acceptable it tags the request context so handlers can switch encoding.
+func Negotiator(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flags := features.Get()
+		if flags.HTTPEncoding == params.EncodingJSON {
+			next.ServeHTTP(w, r)
+			return
+		}
+		accept := r.Header.Get("Accept")
+		acceptSSZ := strings.Contains(accept, "application/octet-stream") || strings.Contains(accept, "*/") || strings.Contains(accept, "")
+		switch flags.HTTPEncoding {
+		case params.EncodingSSZ:
+		if acceptSSZ {
+			r = r.WithContext(context.WithValue(r.Context(), preferSSZKey, true))
+					} 
+	case params.EncodingAuto:		
+		if acceptSSZ {
+			r = r.WithContext(context.WithValue(r.Context(), preferSSZKey, true))
+			
+		}
+	
+	}
+	next.ServeHTTP(w, r)
+	})
+}
 
 // NormalizeQueryValuesHandler normalizes an input query of "key=value1,value2,value3" to "key=value1&key=value2&key=value3"
 func NormalizeQueryValuesHandler(next http.Handler) http.Handler {

--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -172,6 +172,7 @@ func (s *Service) builderEndpoints(stater lookup.Stater) []endpoint {
 			name:     namespace + ".ExpectedWithdrawals",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.ExpectedWithdrawals,
 			methods: []string{http.MethodGet},
@@ -194,6 +195,7 @@ func (s *Service) blobEndpoints(blocker lookup.Blocker) []endpoint {
 			name:     namespace + ".Blobs",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.Blobs,
 			methods: []string{http.MethodGet},
@@ -383,6 +385,7 @@ func (s *Service) validatorEndpoints(
 			name:     namespace + ".ProduceBlockV3",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.ProduceBlockV3,
 			methods: []string{http.MethodGet},
@@ -620,6 +623,7 @@ func (s *Service) beaconEndpoints(
 			name:     namespace + ".GetBlockV2",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetBlockV2,
 			methods: []string{http.MethodGet},
@@ -648,6 +652,7 @@ func (s *Service) beaconEndpoints(
 			name:     namespace + ".GetBlindedBlock",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetBlindedBlock,
 			methods: []string{http.MethodGet},
@@ -877,6 +882,7 @@ func (s *Service) beaconEndpoints(
 			middleware: []middleware.Middleware{
 				middleware.ContentTypeHandler([]string{api.JsonMediaType}),
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetValidatorIdentities,
 			methods: []string{http.MethodPost},
@@ -971,6 +977,7 @@ func (s *Service) lightClientEndpoints(blocker lookup.Blocker, stater lookup.Sta
 			name:     namespace + ".GetLightClientBootstrap",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetLightClientBootstrap,
 			methods: []string{http.MethodGet},
@@ -980,6 +987,7 @@ func (s *Service) lightClientEndpoints(blocker lookup.Blocker, stater lookup.Sta
 			name:     namespace + ".GetLightClientUpdatesByRange",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetLightClientUpdatesByRange,
 			methods: []string{http.MethodGet},
@@ -989,6 +997,7 @@ func (s *Service) lightClientEndpoints(blocker lookup.Blocker, stater lookup.Sta
 			name:     namespace + ".GetLightClientFinalityUpdate",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetLightClientFinalityUpdate,
 			methods: []string{http.MethodGet},
@@ -998,6 +1007,7 @@ func (s *Service) lightClientEndpoints(blocker lookup.Blocker, stater lookup.Sta
 			name:     namespace + ".GetLightClientOptimisticUpdate",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetLightClientOptimisticUpdate,
 			methods: []string{http.MethodGet},
@@ -1024,6 +1034,7 @@ func (s *Service) debugEndpoints(stater lookup.Stater) []endpoint {
 			name:     namespace + ".GetBeaconStateV2",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.Negotiator,
 			},
 			handler: server.GetBeaconStateV2,
 			methods: []string{http.MethodGet},

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pkg/errors"
 	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/sirupsen/logrus"
+	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
 )
 
 const (
@@ -169,7 +170,7 @@ func (s *Server) GetBlockV2(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if httputil.RespondWithSsz(r) {
+	if httputil.RespondWithSsz(r) || middleware.PreferSSZ(r) {
 		s.getBlockV2Ssz(w, blk)
 	} else {
 		s.getBlockV2Json(ctx, w, blk)
@@ -200,7 +201,7 @@ func (s *Server) GetBlindedBlock(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if httputil.RespondWithSsz(r) {
+	if httputil.RespondWithSsz(r) || middleware.PreferSSZ(r) {
 		s.getBlockV2Ssz(w, blk)
 	} else {
 		s.getBlockV2Json(ctx, w, blk)

--- a/beacon-chain/rpc/eth/beacon/handlers_validator.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_validator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
+	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
 )
 
 // GetValidators returns filterable list of validators with their balance, status and index.
@@ -358,7 +359,7 @@ func (s *Server) GetValidatorIdentities(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if httputil.RespondWithSsz(r) {
+	if httputil.RespondWithSsz(r) || middleware.PreferSSZ(r) {
 		s.getValidatorIdentitiesSSZ(w, st, rawIds, ids)
 	} else {
 		s.getValidatorIdentitiesJSON(r.Context(), w, st, stateId, rawIds, ids)

--- a/beacon-chain/rpc/eth/blob/handlers.go
+++ b/beacon-chain/rpc/eth/blob/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
+	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
 )
 
 // Blobs is an HTTP handler for Beacon API getBlobs.
@@ -63,7 +64,7 @@ func (s *Server) Blobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if httputil.RespondWithSsz(r) {
+	if httputil.RespondWithSsz(r) || middleware.PreferSSZ(r){
 		sszResp, err := buildSidecarsSSZResponse(verifiedBlobs)
 		if err != nil {
 			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)

--- a/beacon-chain/rpc/eth/debug/handlers.go
+++ b/beacon-chain/rpc/eth/debug/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/network/httputil"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
 )
 
 const errMsgStateFromConsensus = "Could not convert consensus state to response"
@@ -29,7 +30,7 @@ func (s *Server) GetBeaconStateV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if httputil.RespondWithSsz(r) {
+	if httputil.RespondWithSsz(r) || middleware.PreferSSZ(r) {
 		s.getBeaconStateSSZV2(ctx, w, []byte(stateId))
 	} else {
 		s.getBeaconStateV2(ctx, w, []byte(stateId))

--- a/beacon-chain/rpc/eth/light-client/handlers.go
+++ b/beacon-chain/rpc/eth/light-client/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/OffchainLabs/prysm/v6/api"
+	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
 	"github.com/OffchainLabs/prysm/v6/api/server/structs"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/rpc/eth/shared"
@@ -45,7 +46,7 @@ func (s *Server) GetLightClientBootstrap(w http.ResponseWriter, req *http.Reques
 
 	w.Header().Set(api.VersionHeader, version.String(bootstrap.Version()))
 
-	if httputil.RespondWithSsz(req) {
+	if httputil.RespondWithSsz(req) || middleware.PreferSSZ(req) {
 		ssz, err := bootstrap.MarshalSSZ()
 		if err != nil {
 			httputil.HandleError(w, "Could not marshal bootstrap to SSZ: "+err.Error(), http.StatusInternalServerError)
@@ -99,7 +100,7 @@ func (s *Server) GetLightClientUpdatesByRange(w http.ResponseWriter, req *http.R
 		return
 	}
 
-	if httputil.RespondWithSsz(req) {
+	if httputil.RespondWithSsz(req) || middleware.PreferSSZ(req){
 		w.Header().Set("Content-Type", "application/octet-stream")
 
 		for i := startPeriod; i <= endPeriod; i++ {
@@ -186,7 +187,7 @@ func (s *Server) GetLightClientFinalityUpdate(w http.ResponseWriter, req *http.R
 	}
 
 	w.Header().Set(api.VersionHeader, version.String(update.Version()))
-	if httputil.RespondWithSsz(req) {
+	if httputil.RespondWithSsz(req) || middleware.PreferSSZ(req) {
 		data, err := update.MarshalSSZ()
 		if err != nil {
 			httputil.HandleError(w, "Could not marshal finality update to SSZ: "+err.Error(), http.StatusInternalServerError)
@@ -219,7 +220,7 @@ func (s *Server) GetLightClientOptimisticUpdate(w http.ResponseWriter, req *http
 	}
 
 	w.Header().Set(api.VersionHeader, version.String(update.Version()))
-	if httputil.RespondWithSsz(req) {
+	if httputil.RespondWithSsz(req) || middleware.PreferSSZ(req) {
 		data, err := update.MarshalSSZ()
 		if err != nil {
 			httputil.HandleError(w, "Could not marshal optimistic update to SSZ: "+err.Error(), http.StatusInternalServerError)

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -23,6 +23,8 @@ import (
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	"github.com/OffchainLabs/prysm/v6/api/server/middleware"
+
 )
 
 type blockType uint8
@@ -100,7 +102,7 @@ func (s *Server) ProduceBlockV3(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) produceBlockV3(ctx context.Context, w http.ResponseWriter, r *http.Request, v1alpha1req *eth.BlockRequest, requiredType blockType) {
-	isSSZ := httputil.RespondWithSsz(r)
+	isSSZ := httputil.RespondWithSsz(r) || middleware.PreferSSZ(r)
 	v1alpha1resp, err := s.V1Alpha1Server.GetBeaconBlock(ctx, v1alpha1req)
 	if err != nil {
 		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -90,6 +90,8 @@ type Flags struct {
 	// Feature related flags (alignment forced in the end)
 	ForceHead        string                // ForceHead forces the head block to be a specific block root, the last head block, or the last finalized block.
 	BlacklistedRoots map[[32]byte]struct{} // BlacklistedRoots is a list of roots that are blacklisted from processing.
+
+	HTTPEncoding params.HTTPEncoding // HTTPEncoding determines whether responses should be encoded in JSON, SSZ, or negotiated automatically per request.
 }
 
 var featureConfig *Flags
@@ -284,6 +286,11 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		cfg.BlacklistedRoots = parseBlacklistedRoots(ctx.StringSlice(blacklistRoots.Name))
 	}
 
+
+	cfg.HTTPEncoding = parseHTTPEncoding(ctx.String("http-encoding"))
+
+
+
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
 	Init(cfg)
 	return nil
@@ -300,6 +307,19 @@ func parseBlacklistedRoots(blacklistedRoots []string) map[[32]byte]struct{} {
 		roots[[32]byte(r)] = struct{}{}
 	}
 	return roots
+}
+
+func parseHTTPEncoding(raw string) params.HTTPEncoding {
+	switch strings.ToLower(raw) {
+	case "ssz":
+		return params.EncodingSSZ
+	case "json":
+		return params.EncodingJSON
+	case "auto":
+		return params.EncodingAuto
+	default:
+		return params.EncodingJSON
+	}
 }
 
 // ConfigureValidator sets the global config based
@@ -335,6 +355,13 @@ func ConfigureValidator(ctx *cli.Context) error {
 		cfg.EnableBeaconRESTApi = true
 	}
 	cfg.KeystoreImportDebounceInterval = ctx.Duration(dynamicKeyReloadDebounceInterval.Name)
+
+
+		cfg.HTTPEncoding = parseHTTPEncoding(ctx.String("http-encoding"))
+
+
+		
+	
 	Init(cfg)
 	return nil
 }

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -188,6 +188,13 @@ var (
 		Name:  "blacklist-roots",
 		Usage: "A comma-separatted list of 0x-prefixed hexstrings. Declares blocks with the given blockroots to be invalid. It downscores peers that send these blocks.",
 	}
+
+	// httpEncodingFlag controls the default encoding format used for HTTP API responses.
+	httpEncodingFlag = &cli.StringFlag{
+		Name:  "http-encoding",
+		Usage: "Sets the HTTP encoding for the beacon node. Supported values are 'json' and 'ssz'.",
+		Value: "json",
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -208,6 +215,7 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	EnableMinimalSlashingProtection,
 	enableDoppelGangerProtection,
 	EnableBeaconRESTApi,
+	httpEncodingFlag,
 }...)
 
 // E2EValidatorFlags contains a list of the validator feature flags to be tested in E2E.
@@ -247,6 +255,7 @@ var BeaconChainFlags = combinedFlags([]cli.Flag{
 	enableExperimentalAttestationPool,
 	forceHeadFlag,
 	blacklistRoots,
+	httpEncodingFlag,
 }, deprecatedBeaconFlags, deprecatedFlags, upcomingDeprecation)
 
 func combinedFlags(flags ...[]cli.Flag) []cli.Flag {

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -13,6 +13,28 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// HTTPEncoding defines the supported response encoding formats for the beacon node HTTP API.
+type HTTPEncoding int
+
+const (
+	EncodingJSON HTTPEncoding = iota
+	EncodingSSZ
+	EncodingAuto 
+)
+
+// String returns the string representation of the HTTPEncoding value.
+func(e HTTPEncoding) String() string {
+	switch e {
+	case EncodingJSON:
+		return "json"
+	case EncodingSSZ:
+		return "ssz"
+	case EncodingAuto:
+		return "json/ssz"
+	default:
+		return "unkonwn"
+	}
+}
 // BeaconChainConfig contains constant configs for node to participate in beacon chain.
 type BeaconChainConfig struct {
 	// Constants (non-configurable)


### PR DESCRIPTION

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR introduces support for a new `--http-encoding` flag that allows users to configure the response encoding format for HTTP REST API endpoints (JSON, SSZ, or automatic negotiation based on the `Accept` header).

* Adds `--http-encoding` flag to both beacon and validator clients
* Implements middleware (`Negotiator`) that respects the configured encoding and client `Accept` header
* Adds `PreferSSZ()` helper to conditionally serve SSZ responses
* Updates the client to include the correct `Accept` header when making requests
* Adds a test suite that verifies negotiation behavior between client/server in different encoding modes

This is needed to help test and eventually adopt SSZ encoding in REST APIs, especially for endpoints where SSZ is more compact and performant. It will also help in compatibility testing as more endpoints gain SSZ support.

**Which issues(s) does this PR fix?**

Fixes #14805

**Other notes for review**

* The test `TestBeaconNegotiation` covers client-server compatibility matrix for encoding negotiation.
* `WriteSsz` and `MarshalSSZ` logic matches existing conventions (e.g. `getValidatorIdentitiesSSZ`)
* Happy to adjust the flag default or placement depending on review feedback.

**Acknowledgements**

* [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md)
* [ ] I have included a uniquely named changelog
* [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.

