### PR TITLE
Fix blob topic peer count metric

### DIFF
--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -238,10 +238,16 @@ func (s *Service) updateMetrics() {
 		}
 	}
 
+	for i := 0; i < params.BeaconConfig().MaxBlobsPerBlock(s.cfg.clock.CurrentSlot()); i++ {
+		s.collectMetricForSubnet(p2p.BlobSubnetTopicFormat, digest, uint64(i))
+	}
+
 	// We update all other gossip topics.
 	for _, topic := range p2p.AllTopics() {
 		// We already updated attestation subnet topics.
-		if strings.Contains(topic, p2p.GossipAttestationMessage) || strings.Contains(topic, p2p.GossipSyncCommitteeMessage) {
+		if strings.Contains(topic, p2p.GossipAttestationMessage) ||
+			strings.Contains(topic, p2p.GossipSyncCommitteeMessage) ||
+			strings.Contains(topic, p2p.GossipBlobSidecarMessage) {
 			continue
 		}
 		topic += s.cfg.p2p.Encoding().ProtocolSuffix()

--- a/changelog/tt_egg.md
+++ b/changelog/tt_egg.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix blob metric name for peer count


### PR DESCRIPTION
This pr fixes the following `p2p_topic_peer_count` for blob sidecar

```
p2p_topic_peer_count{topic="/eth2/ad532ceb/blob_sidecar_%!d(MISSING)/ssz_snappy"} 0
{topic="/eth2/ad532ceb/blob_sidecar_%!d(MISSING)/ssz_snappy"} 0
```