### PR TITLE
Reclaim memory manually in some tests that fuzz the beacon state

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//proto/prysm/v1alpha1/attestation:go_default_library",
         "//runtime/version:go_default_library",
         "//testing/assert:go_default_library",
+        "//testing/fuzz:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
         "//time:go_default_library",

--- a/beacon-chain/core/altair/attestation_test.go
+++ b/beacon-chain/core/altair/attestation_test.go
@@ -19,9 +19,10 @@ import (
 	"github.com/OffchainLabs/prysm/v6/math"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1/attestation"
+	"github.com/OffchainLabs/prysm/v6/testing/fuzz"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/OffchainLabs/prysm/v6/testing/util"
-	fuzz "github.com/google/gofuzz"
+	gofuzz "github.com/google/gofuzz"
 	"github.com/prysmaticlabs/go-bitfield"
 )
 
@@ -458,7 +459,7 @@ func TestValidatorFlag_Add_ExceedsLength(t *testing.T) {
 }
 
 func TestFuzzProcessAttestationsNoVerify_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	st := &ethpb.BeaconStateAltair{}
 	b := &ethpb.SignedBeaconBlockAltair{Block: &ethpb.BeaconBlockAltair{}}
 	for i := 0; i < 10000; i++ {
@@ -478,6 +479,7 @@ func TestFuzzProcessAttestationsNoVerify_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, s, b)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 

--- a/beacon-chain/core/altair/deposit_fuzz_test.go
+++ b/beacon-chain/core/altair/deposit_fuzz_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/altair"
 	state_native "github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v6/testing/fuzz"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
-	fuzz "github.com/google/gofuzz"
+	gofuzz "github.com/google/gofuzz"
 )
 
 func TestFuzzProcessDeposits_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconStateAltair{}
 	deposits := make([]*ethpb.Deposit, 100)
 	ctx := context.Background()
@@ -27,11 +28,12 @@ func TestFuzzProcessDeposits_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, deposits)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessPreGenesisDeposit_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconStateAltair{}
 	deposit := &ethpb.Deposit{}
 	ctx := context.Background()
@@ -45,11 +47,12 @@ func TestFuzzProcessPreGenesisDeposit_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, deposit)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessPreGenesisDeposit_Phase0_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	deposit := &ethpb.Deposit{}
 	ctx := context.Background()
@@ -63,11 +66,12 @@ func TestFuzzProcessPreGenesisDeposit_Phase0_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, deposit)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessDeposit_Phase0_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	deposit := &ethpb.Deposit{}
 
@@ -80,11 +84,12 @@ func TestFuzzProcessDeposit_Phase0_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, deposit)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessDeposit_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconStateAltair{}
 	deposit := &ethpb.Deposit{}
 
@@ -97,5 +102,6 @@ func TestFuzzProcessDeposit_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, deposit)
 		}
+		fuzz.FreeMemory(i)
 	}
 }

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "//proto/prysm/v1alpha1/attestation/aggregation/attestations:go_default_library",
         "//runtime/version:go_default_library",
         "//testing/assert:go_default_library",
+        "//testing/fuzz:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
         "//time/slots:go_default_library",

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v6/testing/fuzz"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
-	fuzz "github.com/google/gofuzz"
+	gofuzz "github.com/google/gofuzz"
 )
 
 func TestFuzzProcessAttestationNoVerify_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	ctx := context.Background()
 	state := &ethpb.BeaconState{}
 	att := &ethpb.Attestation{}
@@ -28,11 +29,12 @@ func TestFuzzProcessAttestationNoVerify_10000(t *testing.T) {
 		require.NoError(t, err)
 		_, err = ProcessAttestationNoVerifySignature(ctx, s, att)
 		_ = err
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessBlockHeader_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	block := &ethpb.SignedBeaconBlock{}
 
@@ -49,11 +51,12 @@ func TestFuzzProcessBlockHeader_10000(t *testing.T) {
 		require.NoError(t, err)
 		_, err = ProcessBlockHeader(context.Background(), s, wsb)
 		_ = err
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzverifyDepositDataSigningRoot_10000(_ *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	var ba []byte
 	var pubkey [fieldparams.BLSPubkeyLength]byte
 	var sig [96]byte
@@ -77,7 +80,7 @@ func TestFuzzverifyDepositDataSigningRoot_10000(_ *testing.T) {
 }
 
 func TestFuzzProcessEth1DataInBlock_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	e := &ethpb.Eth1Data{}
 	state, err := state_native.InitializeFromProtoUnsafePhase0(&ethpb.BeaconState{})
 	require.NoError(t, err)
@@ -92,7 +95,7 @@ func TestFuzzProcessEth1DataInBlock_10000(t *testing.T) {
 }
 
 func TestFuzzareEth1DataEqual_10000(_ *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	eth1data := &ethpb.Eth1Data{}
 	eth1data2 := &ethpb.Eth1Data{}
 
@@ -105,7 +108,7 @@ func TestFuzzareEth1DataEqual_10000(_ *testing.T) {
 }
 
 func TestFuzzEth1DataHasEnoughSupport_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	eth1data := &ethpb.Eth1Data{}
 	var stateVotes []*ethpb.Eth1Data
 	for i := 0; i < 100000; i++ {
@@ -122,7 +125,7 @@ func TestFuzzEth1DataHasEnoughSupport_10000(t *testing.T) {
 }
 
 func TestFuzzProcessBlockHeaderNoVerify_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	block := &ethpb.BeaconBlock{}
 
@@ -133,11 +136,12 @@ func TestFuzzProcessBlockHeaderNoVerify_10000(t *testing.T) {
 		require.NoError(t, err)
 		_, err = ProcessBlockHeaderNoVerify(context.Background(), s, block.Slot, block.ProposerIndex, block.ParentRoot, []byte{})
 		_ = err
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessRandao_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	b := &ethpb.SignedBeaconBlock{}
 
@@ -155,11 +159,12 @@ func TestFuzzProcessRandao_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, b)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessRandaoNoVerify_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	blockBody := &ethpb.BeaconBlockBody{}
 
@@ -172,11 +177,12 @@ func TestFuzzProcessRandaoNoVerify_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, blockBody)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	p := &ethpb.ProposerSlashing{}
 	ctx := context.Background()
@@ -189,11 +195,12 @@ func TestFuzzProcessProposerSlashings_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, p)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzVerifyProposerSlashing_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	proposerSlashing := &ethpb.ProposerSlashing{}
 	for i := 0; i < 10000; i++ {
@@ -203,11 +210,12 @@ func TestFuzzVerifyProposerSlashing_10000(t *testing.T) {
 		require.NoError(t, err)
 		err = VerifyProposerSlashing(s, proposerSlashing)
 		_ = err
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	a := &ethpb.AttesterSlashing{}
 	ctx := context.Background()
@@ -220,11 +228,12 @@ func TestFuzzProcessAttesterSlashings_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and slashing: %v", r, err, state, a)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzVerifyAttesterSlashing_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	attesterSlashing := &ethpb.AttesterSlashing{}
 	ctx := context.Background()
@@ -235,11 +244,12 @@ func TestFuzzVerifyAttesterSlashing_10000(t *testing.T) {
 		require.NoError(t, err)
 		err = VerifyAttesterSlashing(ctx, s, attesterSlashing)
 		_ = err
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzIsSlashableAttestationData_10000(_ *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	attestationData := &ethpb.AttestationData{}
 	attestationData2 := &ethpb.AttestationData{}
 
@@ -251,7 +261,7 @@ func TestFuzzIsSlashableAttestationData_10000(_ *testing.T) {
 }
 
 func TestFuzzslashableAttesterIndices_10000(_ *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	attesterSlashing := &ethpb.AttesterSlashing{}
 
 	for i := 0; i < 10000; i++ {
@@ -261,7 +271,7 @@ func TestFuzzslashableAttesterIndices_10000(_ *testing.T) {
 }
 
 func TestFuzzProcessAttestationsNoVerify_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	b := &ethpb.SignedBeaconBlock{}
 	ctx := context.Background()
@@ -279,11 +289,12 @@ func TestFuzzProcessAttestationsNoVerify_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, b)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzVerifyIndexedAttestationn_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	idxAttestation := &ethpb.IndexedAttestation{}
 	ctx := context.Background()
@@ -294,11 +305,12 @@ func TestFuzzVerifyIndexedAttestationn_10000(t *testing.T) {
 		require.NoError(t, err)
 		err = VerifyIndexedAttestation(ctx, s, idxAttestation)
 		_ = err
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzverifyDeposit_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	deposit := &ethpb.Deposit{}
 	for i := 0; i < 10000; i++ {
@@ -312,7 +324,7 @@ func TestFuzzverifyDeposit_10000(t *testing.T) {
 }
 
 func TestFuzzProcessVoluntaryExits_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	e := &ethpb.SignedVoluntaryExit{}
 	ctx := context.Background()
@@ -325,11 +337,12 @@ func TestFuzzProcessVoluntaryExits_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and exit: %v", r, err, state, e)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconState{}
 	e := &ethpb.SignedVoluntaryExit{}
 	for i := 0; i < 10000; i++ {
@@ -341,11 +354,12 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, e)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzVerifyExit_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	ve := &ethpb.SignedVoluntaryExit{}
 	rawVal := &ethpb.Validator{}
 	fork := &ethpb.Fork{}

--- a/beacon-chain/core/electra/BUILD.bazel
+++ b/beacon-chain/core/electra/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/assert:go_default_library",
+        "//testing/fuzz:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
         "//time/slots:go_default_library",

--- a/beacon-chain/core/electra/deposit_fuzz_test.go
+++ b/beacon-chain/core/electra/deposit_fuzz_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/electra"
 	state_native "github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v6/testing/fuzz"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
-	fuzz "github.com/google/gofuzz"
+	gofuzz "github.com/google/gofuzz"
 )
 
 func TestFuzzProcessDeposits_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconStateElectra{}
 	deposits := make([]*ethpb.Deposit, 100)
 	ctx := context.Background()
@@ -27,11 +28,12 @@ func TestFuzzProcessDeposits_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, deposits)
 		}
+		fuzz.FreeMemory(i)
 	}
 }
 
 func TestFuzzProcessDeposit_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	state := &ethpb.BeaconStateElectra{}
 	deposit := &ethpb.Deposit{}
 
@@ -44,5 +46,6 @@ func TestFuzzProcessDeposit_10000(t *testing.T) {
 		if err != nil && r != nil {
 			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, deposit)
 		}
+		fuzz.FreeMemory(i)
 	}
 }

--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//consensus-types/primitives:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/assert:go_default_library",
+        "//testing/fuzz:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/beacon-chain/core/epoch/epoch_processing_fuzz_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_fuzz_test.go
@@ -5,12 +5,13 @@ import (
 
 	state_native "github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v6/testing/fuzz"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
-	fuzz "github.com/google/gofuzz"
+	gofuzz "github.com/google/gofuzz"
 )
 
 func TestFuzzFinalUpdates_10000(t *testing.T) {
-	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer := gofuzz.NewWithSeed(0)
 	base := &ethpb.BeaconState{}
 
 	for i := 0; i < 10000; i++ {
@@ -19,5 +20,6 @@ func TestFuzzFinalUpdates_10000(t *testing.T) {
 		require.NoError(t, err)
 		_, err = ProcessFinalUpdates(s)
 		_ = err
+		fuzz.FreeMemory(i)
 	}
 }

--- a/changelog/radek_state-fuzz-gc.md
+++ b/changelog/radek_state-fuzz-gc.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reclaim memory manually in some tests that fuzz the beacon state.

--- a/testing/fuzz/BUILD.bazel
+++ b/testing/fuzz/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fuzz.go"],
+    importpath = "github.com/OffchainLabs/prysm/v6/testing/fuzz",
+    visibility = ["//visibility:public"],
+)

--- a/testing/fuzz/fuzz.go
+++ b/testing/fuzz/fuzz.go
@@ -1,0 +1,19 @@
+package fuzz
+
+import "runtime/debug"
+
+// FreeMemory calls debug.FreeOSMemory() every 10 loop iterations.
+// This is very useful in tests that fuzz a proto beacon state
+// and initialize a native state from that proto state inside the loop.
+// The reason is that fields of the native beacon state which are multi-value
+// slices always create a slice of proper length for that field, even if
+// the fuzzer creates a smaller slice. Because the beacon state keeps
+// a reference to the multi-value slice, the multi-value slice is not garbage
+// collected fast enough during fuzzing, leading to memory bloat.
+// Freeing memory manually every 10 iterations keeps the in-use memory low.
+// The tradeoff is longer test times.
+func FreeMemory(iteration int) {
+	if iteration%10 == 0 {
+		debug.FreeOSMemory()
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Tests

**What does this PR do? Why is it needed?**

https://github.com/OffchainLabs/prysm/pull/15292 is currently blocked because unit tests that involve fuzzing the state use a ridiculous amount of memory. An example is https://github.com/OffchainLabs/prysm/blob/f5a9394c77daf4950f8437fed795e17d30295397/beacon-chain/core/altair/attestation_test.go#L460-L482

By default the fuzzer initializes slice fields with a maximum length of 10, but multi-value slice constructors for block roots, state roots and randao mixes always use slices with the length equal to the one defined in `fieldparams`, padding the input slices if necessary. Because of this large slices are allocated in every iteration of the test, and because the beacon state keeps a reference to the multi-value slice, the multi-value slice is not garbage collected fast enough during fuzzing.

To fix this, I wrote a helper function `FreeMemory` that calls `debug.FreeOSMemory()` every 10 loop iterations. Each test that fuzzes a proto beacon state and initializes a native state from that proto state inside the loop should call this function. This will significantly reduce in-use memory (usually more than 100x) while still keeping tests times relatively short (out of all existing such tests the longest one took 11 seconds on my machine).

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
