### PR TITLE
Accept header override via env var

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -14,14 +15,17 @@ const (
 	MaxBodySize      int64 = 1 << 23 // 8MB default, WithMaxBodySize can override
 	MaxBodySizeState int64 = 1 << 29 // 512MB
 	MaxErrBodySize   int64 = 1 << 17 // 128KB
+
+	envNameOverrideAccept = "PRYSM_API_OVERRIDE_ACCEPT"
 )
 
 // Client is a wrapper object around the HTTP client.
 type Client struct {
-	hc          *http.Client
-	baseURL     *url.URL
-	token       string
-	maxBodySize int64
+	hc           *http.Client
+	baseURL      *url.URL
+	token        string
+	maxBodySize  int64
+	reqOverrides []ReqOption
 }
 
 // NewClient constructs a new client with the provided options (ex WithTimeout).
@@ -40,7 +44,19 @@ func NewClient(host string, opts ...ClientOpt) (*Client, error) {
 	for _, o := range opts {
 		o(c)
 	}
+	c.appendAcceptOverride()
 	return c, nil
+}
+
+// appendAcceptOverride enables the Accept header to be customized at runtime via an environment variable.
+// This is specified as an env var because it is a niche option that prysm may use for performance testing or debugging
+// bug which users are unlikely to need. Using an env var keeps the set of user-facing flags cleaner.
+func (c *Client) appendAcceptOverride() {
+	if accept := os.Getenv(envNameOverrideAccept); accept != "" {
+		c.reqOverrides = append(c.reqOverrides, func(req *http.Request) {
+			req.Header.Set("Accept", accept)
+		})
+	}
 }
 
 // Token returns the bearer token used for jwt authentication
@@ -55,6 +71,9 @@ func (c *Client) BaseURL() *url.URL {
 
 // Do execute the request against the http client
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	for _, o := range c.reqOverrides {
+		o(req)
+	}
 	return c.hc.Do(req)
 }
 
@@ -87,7 +106,7 @@ func (c *Client) Get(ctx context.Context, path string, opts ...ReqOption) ([]byt
 	for _, o := range opts {
 		o(req)
 	}
-	r, err := c.hc.Do(req)
+	r, err := c.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -1,7 +1,10 @@
 package client
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/testing/require"
@@ -45,4 +48,24 @@ func TestBaseURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "www.offchainlabs.com", cl.BaseURL().Hostname())
 	require.Equal(t, "3500", cl.BaseURL().Port())
+}
+
+func TestAcceptOverride(t *testing.T) {
+	name := "TestAcceptOverride"
+	orig := os.Getenv(envNameOverrideAccept)
+	defer func() {
+		os.Setenv(envNameOverrideAccept, orig)
+	}()
+	os.Setenv(envNameOverrideAccept, name)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, name, r.Header.Get("Accept"))
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	c, err := NewClient(srv.URL)
+	require.NoError(t, err)
+	b, err := c.Get(t.Context(), "/test")
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(b))
 }

--- a/changelog/kasey_customize-http-accept-header.md
+++ b/changelog/kasey_customize-http-accept-header.md
@@ -1,0 +1,2 @@
+## Added
+- env var to force beacon api client to use a custom accept header (eg force json responses).


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This adds support for setting an environment variable which will be used as the Accept header on all beacon api http requests. Whatever value is found in the `PRYSM_API_OVERRIDE_ACCEPT` environment variable will be sent to the server as the `Accept` header without any additional processing. This is intended to enable us to force the beacon api to respond with json for testing or debugging purposes.

**Other notes for review**

An env var is preferrable to a flag here because this will be an undocumented feature, only added for internal testing purposes. An env var requires minimal code plumbing and avoids expanding the set of flags for users to read about and choose from.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
