### PR TITLE
`dataColumnSidecarByRootRPCHandler`: Do not rely any more on map iteration, which does not produce reproducible output order.

### DIFF
--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -12,6 +12,7 @@ import (
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
@@ -98,11 +99,14 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 	log.Debug("Serving data column sidecar by root request")
 
 	count := 0
-	for root, columns := range requestedColumnsByRoot {
+	for _, ident := range requestedColumnIdents {
 		if err := ctx.Err(); err != nil {
 			closeStream(stream, log)
 			return errors.Wrap(err, "context error")
 		}
+
+		root := bytesutil.ToBytes32(ident.BlockRoot)
+		columns := ident.Columns
 
 		// Throttle request processing to no more than batchSize/sec.
 		for range columns {

--- a/changelog/manu-peerdas-dataColumnSidecarByRootRPCHandler.md
+++ b/changelog/manu-peerdas-dataColumnSidecarByRootRPCHandler.md
@@ -1,0 +1,2 @@
+### Fixed 
+- Non deterministic output order of `dataColumnSidecarByRootRPCHandler`. 


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
`dataColumnSidecarByRootRPCHandler`: Do not rely any more on map iteration, which does not produce reproducible output order.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
