### PR TITLE
Put the initialization of LC Store behind the `enable-light-client` flag

### DIFF
--- a/beacon-chain/core/light-client/store.go
+++ b/beacon-chain/core/light-client/store.go
@@ -15,7 +15,6 @@ type Store struct {
 
 func NewLightClientStore() *Store {
 	return &Store{}
-
 }
 
 func (s *Store) SetLastFinalityUpdate(update interfaces.LightClientFinalityUpdate) {

--- a/beacon-chain/core/light-client/store.go
+++ b/beacon-chain/core/light-client/store.go
@@ -13,6 +13,11 @@ type Store struct {
 	lastOptimisticUpdate interfaces.LightClientOptimisticUpdate
 }
 
+func NewLightClientStore() *Store {
+	return &Store{}
+
+}
+
 func (s *Store) SetLastFinalityUpdate(update interfaces.LightClientFinalityUpdate) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -167,7 +167,6 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, opts ...Option) (*Beaco
 		syncChecker:             &initialsync.SyncChecker{},
 		custodyInfo:             &peerdas.CustodyInfo{},
 		slasherEnabled:          cliCtx.Bool(flags.SlasherFlag.Name),
-		lcStore:                 nil,
 	}
 
 	for _, opt := range opts {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -167,7 +167,7 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, opts ...Option) (*Beaco
 		syncChecker:             &initialsync.SyncChecker{},
 		custodyInfo:             &peerdas.CustodyInfo{},
 		slasherEnabled:          cliCtx.Bool(flags.SlasherFlag.Name),
-		lcStore:                 &lightclient.Store{},
+		lcStore:                 nil,
 	}
 
 	for _, opt := range opts {
@@ -234,6 +234,10 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, opts ...Option) (*Beaco
 	// Do not store the finalized state as it has been provided to the respective services during
 	// their initialization.
 	beacon.finalizedStateAtStartUp = nil
+
+	if features.Get().EnableLightClient {
+		beacon.lcStore = lightclient.NewLightClientStore()
+	}
 
 	return beacon, nil
 }

--- a/changelog/bastin_put-lc-store-behind-flag.md
+++ b/changelog/bastin_put-lc-store-behind-flag.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Put the initiation of LC Store behind the `enable-light-client` flag.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Puts the initiation of LC Store behind the `enable-light-client` flag. This will prevent creating the store object when the flag is not set. it will also allow us to modify the initiation of the store in the future. (add initialization logic, mainly pass the beacon.db to the store)