### PR TITLE
Unify LC API 1/2 (bootstrap)

### DIFF
--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -33,6 +33,14 @@ func WithMaxGoroutines(x int) Option {
 	}
 }
 
+// WithLCStore for light client store access.
+func WithLCStore() Option {
+	return func(s *Service) error {
+		s.lcStore = lightclient.NewLightClientStore(s.cfg.BeaconDB)
+		return nil
+	}
+}
+
 // WithWeakSubjectivityCheckpoint for checkpoint sync.
 func WithWeakSubjectivityCheckpoint(c *ethpb.Checkpoint) Option {
 	return func(s *Service) error {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -226,7 +226,7 @@ func (s *Service) processLightClientBootstrap(cfg *postBlockProcessConfig) error
 	if err != nil {
 		return errors.Wrapf(err, "could not create light client bootstrap")
 	}
-	if err := s.cfg.BeaconDB.SaveLightClientBootstrap(cfg.ctx, blockRoot[:], bootstrap); err != nil {
+	if err := s.lcStore.SaveLightClientBootstrap(cfg.ctx, blockRoot, bootstrap); err != nil {
 		return errors.Wrapf(err, "could not save light client bootstrap")
 	}
 	return nil

--- a/beacon-chain/core/light-client/BUILD.bazel
+++ b/beacon-chain/core/light-client/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v6/beacon-chain/core/light-client",
     visibility = ["//visibility:public"],
     deps = [
+        "//beacon-chain/db/iface:go_default_library",
         "//beacon-chain/execution:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//config/fieldparams:go_default_library",

--- a/beacon-chain/core/light-client/store.go
+++ b/beacon-chain/core/light-client/store.go
@@ -1,20 +1,55 @@
 package light_client
 
 import (
+	"context"
 	"sync"
 
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/db/iface"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
+	"github.com/pkg/errors"
 )
+
+var ErrLightClientBootstrapNotFound = errors.New("light client bootstrap not found")
 
 type Store struct {
 	mu sync.RWMutex
 
+	beaconDB             iface.HeadAccessDatabase
 	lastFinalityUpdate   interfaces.LightClientFinalityUpdate
 	lastOptimisticUpdate interfaces.LightClientOptimisticUpdate
 }
 
-func NewLightClientStore() *Store {
-	return &Store{}
+func NewLightClientStore(db iface.HeadAccessDatabase) *Store {
+	return &Store{
+		beaconDB: db,
+	}
+}
+
+func (s *Store) LightClientBootstrap(ctx context.Context, blockRoot [32]byte) (interfaces.LightClientBootstrap, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Fetch the light client bootstrap from the database
+	bootstrap, err := s.beaconDB.LightClientBootstrap(ctx, blockRoot[:])
+	if err != nil {
+		return nil, err
+	}
+	if bootstrap == nil { // not found
+		return nil, ErrLightClientBootstrapNotFound
+	}
+
+	return bootstrap, nil
+}
+
+func (s *Store) SaveLightClientBootstrap(ctx context.Context, blockRoot [32]byte, bootstrap interfaces.LightClientBootstrap) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Save the light client bootstrap to the database
+	if err := s.beaconDB.SaveLightClientBootstrap(ctx, blockRoot[:], bootstrap); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *Store) SetLastFinalityUpdate(update interfaces.LightClientFinalityUpdate) {

--- a/beacon-chain/db/kv/lightclient_test.go
+++ b/beacon-chain/db/kv/lightclient_test.go
@@ -564,14 +564,6 @@ func TestStore_LightClientBootstrap_CanSaveRetrieve(t *testing.T) {
 	cfg.EpochsPerSyncCommitteePeriod = 1
 	params.OverrideBeaconConfig(cfg)
 
-	versionToForkEpoch := map[int]primitives.Epoch{
-		version.Altair:    params.BeaconConfig().AltairForkEpoch,
-		version.Bellatrix: params.BeaconConfig().BellatrixForkEpoch,
-		version.Capella:   params.BeaconConfig().CapellaForkEpoch,
-		version.Deneb:     params.BeaconConfig().DenebForkEpoch,
-		version.Electra:   params.BeaconConfig().ElectraForkEpoch,
-	}
-
 	db := setupDB(t)
 	ctx := t.Context()
 
@@ -583,7 +575,7 @@ func TestStore_LightClientBootstrap_CanSaveRetrieve(t *testing.T) {
 
 	for testVersion := version.Altair; testVersion <= version.Electra; testVersion++ {
 		t.Run(version.String(testVersion), func(t *testing.T) {
-			bootstrap, err := createDefaultLightClientBootstrap(primitives.Slot(uint64(versionToForkEpoch[testVersion]) * uint64(params.BeaconConfig().SlotsPerEpoch)))
+			bootstrap, err := createDefaultLightClientBootstrap(primitives.Slot(uint64(params.BeaconConfig().VersionToForkEpochMap()[testVersion]) * uint64(params.BeaconConfig().SlotsPerEpoch)))
 			require.NoError(t, err)
 
 			err = bootstrap.SetCurrentSyncCommittee(createRandomSyncCommittee())

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -235,7 +235,7 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, opts ...Option) (*Beaco
 	beacon.finalizedStateAtStartUp = nil
 
 	if features.Get().EnableLightClient {
-		beacon.lcStore = lightclient.NewLightClientStore()
+		beacon.lcStore = lightclient.NewLightClientStore(beacon.db)
 	}
 
 	return beacon, nil

--- a/beacon-chain/rpc/eth/light-client/BUILD.bazel
+++ b/beacon-chain/rpc/eth/light-client/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_fastssz//:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -42,19 +42,11 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 	cfg.FuluForkEpoch = 5
 	params.OverrideBeaconConfig(cfg)
 
-	versionToForkEpoch := map[int]primitives.Epoch{
-		version.Altair:    params.BeaconConfig().AltairForkEpoch,
-		version.Bellatrix: params.BeaconConfig().BellatrixForkEpoch,
-		version.Capella:   params.BeaconConfig().CapellaForkEpoch,
-		version.Deneb:     params.BeaconConfig().DenebForkEpoch,
-		version.Electra:   params.BeaconConfig().ElectraForkEpoch,
-	}
-
 	for testVersion := version.Altair; testVersion <= version.Electra; testVersion++ {
 		t.Run(version.String(testVersion), func(t *testing.T) {
 			l := util.NewTestLightClient(t, testVersion)
 
-			slot := primitives.Slot(versionToForkEpoch[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+			slot := primitives.Slot(params.BeaconConfig().VersionToForkEpochMap()[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 			blockRoot, err := l.Block.Block().HashTreeRoot()
 			require.NoError(t, err)
 
@@ -96,7 +88,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		t.Run(version.String(testVersion)+"SSZ", func(t *testing.T) {
 			l := util.NewTestLightClient(t, testVersion)
 
-			slot := primitives.Slot(versionToForkEpoch[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+			slot := primitives.Slot(params.BeaconConfig().VersionToForkEpochMap()[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 			blockRoot, err := l.Block.Block().HashTreeRoot()
 			require.NoError(t, err)
 

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -53,13 +53,13 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 			bootstrap, err := lightclient.NewLightClientBootstrapFromBeaconState(l.Ctx, slot, l.State, l.Block)
 			require.NoError(t, err)
 
-			db := dbtesting.SetupDB(t)
+			lcStore := lightclient.NewLightClientStore(dbtesting.SetupDB(t))
 
-			err = db.SaveLightClientBootstrap(l.Ctx, blockRoot[:], bootstrap)
+			err = lcStore.SaveLightClientBootstrap(l.Ctx, blockRoot, bootstrap)
 			require.NoError(t, err)
 
 			s := &Server{
-				BeaconDB: db,
+				LCStore: lcStore,
 			}
 			request := httptest.NewRequest("GET", "http://foo.com/", nil)
 			request.SetPathValue("block_root", hexutil.Encode(blockRoot[:]))
@@ -85,6 +85,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 			require.NotNil(t, resp.Data.CurrentSyncCommittee)
 			require.NotNil(t, resp.Data.CurrentSyncCommitteeBranch)
 		})
+
 		t.Run(version.String(testVersion)+"SSZ", func(t *testing.T) {
 			l := util.NewTestLightClient(t, testVersion)
 
@@ -95,13 +96,13 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 			bootstrap, err := lightclient.NewLightClientBootstrapFromBeaconState(l.Ctx, slot, l.State, l.Block)
 			require.NoError(t, err)
 
-			db := dbtesting.SetupDB(t)
+			lcStore := lightclient.NewLightClientStore(dbtesting.SetupDB(t))
 
-			err = db.SaveLightClientBootstrap(l.Ctx, blockRoot[:], bootstrap)
+			err = lcStore.SaveLightClientBootstrap(l.Ctx, blockRoot, bootstrap)
 			require.NoError(t, err)
 
 			s := &Server{
-				BeaconDB: db,
+				LCStore: lcStore,
 			}
 			request := httptest.NewRequest("GET", "http://foo.com/", nil)
 			request.SetPathValue("block_root", hexutil.Encode(blockRoot[:]))
@@ -138,10 +139,8 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 	}
 
 	t.Run("no bootstrap found", func(t *testing.T) {
-		db := dbtesting.SetupDB(t)
-
 		s := &Server{
-			BeaconDB: db,
+			LCStore: lightclient.NewLightClientStore(dbtesting.SetupDB(t)),
 		}
 		request := httptest.NewRequest("GET", "http://foo.com/", nil)
 		request.SetPathValue("block_root", hexutil.Encode([]byte{0x00, 0x01, 0x02}))

--- a/beacon-chain/sync/rpc_light_client.go
+++ b/beacon-chain/sync/rpc_light_client.go
@@ -38,7 +38,7 @@ func (s *Service) lightClientBootstrapRPCHandler(ctx context.Context, msg interf
 	}
 	blkRoot := *rawMsg
 
-	bootstrap, err := s.cfg.beaconDB.LightClientBootstrap(ctx, blkRoot[:])
+	bootstrap, err := s.lcStore.LightClientBootstrap(ctx, blkRoot)
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 		tracing.AnnotateError(span, err)

--- a/beacon-chain/sync/rpc_light_client_test.go
+++ b/beacon-chain/sync/rpc_light_client_test.go
@@ -54,7 +54,7 @@ func TestRPC_LightClientBootstrap(t *testing.T) {
 			stateNotifier: &mockChain.MockStateNotifier{},
 		},
 		chainStarted: abool.New(),
-		lcStore:      &lightClient.Store{},
+		lcStore:      lightClient.NewLightClientStore(d),
 		subHandler:   newSubTopicHandler(),
 		rateLimiter:  newRateLimiter(p1),
 	}
@@ -81,7 +81,7 @@ func TestRPC_LightClientBootstrap(t *testing.T) {
 			blockRoot, err := l.Block.Block().HashTreeRoot()
 			require.NoError(t, err)
 
-			require.NoError(t, r.cfg.beaconDB.SaveLightClientBootstrap(ctx, blockRoot[:], bootstrap))
+			require.NoError(t, r.lcStore.SaveLightClientBootstrap(ctx, blockRoot, bootstrap))
 
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/changelog/bastin_unify-lc-api-bootstrap.md
+++ b/changelog/bastin_unify-lc-api-bootstrap.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move setter/getter functions for LC Bootstrap into LcStore for a unified interface.

--- a/changelog/bastin_version-to-fork-epoch.md
+++ b/changelog/bastin_version-to-fork-epoch.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add method `VersionToForkEpochMap()` to the `BeaconChainConfig` in the `params` package.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -316,6 +316,17 @@ type BeaconChainConfig struct {
 	DeprecatedMaxBlobsPerBlockFulu int `yaml:"MAX_BLOBS_PER_BLOCK_FULU" spec:"true"`
 }
 
+func (b *BeaconChainConfig) VersionToForkEpochMap() map[int]primitives.Epoch {
+	return map[int]primitives.Epoch{
+		version.Altair:    b.AltairForkEpoch,
+		version.Bellatrix: b.BellatrixForkEpoch,
+		version.Capella:   b.CapellaForkEpoch,
+		version.Deneb:     b.DenebForkEpoch,
+		version.Electra:   b.ElectraForkEpoch,
+		version.Fulu:      b.FuluForkEpoch,
+	}
+}
+
 func (b *BeaconChainConfig) ExecutionRequestLimits() enginev1.ExecutionRequestLimits {
 	return enginev1.ExecutionRequestLimits{
 		Deposits:       b.MaxDepositRequestsPerPayload,


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR does three things:
- Passes the DB instance to the light client store object upon node initialization. This will allow the LC Store to have access to the beacon DB.
- It introduces setter/getter functions for LC Bootstrap objects in the Store, so we can have one unified interface for accessing this data. 
- Refactors the users of LC bootstrap to use the new functions instead of accessing the DB directly.

**Which issues(s) does this PR fix?**
This is a prerequisite for the canonical-only lc data PR.

**Notes for reviewers**
This is the first part of a 2-part change. I will add the same changes for LC `updates`.