### PR TITLE
Implement fulu mev-boost change for blinded block submission

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -153,7 +153,8 @@ func (c *Client) NodeURL() string {
 type reqOption func(*http.Request)
 
 // do is a generic, opinionated request function to reduce boilerplate amongst the methods in this package api/client/builder.
-func (c *Client) do(ctx context.Context, method string, path string, body io.Reader, opts ...reqOption) (res []byte, header http.Header, err error) {
+// It validates that the HTTP response status matches the expectedStatus parameter.
+func (c *Client) do(ctx context.Context, method string, path string, body io.Reader, expectedStatus int, opts ...reqOption) (res []byte, header http.Header, err error) {
 	ctx, span := trace.StartSpan(ctx, "builder.client.do")
 	defer func() {
 		tracing.AnnotateError(span, err)
@@ -188,57 +189,8 @@ func (c *Client) do(ctx context.Context, method string, path string, body io.Rea
 			log.WithError(closeErr).Error("Failed to close response body")
 		}
 	}()
-	if r.StatusCode != http.StatusOK {
-		err = non200Err(r)
-		return
-	}
-	res, err = io.ReadAll(io.LimitReader(r.Body, client.MaxBodySize))
-	if err != nil {
-		err = errors.Wrap(err, "error reading http response body from builder server")
-		return
-	}
-	header = r.Header
-	return
-}
-
-// doPostFulu is similar to do but accepts 202 Accepted status code for post-Fulu builder API calls
-func (c *Client) doPostFulu(ctx context.Context, method string, path string, body io.Reader, opts ...reqOption) (res []byte, header http.Header, err error) {
-	ctx, span := trace.StartSpan(ctx, "builder.client.doPostFulu")
-	defer func() {
-		tracing.AnnotateError(span, err)
-		span.End()
-	}()
-
-	u := c.baseURL.ResolveReference(&url.URL{Path: path})
-
-	span.SetAttributes(trace.StringAttribute("url", u.String()),
-		trace.StringAttribute("method", method))
-
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
-	if err != nil {
-		return
-	}
-	req.Header.Add("User-Agent", version.BuildData())
-	for _, o := range opts {
-		o(req)
-	}
-	for _, o := range c.obvs {
-		if err = o.observe(req); err != nil {
-			return
-		}
-	}
-	r, err := c.hc.Do(req)
-	if err != nil {
-		return
-	}
-	defer func() {
-		closeErr := r.Body.Close()
-		if closeErr != nil {
-			log.WithError(closeErr).Error("Failed to close response body")
-		}
-	}()
-	if r.StatusCode != http.StatusAccepted {
-		err = non200Err(r)
+	if r.StatusCode != expectedStatus {
+		err = unexpectedStatusErr(r, expectedStatus)
 		return
 	}
 	res, err = io.ReadAll(io.LimitReader(r.Body, client.MaxBodySize))
@@ -286,7 +238,7 @@ func (c *Client) GetHeader(ctx context.Context, slot primitives.Slot, parentHash
 			r.Header.Set("Accept", api.JsonMediaType)
 		}
 	}
-	data, header, err := c.do(ctx, http.MethodGet, path, nil, getOpts)
+	data, header, err := c.do(ctx, http.MethodGet, path, nil, http.StatusOK, getOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting header from builder server")
 	}
@@ -459,7 +411,7 @@ func (c *Client) RegisterValidator(ctx context.Context, svr []*ethpb.SignedValid
 		}
 	}
 
-	if _, _, err = c.do(ctx, http.MethodPost, postRegisterValidatorPath, bytes.NewBuffer(body), postOpts); err != nil {
+	if _, _, err = c.do(ctx, http.MethodPost, postRegisterValidatorPath, bytes.NewBuffer(body), http.StatusOK, postOpts); err != nil {
 		return errors.Wrap(err, "do")
 	}
 	log.WithField("registrationCount", len(svr)).Debug("Successfully registered validator(s) on builder")
@@ -521,7 +473,7 @@ func (c *Client) SubmitBlindedBlock(ctx context.Context, sb interfaces.ReadOnlyS
 
 	// post the blinded block - the execution payload response should contain the unblinded payload, along with the
 	// blobs bundle if it is post deneb.
-	data, header, err := c.do(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), postOpts)
+	data, header, err := c.do(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), http.StatusOK, postOpts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error posting the blinded block to the builder api")
 	}
@@ -560,7 +512,7 @@ func (c *Client) SubmitBlindedBlockPostFulu(ctx context.Context, sb interfaces.R
 	}
 
 	// Post the blinded block - the response should only contain a status code (no payload)
-	_, _, err = c.doPostFulu(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), postOpts)
+	_, _, err = c.do(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), http.StatusAccepted, postOpts)
 	if err != nil {
 		return errors.Wrap(err, "error posting the blinded block to the builder api post-Fulu")
 	}
@@ -725,11 +677,11 @@ func (c *Client) Status(ctx context.Context) error {
 	getOpts := func(r *http.Request) {
 		r.Header.Set("Accept", api.JsonMediaType)
 	}
-	_, _, err := c.do(ctx, http.MethodGet, getStatus, nil, getOpts)
+	_, _, err := c.do(ctx, http.MethodGet, getStatus, nil, http.StatusOK, getOpts)
 	return err
 }
 
-func non200Err(response *http.Response) error {
+func unexpectedStatusErr(response *http.Response, expected int) error {
 	bodyBytes, err := io.ReadAll(io.LimitReader(response.Body, client.MaxErrBodySize))
 	var errMessage ErrorMessage
 	var body string
@@ -738,7 +690,7 @@ func non200Err(response *http.Response) error {
 	} else {
 		body = "response body:\n" + string(bodyBytes)
 	}
-	msg := fmt.Sprintf("code=%d, url=%s, body=%s", response.StatusCode, response.Request.URL, body)
+	msg := fmt.Sprintf("expected=%d, got=%d, url=%s, body=%s", expected, response.StatusCode, response.Request.URL, body)
 	switch response.StatusCode {
 	case http.StatusUnsupportedMediaType:
 		log.WithError(ErrUnsupportedMediaType).Debug(msg)

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -102,6 +102,7 @@ type BuilderClient interface {
 	GetHeader(ctx context.Context, slot primitives.Slot, parentHash [32]byte, pubkey [48]byte) (SignedBid, error)
 	RegisterValidator(ctx context.Context, svr []*ethpb.SignedValidatorRegistrationV1) error
 	SubmitBlindedBlock(ctx context.Context, sb interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, v1.BlobsBundler, error)
+	SubmitBlindedBlockPostFulu(ctx context.Context, sb interfaces.ReadOnlySignedBeaconBlock) error
 	Status(ctx context.Context) error
 }
 
@@ -499,6 +500,24 @@ func (c *Client) SubmitBlindedBlock(ctx context.Context, sb interfaces.ReadOnlyS
 	}
 
 	return ed, blobs, nil
+}
+
+// SubmitBlindedBlockPostFulu calls the builder API endpoint post-Fulu where relays only return status codes.
+// This method is used after the Fulu fork when MEV-boost relays no longer return execution payloads.
+func (c *Client) SubmitBlindedBlockPostFulu(ctx context.Context, sb interfaces.ReadOnlySignedBeaconBlock) error {
+	body, postOpts, err := c.buildBlindedBlockRequest(sb)
+	if err != nil {
+		return err
+	}
+
+	// Post the blinded block - the response should only contain a status code (no payload)
+	_, _, err = c.do(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), postOpts)
+	if err != nil {
+		return errors.Wrap(err, "error posting the blinded block to the builder api post-Fulu")
+	}
+
+	// Success is indicated by no error (status 200)
+	return nil
 }
 
 func (c *Client) checkBlockVersion(respBytes []byte, header http.Header) (int, error) {

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -201,6 +201,55 @@ func (c *Client) do(ctx context.Context, method string, path string, body io.Rea
 	return
 }
 
+// doPostFulu is similar to do but accepts 202 Accepted status code for post-Fulu builder API calls
+func (c *Client) doPostFulu(ctx context.Context, method string, path string, body io.Reader, opts ...reqOption) (res []byte, header http.Header, err error) {
+	ctx, span := trace.StartSpan(ctx, "builder.client.doPostFulu")
+	defer func() {
+		tracing.AnnotateError(span, err)
+		span.End()
+	}()
+
+	u := c.baseURL.ResolveReference(&url.URL{Path: path})
+
+	span.SetAttributes(trace.StringAttribute("url", u.String()),
+		trace.StringAttribute("method", method))
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
+	if err != nil {
+		return
+	}
+	req.Header.Add("User-Agent", version.BuildData())
+	for _, o := range opts {
+		o(req)
+	}
+	for _, o := range c.obvs {
+		if err = o.observe(req); err != nil {
+			return
+		}
+	}
+	r, err := c.hc.Do(req)
+	if err != nil {
+		return
+	}
+	defer func() {
+		closeErr := r.Body.Close()
+		if closeErr != nil {
+			log.WithError(closeErr).Error("Failed to close response body")
+		}
+	}()
+	if r.StatusCode != http.StatusAccepted {
+		err = non200Err(r)
+		return
+	}
+	res, err = io.ReadAll(io.LimitReader(r.Body, client.MaxBodySize))
+	if err != nil {
+		err = errors.Wrap(err, "error reading http response body from builder server")
+		return
+	}
+	header = r.Header
+	return
+}
+
 var execHeaderTemplate = template.Must(template.New("").Parse(getExecHeaderPath))
 
 func execHeaderPath(slot primitives.Slot, parentHash [32]byte, pubkey [48]byte) (string, error) {
@@ -511,12 +560,12 @@ func (c *Client) SubmitBlindedBlockPostFulu(ctx context.Context, sb interfaces.R
 	}
 
 	// Post the blinded block - the response should only contain a status code (no payload)
-	_, _, err = c.do(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), postOpts)
+	_, _, err = c.doPostFulu(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), postOpts)
 	if err != nil {
 		return errors.Wrap(err, "error posting the blinded block to the builder api post-Fulu")
 	}
 
-	// Success is indicated by no error (status 200)
+	// Success is indicated by no error (status 202)
 	return nil
 }
 

--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -1567,7 +1567,7 @@ func TestSubmitBlindedBlockPostFulu(t *testing.T) {
 				require.Equal(t, api.JsonMediaType, r.Header.Get("Accept"))
 				// Post-Fulu: only return status code, no payload
 				return &http.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 					Body:       io.NopCloser(bytes.NewBufferString("")),
 					Request:    r.Clone(ctx),
 				}, nil
@@ -1592,7 +1592,7 @@ func TestSubmitBlindedBlockPostFulu(t *testing.T) {
 				require.Equal(t, api.OctetStreamMediaType, r.Header.Get("Accept"))
 				// Post-Fulu: only return status code, no payload
 				return &http.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusAccepted,
 					Body:       io.NopCloser(bytes.NewBufferString("")),
 					Request:    r.Clone(ctx),
 				}, nil

--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -1555,6 +1555,89 @@ func testSignedBlindedBeaconBlockElectra(t *testing.T) *eth.SignedBlindedBeaconB
 	}
 }
 
+func TestSubmitBlindedBlockPostFulu(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("success", func(t *testing.T) {
+		hc := &http.Client{
+			Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
+				require.Equal(t, postBlindedBeaconBlockPath, r.URL.Path)
+				require.Equal(t, "bellatrix", r.Header.Get("Eth-Consensus-Version"))
+				require.Equal(t, api.JsonMediaType, r.Header.Get("Content-Type"))
+				require.Equal(t, api.JsonMediaType, r.Header.Get("Accept"))
+				// Post-Fulu: only return status code, no payload
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString("")),
+					Request:    r.Clone(ctx),
+				}, nil
+			}),
+		}
+		c := &Client{
+			hc:      hc,
+			baseURL: &url.URL{Host: "localhost:3500", Scheme: "http"},
+		}
+		sbbb, err := blocks.NewSignedBeaconBlock(testSignedBlindedBeaconBlockBellatrix(t))
+		require.NoError(t, err)
+		err = c.SubmitBlindedBlockPostFulu(ctx, sbbb)
+		require.NoError(t, err)
+	})
+
+	t.Run("success_ssz", func(t *testing.T) {
+		hc := &http.Client{
+			Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
+				require.Equal(t, postBlindedBeaconBlockPath, r.URL.Path)
+				require.Equal(t, "bellatrix", r.Header.Get(api.VersionHeader))
+				require.Equal(t, api.OctetStreamMediaType, r.Header.Get("Content-Type"))
+				require.Equal(t, api.OctetStreamMediaType, r.Header.Get("Accept"))
+				// Post-Fulu: only return status code, no payload
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString("")),
+					Request:    r.Clone(ctx),
+				}, nil
+			}),
+		}
+		c := &Client{
+			hc:         hc,
+			baseURL:    &url.URL{Host: "localhost:3500", Scheme: "http"},
+			sszEnabled: true,
+		}
+		sbbb, err := blocks.NewSignedBeaconBlock(testSignedBlindedBeaconBlockBellatrix(t))
+		require.NoError(t, err)
+		err = c.SubmitBlindedBlockPostFulu(ctx, sbbb)
+		require.NoError(t, err)
+	})
+
+	t.Run("error_response", func(t *testing.T) {
+		hc := &http.Client{
+			Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
+				require.Equal(t, postBlindedBeaconBlockPath, r.URL.Path)
+				require.Equal(t, "bellatrix", r.Header.Get("Eth-Consensus-Version"))
+				message := ErrorMessage{
+					Code:    400,
+					Message: "Bad Request",
+				}
+				resp, err := json.Marshal(message)
+				require.NoError(t, err)
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body:       io.NopCloser(bytes.NewBuffer(resp)),
+					Request:    r.Clone(ctx),
+				}, nil
+			}),
+		}
+		c := &Client{
+			hc:      hc,
+			baseURL: &url.URL{Host: "localhost:3500", Scheme: "http"},
+		}
+		sbbb, err := blocks.NewSignedBeaconBlock(testSignedBlindedBeaconBlockBellatrix(t))
+		require.NoError(t, err)
+		err = c.SubmitBlindedBlockPostFulu(ctx, sbbb)
+		require.ErrorIs(t, err, ErrNotOK)
+	})
+}
+
 func TestRequestLogger(t *testing.T) {
 	wo := WithObserver(&requestLogger{})
 	c, err := NewClient("localhost:3500", wo)

--- a/api/client/builder/testing/mock.go
+++ b/api/client/builder/testing/mock.go
@@ -45,6 +45,11 @@ func (MockClient) SubmitBlindedBlock(_ context.Context, _ interfaces.ReadOnlySig
 	return nil, nil, nil
 }
 
+// SubmitBlindedBlockPostFulu --
+func (MockClient) SubmitBlindedBlockPostFulu(_ context.Context, _ interfaces.ReadOnlySignedBeaconBlock) error {
+	return nil
+}
+
 // Status --
 func (MockClient) Status(_ context.Context) error {
 	return nil

--- a/api/client/builder/types_test.go
+++ b/api/client/builder/types_test.go
@@ -1699,7 +1699,7 @@ func TestExecutionPayloadHeaderCapellaRoundtrip(t *testing.T) {
 	require.DeepEqual(t, string(expected[0:len(expected)-1]), string(m))
 }
 
-func TestErrorMessage_non200Err(t *testing.T) {
+func TestErrorMessage_unexpectedStatusErr(t *testing.T) {
 	mockRequest := &http.Request{
 		URL: &url.URL{Path: "example.com"},
 	}
@@ -1779,7 +1779,7 @@ func TestErrorMessage_non200Err(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := non200Err(tt.args)
+			err := unexpectedStatusErr(tt.args, http.StatusOK)
 			if err != nil && tt.wantMessage != "" {
 				require.ErrorContains(t, tt.wantMessage, err)
 			}

--- a/beacon-chain/builder/testing/mock.go
+++ b/beacon-chain/builder/testing/mock.go
@@ -24,21 +24,22 @@ type Config struct {
 
 // MockBuilderService to mock builder.
 type MockBuilderService struct {
-	HasConfigured         bool
-	Payload               *v1.ExecutionPayload
-	PayloadCapella        *v1.ExecutionPayloadCapella
-	PayloadDeneb          *v1.ExecutionPayloadDeneb
-	BlobBundle            *v1.BlobsBundle
-	BlobBundleV2          *v1.BlobsBundleV2
-	ErrSubmitBlindedBlock error
-	Bid                   *ethpb.SignedBuilderBid
-	BidCapella            *ethpb.SignedBuilderBidCapella
-	BidDeneb              *ethpb.SignedBuilderBidDeneb
-	BidElectra            *ethpb.SignedBuilderBidElectra
-	RegistrationCache     *cache.RegistrationCache
-	ErrGetHeader          error
-	ErrRegisterValidator  error
-	Cfg                   *Config
+	HasConfigured                 bool
+	Payload                       *v1.ExecutionPayload
+	PayloadCapella                *v1.ExecutionPayloadCapella
+	PayloadDeneb                  *v1.ExecutionPayloadDeneb
+	BlobBundle                    *v1.BlobsBundle
+	BlobBundleV2                  *v1.BlobsBundleV2
+	ErrSubmitBlindedBlock         error
+	ErrSubmitBlindedBlockPostFulu error
+	Bid                           *ethpb.SignedBuilderBid
+	BidCapella                    *ethpb.SignedBuilderBidCapella
+	BidDeneb                      *ethpb.SignedBuilderBidDeneb
+	BidElectra                    *ethpb.SignedBuilderBidElectra
+	RegistrationCache             *cache.RegistrationCache
+	ErrGetHeader                  error
+	ErrRegisterValidator          error
+	Cfg                           *Config
 }
 
 // Configured for mocking.
@@ -114,4 +115,9 @@ func (s *MockBuilderService) RegistrationByValidatorID(ctx context.Context, id p
 // RegisterValidator for mocking.
 func (s *MockBuilderService) RegisterValidator(context.Context, []*ethpb.SignedValidatorRegistrationV1) error {
 	return s.ErrRegisterValidator
+}
+
+// SubmitBlindedBlockPostFulu for mocking.
+func (s *MockBuilderService) SubmitBlindedBlockPostFulu(_ context.Context, _ interfaces.ReadOnlySignedBeaconBlock) error {
+	return s.ErrSubmitBlindedBlockPostFulu
 }

--- a/changelog/tt_post-fulu-mev-boost-protocol.md
+++ b/changelog/tt_post-fulu-mev-boost-protocol.md
@@ -1,0 +1,3 @@
+### Added
+
+- Implement post-Fulu MEV-boost protocol changes where relays only return status codes for blinded block submissions.


### PR DESCRIPTION
  **Description:**
  Implement the post-Fulu changes where MEV-boost relays only return HTTP status codes instead of execution payloads for blinded blocks.

  **Changes include:**

  **New API Methods**
  - Add `SubmitBlindedBlockPostFulu()` to builder client interface and implementation
  - Post-Fulu method only expects status codes, not payload responses
  - Maintains backward compatibility with existing `SubmitBlindedBlock()`

  **ProposeBeaconBlock Logic**
  - Add early return path for post-Fulu blinded blocks: `if block.IsBlinded() && slots.ToEpoch(block.Block().Slot()) >= params.BeaconConfig().FuluForkEpoch`
  - Post-Fulu blinded blocks submit to relay and return immediately
  - Pre-Fulu blinded blocks continue using existing `handleBlindedBlock` path