### PR TITLE
validator client: removing need to call canonical head api

### DIFF
--- a/changelog/james-prysm_remove-cononical-head.md
+++ b/changelog/james-prysm_remove-cononical-head.md
@@ -1,3 +1,3 @@
 ### Removed
 
-- Validator client will no longer need to call the cononical head api.
+- Validator client will no longer need to call the canonical head api.

--- a/changelog/james-prysm_remove-cononical-head.md
+++ b/changelog/james-prysm_remove-cononical-head.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Validator client will no longer need to call the cononical head api.

--- a/testing/validator-mock/validator_mock.go
+++ b/testing/validator-mock/validator_mock.go
@@ -60,21 +60,6 @@ func (mr *MockValidatorMockRecorder) AccountsChangedChan() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountsChangedChan", reflect.TypeOf((*MockValidator)(nil).AccountsChangedChan))
 }
 
-// CanonicalHeadSlot mocks base method.
-func (m *MockValidator) CanonicalHeadSlot(arg0 context.Context) (primitives.Slot, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanonicalHeadSlot", arg0)
-	ret0, _ := ret[0].(primitives.Slot)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CanonicalHeadSlot indicates an expected call of CanonicalHeadSlot.
-func (mr *MockValidatorMockRecorder) CanonicalHeadSlot(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanonicalHeadSlot", reflect.TypeOf((*MockValidator)(nil).CanonicalHeadSlot), arg0)
-}
-
 // CheckDoppelGanger mocks base method.
 func (m *MockValidator) CheckDoppelGanger(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -155,6 +140,20 @@ func (m *MockValidator) FindHealthyHost(arg0 context.Context) bool {
 func (mr *MockValidatorMockRecorder) FindHealthyHost(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindHealthyHost", reflect.TypeOf((*MockValidator)(nil).FindHealthyHost), arg0)
+}
+
+// GenesisTime mocks base method.
+func (m *MockValidator) GenesisTime() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenesisTime")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GenesisTime indicates an expected call of GenesisTime.
+func (mr *MockValidatorMockRecorder) GenesisTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenesisTime", reflect.TypeOf((*MockValidator)(nil).GenesisTime))
 }
 
 // Graffiti mocks base method.

--- a/validator/client/iface/validator.go
+++ b/validator/client/iface/validator.go
@@ -35,12 +35,12 @@ const (
 // Validator interface defines the primary methods of a validator client.
 type Validator interface {
 	Done()
+	GenesisTime() uint64
 	EventsChan() <-chan *event.Event
 	AccountsChangedChan() <-chan [][fieldparams.BLSPubkeyLength]byte
 	WaitForChainStart(ctx context.Context) error
 	WaitForSync(ctx context.Context) error
 	WaitForActivation(ctx context.Context) error
-	CanonicalHeadSlot(ctx context.Context) (primitives.Slot, error)
 	NextSlot() <-chan primitives.Slot
 	SlotDeadline(slot primitives.Slot) time.Time
 	LogValidatorGainsAndLosses(ctx context.Context, slot primitives.Slot) error

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -131,15 +131,6 @@ func (fv *FakeValidator) SlasherReady(_ context.Context) error {
 	return nil
 }
 
-// CanonicalHeadSlot for mocking.
-func (fv *FakeValidator) CanonicalHeadSlot(_ context.Context) (primitives.Slot, error) {
-	fv.CanonicalHeadSlotCalled++
-	if fv.RetryTillSuccess > fv.CanonicalHeadSlotCalled {
-		return 0, api.ErrConnectionIssue
-	}
-	return 0, nil
-}
-
 // SlotDeadline for mocking.
 func (fv *FakeValidator) SlotDeadline(_ primitives.Slot) time.Time {
 	fv.SlotDeadlineCalled = true

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -40,7 +40,6 @@ type FakeValidator struct {
 	WaitForWalletInitializationCalled bool
 	NextSlotCalled                    bool
 	WaitForActivationCalled           int
-	CanonicalHeadSlotCalled           int
 	WaitForSyncCalled                 int
 	RetryTillSuccess                  int
 	ProposeBlockArg1                  uint64

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -138,6 +138,10 @@ func (v *validator) Done() {
 	}
 }
 
+func (v *validator) GenesisTime() uint64 {
+	return v.genesisTime
+}
+
 func (v *validator) EventsChan() <-chan *eventClient.Event {
 	return v.eventsChannel
 }
@@ -405,18 +409,6 @@ func (v *validator) checkAndLogValidatorStatus() bool {
 		}
 	}
 	return someAreActive
-}
-
-// CanonicalHeadSlot returns the slot of canonical block currently found in the
-// beacon chain via RPC.
-func (v *validator) CanonicalHeadSlot(ctx context.Context) (primitives.Slot, error) {
-	ctx, span := trace.StartSpan(ctx, "validator.CanonicalHeadSlot")
-	defer span.End()
-	head, err := v.chainClient.ChainHead(ctx, &emptypb.Empty{})
-	if err != nil {
-		return 0, errors.Wrap(client.ErrConnectionIssue, err.Error())
-	}
-	return head.HeadSlot, nil
 }
 
 // NextSlot emits the next slot number at the start time of that slot.

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -296,38 +296,6 @@ func TestWaitForChainStart_ReceiveErrorFromStream(t *testing.T) {
 	assert.ErrorContains(t, want, err)
 }
 
-func TestCanonicalHeadSlot_FailedRPC(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	client := validatormock.NewMockChainClient(ctrl)
-	v := validator{
-		chainClient: client,
-		genesisTime: 1,
-	}
-	client.EXPECT().ChainHead(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(nil, errors.New("failed"))
-	_, err := v.CanonicalHeadSlot(t.Context())
-	assert.ErrorContains(t, "failed", err)
-}
-
-func TestCanonicalHeadSlot_OK(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	client := validatormock.NewMockChainClient(ctrl)
-	v := validator{
-		chainClient: client,
-	}
-	client.EXPECT().ChainHead(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(&ethpb.ChainHead{HeadSlot: 0}, nil)
-	headSlot, err := v.CanonicalHeadSlot(t.Context())
-	require.NoError(t, err)
-	assert.Equal(t, primitives.Slot(0), headSlot, "Mismatch slots")
-}
-
 func TestWaitSync_ContextCanceled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

this PR removes the api call for the canonical head slot, we don't need the value which is used for get duties as well as push proposer settings, using the current slot is just fine. 

this api call was introduced in https://github.com/OffchainLabs/prysm/pull/2097 which i don't believe is relevant anymore. we wait for activation in a different way now and waiting for activation happens before the duties call


**Which issues(s) does this PR fix?**

part of https://github.com/OffchainLabs/prysm/issues/13519 to remove non standard APIs from validator client

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
