### PR TITLE
Remove extra lc server fields

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -189,13 +189,13 @@ func (s *Service) processLightClientUpdate(cfg *postBlockProcessConfig) error {
 
 	period := slots.SyncCommitteePeriod(slots.ToEpoch(attestedState.Slot()))
 
-	oldUpdate, err := s.cfg.BeaconDB.LightClientUpdate(cfg.ctx, period)
+	oldUpdate, err := s.lcStore.LightClientUpdate(cfg.ctx, period)
 	if err != nil {
 		return errors.Wrapf(err, "could not get current light client update")
 	}
 
 	if oldUpdate == nil {
-		if err := s.cfg.BeaconDB.SaveLightClientUpdate(cfg.ctx, period, update); err != nil {
+		if err := s.lcStore.SaveLightClientUpdate(cfg.ctx, period, update); err != nil {
 			return errors.Wrapf(err, "could not save light client update")
 		}
 		log.WithField("period", period).Debug("Saved new light client update")
@@ -208,7 +208,7 @@ func (s *Service) processLightClientUpdate(cfg *postBlockProcessConfig) error {
 	}
 
 	if isNewUpdateBetter {
-		if err := s.cfg.BeaconDB.SaveLightClientUpdate(cfg.ctx, period, update); err != nil {
+		if err := s.lcStore.SaveLightClientUpdate(cfg.ctx, period, update); err != nil {
 			return errors.Wrapf(err, "could not save light client update")
 		}
 		log.WithField("period", period).Debug("Saved new light client update")

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2708,61 +2708,16 @@ func TestProcessLightClientUpdate(t *testing.T) {
 	featCfg := &features.Flags{}
 	featCfg.EnableLightClient = true
 	reset := features.InitWithReset(featCfg)
+	defer reset()
 
-	s, tr := minimalTestService(t)
+	s, tr := minimalTestService(t, WithLCStore())
 	ctx := tr.ctx
 
-	t.Run("Altair", func(t *testing.T) {
-		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Altair)
+	for testVersion := version.Altair; testVersion <= version.Electra; testVersion++ {
+		t.Run(version.String(testVersion), func(t *testing.T) {
+			l := util.NewTestLightClient(t, testVersion)
 
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			require.NoError(t, s.processLightClientUpdate(cfg))
-
-			// Check that the light client update is saved
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
-			require.NoError(t, err)
-			require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
-			require.Equal(t, u.Version(), version.Altair)
-		})
-
-		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Altair)
-
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
+			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().VersionToForkEpochMap()[testVersion])*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
 
 			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
 			require.NoError(t, err)
@@ -2793,401 +2748,66 @@ func TestProcessLightClientUpdate(t *testing.T) {
 
 			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
 
-			// create and save old update
-			oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
-			require.NoError(t, err)
+			t.Run("no old update", func(t *testing.T) {
+				require.NoError(t, s.processLightClientUpdate(cfg))
 
-			err = s.cfg.BeaconDB.SaveLightClientUpdate(ctx, period, oldUpdate)
-			require.NoError(t, err)
-
-			require.NoError(t, s.processLightClientUpdate(cfg))
-
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
-			require.NoError(t, err)
-			require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
-			require.Equal(t, u.Version(), version.Altair)
-		})
-
-		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Altair)
-
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().AltairForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-
-			// create and save old update
-			oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
-			require.NoError(t, err)
-
-			scb := make([]byte, 64)
-			for i := 0; i < 5; i++ {
-				scb[i] = 0x01
-			}
-			oldUpdate.SetSyncAggregate(&ethpb.SyncAggregate{
-				SyncCommitteeBits:      scb,
-				SyncCommitteeSignature: make([]byte, 96),
+				// Check that the light client update is saved
+				u, err := s.lcStore.LightClientUpdate(ctx, period)
+				require.NoError(t, err)
+				require.NotNil(t, u)
+				attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
+				require.NoError(t, err)
+				require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
+				require.Equal(t, u.Version(), testVersion)
 			})
 
-			err = s.cfg.BeaconDB.SaveLightClientUpdate(ctx, period, oldUpdate)
-			require.NoError(t, err)
+			t.Run("new update is better", func(t *testing.T) {
+				// create and save old update
+				oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
+				require.NoError(t, err)
 
-			require.NoError(t, s.processLightClientUpdate(cfg))
+				err = s.lcStore.SaveLightClientUpdate(ctx, period, oldUpdate)
+				require.NoError(t, err)
 
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			require.DeepEqual(t, oldUpdate, u)
-			require.Equal(t, u.Version(), version.Altair)
-		})
-	})
+				require.NoError(t, s.processLightClientUpdate(cfg))
 
-	t.Run("Capella", func(t *testing.T) {
-		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Capella)
-
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			require.NoError(t, s.processLightClientUpdate(cfg))
-
-			// Check that the light client update is saved
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
-			require.NoError(t, err)
-			require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
-			require.Equal(t, u.Version(), version.Capella)
-		})
-
-		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Capella)
-
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-
-			// create and save old update
-			oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveLightClientUpdate(ctx, period, oldUpdate)
-			require.NoError(t, err)
-
-			require.NoError(t, s.processLightClientUpdate(cfg))
-
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
-			require.NoError(t, err)
-			require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
-			require.Equal(t, u.Version(), version.Capella)
-		})
-
-		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Capella)
-
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().CapellaForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-
-			// create and save old update
-			oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
-			require.NoError(t, err)
-
-			scb := make([]byte, 64)
-			for i := 0; i < 5; i++ {
-				scb[i] = 0x01
-			}
-			oldUpdate.SetSyncAggregate(&ethpb.SyncAggregate{
-				SyncCommitteeBits:      scb,
-				SyncCommitteeSignature: make([]byte, 96),
+				u, err := s.lcStore.LightClientUpdate(ctx, period)
+				require.NoError(t, err)
+				require.NotNil(t, u)
+				attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
+				require.NoError(t, err)
+				require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
+				require.Equal(t, u.Version(), testVersion)
 			})
 
-			err = s.cfg.BeaconDB.SaveLightClientUpdate(ctx, period, oldUpdate)
-			require.NoError(t, err)
+			t.Run("old update is better", func(t *testing.T) {
+				// create and save old update
+				oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
+				require.NoError(t, err)
 
-			require.NoError(t, s.processLightClientUpdate(cfg))
+				// set a better sync aggregate
+				scb := make([]byte, 64)
+				for i := 0; i < 5; i++ {
+					scb[i] = 0x01
+				}
+				oldUpdate.SetSyncAggregate(&ethpb.SyncAggregate{
+					SyncCommitteeBits:      scb,
+					SyncCommitteeSignature: make([]byte, 96),
+				})
 
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			require.DeepEqual(t, oldUpdate, u)
-			require.Equal(t, u.Version(), version.Capella)
-		})
-	})
+				err = s.lcStore.SaveLightClientUpdate(ctx, period, oldUpdate)
+				require.NoError(t, err)
 
-	t.Run("Deneb", func(t *testing.T) {
-		t.Run("No old update", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Deneb)
+				require.NoError(t, s.processLightClientUpdate(cfg))
 
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			require.NoError(t, s.processLightClientUpdate(cfg))
-
-			// Check that the light client update is saved
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
-			require.NoError(t, err)
-			require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
-			require.Equal(t, u.Version(), version.Deneb)
-		})
-
-		t.Run("New update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Deneb)
-
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-
-			// create and save old update
-			oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveLightClientUpdate(ctx, period, oldUpdate)
-			require.NoError(t, err)
-
-			require.NoError(t, s.processLightClientUpdate(cfg))
-
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			attestedStateRoot, err := l.AttestedState.HashTreeRoot(ctx)
-			require.NoError(t, err)
-			require.Equal(t, attestedStateRoot, [32]byte(u.AttestedHeader().Beacon().StateRoot))
-			require.Equal(t, u.Version(), version.Deneb)
-		})
-
-		t.Run("Old update is better", func(t *testing.T) {
-			l := util.NewTestLightClient(t, version.Deneb)
-
-			s.genesisTime = time.Unix(time.Now().Unix()-(int64(params.BeaconConfig().DenebForkEpoch)*int64(params.BeaconConfig().SlotsPerEpoch)*int64(params.BeaconConfig().SecondsPerSlot)), 0)
-
-			err := s.cfg.BeaconDB.SaveBlock(ctx, l.AttestedBlock)
-			require.NoError(t, err)
-			attestedBlockRoot, err := l.AttestedBlock.Block().HashTreeRoot()
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.AttestedState, attestedBlockRoot)
-			require.NoError(t, err)
-
-			currentBlockRoot, err := l.Block.Block().HashTreeRoot()
-			require.NoError(t, err)
-			roblock, err := consensusblocks.NewROBlockWithRoot(l.Block, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, roblock)
-			require.NoError(t, err)
-			err = s.cfg.BeaconDB.SaveState(ctx, l.State, currentBlockRoot)
-			require.NoError(t, err)
-
-			err = s.cfg.BeaconDB.SaveBlock(ctx, l.FinalizedBlock)
-			require.NoError(t, err)
-
-			cfg := &postBlockProcessConfig{
-				ctx:            ctx,
-				roblock:        roblock,
-				postState:      l.State,
-				isValidPayload: true,
-			}
-
-			period := slots.SyncCommitteePeriod(slots.ToEpoch(l.AttestedState.Slot()))
-
-			// create and save old update
-			oldUpdate, err := lightClient.CreateDefaultLightClientUpdate(l.AttestedBlock)
-			require.NoError(t, err)
-
-			scb := make([]byte, 64)
-			for i := 0; i < 5; i++ {
-				scb[i] = 0x01
-			}
-			oldUpdate.SetSyncAggregate(&ethpb.SyncAggregate{
-				SyncCommitteeBits:      scb,
-				SyncCommitteeSignature: make([]byte, 96),
+				u, err := s.lcStore.LightClientUpdate(ctx, period)
+				require.NoError(t, err)
+				require.NotNil(t, u)
+				require.DeepEqual(t, oldUpdate, u)
+				require.Equal(t, u.Version(), testVersion)
 			})
-
-			err = s.cfg.BeaconDB.SaveLightClientUpdate(ctx, period, oldUpdate)
-			require.NoError(t, err)
-
-			require.NoError(t, s.processLightClientUpdate(cfg))
-
-			u, err := s.cfg.BeaconDB.LightClientUpdate(ctx, period)
-			require.NoError(t, err)
-			require.NotNil(t, u)
-			require.DeepEqual(t, oldUpdate, u)
-			require.Equal(t, u.Version(), version.Deneb)
 		})
-	})
-
-	reset()
+	}
 }
 
 func TestProcessLightClientBootstrap(t *testing.T) {

--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -956,12 +956,7 @@ func (*Service) configEndpoints() []endpoint {
 
 func (s *Service) lightClientEndpoints(blocker lookup.Blocker, stater lookup.Stater) []endpoint {
 	server := &lightclient.Server{
-		Blocker:          blocker,
-		Stater:           stater,
-		HeadFetcher:      s.cfg.HeadFetcher,
-		ChainInfoFetcher: s.cfg.ChainInfoFetcher,
-		BeaconDB:         s.cfg.BeaconDB,
-		LCStore:          s.cfg.LCStore,
+		LCStore: s.cfg.LCStore,
 	}
 
 	const namespace = "lightclient"

--- a/beacon-chain/rpc/eth/light-client/BUILD.bazel
+++ b/beacon-chain/rpc/eth/light-client/BUILD.bazel
@@ -11,12 +11,9 @@ go_library(
     deps = [
         "//api:go_default_library",
         "//api/server/structs:go_default_library",
-        "//beacon-chain/blockchain:go_default_library",
         "//beacon-chain/core/light-client:go_default_library",
         "//beacon-chain/core/signing:go_default_library",
-        "//beacon-chain/db:go_default_library",
         "//beacon-chain/rpc/eth/shared:go_default_library",
-        "//beacon-chain/rpc/lookup:go_default_library",
         "//config/params:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
@@ -32,10 +29,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "handlers_test.go",
-        "helpers_test.go",
-    ],
+    srcs = ["handlers_test.go"],
     embed = [":go_default_library"],
     deps = [
         "//api/server/structs:go_default_library",

--- a/beacon-chain/rpc/eth/light-client/BUILD.bazel
+++ b/beacon-chain/rpc/eth/light-client/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//api/server/structs:go_default_library",
-        "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/light-client:go_default_library",
         "//beacon-chain/db/testing:go_default_library",

--- a/beacon-chain/rpc/eth/light-client/helpers_test.go
+++ b/beacon-chain/rpc/eth/light-client/helpers_test.go
@@ -1,1 +1,0 @@
-package lightclient

--- a/beacon-chain/rpc/eth/light-client/server.go
+++ b/beacon-chain/rpc/eth/light-client/server.go
@@ -1,17 +1,9 @@
 package lightclient
 
 import (
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
 	lightClient "github.com/OffchainLabs/prysm/v6/beacon-chain/core/light-client"
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/db"
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/rpc/lookup"
 )
 
 type Server struct {
-	Blocker          lookup.Blocker
-	Stater           lookup.Stater
-	HeadFetcher      blockchain.HeadFetcher
-	ChainInfoFetcher blockchain.ChainInfoFetcher
-	BeaconDB         db.HeadAccessDatabase
-	LCStore          *lightClient.Store
+	LCStore *lightClient.Store
 }

--- a/changelog/bastin_refine-lc-rpc-server.md
+++ b/changelog/bastin_refine-lc-rpc-server.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Removed extra/unused fields of the LC Beacon API server.

--- a/changelog/bastin_unify-lc-api-updates.md
+++ b/changelog/bastin_unify-lc-api-updates.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move setter/getter functions for LC Updates into LcStore for a unified interface.


### PR DESCRIPTION
**Review After #15488**

**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Removes the extra/unused fields of the light client RPC (beacon API) server struct. 