### PR TITLE
fix typos in comments and error messages

### DIFF
--- a/beacon-chain/core/peerdas/reconstruction.go
+++ b/beacon-chain/core/peerdas/reconstruction.go
@@ -37,7 +37,7 @@ func ReconstructDataColumnSidecars(inVerifiedRoSidecars []blocks.VerifiedRODataC
 	// Safely retrieve the first sidecar as a reference.
 	referenceSidecar := inVerifiedRoSidecars[0]
 
-	// Check if all columns have the same length and are commmitted to the same block.
+	// Check if all columns have the same length and are committed to the same block.
 	blobCount := len(referenceSidecar.Column)
 	blockRoot := referenceSidecar.BlockRoot()
 	for _, sidecar := range inVerifiedRoSidecars[1:] {

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -43,7 +43,7 @@ func (s *Store) getBlock(ctx context.Context, blockRoot [32]byte, tx *bolt.Tx) (
 		return v, nil
 	}
 	// This method allows the caller to pass in its tx if one is already open.
-	// Or if a nil value is used, a transaction will be managed intenally.
+	// Or if a nil value is used, a transaction will be managed internally.
 	if tx == nil {
 		var err error
 		tx, err = s.db.Begin(false)

--- a/beacon-chain/p2p/types/types.go
+++ b/beacon-chain/p2p/types/types.go
@@ -250,7 +250,7 @@ func (d *DataColumnsByRootIdentifiers) UnmarshalSSZ(buf []byte) error {
 	}
 	valueStart := offsetEnd
 
-	// Decode the identifers.
+	// Decode the identifiers.
 	*d = make([]*eth.DataColumnsByRootIdentifier, count)
 	var start uint32
 	end := uint32(len(buf))

--- a/beacon-chain/p2p/types/types_test.go
+++ b/beacon-chain/p2p/types/types_test.go
@@ -299,7 +299,7 @@ func TestDataColumnSidecarsByRootReq_MarshalUnmarshal(t *testing.T) {
 				in = append(in, byte(0))
 				return in
 			},
-			unmarshalErr: "a is not evenly divisble by b",
+			unmarshalErr: "a is not evenly divisible by b",
 		},
 		{
 			name: "size too big",


### PR DESCRIPTION


---

## Description
This pull request corrects several minor typos in comments and error messages within the codebase, improving overall code clarity and professionalism. No functional changes were made.

- Fixed spelling errors in comments (e.g., "commmitted" → "committed", "intenally" → "internally", "divisble" → "divisible").
- Updated error messages and documentation for better readability.

---

