### PR TITLE
Add configurable batch verifier limit for attestation signature verification

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -889,6 +889,7 @@ func (b *BeaconNode) registerSyncService(initialSyncComplete chan struct{}, bFil
 		regularsync.WithCustodyInfo(b.custodyInfo),
 		regularsync.WithSlasherEnabled(b.slasherEnabled),
 		regularsync.WithLightClientStore(b.lcStore),
+		regularsync.WithBatchVerifierLimit(b.cliCtx.Int(flags.BatchVerifierLimit.Name)),
 	)
 	return b.services.RegisterService(rs)
 }

--- a/beacon-chain/sync/batch_verifier.go
+++ b/beacon-chain/sync/batch_verifier.go
@@ -13,8 +13,6 @@ import (
 
 const signatureVerificationInterval = 50 * time.Millisecond
 
-const verifierLimit = 50
-
 type signatureVerifier struct {
 	set     *bls.SignatureBatch
 	resChan chan error
@@ -36,7 +34,7 @@ func (s *Service) verifierRoutine() {
 			return
 		case sig := <-s.signatureChan:
 			verifierBatch = append(verifierBatch, sig)
-			if len(verifierBatch) >= verifierLimit {
+			if len(verifierBatch) >= s.cfg.batchVerifierLimit {
 				verifyBatch(verifierBatch)
 				verifierBatch = []*signatureVerifier{}
 			}

--- a/beacon-chain/sync/batch_verifier_test.go
+++ b/beacon-chain/sync/batch_verifier_test.go
@@ -67,6 +67,7 @@ func TestValidateWithBatchVerifier(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			svc := &Service{
 				ctx:           ctx,
+				cfg:           &config{batchVerifierLimit: verifierLimit},
 				cancel:        cancel,
 				signatureChan: make(chan *signatureVerifier, verifierLimit),
 			}

--- a/beacon-chain/sync/options.go
+++ b/beacon-chain/sync/options.go
@@ -222,3 +222,11 @@ func WithLightClientStore(lcs *lightClient.Store) Option {
 		return nil
 	}
 }
+
+// WithBatchVerifierLimit sets the maximum number of signatures to batch verify at once.
+func WithBatchVerifierLimit(limit int) Option {
+	return func(s *Service) error {
+		s.cfg.batchVerifierLimit = limit
+		return nil
+	}
+}

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -40,6 +40,8 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
+var verifierLimit = 1000
+
 func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := dbtest.SetupDB(t)

--- a/changelog/tt_noodles.md
+++ b/changelog/tt_noodles.md
@@ -1,0 +1,7 @@
+### Added
+
+- new `--batch-verifier-limit` flag to configure max number of signatures to batch verify on gossip
+
+### Changed
+
+- default batch signature verification limit increased from 50 to 1000

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -338,4 +338,10 @@ var (
 		Name:  "subscribe-all-data-subnets",
 		Usage: "Enable subscription to all data subnets.",
 	}
+	// BatchVerifierLimit sets the maximum number of signatures to batch verify at once.
+	BatchVerifierLimit = &cli.IntFlag{
+		Name:  "batch-verifier-limit",
+		Usage: "Maximum number of signatures to batch verify at once for beacon attestation p2p gossip.",
+		Value: 1000,
+	}
 )

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -149,6 +149,7 @@ var appFlags = []cli.Flag{
 	bflags.BackfillBatchSize,
 	bflags.BackfillWorkerCount,
 	bflags.BackfillOldestSlot,
+	flags.BatchVerifierLimit,
 }
 
 func init() {

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -72,6 +72,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.NetworkID,
 			flags.RPCHost,
 			flags.RPCPort,
+			flags.BatchVerifierLimit,
 		},
 	},
 	{


### PR DESCRIPTION
  This PR introduces a configurable batch verifier limit for beacon attestation p2p gossip signature verification, replacing
  the hardcoded limit of 50 with a cli flag defaulting to 1000.

 ### Background

  This controls the batch size for accumulating signatures before batch verifying them for beacon and aggregate attestation
  subnets. Performance testing captured CPU profiles (`go tool pprof -top`) over 30s periods in two modes:
  - No-validator mode: Subscribe only to aggregate attestation subnets
  - Validator mode: Subscribe to ALL beacon attestation subnets + aggregates

 ### Results
  No-validator mode (aggregate subnets only):
  | Batch Size | Total CPU Time | CPU %  | Improvement |
  |------------|----------------|--------|-------------|
  | 50         | 7.28s          | 24.27% | baseline    |
  | 1000       | 6.12s          | 20.29% | -16%        |
  | 10000      | 6.82s          | 22.73% | -6%         |

  Validator mode (all subnets):
  | Batch Size | Total CPU Time | CPU %   | Improvement |
  |------------|----------------|---------|-------------|
  | 50         | 34.54s         | 115.13% | baseline    |
  | 1000       | 32.52s         | 107.90% | -6%         |
  | 10000      | 32.87s         | 108.98% | -5%         |

  CPU Time = total CPU consumed; CPU % = CPU time / wall time

  #### Rationale for 1000 default
 1000 batch size shows the best cpu efficiency (16% reduction in no-validator mode, 6% in
  validator mode) and outperforms both the original 50 and larger 10000 batch sizes

 #### Tradeoffs
 Memory: ~200KB additional storage (each signature set ≈200 bytes, so 950 extra signatures × 200 bytes)