### PR TITLE
chore: fix the format of the deprecated comment

### DIFF
--- a/changelog/largemouth_fix_format.md
+++ b/changelog/largemouth_fix_format.md
@@ -1,0 +1,1 @@
+Fix the format of the deprecated comment

--- a/validator/rpc/handler_wallet.go
+++ b/validator/rpc/handler_wallet.go
@@ -168,7 +168,7 @@ func (s *Server) WalletConfig(w http.ResponseWriter, r *http.Request) {
 // Create N validator keystores from the seed specified by req.NumAccounts.
 // Set the wallet password to req.WalletPassword, then create the wallet from
 // the provided Mnemonic and return CreateWalletResponse.
-// DEPRECATED: this endpoint will be removed to improve the safety and security of interacting with wallets
+// Deprecated: this endpoint will be removed to improve the safety and security of interacting with wallets
 func (s *Server) RecoverWallet(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "validator.web.RecoverWallet")
 	defer span.End()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Documentation


**What does this PR do? Why is it needed?**

I forked the project and added gocritic checks and found a warning: deprecatedComment: use `Deprecated: ` (note the casing) instead of `DEPRECATED: ` '



**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
