### PR TITLE
Update GitHub Actions in CI Workflows

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Is this step failing for you? 
       # Run: clang-format -i proto/**/*.proto
       # See: https://clang.llvm.org/docs/ClangFormat.html

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.23.5'
       - id: list
@@ -33,8 +33,8 @@ jobs:
       matrix:
         include: ${{fromJson(needs.list.outputs.fuzz-tests)}}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.23.5'
       - uses: shogo82148/actions-go-fuzz/run@v0


### PR DESCRIPTION

1. actions/checkout updates:
   - Updates `actions/checkout@v2` → `actions/checkout@v4`
   - Updates `actions/checkout@v3` → `actions/checkout@v4`

2. actions/setup-go updates:
   - Updates `actions/setup-go@v4` → `actions/setup-go@v5`

- actions/checkout v4.2.2: https://github.com/actions/checkout/releases/tag/v4.2.2
- actions/setup-go v5.5.0: https://github.com/actions/setup-go/releases/tag/v5.5.0

This update ensures we're using the most recent stable versions of these actions in our CI pipelines, providing better security, performance, and reliability improvements.
