### PR TITLE
Log: Add 2 decimals to log timestamps

### DIFF
--- a/changelog/manu-log-ms.md
+++ b/changelog/manu-log-ms.md
@@ -1,0 +1,3 @@
+### Changed
+- Add milliseconds to log timestamps.
+

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	runtimeDebug "runtime/debug"
-	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/builder"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/node"
@@ -167,7 +166,7 @@ func before(ctx *cli.Context) error {
 	switch format {
 	case "text":
 		formatter := new(prefixed.TextFormatter)
-		formatter.TimestampFormat = time.DateTime
+		formatter.TimestampFormat = "2006-01-02 15:04:05.00"
 		formatter.FullTimestamp = true
 
 		// If persistent log files are written - we disable the log messages coloring because
@@ -183,7 +182,9 @@ func before(ctx *cli.Context) error {
 
 		logrus.SetFormatter(f)
 	case "json":
-		logrus.SetFormatter(&logrus.JSONFormatter{})
+		logrus.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: "2006-01-02 15:04:05.00",
+		})
 	case "journald":
 		if err := journald.Enable(); err != nil {
 			return err

--- a/cmd/client-stats/main.go
+++ b/cmd/client-stats/main.go
@@ -60,7 +60,7 @@ func main() {
 		switch format {
 		case "text":
 			formatter := new(prefixed.TextFormatter)
-			formatter.TimestampFormat = time.DateTime
+			formatter.TimestampFormat = "2006-01-02 15:04:05.00"
 			formatter.FullTimestamp = true
 			// If persistent log files are written - we disable the log messages coloring because
 			// the colors are ANSI codes and seen as gibberish in the log files.
@@ -73,7 +73,9 @@ func main() {
 			}
 			logrus.SetFormatter(f)
 		case "json":
-			logrus.SetFormatter(&logrus.JSONFormatter{})
+			logrus.SetFormatter(&logrus.JSONFormatter{
+				TimestampFormat: "2006-01-02 15:04:05.00",
+			})
 		case "journald":
 			if err := journald.Enable(); err != nil {
 				return err

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	runtimeDebug "runtime/debug"
-	"time"
 
 	"github.com/OffchainLabs/prysm/v6/cmd"
 	accountcommands "github.com/OffchainLabs/prysm/v6/cmd/validator/accounts"
@@ -152,7 +151,7 @@ func main() {
 			switch format {
 			case "text":
 				formatter := new(prefixed.TextFormatter)
-				formatter.TimestampFormat = time.DateTime
+				formatter.TimestampFormat = "2006-01-02 15:04:05.00"
 				formatter.FullTimestamp = true
 				// If persistent log files are written - we disable the log messages coloring because
 				// the colors are ANSI codes and seen as gibberish in the log files.
@@ -165,7 +164,9 @@ func main() {
 				}
 				logrus.SetFormatter(f)
 			case "json":
-				logrus.SetFormatter(&logrus.JSONFormatter{})
+				logrus.SetFormatter(&logrus.JSONFormatter{
+					TimestampFormat: "2006-01-02 15:04:05.00",
+				})
 			case "journald":
 				if err := journald.Enable(); err != nil {
 					return err

--- a/tools/pcli/main.go
+++ b/tools/pcli/main.go
@@ -303,7 +303,7 @@ var stateTransitionCommand = &cli.Command{
 
 func main() {
 	customFormatter := new(prefixed.TextFormatter)
-	customFormatter.TimestampFormat = time.DateTime
+	customFormatter.TimestampFormat = "2006-01-02 15:04:05.00"
 	customFormatter.FullTimestamp = true
 	log.SetFormatter(customFormatter)
 	app := cli.App{}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Log: Add 2 decimals to log timestamps

**Before:**
_Text:_
```
[2025-07-16 07:30:30] DEBUG node: Registering RPC Service
```
_JSON:_
```
{"level":"debug","msg":"Registering RPC Service","prefix":"node","time":"2025-07-16T07:33:06Z"}
```

**After:**
_Text:_
```
[2025-07-16 07:29:10.89] DEBUG node: Registering RPC Service
```
_JSON:_
```
{"level":"debug","msg":"Registering RPC Service","prefix":"node","time":"2025-07-16 07:37:57.25"}
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
