### PR TITLE
move validator run slot ticker

### DIFF
--- a/changelog/james-prysm_move-ticker.md
+++ b/changelog/james-prysm_move-ticker.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixes edge case starting validator client with new validator keys starts the slot ticker too early resulting in replayed slots in the main runner loop. Fixes edge case of replayed slots when waiting for account acivations. 

--- a/testing/validator-mock/validator_mock.go
+++ b/testing/validator-mock/validator_mock.go
@@ -363,6 +363,18 @@ func (mr *MockValidatorMockRecorder) SetProposerSettings(arg0, arg1 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProposerSettings", reflect.TypeOf((*MockValidator)(nil).SetProposerSettings), arg0, arg1)
 }
 
+// SetTicker mocks base method.
+func (m *MockValidator) SetTicker() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTicker")
+}
+
+// SetTicker indicates an expected call of SetTicker.
+func (mr *MockValidatorMockRecorder) SetTicker() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTicker", reflect.TypeOf((*MockValidator)(nil).SetTicker))
+}
+
 // SignValidatorRegistrationRequest mocks base method.
 func (m *MockValidator) SignValidatorRegistrationRequest(arg0 context.Context, arg1 iface.SigningFunc, arg2 *eth.ValidatorRegistrationV1) (*eth.SignedValidatorRegistrationV1, bool, error) {
 	m.ctrl.T.Helper()

--- a/validator/client/iface/validator.go
+++ b/validator/client/iface/validator.go
@@ -70,6 +70,7 @@ type Validator interface {
 	DeleteGraffiti(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte) error
 	Host() string
 	FindHealthyHost(ctx context.Context) bool
+	SetTicker()
 }
 
 // SigningFunc interface defines a type for the function that signs a message

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -66,7 +66,6 @@ func newRunner(ctx context.Context, v iface.Validator, monitor *healthMonitor) (
 		v.Done()
 		return nil, errors.Wrap(err, "failed to update proposer settings")
 	}
-
 	return &runner{
 		validator:     v,
 		healthMonitor: monitor,
@@ -85,7 +84,7 @@ func (r *runner) run(ctx context.Context) {
 	v := r.validator
 	cleanup := v.Done
 	defer cleanup()
-
+	v.SetTicker()
 	for {
 		select {
 		case <-ctx.Done():
@@ -168,6 +167,9 @@ func onAccountsChanged(ctx context.Context, v iface.Validator, current [][48]byt
 		err := v.WaitForActivation(ctx)
 		if err != nil {
 			log.WithError(err).Warn("Could not wait for validator activation")
+		} else {
+			log.Debug("Resetting slot ticker after waiting for validator activation.")
+			v.SetTicker()
 		}
 	}
 }

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -343,3 +343,6 @@ func (*FakeValidator) Host() string {
 func (fv *FakeValidator) FindHealthyHost(_ context.Context) bool {
 	return fv.CanChangeHost
 }
+
+func (fv *FakeValidator) SetTicker() {
+}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -333,6 +333,16 @@ func (v *validator) WaitForChainStart(ctx context.Context) error {
 func (v *validator) SetTicker() {
 	// If a ticker already exists, stop it before creating a new one
 	// to prevent resource leaks.
+
+	// note to reader:
+	// This function chooses to adapt to the existing slot ticker instead of changing how it works
+	// The slot ticker will currently start from genesis time but tick based on the current time.
+	// This means that sometimes we need to reset the ticker to avoid replaying old ticks on a slow consumer of the ticks.
+	// i.e.,
+	// 1. tick starts at 0
+	// 2. loop stops consuming on slot 10 due to accounts changed tigger with no active keys
+	// 3. new active keys are added in slot 20 resolving wait for activation
+	// 4. new tick starts ticking from slot 20 instead of slot 10
 	if v.ticker != nil {
 		v.ticker.Done()
 	}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -306,7 +306,6 @@ func (v *validator) WaitForChainStart(ctx context.Context) error {
 			return errors.Wrap(err, "could not save genesis validators root")
 		}
 
-		v.setTicker()
 		return nil
 	}
 
@@ -324,11 +323,15 @@ func (v *validator) WaitForChainStart(ctx context.Context) error {
 		)
 	}
 
-	v.setTicker()
 	return nil
 }
 
-func (v *validator) setTicker() {
+func (v *validator) SetTicker() {
+	// If a ticker already exists, stop it before creating a new one
+	// to prevent resource leaks.
+	if v.ticker != nil {
+		v.ticker.Done()
+	}
 	// Once the ChainStart log is received, we update the genesis time of the validator client
 	// and begin a slot ticker used to track the current slot the beacon node is in.
 	v.ticker = slots.NewSlotTicker(time.Unix(int64(v.genesisTime), 0), params.BeaconConfig().SecondsPerSlot)

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -192,7 +192,6 @@ func TestWaitForChainStart_SetsGenesisInfo(t *testing.T) {
 
 			assert.DeepEqual(t, genesisValidatorsRoot[:], savedGenValRoot, "Unexpected saved genesis validators root")
 			assert.Equal(t, genesis, v.genesisTime, "Unexpected chain start time")
-			assert.NotNil(t, v.ticker, "Expected ticker to be set, received nil")
 
 			// Make sure there are no errors running if it is the same data.
 			client.EXPECT().WaitForChainStart(
@@ -236,7 +235,6 @@ func TestWaitForChainStart_SetsGenesisInfo_IncorrectSecondTry(t *testing.T) {
 
 			assert.DeepEqual(t, genesisValidatorsRoot[:], savedGenValRoot, "Unexpected saved genesis validators root")
 			assert.Equal(t, genesis, v.genesisTime, "Unexpected chain start time")
-			assert.NotNil(t, v.ticker, "Expected ticker to be set, received nil")
 
 			genesisValidatorsRoot = bytesutil.ToBytes32([]byte("badvalidators"))
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

This is a bug fix for an edge case when starting the validator client with no active keys resulting in waiting for activation and context deadlines due to replaying old slots on the runner loop.

This is because previously, the v.setTicker function was on the WaitForChainStart function which occurs before the WaitForActivation function. Waiting for activation could take several epochs and so the ticker tries to tick continuously but the consumer in the main runner loop https://github.com/OffchainLabs/prysm/blob/288b33750d28ba8953fa51af5c51f0e3b85c7715/validator/client/runner.go#L94 has not consumed the ticks yet. When the validator keys do eventually activate and enter the main runner loop, the loop tries to quickly replay the old slots, but will context deadline because the current slot is past that time. 

by moving the setticker function to right before the loop as well as right after waitForActivation we avoid this situation.

Tested via Kurtosis
```
participants:
  - el_type: geth
    el_image: ethpandaops/geth:master
 
    cl_type: prysm
    cl_image: gcr.io/offchainlabs/prysm/beacon-chain:latest
    cl_extra_params: [--minimal-config=true]
    vc_image: gcr.io/offchainlabs/prysm/validator:latest
    vc_extra_params: [--minimal-config=true]
    count: 3
  - el_type: geth
    el_image: ethpandaops/geth:master
    cl_type: prysm
    cl_image: gcr.io/offchainlabs/prysm/beacon-chain:latest
    cl_extra_params: [--minimal-config=true]
    vc_image: gcr.io/offchainlabs/prysm/validator:latest
    vc_extra_params: [--minimal-config=true]
    validator_count: 1
    
network_params:
  electra_fork_epoch: 1
  preset: minimal
keymanager_enabled: true
additional_services:
  - dora
  - assertoor
assertoor_params:
  image: "ethpandaops/assertoor:master-latest"
  tests:
    - file: "https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/dev/dev-deposits.yaml"
      config:
        validatorMnemonic: "horror tomorrow similar carry smart bunker reform capable potato carpet car denial spawn isolate amused slight diagram use remind junk cart rely sell face"
        depositCount: 4
        depositAmount: 32
        # depositContract: "0x4242424242424242424242424242424242424242"
        depositContract: "0x00000000219ab540356cBB839Cbe05303d7705Fa"
        waitForElectra: true
 ```
 
update validator 4's keys with keys generated from mnemonic, then wait for deposit.

2 cases 
- update keys + restart validator client
- only update keys

Error before
```
[2025-07-09 19:05:36]  INFO client: Updated duties due to previous dependent root change
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=60
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=61
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=62
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=63
[2025-07-09 19:05:36] ERROR client: error getting validator duties error=getDuties: rpc error: code = DeadlineExceeded desc = context deadline exceeded: could not connect
[2025-07-09 19:05:36] ERROR client: Failed to update assignments error=getDuties: rpc error: code = DeadlineExceeded desc = context deadline exceeded: could not connect
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=65
[2025-07-09 19:05:36] ERROR client: Could not get validator roles error=validator duties are not initialized slot=65
[2025-07-09 19:05:36] ERROR client: Could not report validator's rewards/penalties error=rpc error: code = DeadlineExceeded desc = context deadline exceeded
[2025-07-09 19:05:36] ERROR client: Failed to update domain data for domain [2 0 0 0] error=rpc error: code = DeadlineExceeded desc = context deadline exceeded
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=66
[2025-07-09 19:05:36] ERROR client: Could not get validator roles error=validator duties are not initialized slot=66
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=67
[2025-07-09 19:05:36] ERROR client: Could not get validator roles error=validator duties are not initialized slot=67
[2025-07-09 19:05:36]  WARN client: Failed to update proposer settings error=rpc error: code = DeadlineExceeded desc = context deadline exceeded slot=68
```

Now

```
2025-07-09 20:49:29]  INFO client: Validator activated index=193 pubkey=0x8a356bb1c9a1 status=ACTIVE validatorIndex=193
[2025-07-09 20:49:29]  INFO client: Validator activated index=195 pubkey=0xa5684c5410e7 status=ACTIVE validatorIndex=195
[2025-07-09 20:49:29]  INFO client: Waiting for deposit to be observed by beacon node pubkey=0x97c71605e703 status=UNKNOWN_STATUS
[2025-07-09 20:49:29]  INFO client: Waiting for deposit to be observed by beacon node pubkey=0xac791c4f976b status=UNKNOWN_STATUS
[2025-07-09 20:49:29]  INFO client: Validator activated index=194 pubkey=0x888d50457e58 status=ACTIVE validatorIndex=194
[2025-07-09 20:49:29]  INFO client: Validator activated index=196 pubkey=0x8ff8c02998c0 status=ACTIVE validatorIndex=196
[2025-07-09 20:49:29]  INFO client: Waiting for deposit to be observed by beacon node pubkey=0x87a3784b2406 status=UNKNOWN_STATUS
[2025-07-09 20:49:29]  INFO client: Waiting for deposit to be observed by beacon node pubkey=0x850f50ab75e6 status=UNKNOWN_STATUS
[2025-07-09 20:49:29]  INFO client: Waiting for deposit to be observed by beacon node pubkey=0x8daea2a188b3 status=UNKNOWN_STATUS
[2025-07-09 20:49:29]  INFO client: Waiting for deposit to be observed by beacon node pubkey=0x943e43057b50 status=UNKNOWN_STATUS
[2025-07-09 20:49:29]  INFO client: Schedule for epoch 12 attesterCount=4 proposerCount=0
[2025-07-09 20:49:29]  INFO client: Duties schedule attesterCount=1 attesterPubkeys=[0xa5684c5410e7] slot=96 slotInEpoch=0
[2025-07-09 20:49:29]  INFO client: Duties schedule attesterCount=2 attesterPubkeys=[0x8a356bb1c9a1 0x8ff8c02998c0] slot=102 slotInEpoch=6 timeUntilDuty=36s
[2025-07-09 20:49:29]  INFO client: Duties schedule attesterCount=1 attesterPubkeys=[0x888d50457e58] slot=103 slotInEpoch=7 timeUntilDuty=42s
[2025-07-09 20:49:29]  INFO client: Beacon chain started genesisTime=2025-07-09 20:39:53 +0000 UTC
[2025-07-09 20:49:29]  INFO client: Starting event stream topics=[head]
[2025-07-09 20:50:09]  INFO client: Submitted new attestations blockRoot=0x4205b5d1d9f2 committeeIndices=[0 1] pubkeys=[0x8ff8c02998c0 0x8a356bb1c9a1] slot=102 sourceEpoch=11 sourceRoot=0xaba17b90fb8e targetEpoch=12 targetRoot=0x0a7d68c08476
[2025-07-09 20:50:09]  INFO client: Submitted new aggregate attestations blockRoot=0x4205b5d1d9f2 committeeIndices=[0 1] pubkeys=[0x8ff8c02998c0 0x8a356bb1c9a1] slot=102 sourceEpoch=11 sourceRoot=0xaba17b90fb8e targetEpoch=12 targetRoot=0x0a7d68c08476
[2025-07-09 20:50:15]  INFO client: Submitted new attestations blockRoot=0x32bca6cadf23 committeeIndices=[1] pubkeys=[0x888d50457e58] slot=103 sourceEpoch=11 sourceRoot=0xaba17b90fb8e targetEpoch=12 targetRoot=0x0a7d68c08476
[2025-07-09 20:50:15]  INFO client: Submitted new aggregate attestations blockRoot=0x32bca6cadf23 committeeIndices=[1] pubkeys=[0x888d50457e58] slot=103 sourceEpoch=11 sourceRoot=0xaba17b90fb8e targetEpoch=12 targetRoot=0x0a7d68c08476
[2025-07-09 20:50:17]  INFO client: Schedule for epoch 13 attesterCount=4 proposerCount=0
```

originally part of https://github.com/OffchainLabs/prysm/pull/14779

**Which issues(s) does this PR fix?**


**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
