### PR TITLE
Isolate committee cache

### DIFF
--- a/beacon-chain/blockchain/head_sync_committee_info.go
+++ b/beacon-chain/blockchain/head_sync_committee_info.go
@@ -18,9 +18,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Initialize the state cache for sync committees.
-var syncCommitteeHeadStateCache = cache.NewSyncCommitteeHeadState()
-
 // HeadSyncCommitteeFetcher is the interface that wraps the head sync committee related functions.
 // The head sync committee functions return callers sync committee indices and public keys with respect to current head state.
 type HeadSyncCommitteeFetcher interface {
@@ -143,7 +140,7 @@ func (s *Service) getSyncCommitteeHeadState(ctx context.Context, slot primitives
 	defer mLock.Unlock()
 
 	// If there's already a head state exists with the request slot, we don't need to process slots.
-	cachedState, err := syncCommitteeHeadStateCache.Get(slot)
+	cachedState, err := s.syncCommitteeHeadState.Get(slot)
 	switch {
 	case err == nil:
 		syncHeadStateHit.Inc()
@@ -166,7 +163,7 @@ func (s *Service) getSyncCommitteeHeadState(ctx context.Context, slot primitives
 			return nil, err
 		}
 		syncHeadStateMiss.Inc()
-		err = syncCommitteeHeadStateCache.Put(slot, headState)
+		err = s.syncCommitteeHeadState.Put(slot, headState)
 		return headState, err
 	default:
 		// In the event, we encounter another error

--- a/beacon-chain/blockchain/head_sync_committee_info_test.go
+++ b/beacon-chain/blockchain/head_sync_committee_info_test.go
@@ -121,13 +121,14 @@ func TestService_HeadSyncSelectionProofDomain(t *testing.T) {
 }
 
 func TestSyncCommitteeHeadStateCache_RoundTrip(t *testing.T) {
+	s := testServiceNoDB(t)
 	beaconState, _ := util.DeterministicGenesisStateAltair(t, 100)
 	require.NoError(t, beaconState.SetSlot(100))
-	cachedState, err := syncCommitteeHeadStateCache.Get(101)
+	cachedState, err := s.syncCommitteeHeadState.Get(101)
 	require.ErrorContains(t, cache.ErrNotFound.Error(), err)
 	require.Equal(t, nil, cachedState)
-	require.NoError(t, syncCommitteeHeadStateCache.Put(101, beaconState))
-	cachedState, err = syncCommitteeHeadStateCache.Get(101)
+	require.NoError(t, s.syncCommitteeHeadState.Put(101, beaconState))
+	cachedState, err = s.syncCommitteeHeadState.Get(101)
 	require.NoError(t, err)
 	require.DeepEqual(t, beaconState, cachedState)
 }

--- a/beacon-chain/blockchain/head_sync_committee_info_test.go
+++ b/beacon-chain/blockchain/head_sync_committee_info_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/cache"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
-	dbTest "github.com/OffchainLabs/prysm/v6/beacon-chain/db/testing"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
@@ -15,7 +14,7 @@ import (
 
 func TestService_HeadSyncCommitteeIndices(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
-	c := &Service{cfg: &config{BeaconDB: dbTest.SetupDB(t)}}
+	c := testServiceWithDB(t)
 	c.head = &head{state: s}
 
 	// Current period
@@ -38,7 +37,7 @@ func TestService_HeadSyncCommitteeIndices(t *testing.T) {
 
 func TestService_headCurrentSyncCommitteeIndices(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
-	c := &Service{cfg: &config{BeaconDB: dbTest.SetupDB(t)}}
+	c := testServiceWithDB(t)
 	c.head = &head{state: s}
 
 	// Process slot up to `EpochsPerSyncCommitteePeriod` so it can `ProcessSyncCommitteeUpdates`.
@@ -52,7 +51,7 @@ func TestService_headCurrentSyncCommitteeIndices(t *testing.T) {
 
 func TestService_headNextSyncCommitteeIndices(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
-	c := &Service{}
+	c := testServiceWithDB(t)
 	c.head = &head{state: s}
 
 	// Process slot up to `EpochsPerSyncCommitteePeriod` so it can `ProcessSyncCommitteeUpdates`.
@@ -66,7 +65,7 @@ func TestService_headNextSyncCommitteeIndices(t *testing.T) {
 
 func TestService_HeadSyncCommitteePubKeys(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
-	c := &Service{cfg: &config{BeaconDB: dbTest.SetupDB(t)}}
+	c := testServiceWithDB(t)
 	c.head = &head{state: s}
 
 	// Process slot up to 2 * `EpochsPerSyncCommitteePeriod` so it can run `ProcessSyncCommitteeUpdates` twice.
@@ -81,7 +80,7 @@ func TestService_HeadSyncCommitteePubKeys(t *testing.T) {
 
 func TestService_HeadSyncCommitteeDomain(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
-	c := &Service{cfg: &config{BeaconDB: dbTest.SetupDB(t)}}
+	c := testServiceWithDB(t)
 	c.head = &head{state: s}
 
 	wanted, err := signing.Domain(s.Fork(), slots.ToEpoch(s.Slot()), params.BeaconConfig().DomainSyncCommittee, s.GenesisValidatorsRoot())
@@ -95,7 +94,7 @@ func TestService_HeadSyncCommitteeDomain(t *testing.T) {
 
 func TestService_HeadSyncContributionProofDomain(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
-	c := &Service{}
+	c := testServiceWithDB(t)
 	c.head = &head{state: s}
 
 	wanted, err := signing.Domain(s.Fork(), slots.ToEpoch(s.Slot()), params.BeaconConfig().DomainContributionAndProof, s.GenesisValidatorsRoot())
@@ -109,7 +108,7 @@ func TestService_HeadSyncContributionProofDomain(t *testing.T) {
 
 func TestService_HeadSyncSelectionProofDomain(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
-	c := &Service{}
+	c := testServiceWithDB(t)
 	c.head = &head{state: s}
 
 	wanted, err := signing.Domain(s.Fork(), slots.ToEpoch(s.Slot()), params.BeaconConfig().DomainSyncCommitteeSelectionProof, s.GenesisValidatorsRoot())
@@ -122,17 +121,13 @@ func TestService_HeadSyncSelectionProofDomain(t *testing.T) {
 }
 
 func TestSyncCommitteeHeadStateCache_RoundTrip(t *testing.T) {
-	c := syncCommitteeHeadStateCache
-	t.Cleanup(func() {
-		syncCommitteeHeadStateCache = cache.NewSyncCommitteeHeadState()
-	})
 	beaconState, _ := util.DeterministicGenesisStateAltair(t, 100)
 	require.NoError(t, beaconState.SetSlot(100))
-	cachedState, err := c.Get(101)
+	cachedState, err := syncCommitteeHeadStateCache.Get(101)
 	require.ErrorContains(t, cache.ErrNotFound.Error(), err)
 	require.Equal(t, nil, cachedState)
-	require.NoError(t, c.Put(101, beaconState))
-	cachedState, err = c.Get(101)
+	require.NoError(t, syncCommitteeHeadStateCache.Put(101, beaconState))
+	cachedState, err = syncCommitteeHeadStateCache.Get(101)
 	require.NoError(t, err)
 	require.DeepEqual(t, beaconState, cachedState)
 }

--- a/beacon-chain/blockchain/mock_test.go
+++ b/beacon-chain/blockchain/mock_test.go
@@ -8,9 +8,10 @@ import (
 	doublylinkedtree "github.com/OffchainLabs/prysm/v6/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stategen"
+	"github.com/OffchainLabs/prysm/v6/testing/require"
 )
 
-func testServiceOptsWithDB(t *testing.T) []Option {
+func testServiceOptsWithDB(t testing.TB) []Option {
 	beaconDB := testDB.SetupDB(t)
 	fcs := doublylinkedtree.New()
 	cs := startup.NewClockSynchronizer()
@@ -30,4 +31,16 @@ func testServiceOptsWithDB(t *testing.T) []Option {
 func testServiceOptsNoDB() []Option {
 	cs := startup.NewClockSynchronizer()
 	return []Option{WithClockSynchronizer(cs)}
+}
+
+func testServiceNoDB(t testing.TB) *Service {
+	s, err := NewService(t.Context(), testServiceOptsNoDB()...)
+	require.NoError(t, err)
+	return s
+}
+
+func testServiceWithDB(t testing.TB) *Service {
+	s, err := NewService(t.Context(), testServiceOptsWithDB(t)...)
+	require.NoError(t, err)
+	return s
 }

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -59,11 +59,8 @@ func Test_pruneAttsFromPool_Electra(t *testing.T) {
 	cfg.TargetCommitteeSize = 8
 	params.OverrideBeaconConfig(cfg)
 
-	s := Service{
-		cfg: &config{
-			AttPool: kv.NewAttCaches(),
-		},
-	}
+	s := testServiceNoDB(t)
+	s.cfg.AttPool = kv.NewAttCaches()
 
 	data := &ethpb.AttestationData{
 		BeaconBlockRoot: make([]byte, 32),
@@ -471,7 +468,8 @@ func blockTree1(t *testing.T, beaconDB db.Database, genesisRoot []byte) ([][]byt
 }
 
 func TestCurrentSlot_HandlesOverflow(t *testing.T) {
-	svc := Service{genesisTime: prysmTime.Now().Add(1 * time.Hour)}
+	svc := testServiceNoDB(t)
+	svc.genesisTime = prysmTime.Now().Add(1 * time.Hour)
 
 	slot := svc.CurrentSlot()
 	require.Equal(t, primitives.Slot(0), slot, "Unexpected slot")

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -69,6 +69,7 @@ type Service struct {
 	slasherEnabled                 bool
 	lcStore                        *lightClient.Store
 	startWaitingDataColumnSidecars chan bool // for testing purposes only
+	syncCommitteeHeadState         *cache.SyncCommitteeHeadStateCache
 }
 
 // config options for the service.
@@ -180,14 +181,15 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		seenIndex: make(map[[32]byte][]bool),
 	}
 	srv := &Service{
-		ctx:                  ctx,
-		cancel:               cancel,
-		boundaryRoots:        [][32]byte{},
-		checkpointStateCache: cache.NewCheckpointStateCache(),
-		initSyncBlocks:       make(map[[32]byte]interfaces.ReadOnlySignedBeaconBlock),
-		blobNotifiers:        bn,
-		cfg:                  &config{},
-		blockBeingSynced:     &currentlySyncingBlock{roots: make(map[[32]byte]struct{})},
+		ctx:                    ctx,
+		cancel:                 cancel,
+		boundaryRoots:          [][32]byte{},
+		checkpointStateCache:   cache.NewCheckpointStateCache(),
+		initSyncBlocks:         make(map[[32]byte]interfaces.ReadOnlySignedBeaconBlock),
+		blobNotifiers:          bn,
+		cfg:                    &config{},
+		blockBeingSynced:       &currentlySyncingBlock{roots: make(map[[32]byte]struct{})},
+		syncCommitteeHeadState: cache.NewSyncCommitteeHeadState(),
 	}
 	for _, opt := range opts {
 		if err := opt(srv); err != nil {

--- a/beacon-chain/blockchain/service_norace_test.go
+++ b/beacon-chain/blockchain/service_norace_test.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"testing"
 
-	testDB "github.com/OffchainLabs/prysm/v6/beacon-chain/db/testing"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/OffchainLabs/prysm/v6/testing/util"
@@ -17,10 +16,7 @@ func init() {
 }
 
 func TestChainService_SaveHead_DataRace(t *testing.T) {
-	beaconDB := testDB.SetupDB(t)
-	s := &Service{
-		cfg: &config{BeaconDB: beaconDB},
-	}
+	s := testServiceWithDB(t)
 	b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 	st, _ := util.DeterministicGenesisState(t, 1)
 	require.NoError(t, err)

--- a/changelog/kasey_isolate-committee-cache.md
+++ b/changelog/kasey_isolate-committee-cache.md
@@ -1,0 +1,2 @@
+### Ignored
+- Committee cache moved from a package var to a service struct.


### PR DESCRIPTION
**What type of PR is this?**

 Other

**What does this PR do? Why is it needed?**

The head state committee cache is currently a package-level variable, which can lead to deterministic behavior in tests. This PR moves the cache to a field on the service struct.

**Other notes for review**

The cache is a pointer type so it needs to be initialized. There are many tests that directly construct a `Service` struct, so I added some more tests service setup helpers to move all of the tests away from directly initializing the struct (ensuring we don't have to worry about nil pointers for the cache in tests). So I tried to organize the change with the in 2 steps: move all the tests to using the helper func, then actually relocate the cache.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
