### PR TITLE
Write `Content-Encoding` header in the response properly when gzip encoding is requested

### DIFF
--- a/api/server/middleware/middleware_test.go
+++ b/api/server/middleware/middleware_test.go
@@ -132,6 +132,7 @@ func TestAcceptEncodingHeaderHandler(t *testing.T) {
 	dummyContent := "Test gzip middleware content"
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", r.Header.Get("Accept"))
+		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(dummyContent))
 		require.NoError(t, err)
 	})
@@ -145,19 +146,19 @@ func TestAcceptEncodingHeaderHandler(t *testing.T) {
 		expectCompressed bool
 	}{
 		{
-			name:             "Gzip supported",
+			name:             "Accept gzip",
 			accept:           api.JsonMediaType,
 			acceptEncoding:   "gzip",
 			expectCompressed: true,
 		},
 		{
-			name:             "Multiple encodings supported",
+			name:             "Accept multiple encodings",
 			accept:           api.JsonMediaType,
 			acceptEncoding:   "deflate, gzip",
 			expectCompressed: true,
 		},
 		{
-			name:             "Gzip not supported",
+			name:             "Accept unsupported encoding",
 			accept:           api.JsonMediaType,
 			acceptEncoding:   "deflate",
 			expectCompressed: false,

--- a/api/server/middleware/middleware_test.go
+++ b/api/server/middleware/middleware_test.go
@@ -13,6 +13,23 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// frozenHeaderRecorder allows asserting that response headers were not modified
+// after the call to WriteHeader.
+//
+// Its purpose is to have a regression test for https://github.com/OffchainLabs/prysm/pull/15499.
+type frozenHeaderRecorder struct {
+	*httptest.ResponseRecorder
+	frozenHeader http.Header
+}
+
+func (r *frozenHeaderRecorder) WriteHeader(code int) {
+	if r.frozenHeader != nil {
+		return
+	}
+	r.ResponseRecorder.WriteHeader(code)
+	r.frozenHeader = r.ResponseRecorder.Header().Clone()
+}
+
 func TestNormalizeQueryValuesHandler(t *testing.T) {
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("next handler"))
@@ -184,12 +201,12 @@ func TestAcceptEncodingHeaderHandler(t *testing.T) {
 			if tt.acceptEncoding != "" {
 				req.Header.Set("Accept-Encoding", tt.acceptEncoding)
 			}
-			rr := httptest.NewRecorder()
+			rr := &frozenHeaderRecorder{ResponseRecorder: httptest.NewRecorder()}
 
 			handler.ServeHTTP(rr, req)
 
 			if tt.expectCompressed {
-				require.Equal(t, "gzip", rr.Header().Get("Content-Encoding"), "Expected Content-Encoding header to be 'gzip'")
+				require.Equal(t, "gzip", rr.frozenHeader.Get("Content-Encoding"), "Expected Content-Encoding header to be 'gzip'")
 
 				compressedBody := rr.Body.Bytes()
 				require.NotEqual(t, dummyContent, string(compressedBody), "Response body should be compressed and differ from the original")

--- a/changelog/radek_fix-gzip.md
+++ b/changelog/radek_fix-gzip.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Write `Content-Encoding` header in the response properly when gzip encoding is requested.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

#14982 has a pretty bad bug - it tries setting the `Content-Encoding` header after the API endpoint handler completes, but this means that the call to `WriteHeader` on the underlying response writer has already happened, and it's not possible to modify the header map anymore at that point. The fix is to implement `WriteHeader` on the gzip writer and set `Content-Encoding` there.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
