### PR TITLE
SSZ support for submitAttestationsV2

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -694,7 +694,7 @@ func (s *Service) beaconEndpoints(
 			template: "/eth/v2/beacon/pool/attestations",
 			name:     namespace + ".SubmitAttestationsV2",
 			middleware: []middleware.Middleware{
-				middleware.ContentTypeHandler([]string{api.JsonMediaType}),
+				middleware.ContentTypeHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
 				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
 			},
 			handler: server.SubmitAttestationsV2,

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -402,6 +402,7 @@ func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFa
 
 		i := 0
 		for len(body) > 0 {
+			// Since AggregationBits in Attestation is variable length, the length of the Attestation object will be added as the first byte, per SSZ spec.
 			sszLen := 1 + int(body[0])
 			var sourceAtt eth.Attestation
 			if err := sourceAtt.UnmarshalSSZ(body[:sszLen]); err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -431,7 +431,7 @@ func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFa
 		case errors.Is(err, io.EOF):
 			return nil, nil, errors.New("no data submitted")
 		case err != nil:
-			return nil, nil, errors.Wrap(err, "Could not decode request body")
+			return nil, nil, errors.Wrap(err, "could not decode request body")
 		}
 
 		if err = json.Unmarshal(req.Data, &sourceAttestations); err != nil {

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -271,17 +271,17 @@ func (s *Server) handleAttestationsElectra(
 		sszLen := (&eth.SingleAttestation{}).SizeSSZ()
 		body, err := readRequestBody(r)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "Could not read request body")
+			return nil, nil, errors.Wrap(err, "could not read request body")
 		}
 		if len(body) < sszLen {
-			return nil, nil, errors.New("No data submitted")
+			return nil, nil, errors.New("no data submitted")
 		}
 
 		i := 0
 		for len(body) >= sszLen {
 			var sourceAtt eth.SingleAttestation
 			if err := sourceAtt.UnmarshalSSZ(body[:sszLen]); err != nil {
-				return nil, nil, errors.Wrap(err, "Could not unmarshal ssz attestation")
+				return nil, nil, errors.Wrap(err, "could not unmarshal ssz attestation")
 			}
 			body = body[sszLen:]
 
@@ -298,7 +298,7 @@ func (s *Server) handleAttestationsElectra(
 		}
 
 		if len(body) > 0 {
-			return nil, nil, errors.New("Could not decode request body, extra bytes found")
+			return nil, nil, errors.New("could not decode request body, extra bytes found")
 		}
 	} else {
 		var sourceAttestations []*structs.SingleAttestation
@@ -306,9 +306,9 @@ func (s *Server) handleAttestationsElectra(
 		err = json.NewDecoder(r.Body).Decode(&req.Data)
 		switch {
 		case errors.Is(err, io.EOF):
-			return nil, nil, errors.New("No data submitted")
+			return nil, nil, errors.New("no data submitted")
 		case err != nil:
-			return nil, nil, errors.Wrap(err, "Could not decode request body")
+			return nil, nil, errors.Wrap(err, "could not decode request body")
 		}
 
 		if err = json.Unmarshal(req.Data, &sourceAttestations); err != nil {
@@ -394,10 +394,10 @@ func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFa
 	if httputil.IsRequestSsz(r) {
 		body, err := readRequestBody(r)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "Could not read request body")
+			return nil, nil, errors.Wrap(err, "could not read request body")
 		}
 		if len(body) == 0 {
-			return nil, nil, errors.New("No data submitted")
+			return nil, nil, errors.New("no data submitted")
 		}
 
 		i := 0
@@ -405,7 +405,7 @@ func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFa
 			sszLen := 1 + int(body[0])
 			var sourceAtt eth.Attestation
 			if err := sourceAtt.UnmarshalSSZ(body[:sszLen]); err != nil {
-				return nil, nil, errors.Wrap(err, "Could not unmarshal ssz attestation")
+				return nil, nil, errors.Wrap(err, "could not unmarshal ssz attestation")
 			}
 			body = body[sszLen:]
 
@@ -422,7 +422,7 @@ func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFa
 		}
 
 		if len(body) > 0 {
-			return nil, nil, errors.New("Could not decode request body, extra bytes found")
+			return nil, nil, errors.New("could not decode request body, extra bytes found")
 		}
 	} else {
 		var sourceAttestations []*structs.Attestation
@@ -430,7 +430,7 @@ func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFa
 		err = json.NewDecoder(r.Body).Decode(&req.Data)
 		switch {
 		case errors.Is(err, io.EOF):
-			return nil, nil, errors.New("No data submitted")
+			return nil, nil, errors.New("no data submitted")
 		case err != nil:
 			return nil, nil, errors.Wrap(err, "Could not decode request body")
 		}

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -183,18 +183,7 @@ func (s *Server) SubmitAttestations(w http.ResponseWriter, r *http.Request) {
 	ctx, span := trace.StartSpan(r.Context(), "beacon.SubmitAttestations")
 	defer span.End()
 
-	var req structs.SubmitAttestationsRequest
-	err := json.NewDecoder(r.Body).Decode(&req.Data)
-	switch {
-	case errors.Is(err, io.EOF):
-		httputil.HandleError(w, "No data submitted", http.StatusBadRequest)
-		return
-	case err != nil:
-		httputil.HandleError(w, "Could not decode request body: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	attFailures, failedBroadcasts, err := s.handleAttestations(ctx, req.Data)
+	attFailures, failedBroadcasts, err := s.handleAttestations(ctx, r)
 	if err != nil {
 		httputil.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
@@ -236,24 +225,13 @@ func (s *Server) SubmitAttestationsV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req structs.SubmitAttestationsRequest
-	err = json.NewDecoder(r.Body).Decode(&req.Data)
-	switch {
-	case errors.Is(err, io.EOF):
-		httputil.HandleError(w, "No data submitted", http.StatusBadRequest)
-		return
-	case err != nil:
-		httputil.HandleError(w, "Could not decode request body: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	var attFailures []*server.IndexedVerificationFailure
 	var failedBroadcasts []string
 
 	if v >= version.Electra {
-		attFailures, failedBroadcasts, err = s.handleAttestationsElectra(ctx, req.Data)
+		attFailures, failedBroadcasts, err = s.handleAttestationsElectra(ctx, r)
 	} else {
-		attFailures, failedBroadcasts, err = s.handleAttestations(ctx, req.Data)
+		attFailures, failedBroadcasts, err = s.handleAttestations(ctx, r)
 	}
 	if err != nil {
 		httputil.HandleError(w, fmt.Sprintf("Failed to handle attestations: %v", err), http.StatusBadRequest)
@@ -281,40 +259,84 @@ func (s *Server) SubmitAttestationsV2(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleAttestationsElectra(
 	ctx context.Context,
-	data json.RawMessage,
+	r *http.Request,
 ) (attFailures []*server.IndexedVerificationFailure, failedBroadcasts []string, err error) {
-	var sourceAttestations []*structs.SingleAttestation
+	var validAttestations []*eth.SingleAttestation
 	currentEpoch := slots.ToEpoch(s.TimeFetcher.CurrentSlot())
 	if currentEpoch < params.BeaconConfig().ElectraForkEpoch {
 		return nil, nil, errors.Errorf("electra attestations have not been enabled, current epoch %d enabled epoch %d", currentEpoch, params.BeaconConfig().ElectraForkEpoch)
 	}
 
-	if err = json.Unmarshal(data, &sourceAttestations); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to unmarshal attestation")
-	}
-
-	if len(sourceAttestations) == 0 {
-		return nil, nil, errors.New("no data submitted")
-	}
-
-	var validAttestations []*eth.SingleAttestation
-	for i, sourceAtt := range sourceAttestations {
-		att, err := sourceAtt.ToConsensus()
+	if httputil.IsRequestSsz(r) {
+		sszLen := (&eth.SingleAttestation{}).SizeSSZ()
+		body, err := readRequestBody(r)
 		if err != nil {
-			attFailures = append(attFailures, &server.IndexedVerificationFailure{
-				Index:   i,
-				Message: "Could not convert request attestation to consensus attestation: " + err.Error(),
-			})
-			continue
+			return nil, nil, errors.Wrap(err, "Could not read request body")
 		}
-		if _, err = bls.SignatureFromBytes(att.Signature); err != nil {
-			attFailures = append(attFailures, &server.IndexedVerificationFailure{
-				Index:   i,
-				Message: "Incorrect attestation signature: " + err.Error(),
-			})
-			continue
+		if len(body) < sszLen {
+			return nil, nil, errors.New("No data submitted")
 		}
-		validAttestations = append(validAttestations, att)
+
+		i := 0
+		for len(body) >= sszLen {
+			var sourceAtt eth.SingleAttestation
+			if err := sourceAtt.UnmarshalSSZ(body[:sszLen]); err != nil {
+				return nil, nil, errors.Wrap(err, "Could not unmarshal ssz attestation")
+			}
+			body = body[sszLen:]
+
+			if _, err = bls.SignatureFromBytes(sourceAtt.Signature); err != nil {
+				attFailures = append(attFailures, &server.IndexedVerificationFailure{
+					Index:   i,
+					Message: "Incorrect attestation signature: " + err.Error(),
+				})
+				i++
+				continue
+			}
+			validAttestations = append(validAttestations, &sourceAtt)
+			i++
+		}
+
+		if len(body) > 0 {
+			return nil, nil, errors.New("Could not decode request body, extra bytes found")
+		}
+	} else {
+		var sourceAttestations []*structs.SingleAttestation
+		var req structs.SubmitAttestationsRequest
+		err = json.NewDecoder(r.Body).Decode(&req.Data)
+		switch {
+		case errors.Is(err, io.EOF):
+			return nil, nil, errors.New("No data submitted")
+		case err != nil:
+			return nil, nil, errors.Wrap(err, "Could not decode request body")
+		}
+
+		if err = json.Unmarshal(req.Data, &sourceAttestations); err != nil {
+			return nil, nil, errors.Wrap(err, "failed to unmarshal attestation")
+		}
+
+		if len(sourceAttestations) == 0 {
+			return nil, nil, errors.New("no data submitted")
+		}
+
+		for i, sourceAtt := range sourceAttestations {
+			att, err := sourceAtt.ToConsensus()
+			if err != nil {
+				attFailures = append(attFailures, &server.IndexedVerificationFailure{
+					Index:   i,
+					Message: "Could not convert request attestation to consensus attestation: " + err.Error(),
+				})
+				continue
+			}
+			if _, err = bls.SignatureFromBytes(att.Signature); err != nil {
+				attFailures = append(attFailures, &server.IndexedVerificationFailure{
+					Index:   i,
+					Message: "Incorrect attestation signature: " + err.Error(),
+				})
+				continue
+			}
+			validAttestations = append(validAttestations, att)
+		}
 	}
 
 	for i, singleAtt := range validAttestations {
@@ -362,39 +384,83 @@ func (s *Server) handleAttestationsElectra(
 	return attFailures, failedBroadcasts, nil
 }
 
-func (s *Server) handleAttestations(ctx context.Context, data json.RawMessage) (attFailures []*server.IndexedVerificationFailure, failedBroadcasts []string, err error) {
-	var sourceAttestations []*structs.Attestation
+func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFailures []*server.IndexedVerificationFailure, failedBroadcasts []string, err error) {
+	var validAttestations []*eth.Attestation
 
 	if slots.ToEpoch(s.TimeFetcher.CurrentSlot()) >= params.BeaconConfig().ElectraForkEpoch {
 		return nil, nil, errors.New("old attestation format, only electra attestations should be sent")
 	}
 
-	if err = json.Unmarshal(data, &sourceAttestations); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to unmarshal attestation")
-	}
-
-	if len(sourceAttestations) == 0 {
-		return nil, nil, errors.New("no data submitted")
-	}
-
-	var validAttestations []*eth.Attestation
-	for i, sourceAtt := range sourceAttestations {
-		att, err := sourceAtt.ToConsensus()
+	if httputil.IsRequestSsz(r) {
+		body, err := readRequestBody(r)
 		if err != nil {
-			attFailures = append(attFailures, &server.IndexedVerificationFailure{
-				Index:   i,
-				Message: "Could not convert request attestation to consensus attestation: " + err.Error(),
-			})
-			continue
+			return nil, nil, errors.Wrap(err, "Could not read request body")
 		}
-		if _, err = bls.SignatureFromBytes(att.Signature); err != nil {
-			attFailures = append(attFailures, &server.IndexedVerificationFailure{
-				Index:   i,
-				Message: "Incorrect attestation signature: " + err.Error(),
-			})
-			continue
+		if len(body) == 0 {
+			return nil, nil, errors.New("No data submitted")
 		}
-		validAttestations = append(validAttestations, att)
+
+		i := 0
+		for len(body) > 0 {
+			sszLen := 1 + int(body[0])
+			var sourceAtt eth.Attestation
+			if err := sourceAtt.UnmarshalSSZ(body[:sszLen]); err != nil {
+				return nil, nil, errors.Wrap(err, "Could not unmarshal ssz attestation")
+			}
+			body = body[sszLen:]
+
+			if _, err = bls.SignatureFromBytes(sourceAtt.Signature); err != nil {
+				attFailures = append(attFailures, &server.IndexedVerificationFailure{
+					Index:   i,
+					Message: "Incorrect attestation signature: " + err.Error(),
+				})
+				i++
+				continue
+			}
+			validAttestations = append(validAttestations, &sourceAtt)
+			i++
+		}
+
+		if len(body) > 0 {
+			return nil, nil, errors.New("Could not decode request body, extra bytes found")
+		}
+	} else {
+		var sourceAttestations []*structs.Attestation
+		var req structs.SubmitAttestationsRequest
+		err = json.NewDecoder(r.Body).Decode(&req.Data)
+		switch {
+		case errors.Is(err, io.EOF):
+			return nil, nil, errors.New("No data submitted")
+		case err != nil:
+			return nil, nil, errors.Wrap(err, "Could not decode request body")
+		}
+
+		if err = json.Unmarshal(req.Data, &sourceAttestations); err != nil {
+			return nil, nil, errors.Wrap(err, "failed to unmarshal attestation")
+		}
+
+		if len(sourceAttestations) == 0 {
+			return nil, nil, errors.New("no data submitted")
+		}
+
+		for i, sourceAtt := range sourceAttestations {
+			att, err := sourceAtt.ToConsensus()
+			if err != nil {
+				attFailures = append(attFailures, &server.IndexedVerificationFailure{
+					Index:   i,
+					Message: "Could not convert request attestation to consensus attestation: " + err.Error(),
+				})
+				continue
+			}
+			if _, err = bls.SignatureFromBytes(att.Signature); err != nil {
+				attFailures = append(attFailures, &server.IndexedVerificationFailure{
+					Index:   i,
+					Message: "Incorrect attestation signature: " + err.Error(),
+				})
+				continue
+			}
+			validAttestations = append(validAttestations, att)
+		}
 	}
 
 	for i, att := range validAttestations {

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -414,10 +414,9 @@ func (s *Server) handleAttestations(ctx context.Context, r *http.Request) (attFa
 					Index:   i,
 					Message: "Incorrect attestation signature: " + err.Error(),
 				})
-				i++
-				continue
+			} else {
+				validAttestations = append(validAttestations, &sourceAtt)
 			}
-			validAttestations = append(validAttestations, &sourceAtt)
 			i++
 		}
 

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -676,6 +676,44 @@ func TestSubmitAttestations(t *testing.T) {
 				assert.Equal(t, primitives.Epoch(0), broadcaster.BroadcastAttestations[0].GetData().Target.Epoch)
 				assert.Equal(t, 1, s.AttestationsPool.UnaggregatedAttestationCount())
 			})
+			t.Run("single SSZ", func(t *testing.T) {
+				broadcaster := &p2pMock.MockBroadcaster{}
+				s.Broadcaster = broadcaster
+				s.AttestationsPool = attestations.NewPool()
+
+				var jsonSingleAtt []structs.Attestation
+				err = json.NewDecoder(strings.NewReader(singleAtt)).Decode(&jsonSingleAtt)
+				require.NoError(t, err)
+				singleAttConsensus, err := jsonSingleAtt[0].ToConsensus()
+				require.NoError(t, err)
+				sszPayload, err := singleAttConsensus.MarshalSSZ()
+				require.NoError(t, err)
+
+				var body bytes.Buffer
+				_, err = body.Write(sszPayload)
+				require.NoError(t, err)
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
+				request.Header.Set(api.VersionHeader, version.String(version.Phase0))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+
+				assert.Equal(t, http.StatusOK, writer.Code)
+				assert.Equal(t, true, broadcaster.BroadcastCalled.Load())
+				assert.Equal(t, 1, broadcaster.NumAttestations())
+				assert.Equal(t, "0x03", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetAggregationBits()))
+				assert.Equal(t, "0x8146f4397bfd8fd057ebbcd6a67327bdc7ed5fb650533edcb6377b650dea0b6da64c14ecd60846d5c0a0cd43893d6972092500f82c9d8a955e2b58c5ed3cbe885d84008ace6bd86ba9e23652f58e2ec207cec494c916063257abf285b9b15b15", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetSignature()))
+				assert.Equal(t, primitives.Slot(0), broadcaster.BroadcastAttestations[0].GetData().Slot)
+				assert.Equal(t, primitives.CommitteeIndex(0), broadcaster.BroadcastAttestations[0].GetData().CommitteeIndex)
+				assert.Equal(t, "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetData().BeaconBlockRoot))
+				assert.Equal(t, "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetData().Source.Root))
+				assert.Equal(t, primitives.Epoch(0), broadcaster.BroadcastAttestations[0].GetData().Source.Epoch)
+				assert.Equal(t, "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetData().Target.Root))
+				assert.Equal(t, primitives.Epoch(0), broadcaster.BroadcastAttestations[0].GetData().Target.Epoch)
+				assert.Equal(t, 1, s.AttestationsPool.UnaggregatedAttestationCount())
+			})
 			t.Run("multiple", func(t *testing.T) {
 				broadcaster := &p2pMock.MockBroadcaster{}
 				s.Broadcaster = broadcaster
@@ -686,6 +724,38 @@ func TestSubmitAttestations(t *testing.T) {
 				require.NoError(t, err)
 				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
 				request.Header.Set(api.VersionHeader, version.String(version.Phase0))
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+				assert.Equal(t, http.StatusOK, writer.Code)
+				assert.Equal(t, true, broadcaster.BroadcastCalled.Load())
+				assert.Equal(t, 2, broadcaster.NumAttestations())
+				assert.Equal(t, 2, s.AttestationsPool.UnaggregatedAttestationCount())
+			})
+			t.Run("multiple SSZ", func(t *testing.T) {
+				broadcaster := &p2pMock.MockBroadcaster{}
+				s.Broadcaster = broadcaster
+				s.AttestationsPool = attestations.NewPool()
+
+				var jsonAttList []structs.Attestation
+				err = json.NewDecoder(strings.NewReader(multipleAtts)).Decode(&jsonAttList)
+				require.NoError(t, err)
+				var sszPayload []byte
+				for _, att := range jsonAttList {
+					attConsensus, err := att.ToConsensus()
+					require.NoError(t, err)
+					attSSZ, err := attConsensus.MarshalSSZ()
+					require.NoError(t, err)
+					sszPayload = append(sszPayload, attSSZ...)
+				}
+
+				var body bytes.Buffer
+				_, err := body.Write(sszPayload)
+				require.NoError(t, err)
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
+				request.Header.Set(api.VersionHeader, version.String(version.Phase0))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
 				writer := httptest.NewRecorder()
 				writer.Body = &bytes.Buffer{}
 
@@ -745,6 +815,20 @@ func TestSubmitAttestations(t *testing.T) {
 				assert.Equal(t, http.StatusBadRequest, e.Code)
 				assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
 			})
+			t.Run("no body SSZ", func(t *testing.T) {
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+				request.Header.Set(api.VersionHeader, version.String(version.Phase0))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+				assert.Equal(t, http.StatusBadRequest, writer.Code)
+				e := &httputil.DefaultJsonError{}
+				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+				assert.Equal(t, http.StatusBadRequest, e.Code)
+				assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
+			})
 			t.Run("empty", func(t *testing.T) {
 				var body bytes.Buffer
 				_, err := body.WriteString("[]")
@@ -767,6 +851,32 @@ func TestSubmitAttestations(t *testing.T) {
 				require.NoError(t, err)
 				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
 				request.Header.Set(api.VersionHeader, version.String(version.Phase0))
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+				assert.Equal(t, http.StatusBadRequest, writer.Code)
+				e := &server.IndexedVerificationFailureError{}
+				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+				assert.Equal(t, http.StatusBadRequest, e.Code)
+				require.Equal(t, 1, len(e.Failures))
+				assert.Equal(t, true, strings.Contains(e.Failures[0].Message, "Incorrect attestation signature"))
+			})
+			t.Run("invalid SSZ", func(t *testing.T) {
+				var jsonSingleAtt []structs.Attestation
+				err = json.NewDecoder(strings.NewReader(invalidAtt)).Decode(&jsonSingleAtt)
+				require.NoError(t, err)
+				singleAttConsensus, err := jsonSingleAtt[0].ToConsensus()
+				require.NoError(t, err)
+				sszPayload, err := singleAttConsensus.MarshalSSZ()
+				require.NoError(t, err)
+
+				var body bytes.Buffer
+				_, err = body.Write(sszPayload)
+				require.NoError(t, err)
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
+				request.Header.Set(api.VersionHeader, version.String(version.Phase0))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
 				writer := httptest.NewRecorder()
 				writer.Body = &bytes.Buffer{}
 
@@ -814,6 +924,44 @@ func TestSubmitAttestations(t *testing.T) {
 				assert.Equal(t, primitives.Epoch(0), broadcaster.BroadcastAttestations[0].GetData().Target.Epoch)
 				assert.Equal(t, 1, s.AttestationsPool.UnaggregatedAttestationCount())
 			})
+			t.Run("single SSZ", func(t *testing.T) {
+				broadcaster := &p2pMock.MockBroadcaster{}
+				s.Broadcaster = broadcaster
+				s.AttestationsPool = attestations.NewPool()
+
+				var jsonSingleAttElectra []structs.SingleAttestation
+				err = json.NewDecoder(strings.NewReader(singleAttElectra)).Decode(&jsonSingleAttElectra)
+				require.NoError(t, err)
+				singleAttElectraConsensus, err := jsonSingleAttElectra[0].ToConsensus()
+				require.NoError(t, err)
+				sszPayload, err := singleAttElectraConsensus.MarshalSSZ()
+				require.NoError(t, err)
+
+				var body bytes.Buffer
+				_, err = body.Write(sszPayload)
+				require.NoError(t, err)
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
+				request.Header.Set(api.VersionHeader, version.String(version.Electra))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+
+				assert.Equal(t, http.StatusOK, writer.Code)
+				assert.Equal(t, true, broadcaster.BroadcastCalled.Load())
+				assert.Equal(t, 1, broadcaster.NumAttestations())
+				assert.Equal(t, primitives.ValidatorIndex(1), broadcaster.BroadcastAttestations[0].GetAttestingIndex())
+				assert.Equal(t, "0x8146f4397bfd8fd057ebbcd6a67327bdc7ed5fb650533edcb6377b650dea0b6da64c14ecd60846d5c0a0cd43893d6972092500f82c9d8a955e2b58c5ed3cbe885d84008ace6bd86ba9e23652f58e2ec207cec494c916063257abf285b9b15b15", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetSignature()))
+				assert.Equal(t, primitives.Slot(0), broadcaster.BroadcastAttestations[0].GetData().Slot)
+				assert.Equal(t, primitives.CommitteeIndex(0), broadcaster.BroadcastAttestations[0].GetData().CommitteeIndex)
+				assert.Equal(t, "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetData().BeaconBlockRoot))
+				assert.Equal(t, "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetData().Source.Root))
+				assert.Equal(t, primitives.Epoch(0), broadcaster.BroadcastAttestations[0].GetData().Source.Epoch)
+				assert.Equal(t, "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", hexutil.Encode(broadcaster.BroadcastAttestations[0].GetData().Target.Root))
+				assert.Equal(t, primitives.Epoch(0), broadcaster.BroadcastAttestations[0].GetData().Target.Epoch)
+				assert.Equal(t, 1, s.AttestationsPool.UnaggregatedAttestationCount())
+			})
 			t.Run("multiple", func(t *testing.T) {
 				broadcaster := &p2pMock.MockBroadcaster{}
 				s.Broadcaster = broadcaster
@@ -833,9 +981,56 @@ func TestSubmitAttestations(t *testing.T) {
 				assert.Equal(t, 2, broadcaster.NumAttestations())
 				assert.Equal(t, 2, s.AttestationsPool.UnaggregatedAttestationCount())
 			})
+			t.Run("multiple SSZ", func(t *testing.T) {
+				broadcaster := &p2pMock.MockBroadcaster{}
+				s.Broadcaster = broadcaster
+				s.AttestationsPool = attestations.NewPool()
+
+				var jsonAttsList []structs.SingleAttestation
+				err = json.NewDecoder(strings.NewReader(multipleAttsElectra)).Decode(&jsonAttsList)
+				require.NoError(t, err)
+
+				var sszPayload []byte
+				for _, att := range jsonAttsList {
+					singleAttElectraConsensus, err := att.ToConsensus()
+					require.NoError(t, err)
+					sszPayloadPart, err := singleAttElectraConsensus.MarshalSSZ()
+					require.NoError(t, err)
+					sszPayload = append(sszPayload, sszPayloadPart...)
+				}
+
+				var body bytes.Buffer
+				_, err = body.Write(sszPayload)
+				require.NoError(t, err)
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
+				request.Header.Set(api.VersionHeader, version.String(version.Electra))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+				assert.Equal(t, http.StatusOK, writer.Code)
+				assert.Equal(t, true, broadcaster.BroadcastCalled.Load())
+				assert.Equal(t, 2, broadcaster.NumAttestations())
+				assert.Equal(t, 2, s.AttestationsPool.UnaggregatedAttestationCount())
+			})
 			t.Run("no body", func(t *testing.T) {
 				request := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 				request.Header.Set(api.VersionHeader, version.String(version.Electra))
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+				assert.Equal(t, http.StatusBadRequest, writer.Code)
+				e := &httputil.DefaultJsonError{}
+				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+				assert.Equal(t, http.StatusBadRequest, e.Code)
+				assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
+			})
+			t.Run("no body SSZ", func(t *testing.T) {
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+				request.Header.Set(api.VersionHeader, version.String(version.Electra))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
 				writer := httptest.NewRecorder()
 				writer.Body = &bytes.Buffer{}
 
@@ -868,6 +1063,32 @@ func TestSubmitAttestations(t *testing.T) {
 				require.NoError(t, err)
 				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
 				request.Header.Set(api.VersionHeader, version.String(version.Electra))
+				writer := httptest.NewRecorder()
+				writer.Body = &bytes.Buffer{}
+
+				s.SubmitAttestationsV2(writer, request)
+				assert.Equal(t, http.StatusBadRequest, writer.Code)
+				e := &server.IndexedVerificationFailureError{}
+				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+				assert.Equal(t, http.StatusBadRequest, e.Code)
+				require.Equal(t, 1, len(e.Failures))
+				assert.Equal(t, true, strings.Contains(e.Failures[0].Message, "Incorrect attestation signature"))
+			})
+			t.Run("invalid SSZ", func(t *testing.T) {
+				var jsonInvalidAttElectra []structs.SingleAttestation
+				err = json.NewDecoder(strings.NewReader(invalidAttElectra)).Decode(&jsonInvalidAttElectra)
+				require.NoError(t, err)
+				invalidAttElectraConsensus, err := jsonInvalidAttElectra[0].ToConsensus()
+				require.NoError(t, err)
+				sszPayload, err := invalidAttElectraConsensus.MarshalSSZ()
+				require.NoError(t, err)
+
+				var body bytes.Buffer
+				_, err = body.Write(sszPayload)
+				require.NoError(t, err)
+				request := httptest.NewRequest(http.MethodPost, "http://example.com", &body)
+				request.Header.Set(api.VersionHeader, version.String(version.Electra))
+				request.Header.Set("Content-Type", api.OctetStreamMediaType)
 				writer := httptest.NewRecorder()
 				writer.Body = &bytes.Buffer{}
 

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -611,7 +611,7 @@ func TestSubmitAttestations(t *testing.T) {
 			e := &httputil.DefaultJsonError{}
 			require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 			assert.Equal(t, http.StatusBadRequest, e.Code)
-			assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
+			assert.Equal(t, true, strings.Contains(e.Message, "no data submitted"))
 		})
 		t.Run("empty", func(t *testing.T) {
 			var body bytes.Buffer
@@ -813,7 +813,7 @@ func TestSubmitAttestations(t *testing.T) {
 				e := &httputil.DefaultJsonError{}
 				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 				assert.Equal(t, http.StatusBadRequest, e.Code)
-				assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
+				assert.Equal(t, true, strings.Contains(e.Message, "no data submitted"))
 			})
 			t.Run("no body SSZ", func(t *testing.T) {
 				request := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -827,7 +827,7 @@ func TestSubmitAttestations(t *testing.T) {
 				e := &httputil.DefaultJsonError{}
 				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 				assert.Equal(t, http.StatusBadRequest, e.Code)
-				assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
+				assert.Equal(t, true, strings.Contains(e.Message, "no data submitted"))
 			})
 			t.Run("empty", func(t *testing.T) {
 				var body bytes.Buffer
@@ -1025,7 +1025,7 @@ func TestSubmitAttestations(t *testing.T) {
 				e := &httputil.DefaultJsonError{}
 				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 				assert.Equal(t, http.StatusBadRequest, e.Code)
-				assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
+				assert.Equal(t, true, strings.Contains(e.Message, "no data submitted"))
 			})
 			t.Run("no body SSZ", func(t *testing.T) {
 				request := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -1039,7 +1039,7 @@ func TestSubmitAttestations(t *testing.T) {
 				e := &httputil.DefaultJsonError{}
 				require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 				assert.Equal(t, http.StatusBadRequest, e.Code)
-				assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
+				assert.Equal(t, true, strings.Contains(e.Message, "no data submitted"))
 			})
 			t.Run("empty", func(t *testing.T) {
 				var body bytes.Buffer

--- a/changelog/bastin_submit-attestation-api-ssz.md
+++ b/changelog/bastin_submit-attestation-api-ssz.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add SSZ support for `submitPoolAttestationsV2` beacon API.


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR adds SSZ support for the `submitPoolAttestationsV2` beacon API.


**Which issues(s) does this PR fix?**
Per [this PR](https://github.com/ethereum/beacon-APIs/pull/527)
