### PR TITLE
Increase mainnet default builder gas limit to 45M

### DIFF
--- a/changelog/tt_45.md
+++ b/changelog/tt_45.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Increase mainnet DefaultBuilderGasLimit from 36M to 45M

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -268,7 +268,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	BytesPerLogsBloom:                256,
 	MaxExtraDataBytes:                32,
 	EthBurnAddressHex:                "0x0000000000000000000000000000000000000000",
-	DefaultBuilderGasLimit:           uint64(36000000),
+	DefaultBuilderGasLimit:           uint64(45000000),
 
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,

--- a/config/proposer/loader/testdata/good-prepare-beacon-proposer-config-multiple.json
+++ b/config/proposer/loader/testdata/good-prepare-beacon-proposer-config-multiple.json
@@ -4,7 +4,7 @@
       "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3",
       "builder": {
         "enabled": true,
-        "gas_limit": "36000000"
+        "gas_limit": "45000000"
       }
     },
     "0xb057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7b": {

--- a/config/proposer/loader/testdata/good-prepare-beacon-proposer-config.yaml
+++ b/config/proposer/loader/testdata/good-prepare-beacon-proposer-config.yaml
@@ -9,4 +9,4 @@ default_config:
   fee_recipient: '0x6e35733c5af9B61374A128e6F85f553aF09ff89A'
   builder:
     enabled: false
-    gas_limit: '36000000'
+    gas_limit: '45000000'


### PR DESCRIPTION
This PR raises the default gas limit for mev-boost builders from 36M to 45M to align with recent EL client releases that have increased their default gas limits to 45M:
  - Ethpandaops rec: https://ethpandaops.io/posts/gaslimit-scaling/
  - Nethermind 1.32.0: https://github.com/NethermindEth/nethermind/releases/tag/1.32.0
  - Geth 1.16.0: https://github.com/ethereum/go-ethereum/releases/tag/v1.16.0
  - Reth 1.4.8: https://github.com/paradigmxyz/reth/releases/tag/v1.4.8
  - Erigon 3.0.5: https://github.com/erigontech/erigon/releases/tag/v3.0.5
  - Besu (?)