### PR TITLE
fix(execution): skip genesis block retrieval when EIP-6110 is active

### DIFF
--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -557,8 +557,8 @@ func (s *Service) initPOWService() {
 				}
 			}
 			// Handle edge case with embedded genesis state by fetching genesis header to determine
-			// its height.
-			if s.chainStartData.Chainstarted && s.chainStartData.GenesisBlock == 0 {
+			// its height only if the deposit requests have not started yet (Pre Pectra EIP-6110 behavior).
+			if s.chainStartData.Chainstarted && s.chainStartData.GenesisBlock == 0 && !s.depositRequestsStarted {
 				genHash := common.BytesToHash(s.chainStartData.Eth1Data.BlockHash)
 				genBlock := s.chainStartData.GenesisBlock
 				// In the event our provided chainstart data references a non-existent block hash,

--- a/changelog/fix-genesis-block-eip6110.md
+++ b/changelog/fix-genesis-block-eip6110.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Skip genesis block retrieval when EIP-6110 deposit requests have started to prevent "pruned history unavailable" errors with execution clients that have pruned pre-merge data


### PR DESCRIPTION
This fixes the following periodic error:
```
 level=error msg="Unable to retrieve proof-of-stake genesis block data" error="HeaderByHash, hash=0xeeea1373d4aa9e099d7c9deddb694db9aeb4577755ef83f9b6345ce4357d9abf: pruned history unavailable" prefix=execution
```