### PR TITLE
Don't pad outer slice in mvslice constructors

### DIFF
--- a/beacon-chain/state/state-native/multi_value_slices.go
+++ b/beacon-chain/state/state-native/multi_value_slices.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native/types"
-	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	multi_value_slice "github.com/OffchainLabs/prysm/v6/container/multi-value-slice"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
@@ -40,7 +39,7 @@ type MultiValueRandaoMixes = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueRandaoMixes creates a new slice whose shared items will be populated with copies of input values.
 func NewMultiValueRandaoMixes(mixes [][]byte) *MultiValueRandaoMixes {
-	items := make([][32]byte, fieldparams.RandaoMixesLength)
+	items := make([][32]byte, len(mixes))
 	for i, v := range mixes {
 		items[i] = [32]byte(bytesutil.PadTo(v, 32))
 	}
@@ -56,7 +55,7 @@ type MultiValueBlockRoots = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueBlockRoots creates a new slice whose shared items will be populated with copies of input values.
 func NewMultiValueBlockRoots(roots [][]byte) *MultiValueBlockRoots {
-	items := make([][32]byte, fieldparams.BlockRootsLength)
+	items := make([][32]byte, len(roots))
 	for i, v := range roots {
 		items[i] = [32]byte(bytesutil.PadTo(v, 32))
 	}
@@ -72,7 +71,7 @@ type MultiValueStateRoots = multi_value_slice.Slice[[32]byte]
 
 // NewMultiValueStateRoots creates a new slice whose shared items will be populated with copies of input values.
 func NewMultiValueStateRoots(roots [][]byte) *MultiValueStateRoots {
-	items := make([][32]byte, fieldparams.StateRootsLength)
+	items := make([][32]byte, len(roots))
 	for i, v := range roots {
 		items[i] = [32]byte(bytesutil.PadTo(v, 32))
 	}

--- a/changelog/radek_mvslice-dont-pad.md
+++ b/changelog/radek_mvslice-dont-pad.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Don't pad outer slice in mvslice constructors.


### PR DESCRIPTION
**What type of PR is this?**

Tests

**What does this PR do? Why is it needed?**

https://github.com/OffchainLabs/prysm/pull/15292 is currently blocked because unit tests that involve fuzzing the state use a ridiculous amount of memory. An example is https://github.com/OffchainLabs/prysm/blob/f5a9394c77daf4950f8437fed795e17d30295397/beacon-chain/core/altair/attestation_test.go#L460-L482

By default the fuzzer initializes slice fields with a maximum length of 10, but multi-value slice constructors for block roots, state roots and randao mixes always use slices with the length equal to the one defined in `fieldparams`, padding the input slices if necessary. Because of this large slices are allocated in every iteration of the test. This padding doesn't make much sense as it won't help with anything in production code, so this PR removes it.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
