### PR TITLE
Custom fuzzing of multi-value slice state fields

### DIFF
--- a/beacon-chain/state/state-native/multi_value_slices.go
+++ b/beacon-chain/state/state-native/multi_value_slices.go
@@ -1,11 +1,12 @@
 package state_native
 
 import (
+	"fmt"
 	"runtime"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native/types"
+	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	multi_value_slice "github.com/OffchainLabs/prysm/v6/container/multi-value-slice"
-	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -38,48 +39,57 @@ var (
 type MultiValueRandaoMixes = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueRandaoMixes creates a new slice whose shared items will be populated with copies of input values.
-func NewMultiValueRandaoMixes(mixes [][]byte) *MultiValueRandaoMixes {
+func NewMultiValueRandaoMixes(mixes [][]byte) (*MultiValueRandaoMixes, error) {
 	items := make([][32]byte, len(mixes))
 	for i, v := range mixes {
-		items[i] = [32]byte(bytesutil.PadTo(v, 32))
+		if len(v) != fieldparams.RootLength {
+			return nil, fmt.Errorf("item has length %d instead of required %d", len(v), fieldparams.RootLength)
+		}
+		items[i] = [32]byte(v)
 	}
 	mv := &MultiValueRandaoMixes{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.RandaoMixes.String()).Inc()
 	runtime.SetFinalizer(mv, randaoMixesFinalizer)
-	return mv
+	return mv, nil
 }
 
 // MultiValueBlockRoots is a multi-value slice of block roots.
 type MultiValueBlockRoots = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueBlockRoots creates a new slice whose shared items will be populated with copies of input values.
-func NewMultiValueBlockRoots(roots [][]byte) *MultiValueBlockRoots {
+func NewMultiValueBlockRoots(roots [][]byte) (*MultiValueBlockRoots, error) {
 	items := make([][32]byte, len(roots))
 	for i, v := range roots {
-		items[i] = [32]byte(bytesutil.PadTo(v, 32))
+		if len(v) != fieldparams.RootLength {
+			return nil, fmt.Errorf("item has length %d instead of required %d", len(v), fieldparams.RootLength)
+		}
+		items[i] = [32]byte(v)
 	}
 	mv := &MultiValueBlockRoots{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.BlockRoots.String()).Inc()
 	runtime.SetFinalizer(mv, blockRootsFinalizer)
-	return mv
+	return mv, nil
 }
 
 // MultiValueStateRoots is a multi-value slice of state roots.
 type MultiValueStateRoots = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueStateRoots creates a new slice whose shared items will be populated with copies of input values.
-func NewMultiValueStateRoots(roots [][]byte) *MultiValueStateRoots {
+func NewMultiValueStateRoots(roots [][]byte) (*MultiValueStateRoots, error) {
 	items := make([][32]byte, len(roots))
 	for i, v := range roots {
-		items[i] = [32]byte(bytesutil.PadTo(v, 32))
+		if len(v) != fieldparams.RootLength {
+			return nil, fmt.Errorf("item has length %d instead of required %d", len(v), fieldparams.RootLength)
+		}
+		items[i] = [32]byte(v)
 	}
 	mv := &MultiValueStateRoots{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.StateRoots.String()).Inc()
 	runtime.SetFinalizer(mv, stateRootsFinalizer)
-	return mv
+	return mv, nil
 }
 
 // MultiValueBalances is a multi-value slice of balances.

--- a/beacon-chain/state/state-native/multi_value_slices.go
+++ b/beacon-chain/state/state-native/multi_value_slices.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native/types"
-	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	multi_value_slice "github.com/OffchainLabs/prysm/v6/container/multi-value-slice"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
@@ -40,7 +39,7 @@ type MultiValueRandaoMixes = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueRandaoMixes creates a new slice whose shared items will be populated with copies of input values.
 func NewMultiValueRandaoMixes(mixes [][]byte) *MultiValueRandaoMixes {
-	items := make([][32]byte, fieldparams.RandaoMixesLength)
+	items := make([][32]byte, len(mixes))
 	for i, v := range mixes {
 		items[i] = [32]byte(bytesutil.PadTo(v, 32))
 	}
@@ -56,7 +55,7 @@ type MultiValueBlockRoots = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueBlockRoots creates a new slice whose shared items will be populated with copies of input values.
 func NewMultiValueBlockRoots(roots [][]byte) *MultiValueBlockRoots {
-	items := make([][32]byte, fieldparams.BlockRootsLength)
+	items := make([][32]byte, len(roots))
 	for i, v := range roots {
 		items[i] = [32]byte(bytesutil.PadTo(v, 32))
 	}
@@ -72,7 +71,7 @@ type MultiValueStateRoots = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueStateRoots creates a new slice whose shared items will be populated with copies of input values.
 func NewMultiValueStateRoots(roots [][]byte) *MultiValueStateRoots {
-	items := make([][32]byte, fieldparams.StateRootsLength)
+	items := make([][32]byte, len(roots))
 	for i, v := range roots {
 		items[i] = [32]byte(bytesutil.PadTo(v, 32))
 	}

--- a/beacon-chain/state/state-native/setters_block.go
+++ b/beacon-chain/state/state-native/setters_block.go
@@ -30,7 +30,11 @@ func (b *BeaconState) SetBlockRoots(val [][]byte) error {
 		if b.blockRootsMultiValue != nil {
 			b.blockRootsMultiValue.Detach(b)
 		}
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(val)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(val)
+		if err != nil {
+			return err
+		}
 	} else {
 		b.sharedFieldReferences[types.BlockRoots].MinusRef()
 		b.sharedFieldReferences[types.BlockRoots] = stateutil.NewRef(1)

--- a/beacon-chain/state/state-native/setters_randao.go
+++ b/beacon-chain/state/state-native/setters_randao.go
@@ -19,7 +19,11 @@ func (b *BeaconState) SetRandaoMixes(val [][]byte) error {
 		if b.randaoMixesMultiValue != nil {
 			b.randaoMixesMultiValue.Detach(b)
 		}
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(val)
+		var err error
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(val)
+		if err != nil {
+			return err
+		}
 	} else {
 		b.sharedFieldReferences[types.RandaoMixes].MinusRef()
 		b.sharedFieldReferences[types.RandaoMixes] = stateutil.NewRef(1)

--- a/beacon-chain/state/state-native/setters_state.go
+++ b/beacon-chain/state/state-native/setters_state.go
@@ -19,7 +19,11 @@ func (b *BeaconState) SetStateRoots(val [][]byte) error {
 		if b.stateRootsMultiValue != nil {
 			b.stateRootsMultiValue.Detach(b)
 		}
-		b.stateRootsMultiValue = NewMultiValueStateRoots(val)
+		var err error
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(val)
+		if err != nil {
+			return err
+		}
 	} else {
 		b.sharedFieldReferences[types.StateRoots].MinusRef()
 		b.sharedFieldReferences[types.StateRoots] = stateutil.NewRef(1)

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -205,9 +205,19 @@ func InitializeFromProtoUnsafePhase0(st *ethpb.BeaconState) (state.BeaconState, 
 	}
 
 	if features.Get().EnableExperimentalState {
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
-		b.stateRootsMultiValue = NewMultiValueStateRoots(st.StateRoots)
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(st.RandaoMixes)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(st.BlockRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(st.StateRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(st.RandaoMixes)
+		if err != nil {
+			return nil, err
+		}
 		b.balancesMultiValue = NewMultiValueBalances(st.Balances)
 		b.validatorsMultiValue = NewMultiValueValidators(st.Validators)
 		b.sharedFieldReferences = make(map[types.FieldIndex]*stateutil.Reference, experimentalStatePhase0SharedFieldRefCount)
@@ -311,9 +321,19 @@ func InitializeFromProtoUnsafeAltair(st *ethpb.BeaconStateAltair) (state.BeaconS
 	}
 
 	if features.Get().EnableExperimentalState {
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
-		b.stateRootsMultiValue = NewMultiValueStateRoots(st.StateRoots)
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(st.RandaoMixes)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(st.BlockRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(st.StateRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(st.RandaoMixes)
+		if err != nil {
+			return nil, err
+		}
 		b.balancesMultiValue = NewMultiValueBalances(st.Balances)
 		b.validatorsMultiValue = NewMultiValueValidators(st.Validators)
 		b.inactivityScoresMultiValue = NewMultiValueInactivityScores(st.InactivityScores)
@@ -421,9 +441,19 @@ func InitializeFromProtoUnsafeBellatrix(st *ethpb.BeaconStateBellatrix) (state.B
 	}
 
 	if features.Get().EnableExperimentalState {
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
-		b.stateRootsMultiValue = NewMultiValueStateRoots(st.StateRoots)
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(st.RandaoMixes)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(st.BlockRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(st.StateRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(st.RandaoMixes)
+		if err != nil {
+			return nil, err
+		}
 		b.balancesMultiValue = NewMultiValueBalances(st.Balances)
 		b.validatorsMultiValue = NewMultiValueValidators(st.Validators)
 		b.inactivityScoresMultiValue = NewMultiValueInactivityScores(st.InactivityScores)
@@ -535,9 +565,19 @@ func InitializeFromProtoUnsafeCapella(st *ethpb.BeaconStateCapella) (state.Beaco
 	}
 
 	if features.Get().EnableExperimentalState {
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
-		b.stateRootsMultiValue = NewMultiValueStateRoots(st.StateRoots)
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(st.RandaoMixes)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(st.BlockRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(st.StateRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(st.RandaoMixes)
+		if err != nil {
+			return nil, err
+		}
 		b.balancesMultiValue = NewMultiValueBalances(st.Balances)
 		b.validatorsMultiValue = NewMultiValueValidators(st.Validators)
 		b.inactivityScoresMultiValue = NewMultiValueInactivityScores(st.InactivityScores)
@@ -648,9 +688,19 @@ func InitializeFromProtoUnsafeDeneb(st *ethpb.BeaconStateDeneb) (state.BeaconSta
 	}
 
 	if features.Get().EnableExperimentalState {
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
-		b.stateRootsMultiValue = NewMultiValueStateRoots(st.StateRoots)
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(st.RandaoMixes)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(st.BlockRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(st.StateRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(st.RandaoMixes)
+		if err != nil {
+			return nil, err
+		}
 		b.balancesMultiValue = NewMultiValueBalances(st.Balances)
 		b.validatorsMultiValue = NewMultiValueValidators(st.Validators)
 		b.inactivityScoresMultiValue = NewMultiValueInactivityScores(st.InactivityScores)
@@ -770,9 +820,19 @@ func InitializeFromProtoUnsafeElectra(st *ethpb.BeaconStateElectra) (state.Beaco
 	}
 
 	if features.Get().EnableExperimentalState {
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
-		b.stateRootsMultiValue = NewMultiValueStateRoots(st.StateRoots)
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(st.RandaoMixes)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(st.BlockRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(st.StateRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(st.RandaoMixes)
+		if err != nil {
+			return nil, err
+		}
 		b.balancesMultiValue = NewMultiValueBalances(st.Balances)
 		b.validatorsMultiValue = NewMultiValueValidators(st.Validators)
 		b.inactivityScoresMultiValue = NewMultiValueInactivityScores(st.InactivityScores)
@@ -895,9 +955,19 @@ func InitializeFromProtoUnsafeFulu(st *ethpb.BeaconStateElectra) (state.BeaconSt
 	}
 
 	if features.Get().EnableExperimentalState {
-		b.blockRootsMultiValue = NewMultiValueBlockRoots(st.BlockRoots)
-		b.stateRootsMultiValue = NewMultiValueStateRoots(st.StateRoots)
-		b.randaoMixesMultiValue = NewMultiValueRandaoMixes(st.RandaoMixes)
+		var err error
+		b.blockRootsMultiValue, err = NewMultiValueBlockRoots(st.BlockRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.stateRootsMultiValue, err = NewMultiValueStateRoots(st.StateRoots)
+		if err != nil {
+			return nil, err
+		}
+		b.randaoMixesMultiValue, err = NewMultiValueRandaoMixes(st.RandaoMixes)
+		if err != nil {
+			return nil, err
+		}
 		b.balancesMultiValue = NewMultiValueBalances(st.Balances)
 		b.validatorsMultiValue = NewMultiValueValidators(st.Validators)
 		b.inactivityScoresMultiValue = NewMultiValueInactivityScores(st.InactivityScores)

--- a/changelog/radek_custom-state-fuzzing.md
+++ b/changelog/radek_custom-state-fuzzing.md
@@ -1,0 +1,3 @@
+### Added
+
+-  Custom fuzzing of multi-value slice state fields.

--- a/proto/prysm/v1alpha1/BUILD.bazel
+++ b/proto/prysm/v1alpha1/BUILD.bazel
@@ -341,6 +341,7 @@ go_library(
         "beacon_block.go",
         "cloners.go",
         "eip_7521.go",
+        "fuzz_state.go",
         "log.go",
         "sync_committee_mainnet.go",
         "sync_committee_minimal.go",  # keep

--- a/proto/prysm/v1alpha1/BUILD.bazel
+++ b/proto/prysm/v1alpha1/BUILD.bazel
@@ -367,6 +367,7 @@ go_library(
         "//consensus-types/primitives:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",  # keep
         "@googleapis//google/api:annotations_go_proto",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",

--- a/proto/prysm/v1alpha1/fuzz_state.go
+++ b/proto/prysm/v1alpha1/fuzz_state.go
@@ -1,0 +1,68 @@
+package eth
+
+import (
+	fuzz "github.com/google/gofuzz"
+)
+
+// Fuzz makes sure that a fuzzed beacon state follows the following rules:
+//   - Items of block roots, state roots and randao mixes have correct lengths. This is to satisfy multi-value slice constructors.
+func (b *BeaconState) Fuzz(c fuzz.Continue) {
+	c.FuzzNoCustom(b)
+	fuzzFields(b.BlockRoots, b.StateRoots, b.RandaoMixes, c)
+}
+
+// Fuzz makes sure that a fuzzed beacon state follows the following rules:
+//   - Items of block roots, state roots and randao mixes have correct lengths. This is to satisfy multi-value slice constructors.
+func (b *BeaconStateAltair) Fuzz(c fuzz.Continue) {
+	c.FuzzNoCustom(b)
+	fuzzFields(b.BlockRoots, b.StateRoots, b.RandaoMixes, c)
+}
+
+// Fuzz makes sure that a fuzzed beacon state follows the following rules:
+//   - Items of block roots, state roots and randao mixes have correct lengths. This is to satisfy multi-value slice constructors.
+func (b *BeaconStateBellatrix) Fuzz(c fuzz.Continue) {
+	c.FuzzNoCustom(b)
+	fuzzFields(b.BlockRoots, b.StateRoots, b.RandaoMixes, c)
+}
+
+// Fuzz makes sure that a fuzzed beacon state follows the following rules:
+//   - Items of block roots, state roots and randao mixes have correct lengths. This is to satisfy multi-value slice constructors.
+func (b *BeaconStateCapella) Fuzz(c fuzz.Continue) {
+	c.FuzzNoCustom(b)
+	fuzzFields(b.BlockRoots, b.StateRoots, b.RandaoMixes, c)
+}
+
+// Fuzz makes sure that a fuzzed beacon state follows the following rules:
+//   - Items of block roots, state roots and randao mixes have correct lengths. This is to satisfy multi-value slice constructors.
+func (b *BeaconStateDeneb) Fuzz(c fuzz.Continue) {
+	c.FuzzNoCustom(b)
+	fuzzFields(b.BlockRoots, b.StateRoots, b.RandaoMixes, c)
+}
+
+// Fuzz makes sure that a fuzzed beacon state follows the following rules:
+//   - Items of block roots, state roots and randao mixes have correct lengths. This is to satisfy multi-value slice constructors.
+func (b *BeaconStateElectra) Fuzz(c fuzz.Continue) {
+	c.FuzzNoCustom(b)
+	fuzzFields(b.BlockRoots, b.StateRoots, b.RandaoMixes, c)
+}
+
+func fuzzFields(blockRoots [][]byte, stateRoots [][]byte, randaoMixes [][]byte, c fuzz.Continue) {
+	for i := 0; i < len(blockRoots); i++ {
+		// We have to fuzz an array because fuzzing a slice can change its length.
+		var arr [32]byte
+		c.Fuzz(&arr)
+		blockRoots[i] = arr[:]
+	}
+	for i := 0; i < len(stateRoots); i++ {
+		// We have to fuzz an array because fuzzing a slice can change its length.
+		var arr [32]byte
+		c.Fuzz(&arr)
+		stateRoots[i] = arr[:]
+	}
+	for i := 0; i < len(randaoMixes); i++ {
+		// We have to fuzz an array because fuzzing a slice can change its length.
+		var arr [32]byte
+		c.Fuzz(&arr)
+		randaoMixes[i] = arr[:]
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Tests

**What does this PR do? Why is it needed?**

https://github.com/OffchainLabs/prysm/pull/15292 is currently blocked because unit tests that involve fuzzing the state use a ridiculous amount of memory. An example is https://github.com/OffchainLabs/prysm/blob/f5a9394c77daf4950f8437fed795e17d30295397/beacon-chain/core/altair/attestation_test.go#L460-L482

By default the fuzzer initializes slice fields with a maximum length of 10, but multi-value slice constructors for block roots, state roots and randao mixes always use slices with the length equal to the one defined in `fieldparams`, padding the input slices if necessary. Because of this large slices are allocated in every iteration of the test. This padding doesn't make much sense as it won't help with anything in production code, so this PR removes it.

The PR also removes padding of individual items, requiring that each has a length of 32 bytes. This will break the same tests because the fuzzer will set the lengths of individual items to random values. To fix this, the PR implements an interface from the `gofuzz` package that tells the fuzzer how to fuzz block roots, state roots and randao mixes. What we do is fuzz a `[32]byte` array and set each item to that array. 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
