### PR TITLE
Remove deposit count from sync new block log

### DIFF
--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -26,9 +26,6 @@ func logStateTransitionData(b interfaces.ReadOnlyBeaconBlock) error {
 	if len(b.Body().Attestations()) > 0 {
 		log = log.WithField("attestations", len(b.Body().Attestations()))
 	}
-	if len(b.Body().Deposits()) > 0 {
-		log = log.WithField("deposits", len(b.Body().Deposits()))
-	}
 	if len(b.Body().AttesterSlashings()) > 0 {
 		log = log.WithField("attesterSlashings", len(b.Body().AttesterSlashings()))
 	}
@@ -111,7 +108,6 @@ func logBlockSyncStatus(block interfaces.ReadOnlyBeaconBlock, blockRoot [32]byte
 			"sinceSlotStartTime":         prysmTime.Now().Sub(startTime),
 			"chainServiceProcessedTime":  prysmTime.Now().Sub(receivedTime) - daWaitedTime,
 			"dataAvailabilityWaitedTime": daWaitedTime,
-			"deposits":                   len(block.Body().Deposits()),
 		}
 		log.WithFields(lf).Debug("Synced new block")
 	} else {
@@ -159,7 +155,9 @@ func logPayload(block interfaces.ReadOnlyBeaconBlock) error {
 		if err != nil {
 			return errors.Wrap(err, "could not get BLSToExecutionChanges")
 		}
-		fields["blsToExecutionChanges"] = len(changes)
+		if len(changes) > 0 {
+			fields["blsToExecutionChanges"] = len(changes)
+		}
 	}
 	log.WithFields(fields).Debug("Synced new payload")
 	return nil

--- a/beacon-chain/blockchain/log_test.go
+++ b/beacon-chain/blockchain/log_test.go
@@ -53,7 +53,7 @@ func Test_logStateTransitionData(t *testing.T) {
 				require.NoError(t, err)
 				return wb
 			},
-			want: "\"Finished applying state transition\" attestations=1 deposits=1 prefix=blockchain slot=0",
+			want: "\"Finished applying state transition\" attestations=1 prefix=blockchain slot=0",
 		},
 		{name: "has attester slashing",
 			b: func() interfaces.ReadOnlyBeaconBlock {
@@ -93,7 +93,7 @@ func Test_logStateTransitionData(t *testing.T) {
 				require.NoError(t, err)
 				return wb
 			},
-			want: "\"Finished applying state transition\" attestations=1 attesterSlashings=1 deposits=1 prefix=blockchain proposerSlashings=1 slot=0 voluntaryExits=1",
+			want: "\"Finished applying state transition\" attestations=1 attesterSlashings=1 prefix=blockchain proposerSlashings=1 slot=0 voluntaryExits=1",
 		},
 		{name: "has payload",
 			b:    func() interfaces.ReadOnlyBeaconBlock { return wrappedPayloadBlk },

--- a/changelog/tt_milk.md
+++ b/changelog/tt_milk.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Remove deposit count from sync new block log


### PR DESCRIPTION
After Pectra, body deposit count is always 0, but we still log it in two places.
First is in `applyStateTransitionDone` where we only log if the count is > 0 , that check feels pointless now, so I removed it. Let me know if you think we should keep it for syncing pre-Pectra blocks.
Second is when syncing new blocks, where we always log `deposit=0`.

Lastly, in BLS to execution, we only log if the count is greater than 0, which feels right

```
[2025-06-17 20:29:00] DEBUG blockchain: Synced new block block=0x1f646700... chainServiceProcessedTime=165.521376ms dataAvailabilityWaitedTime=12.309791ms deposits=0 epoch=373420 finalizedEpoch=373418 finalizedRoot=0x1c9cec91... justifiedEpoch=373419 justifiedRoot=0x157b8d41... parentRoot=0xdcec90e6... sinceSlotStartTime=1.928656s slot=11949443 slotInEpoch=3 version=electra
[2025-06-17 20:29:00] DEBUG blockchain: Synced new payload blockHash=0x641afde018aa blockNumber=22728690 blsToExecutionChanges=0 gasUtilized=0.67 parentHash=0x6a9848eeb73c withdrawals=16
```
