### PR TITLE
Fusaka ENR changes

### DIFF
--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -81,11 +81,23 @@ func updateENR(node *enode.LocalNode, entry, next params.NetworkScheduleEntry) e
 		NextForkVersion:   next.ForkVersion[:],
 		NextForkEpoch:     next.Epoch,
 	}
-	log.
-		WithField("CurrentForkDigest", fmt.Sprintf("%#x", enrForkID.CurrentForkDigest)).
-		WithField("NextForkVersion", fmt.Sprintf("%#x", enrForkID.NextForkVersion)).
-		WithField("NextForkEpoch", fmt.Sprintf("%d", enrForkID.NextForkEpoch)).
-		Info("Updating ENR Fork ID")
+	if entry.Epoch == next.Epoch {
+		enrForkID.NextForkEpoch = params.BeaconConfig().FarFutureEpoch
+	}
+	logFields := logrus.Fields{
+		"CurrentForkDigest": fmt.Sprintf("%#x", enrForkID.CurrentForkDigest),
+		"NextForkVersion":   fmt.Sprintf("%#x", enrForkID.NextForkVersion),
+		"NextForkEpoch":     fmt.Sprintf("%d", enrForkID.NextForkEpoch),
+	}
+	if params.BeaconConfig().FuluForkEpoch != params.BeaconConfig().FarFutureEpoch {
+		if entry.ForkDigest == next.ForkDigest {
+			node.Set(enr.WithEntry(nfdEnrKey, make([]byte, len(next.ForkDigest))))
+		} else {
+			node.Set(enr.WithEntry(nfdEnrKey, next.ForkDigest[:]))
+		}
+		logFields[nfdEnrKey] = fmt.Sprintf("%#x", next.ForkDigest)
+	}
+	log.WithFields(logFields).Info("Updating ENR Fork ID")
 	enc, err := enrForkID.MarshalSSZ()
 	if err != nil {
 		return err

--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -95,7 +95,7 @@ func updateENR(node *enode.LocalNode, entry, next params.NetworkScheduleEntry) e
 		} else {
 			node.Set(enr.WithEntry(nfdEnrKey, next.ForkDigest[:]))
 		}
-		logFields[nfdEnrKey] = fmt.Sprintf("%#x", next.ForkDigest)
+		logFields["NextForkDigest"] = fmt.Sprintf("%#x", next.ForkDigest)
 	}
 	log.WithFields(logFields).Info("Updating ENR Fork ID")
 	enc, err := enrForkID.MarshalSSZ()

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -179,11 +179,15 @@ func TestAddForkEntry_NextForkVersion(t *testing.T) {
 }
 
 func TestUpdateENR_FuluForkDigest(t *testing.T) {
-	setupTest := func(t *testing.T) (*enode.LocalNode, func()) {
+	setupTest := func(t *testing.T, fuluEnabled bool) (*enode.LocalNode, func()) {
 		params.SetupTestConfigCleanup(t)
 
 		cfg := params.BeaconConfig().Copy()
-		cfg.FuluForkEpoch = 100
+		if fuluEnabled {
+			cfg.FuluForkEpoch = 100
+		} else {
+			cfg.FuluForkEpoch = cfg.FarFutureEpoch
+		}
 		cfg.FuluForkVersion = []byte{5, 0, 0, 0}
 		params.OverrideBeaconConfig(cfg)
 		cfg.InitializeForkSchedule()
@@ -203,12 +207,14 @@ func TestUpdateENR_FuluForkDigest(t *testing.T) {
 
 	tests := []struct {
 		name         string
+		fuluEnabled  bool
 		currentEntry params.NetworkScheduleEntry
 		nextEntry    params.NetworkScheduleEntry
 		validateNFD  func(t *testing.T, localNode *enode.LocalNode, nextEntry params.NetworkScheduleEntry)
 	}{
 		{
-			name: "different digests sets nfd to next digest",
+			name:        "different digests sets nfd to next digest",
+			fuluEnabled: true,
 			currentEntry: params.NetworkScheduleEntry{
 				Epoch:       50,
 				ForkDigest:  [4]byte{1, 2, 3, 4},
@@ -227,7 +233,8 @@ func TestUpdateENR_FuluForkDigest(t *testing.T) {
 			},
 		},
 		{
-			name: "same digests sets nfd to empty",
+			name:        "same digests sets nfd to empty",
+			fuluEnabled: true,
 			currentEntry: params.NetworkScheduleEntry{
 				Epoch:       50,
 				ForkDigest:  [4]byte{1, 2, 3, 4},
@@ -245,11 +252,30 @@ func TestUpdateENR_FuluForkDigest(t *testing.T) {
 				assert.DeepEqual(t, make([]byte, len(nextEntry.ForkDigest)), nfdValue, "nfd entry should be empty bytes when digests are same")
 			},
 		},
+		{
+			name:        "fulu disabled does not add nfd field",
+			fuluEnabled: false,
+			currentEntry: params.NetworkScheduleEntry{
+				Epoch:       50,
+				ForkDigest:  [4]byte{1, 2, 3, 4},
+				ForkVersion: [4]byte{1, 0, 0, 0},
+			},
+			nextEntry: params.NetworkScheduleEntry{
+				Epoch:       100,
+				ForkDigest:  [4]byte{5, 6, 7, 8}, // Different from current
+				ForkVersion: [4]byte{2, 0, 0, 0},
+			},
+			validateNFD: func(t *testing.T, localNode *enode.LocalNode, nextEntry params.NetworkScheduleEntry) {
+				var nfdValue []byte
+				err := localNode.Node().Record().Load(enr.WithEntry(nfdEnrKey, &nfdValue))
+				require.ErrorContains(t, "missing ENR key", err, "nfd field should not be present when Fulu fork is disabled")
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			localNode, cleanup := setupTest(t)
+			localNode, cleanup := setupTest(t, tt.fuluEnabled)
 			defer cleanup()
 
 			currentEntry := tt.currentEntry

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -177,3 +177,85 @@ func TestAddForkEntry_NextForkVersion(t *testing.T) {
 		"Wanted Next Fork Version to be equal to last entry in schedule")
 
 }
+
+func TestUpdateENR_FuluForkDigest(t *testing.T) {
+	setupTest := func(t *testing.T) (*enode.LocalNode, func()) {
+		params.SetupTestConfigCleanup(t)
+
+		cfg := params.BeaconConfig().Copy()
+		cfg.FuluForkEpoch = 100
+		cfg.FuluForkVersion = []byte{5, 0, 0, 0}
+		params.OverrideBeaconConfig(cfg)
+		cfg.InitializeForkSchedule()
+
+		pkey, err := privKey(&Config{DataDir: t.TempDir()})
+		require.NoError(t, err, "Could not get private key")
+		db, err := enode.OpenDB("")
+		require.NoError(t, err)
+
+		localNode := enode.NewLocalNode(db, pkey)
+		cleanup := func() {
+			db.Close()
+		}
+
+		return localNode, cleanup
+	}
+
+	tests := []struct {
+		name         string
+		currentEntry params.NetworkScheduleEntry
+		nextEntry    params.NetworkScheduleEntry
+		validateNFD  func(t *testing.T, localNode *enode.LocalNode, nextEntry params.NetworkScheduleEntry)
+	}{
+		{
+			name: "different digests sets nfd to next digest",
+			currentEntry: params.NetworkScheduleEntry{
+				Epoch:       50,
+				ForkDigest:  [4]byte{1, 2, 3, 4},
+				ForkVersion: [4]byte{1, 0, 0, 0},
+			},
+			nextEntry: params.NetworkScheduleEntry{
+				Epoch:       100,
+				ForkDigest:  [4]byte{5, 6, 7, 8}, // Different from current
+				ForkVersion: [4]byte{2, 0, 0, 0},
+			},
+			validateNFD: func(t *testing.T, localNode *enode.LocalNode, nextEntry params.NetworkScheduleEntry) {
+				var nfdValue []byte
+				err := localNode.Node().Record().Load(enr.WithEntry(nfdEnrKey, &nfdValue))
+				require.NoError(t, err)
+				assert.DeepEqual(t, nextEntry.ForkDigest[:], nfdValue, "nfd entry should equal next fork digest")
+			},
+		},
+		{
+			name: "same digests sets nfd to empty",
+			currentEntry: params.NetworkScheduleEntry{
+				Epoch:       50,
+				ForkDigest:  [4]byte{1, 2, 3, 4},
+				ForkVersion: [4]byte{1, 0, 0, 0},
+			},
+			nextEntry: params.NetworkScheduleEntry{
+				Epoch:       100,
+				ForkDigest:  [4]byte{1, 2, 3, 4}, // Same as current
+				ForkVersion: [4]byte{2, 0, 0, 0},
+			},
+			validateNFD: func(t *testing.T, localNode *enode.LocalNode, nextEntry params.NetworkScheduleEntry) {
+				var nfdValue []byte
+				err := localNode.Node().Record().Load(enr.WithEntry(nfdEnrKey, &nfdValue))
+				require.NoError(t, err)
+				assert.DeepEqual(t, make([]byte, len(nextEntry.ForkDigest)), nfdValue, "nfd entry should be empty bytes when digests are same")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localNode, cleanup := setupTest(t)
+			defer cleanup()
+
+			currentEntry := tt.currentEntry
+			nextEntry := tt.nextEntry
+			require.NoError(t, updateENR(localNode, currentEntry, nextEntry))
+			tt.validateNFD(t, localNode, nextEntry)
+		})
+	}
+}

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -27,6 +27,8 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 )
 
+const nfdEnrKey = "nfd" // The ENR record key for "nfd" (Next Fork Digest).
+
 var (
 	attestationSubnetCount = params.BeaconConfig().AttestationSubnetCount
 	syncCommsSubnetCount   = params.BeaconConfig().SyncCommitteeSubnetCount

--- a/changelog/kasey_fusaka-nfd.md
+++ b/changelog/kasey_fusaka-nfd.md
@@ -1,0 +1,2 @@
+### Added
+- Support for fusaka `nfd` enr field, and changes to the semantics of the eth2 field.


### PR DESCRIPTION
**What type of PR is this?**

Feature


**What does this PR do? Why is it needed?**

This adds support for the following changes which fulu makes to the ENR:
- [nfd (next fork digest) ENR key](https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#next-fork-digest)
- [changes in semantics of the eth2 field](https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#eth2-field). This change is partly rooted in the changes in the parent branch (`refactor-fork-schedules`), which modifies the handling of fork digests and BPOs.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
