### PR TITLE
Optimize `BuildBlobSidecars` Merkle proof computation by pre-computing subtrees

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deneb.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deneb.go
@@ -28,8 +28,14 @@ func BuildBlobSidecars(blk interfaces.SignedBeaconBlock, blobs [][]byte, kzgProo
 		return nil, err
 	}
 	body := blk.Block().Body()
+	// Pre-compute subtrees once before the loop to avoid redundant calculations
+	proofComponents, err := blocks.PrecomputeMerkleProofComponents(body)
+	if err != nil {
+		return nil, err
+	}
+
 	for i := range blobSidecars {
-		proof, err := blocks.MerkleProofKZGCommitment(body, i)
+		proof, err := blocks.MerkleProofKZGCommitmentFromComponents(proofComponents, i)
 		if err != nil {
 			return nil, err
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deneb_bench_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deneb_bench_test.go
@@ -1,0 +1,224 @@
+package validator
+
+import (
+	"errors"
+	"testing"
+
+	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v6/runtime/version"
+	"github.com/OffchainLabs/prysm/v6/testing/util"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// BuildBlobSidecarsOriginal is the original implementation for comparison
+func BuildBlobSidecarsOriginal(blk interfaces.SignedBeaconBlock, blobs [][]byte, kzgProofs [][]byte) ([]*ethpb.BlobSidecar, error) {
+	if blk.Version() < version.Deneb {
+		return nil, nil // No blobs before deneb.
+	}
+	commits, err := blk.Block().Body().BlobKzgCommitments()
+	if err != nil {
+		return nil, err
+	}
+	cLen := len(commits)
+	if cLen != len(blobs) || cLen != len(kzgProofs) {
+		return nil, errors.New("blob KZG commitments don't match number of blobs or KZG proofs")
+	}
+	blobSidecars := make([]*ethpb.BlobSidecar, cLen)
+	header, err := blk.Header()
+	if err != nil {
+		return nil, err
+	}
+	body := blk.Block().Body()
+	for i := range blobSidecars {
+		proof, err := blocks.MerkleProofKZGCommitment(body, i)
+		if err != nil {
+			return nil, err
+		}
+		blobSidecars[i] = &ethpb.BlobSidecar{
+			Index:                    uint64(i),
+			Blob:                     blobs[i],
+			KzgCommitment:            commits[i],
+			KzgProof:                 kzgProofs[i],
+			SignedBlockHeader:        header,
+			CommitmentInclusionProof: proof,
+		}
+	}
+	return blobSidecars, nil
+}
+
+func setupBenchmarkData(b *testing.B, numBlobs int) (interfaces.SignedBeaconBlock, [][]byte, [][]byte) {
+	b.Helper()
+
+	// Create KZG commitments
+	kzgCommitments := make([][]byte, numBlobs)
+	for i := 0; i < numBlobs; i++ {
+		kzgCommitments[i] = bytesutil.PadTo([]byte{byte(i)}, 48)
+	}
+
+	// Create block with KZG commitments
+	blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockDeneb())
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := blk.SetBlobKzgCommitments(kzgCommitments); err != nil {
+		b.Fatal(err)
+	}
+
+	// Create blobs
+	blobs := make([][]byte, numBlobs)
+	for i := 0; i < numBlobs; i++ {
+		blobs[i] = make([]byte, fieldparams.BlobLength)
+		// Add some variation to the blob data
+		blobs[i][0] = byte(i)
+	}
+
+	// Create KZG proofs
+	proof, err := hexutil.Decode("0xb4021b0de10f743893d4f71e1bf830c019e832958efd6795baf2f83b8699a9eccc5dc99015d8d4d8ec370d0cc333c06a")
+	if err != nil {
+		b.Fatal(err)
+	}
+	kzgProofs := make([][]byte, numBlobs)
+	for i := 0; i < numBlobs; i++ {
+		kzgProofs[i] = proof
+	}
+
+	return blk, blobs, kzgProofs
+}
+
+func BenchmarkBuildBlobSidecars_Original_1Blob(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecarsOriginal(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildBlobSidecars_Optimized_1Blob(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecars(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildBlobSidecars_Original_2Blobs(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 2)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecarsOriginal(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildBlobSidecars_Optimized_3Blobs(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 3)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecars(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildBlobSidecars_Original_3Blobs(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 3)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecarsOriginal(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildBlobSidecars_Optimized_4Blobs(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 4)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecars(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildBlobSidecars_Original_9Blobs(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 9)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecarsOriginal(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildBlobSidecars_Optimized_9Blobs(b *testing.B) {
+	blk, blobs, kzgProofs := setupBenchmarkData(b, 9)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := BuildBlobSidecars(blk, blobs, kzgProofs)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Benchmark the individual components to understand where the improvements come from
+func BenchmarkMerkleProofKZGCommitment_Original(b *testing.B) {
+	blk, _, _ := setupBenchmarkData(b, 4)
+	body := blk.Block().Body()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 4; j++ {
+			_, err := blocks.MerkleProofKZGCommitment(body, j)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkMerkleProofKZGCommitment_Optimized(b *testing.B) {
+	blk, _, _ := setupBenchmarkData(b, 4)
+	body := blk.Block().Body()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Pre-compute components once
+		components, err := blocks.PrecomputeMerkleProofComponents(body)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		// Generate proofs for each index
+		for j := 0; j < 4; j++ {
+			_, err := blocks.MerkleProofKZGCommitmentFromComponents(components, j)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/changelog/tt_sushi.md
+++ b/changelog/tt_sushi.md
@@ -1,0 +1,2 @@
+# Changed
+Optimize proposer inclusion proof calcuation by pre caching subtries

--- a/changelog/tt_sushi.md
+++ b/changelog/tt_sushi.md
@@ -1,2 +1,3 @@
-# Changed
-Optimize proposer inclusion proof calcuation by pre caching subtries
+### Changed
+
+- Optimize proposer inclusion proof calcuation by pre caching subtries


### PR DESCRIPTION
This PR fixes #13254

## Summary
Optimizes `BuildBlobSidecars` by pre-computing shared Merkle tree components once instead of recalculating for each blob, eliminating O(n) redundant computations.

## Changes
  - Add `PrecomputeMerkleProofComponents()` to cache expensive subtree operations
  - Add `MerkleProofKZGCommitmentFromComponents()` for efficient index-specific proofs
  - Update `BuildBlobSidecars()` to use pre-computed components

  ## Performance Impact
  | Blob Count | Speed Improvement | Memory Reduction |
  |------------|-------------------|------------------|
  | 3 blobs    | **2.12x faster**  | 53% less memory  |
  | 9 blobs    | **5.16x faster**  | 77% less memory  |

```
goos: darwin
goarch: arm64
pkg: github.com/OffchainLabs/prysm/v6/beacon-chain/rpc/prysm/v1alpha1/validator
cpu: Apple M4 Pro
BenchmarkBuildBlobSidecars_Original_1Blob-14              106045             10217 ns/op           17900 B/op        238 allocs/op
BenchmarkBuildBlobSidecars_Optimized_1Blob-14             116745             10210 ns/op           17951 B/op        239 allocs/op
BenchmarkBuildBlobSidecars_Original_2Blobs-14              71059             16859 ns/op           31400 B/op        440 allocs/op
BenchmarkBuildBlobSidecars_Optimized_3Blobs-14            106286             11249 ns/op           21955 B/op        282 allocs/op
BenchmarkBuildBlobSidecars_Original_3Blobs-14              49640             24587 ns/op           46355 B/op        661 allocs/op
BenchmarkBuildBlobSidecars_Optimized_4Blobs-14            104604             11458 ns/op           23420 B/op        300 allocs/op
BenchmarkBuildBlobSidecars_Original_9Blobs-14              16446             72943 ns/op          151024 B/op       2206 allocs/op
BenchmarkBuildBlobSidecars_Optimized_9Blobs-14             81859             14643 ns/op           34711 B/op        423 allocs/op
PASS
ok      github.com/OffchainLabs/prysm/v6/beacon-chain/rpc/prysm/v1alpha1/validator      11.653s

goos: darwin
goarch: arm64
pkg: github.com/OffchainLabs/prysm/v6/beacon-chain/rpc/prysm/v1alpha1/validator
cpu: Apple M4 Pro
BenchmarkMerkleProofKZGCommitment_Original-14              43825             26859 ns/op           54335 B/op        824 allocs/op
BenchmarkMerkleProofKZGCommitment_Optimized-14            156106              7673 ns/op           17765 B/op        252 allocs/op
PASS
ok      github.com/OffchainLabs/prysm/v6/beacon-chain/rpc/prysm/v1alpha1/validator      3.133s
```