### PR TITLE
Move data col reconstruction log to after reconstruction / save complete

### DIFF
--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -85,11 +85,11 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(
 
 	slotStartTime := slots.StartTime(uint64(s.cfg.clock.GenesisTime().Unix()), slot)
 	log.WithFields(logrus.Fields{
-		"root":               fmt.Sprintf("%#x", root),
-		"slot":               slot,
-		"fromColumnsCount":   storedColumnsCount,
-		"sinceSlotStartTime": time.Since(slotStartTime),
-		"reconstructionTime": time.Since(startTime),
+		"root":                   fmt.Sprintf("%#x", root),
+		"slot":                   slot,
+		"fromColumnsCount":       storedColumnsCount,
+		"sinceSlotStartTime":     time.Since(slotStartTime),
+		"reconstructionDuration": time.Since(startTime),
 	}).Debug("Data columns reconstructed and saved")
 
 	// Update reconstruction metrics

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -83,6 +83,15 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(
 		return errors.Wrap(err, "save data column sidecars")
 	}
 
+	slotStartTime := slots.StartTime(uint64(s.cfg.clock.GenesisTime().Unix()), slot)
+	log.WithFields(logrus.Fields{
+		"root":               fmt.Sprintf("%#x", root),
+		"slot":               slot,
+		"fromColumnsCount":   storedColumnsCount,
+		"sinceSlotStartTime": time.Since(slotStartTime),
+		"reconstructionTime": time.Since(startTime),
+	}).Debug("Data columns reconstructed and saved")
+
 	// Update reconstruction metrics
 	dataColumnReconstructionHistogram.Observe(float64(time.Since(startTime).Milliseconds()))
 	dataColumnReconstructionCounter.Add(float64(len(reconstructedSidecars) - len(verifiedSidecars)))
@@ -91,12 +100,6 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(
 	if err := s.scheduleMissingDataColumnSidecarsBroadcast(ctx, root, proposerIndex, slot); err != nil {
 		return errors.Wrap(err, "schedule reconstructed data columns broadcast")
 	}
-
-	log.WithFields(logrus.Fields{
-		"root":             fmt.Sprintf("%#x", root),
-		"slot":             slot,
-		"fromColumnsCount": storedColumnsCount,
-	}).Debug("Data columns reconstructed and saved")
 
 	return nil
 }

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -85,11 +85,11 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(
 
 	slotStartTime := slots.StartTime(uint64(s.cfg.clock.GenesisTime().Unix()), slot)
 	log.WithFields(logrus.Fields{
-		"root":                   fmt.Sprintf("%#x", root),
-		"slot":                   slot,
-		"fromColumnsCount":       storedColumnsCount,
-		"sinceSlotStartTime":     time.Since(slotStartTime),
-		"reconstructionDuration": time.Since(startTime),
+		"root":                          fmt.Sprintf("%#x", root),
+		"slot":                          slot,
+		"fromColumnsCount":              storedColumnsCount,
+		"sinceSlotStartTime":            time.Since(slotStartTime),
+		"reconstructionAndSaveDuration": time.Since(startTime),
 	}).Debug("Data columns reconstructed and saved")
 
 	// Update reconstruction metrics

--- a/changelog/tt_onion.md
+++ b/changelog/tt_onion.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move data col reconstruction log to a more accurate place in the code.


### PR DESCRIPTION
`scheduleMissingDataColumnSidecarsBroadcast` adds a random delay so `Data columns reconstructed and saved` shows up late in log after broadcast, we could fix this by moving it after `s.cfg.dataColumnStorage.Save(`