### PR TITLE
`--chain-config-file`: Do not use any more mainnet boot nodes.

### DIFF
--- a/changelog/manu-bootnodes.md
+++ b/changelog/manu-bootnodes.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `--chain-config-file`: Do not use any more mainnet boot nodes.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -156,7 +156,8 @@ func configureTestnet(ctx *cli.Context) error {
 		params.UseHoodiNetworkConfig()
 	} else {
 		if ctx.IsSet(cmd.ChainConfigFileFlag.Name) {
-			log.Warn("Running on custom Ethereum network specified in a chain configuration yaml file")
+			log.Warning("Running on custom Ethereum network specified in a chain configuration YAML file")
+			params.UseCustomNetworkConfig()
 		} else {
 			log.Info("Running on Ethereum Mainnet")
 		}
@@ -168,11 +169,11 @@ func configureTestnet(ctx *cli.Context) error {
 }
 
 // Insert feature flags within the function to be enabled for Sepolia testnet.
-func applySepoliaFeatureFlags(ctx *cli.Context) {
+func applySepoliaFeatureFlags(_ *cli.Context) {
 }
 
 // Insert feature flags within the function to be enabled for Holesky testnet.
-func applyHoleskyFeatureFlags(ctx *cli.Context) {
+func applyHoleskyFeatureFlags(_ *cli.Context) {
 }
 
 // ConfigureBeaconChain sets the global config based

--- a/config/params/BUILD.bazel
+++ b/config/params/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "mainnet_config.go",
         "minimal_config.go",
         "network_config.go",
+        "testnet_custom_network_config.go",
         "testnet_e2e_config.go",
         "testnet_holesky_config.go",
         "testnet_hoodi_config.go",

--- a/config/params/testnet_custom_network_config.go
+++ b/config/params/testnet_custom_network_config.go
@@ -1,0 +1,9 @@
+package params
+
+func UseCustomNetworkConfig() {
+	cfg := BeaconNetworkConfig().Copy()
+	cfg.ContractDeploymentBlock = 0
+	cfg.BootstrapNodes = []string{}
+
+	OverrideBeaconNetworkConfig(cfg)
+}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix.

**What does this PR do? Why is it needed?**
Before this PR, with the `--chain-config-file` flag, Prysm used both bootnodes specified with `--bootstrap-node` (if any) **AND** mainnet boot nodes (which is a nonsense, and leads to useless connections).

With this PR, using the `--chain-config-file` flag, Prysm **only** uses bootnodes specified with `--bootstrap-node` (if any).

As a consequence, using `--chain-config-file` **without** using `--bootstrap-node` leads to a lack of connectivity.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
