### PR TITLE
fix: optimize regex pattern in specs-checker tool

### DIFF
--- a/tools/specs-checker/download.go
+++ b/tools/specs-checker/download.go
@@ -17,7 +17,7 @@ import (
 const baseUrl = "https://raw.githubusercontent.com/ethereum/consensus-specs/dev"
 
 // Regex to find Python's code snippets in markdown.
-var reg2 = regexp.MustCompile(`(?msU)^\x60\x60\x60python\n+def\s(.*)^\x60\x60\x60`)
+var reg2 = regexp.MustCompile(`(?ms)^\x60\x60\x60python\n+def\s(.*?)^\x60\x60\x60`)
 
 func download(cliCtx *cli.Context) error {
 	fmt.Print("Downloading specs:\n")


### PR DESCRIPTION
Improved the regular expression in tools/specs-checker/download.go by replacing the global ungreedy flag (?msU) with a more targeted approach using (?ms) and a lazy quantifier (.*?). This change makes the regex more efficient and follows best practices for regular expression patterns while maintaining the same functionality.
**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
