### PR TITLE
Add `versionToForkEpoch` map to `BeaconConfig()`

### DIFF
--- a/beacon-chain/db/kv/lightclient_test.go
+++ b/beacon-chain/db/kv/lightclient_test.go
@@ -564,14 +564,6 @@ func TestStore_LightClientBootstrap_CanSaveRetrieve(t *testing.T) {
 	cfg.EpochsPerSyncCommitteePeriod = 1
 	params.OverrideBeaconConfig(cfg)
 
-	versionToForkEpoch := map[int]primitives.Epoch{
-		version.Altair:    params.BeaconConfig().AltairForkEpoch,
-		version.Bellatrix: params.BeaconConfig().BellatrixForkEpoch,
-		version.Capella:   params.BeaconConfig().CapellaForkEpoch,
-		version.Deneb:     params.BeaconConfig().DenebForkEpoch,
-		version.Electra:   params.BeaconConfig().ElectraForkEpoch,
-	}
-
 	db := setupDB(t)
 	ctx := t.Context()
 
@@ -583,7 +575,7 @@ func TestStore_LightClientBootstrap_CanSaveRetrieve(t *testing.T) {
 
 	for testVersion := version.Altair; testVersion <= version.Electra; testVersion++ {
 		t.Run(version.String(testVersion), func(t *testing.T) {
-			bootstrap, err := createDefaultLightClientBootstrap(primitives.Slot(uint64(versionToForkEpoch[testVersion]) * uint64(params.BeaconConfig().SlotsPerEpoch)))
+			bootstrap, err := createDefaultLightClientBootstrap(primitives.Slot(uint64(params.BeaconConfig().VersionToForkEpochMap()[testVersion]) * uint64(params.BeaconConfig().SlotsPerEpoch)))
 			require.NoError(t, err)
 
 			err = bootstrap.SetCurrentSyncCommittee(createRandomSyncCommittee())

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -42,19 +42,11 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 	cfg.FuluForkEpoch = 5
 	params.OverrideBeaconConfig(cfg)
 
-	versionToForkEpoch := map[int]primitives.Epoch{
-		version.Altair:    params.BeaconConfig().AltairForkEpoch,
-		version.Bellatrix: params.BeaconConfig().BellatrixForkEpoch,
-		version.Capella:   params.BeaconConfig().CapellaForkEpoch,
-		version.Deneb:     params.BeaconConfig().DenebForkEpoch,
-		version.Electra:   params.BeaconConfig().ElectraForkEpoch,
-	}
-
 	for testVersion := version.Altair; testVersion <= version.Electra; testVersion++ {
 		t.Run(version.String(testVersion), func(t *testing.T) {
 			l := util.NewTestLightClient(t, testVersion)
 
-			slot := primitives.Slot(versionToForkEpoch[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+			slot := primitives.Slot(params.BeaconConfig().VersionToForkEpochMap()[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 			blockRoot, err := l.Block.Block().HashTreeRoot()
 			require.NoError(t, err)
 
@@ -96,7 +88,7 @@ func TestLightClientHandler_GetLightClientBootstrap(t *testing.T) {
 		t.Run(version.String(testVersion)+"SSZ", func(t *testing.T) {
 			l := util.NewTestLightClient(t, testVersion)
 
-			slot := primitives.Slot(versionToForkEpoch[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
+			slot := primitives.Slot(params.BeaconConfig().VersionToForkEpochMap()[testVersion] * primitives.Epoch(params.BeaconConfig().SlotsPerEpoch)).Add(1)
 			blockRoot, err := l.Block.Block().HashTreeRoot()
 			require.NoError(t, err)
 

--- a/changelog/bastin_version-to-fork-epoch.md
+++ b/changelog/bastin_version-to-fork-epoch.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add method `VersionToForkEpochMap()` to the `BeaconChainConfig` in the `params` package.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -316,6 +316,17 @@ type BeaconChainConfig struct {
 	DeprecatedMaxBlobsPerBlockFulu int `yaml:"MAX_BLOBS_PER_BLOCK_FULU" spec:"true"`
 }
 
+func (b *BeaconChainConfig) VersionToForkEpochMap() map[int]primitives.Epoch {
+	return map[int]primitives.Epoch{
+		version.Altair:    b.AltairForkEpoch,
+		version.Bellatrix: b.BellatrixForkEpoch,
+		version.Capella:   b.CapellaForkEpoch,
+		version.Deneb:     b.DenebForkEpoch,
+		version.Electra:   b.ElectraForkEpoch,
+		version.Fulu:      b.FuluForkEpoch,
+	}
+}
+
 func (b *BeaconChainConfig) ExecutionRequestLimits() enginev1.ExecutionRequestLimits {
 	return enginev1.ExecutionRequestLimits{
 		Deposits:       b.MaxDepositRequestsPerPayload,


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR adds a new method `VersionToForkEpochMap()` to the `BeaconChainConfig` in the `params` package. 

**Which issues(s) does this PR fix?**
I found myself copying this map over and over again when writing tests looping over different versions, so it helps to have it in params. It also generally sounds like valuable to have.
