### PR TITLE
beacon api: stream event for data column sidecar

### DIFF
--- a/api/server/structs/endpoints_events.go
+++ b/api/server/structs/endpoints_events.go
@@ -25,6 +25,13 @@ type BlockGossipEvent struct {
 	Block string `json:"block"`
 }
 
+type DataColumnGossipEvent struct {
+	Slot           string   `json:"slot"`
+	Index          string   `json:"index"`
+	BlockRoot      string   `json:"block_root"`
+	KzgCommitments []string `json:"kzg_commitments"`
+}
+
 type AggregatedAttEventSource struct {
 	Aggregate *Attestation `json:"aggregate"`
 }

--- a/beacon-chain/core/feed/operation/BUILD.bazel
+++ b/beacon-chain/core/feed/operation/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//async/event:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
+        "//consensus-types/primitives:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
     ],
 )

--- a/beacon-chain/core/feed/operation/events.go
+++ b/beacon-chain/core/feed/operation/events.go
@@ -4,6 +4,7 @@ package operation
 import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 )
 
@@ -39,6 +40,9 @@ const (
 
 	// BlockGossipReceived is sent after a block has been received from gossip or API that passes validation rules.
 	BlockGossipReceived = 10
+
+	// DataColumnReceived is sent after a data column has been seen after gossip validation rules.
+	DataColumnReceived = 11
 )
 
 // UnAggregatedAttReceivedData is the data sent with UnaggregatedAttReceived events.
@@ -94,4 +98,11 @@ type SingleAttReceivedData struct {
 type BlockGossipReceivedData struct {
 	// SignedBlock is the block that was received.
 	SignedBlock interfaces.ReadOnlySignedBeaconBlock
+}
+
+type DataColumnReceivedData struct {
+	Slot           primitives.Slot
+	Index          uint64
+	BlockRoot      [32]byte
+	KzgCommitments [][]byte
 }

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/OffchainLabs/prysm/v6/testing/util"
 	"github.com/ethereum/go-ethereum/common"
-	sse "github.com/r3labs/sse/v2"
+	"github.com/r3labs/sse/v2"
 	"github.com/sirupsen/logrus"
 )
 
@@ -121,6 +121,7 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 		AttesterSlashingTopic,
 		ProposerSlashingTopic,
 		BlockGossipTopic,
+		DataColumnTopic,
 	})
 	require.NoError(t, err)
 	ro, err := blocks.NewROBlob(util.HydrateBlobSidecar(&eth.BlobSidecar{}))
@@ -299,6 +300,15 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 			Type: operation.BlockGossipReceived,
 			Data: &operation.BlockGossipReceivedData{
 				SignedBlock: signedBlock,
+			},
+		},
+		{
+			Type: operation.DataColumnReceived,
+			Data: &operation.DataColumnReceivedData{
+				Slot:           1,
+				Index:          2,
+				BlockRoot:      [32]byte{'a'},
+				KzgCommitments: [][]byte{{'a'}, {'b'}, {'c'}},
 			},
 		},
 	}
@@ -709,7 +719,7 @@ func TestStuckReaderScenarios(t *testing.T) {
 
 func wedgedWriterTestCase(t *testing.T, queueDepth func([]*feed.Event) int) {
 	topics, events := operationEventsFixtures(t)
-	require.Equal(t, 11, len(events))
+	require.Equal(t, 12, len(events))
 
 	// set eventFeedDepth to a number lower than the events we intend to send to force the server to drop the reader.
 	stn := mockChain.NewEventFeedWrapper()

--- a/changelog/tt_fish.md
+++ b/changelog/tt_fish.md
@@ -1,0 +1,3 @@
+### Added
+
+- Data column support for beacon api event end point


### PR DESCRIPTION
This PR implements https://github.com/ethereum/beacon-APIs/pull/535
Data column sidecar is streamed using beacon api event API which may be useful for xatu or other instrumentations 