### PR TITLE
Fix downscore by peers when a node gracefully stops.

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -104,6 +104,7 @@ go_library(
         "@com_github_libp2p_go_mplex//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
         "@com_github_multiformats_go_multiaddr//net:go_default_library",
+        "@com_github_patrickmn_go_cache//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -147,7 +147,7 @@ func (s *Service) AddConnectionHandler(reqFunc, goodByeFunc func(ctx context.Con
 					return
 				}
 
-				if direction == network.DirOutbound || direction == network.DirUnknown {
+				if direction != network.DirInbound {
 					s.peers.SetConnectionState(conn.RemotePeer(), peers.Connecting)
 					if err := reqFunc(context.TODO(), conn.RemotePeer()); err != nil && !errors.Is(err, io.EOF) {
 						s.disconnectFromPeerOnError(conn, goodByeFunc, err)

--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -133,57 +133,62 @@ func (s *Service) AddConnectionHandler(reqFunc, goodByeFunc func(ctx context.Con
 					return
 				}
 
-				// Do not perform handshake on inbound dials.
-				if conn.Stat().Direction == network.DirInbound {
-					_, err := s.peers.ChainState(remotePeer)
-					peerExists := err == nil
-					currentTime := prysmTime.Now()
-
-					// Wait for peer to initiate handshake
-					time.Sleep(timeForStatus)
-
-					// Exit if we are disconnected with the peer.
-					if s.host.Network().Connectedness(remotePeer) != network.Connected {
+				direction := conn.Stat().Direction
+				if direction == network.DirOutbound || direction == network.DirUnknown {
+					s.peers.SetConnectionState(conn.RemotePeer(), peers.Connecting)
+					if err := reqFunc(context.TODO(), conn.RemotePeer()); err != nil && !errors.Is(err, io.EOF) {
+						s.disconnectFromPeerOnError(conn, goodByeFunc, err)
 						return
-					}
-
-					// If peer hasn't sent a status request, we disconnect with them
-					if _, err := s.peers.ChainState(remotePeer); errors.Is(err, peerdata.ErrPeerUnknown) || errors.Is(err, peerdata.ErrNoPeerStatus) {
-						statusMessageMissing.Inc()
-						s.disconnectFromPeerOnError(conn, goodByeFunc, errors.Wrap(err, "chain state"))
-						return
-					}
-
-					if peerExists {
-						updated, err := s.peers.ChainStateLastUpdated(remotePeer)
-						if err != nil {
-							s.disconnectFromPeerOnError(conn, goodByeFunc, errors.Wrap(err, "chain state last updated"))
-							return
-						}
-
-						// Exit if we don't receive any current status messages from peer.
-						if updated.IsZero() {
-							s.disconnectFromPeerOnError(conn, goodByeFunc, errors.New("is zero"))
-							return
-						}
-
-						if updated.Before(currentTime) {
-							s.disconnectFromPeerOnError(conn, goodByeFunc, errors.New("did not update"))
-							return
-						}
 					}
 
 					s.connectToPeer(conn)
 					return
 				}
 
-				s.peers.SetConnectionState(conn.RemotePeer(), peers.Connecting)
-				if err := reqFunc(context.TODO(), conn.RemotePeer()); err != nil && !errors.Is(err, io.EOF) {
-					s.disconnectFromPeerOnError(conn, goodByeFunc, err)
+				// The connection is inbound.
+				_, err = s.peers.ChainState(remotePeer)
+				peerExists := err == nil
+				currentTime := prysmTime.Now()
+
+				// Wait for peer to initiate handshake
+				time.Sleep(timeForStatus)
+
+				// Exit if we are disconnected with the peer.
+				if s.host.Network().Connectedness(remotePeer) != network.Connected {
+					return
+				}
+
+				// If peer hasn't sent a status request, we disconnect with them
+				if _, err := s.peers.ChainState(remotePeer); errors.Is(err, peerdata.ErrPeerUnknown) || errors.Is(err, peerdata.ErrNoPeerStatus) {
+					statusMessageMissing.Inc()
+					s.disconnectFromPeerOnError(conn, goodByeFunc, errors.Wrap(err, "chain state"))
+					return
+				}
+
+				if !peerExists {
+					s.connectToPeer(conn)
+					return
+				}
+
+				updated, err := s.peers.ChainStateLastUpdated(remotePeer)
+				if err != nil {
+					s.disconnectFromPeerOnError(conn, goodByeFunc, errors.Wrap(err, "chain state last updated"))
+					return
+				}
+
+				// Exit if we don't receive any current status messages from peer.
+				if updated.IsZero() {
+					s.disconnectFromPeerOnError(conn, goodByeFunc, errors.New("is zero"))
+					return
+				}
+
+				if updated.Before(currentTime) {
+					s.disconnectFromPeerOnError(conn, goodByeFunc, errors.New("did not update"))
 					return
 				}
 
 				s.connectToPeer(conn)
+				return
 			}()
 		},
 	})

--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -79,8 +80,8 @@ func (s *Service) disconnectFromPeerOnError(
 // and validating the response from the peer.
 func (s *Service) AddConnectionHandler(reqFunc, goodByeFunc func(ctx context.Context, id peer.ID) error) {
 	// Peer map and lock to keep track of current connection attempts.
+	var peerLock sync.Mutex
 	peerMap := make(map[peer.ID]bool)
-	peerLock := new(sync.Mutex)
 
 	// This is run at the start of each connection attempt, to ensure
 	// that there aren't multiple inflight connection requests for the
@@ -108,6 +109,19 @@ func (s *Service) AddConnectionHandler(reqFunc, goodByeFunc func(ctx context.Con
 	s.host.Network().Notify(&network.NotifyBundle{
 		ConnectedF: func(_ network.Network, conn network.Conn) {
 			remotePeer := conn.RemotePeer()
+			log := log.WithField("peer", remotePeer)
+			direction := conn.Stat().Direction
+
+			// For some reason, right after a disconnection, this `ConnectedF` callback
+			// is called. We want to avoid processing this connection if the peer was
+			// disconnected too recently and if we are at the initiative of this connection.
+			// This is very probably a bug in libp2p.
+			if direction == network.DirOutbound {
+				if err := s.wasDisconnectedTooRecently(remotePeer); err != nil {
+					log.WithError(err).Debug("Skipping connection handler")
+					return
+				}
+			}
 
 			// Connection handler must be non-blocking as part of libp2p design.
 			go func() {
@@ -133,7 +147,6 @@ func (s *Service) AddConnectionHandler(reqFunc, goodByeFunc func(ctx context.Con
 					return
 				}
 
-				direction := conn.Stat().Direction
 				if direction == network.DirOutbound || direction == network.DirUnknown {
 					s.peers.SetConnectionState(conn.RemotePeer(), peers.Connecting)
 					if err := reqFunc(context.TODO(), conn.RemotePeer()); err != nil && !errors.Is(err, io.EOF) {
@@ -188,7 +201,6 @@ func (s *Service) AddConnectionHandler(reqFunc, goodByeFunc func(ctx context.Con
 				}
 
 				s.connectToPeer(conn)
-				return
 			}()
 		},
 	})
@@ -225,6 +237,9 @@ func (s *Service) AddDisconnectionHandler(handler func(ctx context.Context, id p
 				}
 
 				s.peers.SetConnectionState(peerID, peers.Disconnected)
+				if err := s.peerDisconnectionTime.Add(peerID.String(), time.Now(), cache.DefaultExpiration); err != nil {
+					log.WithError(err).Error("Failed to set peer disconnection time")
+				}
 
 				// Only log disconnections if we were fully connected.
 				if priorState == peers.Connected {
@@ -234,6 +249,28 @@ func (s *Service) AddDisconnectionHandler(handler func(ctx context.Context, id p
 			}()
 		},
 	})
+}
+
+// wasDisconnectedTooRecently checks if the peer was disconnected within the last second.
+func (s *Service) wasDisconnectedTooRecently(peerID peer.ID) error {
+	const disconnectionDurationThreshold = 1 * time.Second
+
+	peerDisconnectionTimeObj, ok := s.peerDisconnectionTime.Get(peerID.String())
+	if !ok {
+		return nil
+	}
+
+	peerDisconnectionTime, ok := peerDisconnectionTimeObj.(time.Time)
+	if !ok {
+		return errors.New("invalid peer disconnection time type")
+	}
+
+	timeSinceDisconnection := time.Since(peerDisconnectionTime)
+	if timeSinceDisconnection < disconnectionDurationThreshold {
+		return errors.Errorf("peer %s was disconnected too recently: %s", peerID, timeSinceDisconnection)
+	}
+
+	return nil
 }
 
 func agentString(pid peer.ID, hst host.Host) string {

--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -238,7 +238,10 @@ func (s *Service) AddDisconnectionHandler(handler func(ctx context.Context, id p
 
 				s.peers.SetConnectionState(peerID, peers.Disconnected)
 				if err := s.peerDisconnectionTime.Add(peerID.String(), time.Now(), cache.DefaultExpiration); err != nil {
-					log.WithError(err).Error("Failed to set peer disconnection time")
+					// The `DisconnectedF` funcition already called for this peer less than `cache.DefaultExpiration` ago. Skip.
+					// (Very probably a bug in libp2p.)
+					log.WithError(err).Trace("Failed to set peer disconnection time")
+					return
 				}
 
 				// Only log disconnections if we were fully connected.

--- a/beacon-chain/p2p/peers/scorers/bad_responses.go
+++ b/beacon-chain/p2p/peers/scorers/bad_responses.go
@@ -101,21 +101,24 @@ func (s *BadResponsesScorer) countNoLock(pid peer.ID) (int, error) {
 
 // Increment increments the number of bad responses we have received from the given remote peer.
 // If peer doesn't exist this method is no-op.
-func (s *BadResponsesScorer) Increment(pid peer.ID) {
+func (s *BadResponsesScorer) Increment(pid peer.ID) int {
 	if pid == "" {
-		return
+		return 0
 	}
+
 	s.store.Lock()
 	defer s.store.Unlock()
 
 	peerData, ok := s.store.PeerData(pid)
-	if !ok {
-		s.store.SetPeerData(pid, &peerdata.PeerData{
-			BadResponses: 1,
-		})
-		return
+	if ok {
+		peerData.BadResponses++
+		return peerData.BadResponses
 	}
-	peerData.BadResponses++
+
+	const badResponses = 1
+	peerData = &peerdata.PeerData{BadResponses: badResponses}
+	s.store.SetPeerData(pid, peerData)
+	return badResponses
 }
 
 // IsBadPeer states if the peer is to be considered bad.

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -498,9 +498,7 @@ func (s *Service) connectWithPeer(ctx context.Context, info peer.AddrInfo) error
 	defer cancel()
 
 	if err := s.host.Connect(ctx, info); err != nil {
-		newScore := s.Peers().Scorers().BadResponsesScorer().Increment(info.ID)
-		log.WithError(err).WithFields(logrus.Fields{"peerID": info.ID, "reason": "connectionError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(info.ID, "connectionError")
 		return errors.Wrap(err, "peer connect")
 	}
 	return nil
@@ -531,4 +529,9 @@ func (s *Service) connectToBootnodes() error {
 // required for discovery and pubsub validation.
 func (s *Service) isInitialized() bool {
 	return !s.genesisTime.IsZero() && len(s.genesisValidatorsRoot) == 32
+}
+
+func (s *Service) downscorePeer(peerID peer.ID, reason string) {
+	newScore := s.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason, "newScore": newScore}).Debug("Downscore peer")
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -486,14 +486,19 @@ func (s *Service) connectWithPeer(ctx context.Context, info peer.AddrInfo) error
 	if info.ID == s.host.ID() {
 		return nil
 	}
+
 	if err := s.Peers().IsBad(info.ID); err != nil {
-		return errors.Wrap(err, "refused to connect to bad peer")
+		return errors.Wrap(err, "bad peer")
 	}
+
 	ctx, cancel := context.WithTimeout(ctx, maxDialTimeout)
 	defer cancel()
+
 	if err := s.host.Connect(ctx, info); err != nil {
-		s.Peers().Scorers().BadResponsesScorer().Increment(info.ID)
-		return err
+		newScore := s.Peers().Scorers().BadResponsesScorer().Increment(info.ID)
+		log.WithFields(logrus.Fields{"peerID": info.ID, "reason": "connectionError", "newScore": newScore}).Debug("Downscore peer")
+
+		return errors.Wrap(err, "peer connect")
 	}
 	return nil
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/multiformats/go-multiaddr"
+	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -86,6 +87,7 @@ type Service struct {
 	genesisTime           time.Time
 	genesisValidatorsRoot []byte
 	activeValidatorCount  uint64
+	peerDisconnectionTime *cache.Cache
 }
 
 // NewService initializes a new p2p service compatible with shared.Service interface. No
@@ -115,16 +117,17 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 	ipLimiter := leakybucket.NewCollector(ipLimit, ipBurst, 30*time.Second, true /* deleteEmptyBuckets */)
 
 	s := &Service{
-		ctx:          ctx,
-		cancel:       cancel,
-		cfg:          cfg,
-		addrFilter:   addrFilter,
-		ipLimiter:    ipLimiter,
-		privKey:      privKey,
-		metaData:     metaData,
-		isPreGenesis: true,
-		joinedTopics: make(map[string]*pubsub.Topic, len(gossipTopicMappings)),
-		subnetsLock:  make(map[uint64]*sync.RWMutex),
+		ctx:                   ctx,
+		cancel:                cancel,
+		cfg:                   cfg,
+		addrFilter:            addrFilter,
+		ipLimiter:             ipLimiter,
+		privKey:               privKey,
+		metaData:              metaData,
+		isPreGenesis:          true,
+		joinedTopics:          make(map[string]*pubsub.Topic, len(gossipTopicMappings)),
+		subnetsLock:           make(map[uint64]*sync.RWMutex),
+		peerDisconnectionTime: cache.New(1*time.Second, 1*time.Minute),
 	}
 
 	ipAddr := prysmnetwork.IPAddr()
@@ -496,7 +499,7 @@ func (s *Service) connectWithPeer(ctx context.Context, info peer.AddrInfo) error
 
 	if err := s.host.Connect(ctx, info); err != nil {
 		newScore := s.Peers().Scorers().BadResponsesScorer().Increment(info.ID)
-		log.WithFields(logrus.Fields{"peerID": info.ID, "reason": "connectionError", "newScore": newScore}).Debug("Downscore peer")
+		log.WithError(err).WithFields(logrus.Fields{"peerID": info.ID, "reason": "connectionError", "newScore": newScore}).Debug("Downscore peer")
 
 		return errors.Wrap(err, "peer connect")
 	}

--- a/beacon-chain/p2p/service_test.go
+++ b/beacon-chain/p2p/service_test.go
@@ -403,7 +403,7 @@ func TestService_connectWithPeer(t *testing.T) {
 				return ps
 			}(),
 			info:    peer.AddrInfo{ID: "bad"},
-			wantErr: "refused to connect to bad peer",
+			wantErr: "bad peer",
 		},
 	}
 	for _, tt := range tests {

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -181,6 +181,11 @@ func (s *Service) findPeersWithSubnets(
 		// Get all needed subnets that the node is subscribed to.
 		// Skip nodes that are not subscribed to any of the defective subnets.
 		node := iterator.Node()
+
+		if !s.filterPeer(node) {
+			continue
+		}
+
 		nodeSubnets, err := filter(node)
 		if err != nil {
 			return nil, errors.Wrap(err, "filter node")

--- a/beacon-chain/sync/backfill/service.go
+++ b/beacon-chain/sync/backfill/service.go
@@ -212,9 +212,7 @@ func (s *Service) importBatches(ctx context.Context) {
 		_, err := s.batchImporter(ctx, current, ib, s.store)
 		if err != nil {
 			log.WithError(err).WithFields(ib.logFields()).Debug("Backfill batch failed to import")
-			newScore := s.p2p.Peers().Scorers().BadResponsesScorer().Increment(ib.blockPid)
-			log.WithFields(logrus.Fields{"peerID": ib.blockPid, "reason": "backfillBatchImportError", "newScore": newScore}).Debug("Downscore peer")
-
+			s.downscorePeer(ib.blockPid, "backfillBatchImportError")
 			s.batchSeq.update(ib.withState(batchErrRetryable))
 			// If a batch fails, the subsequent batches are no longer considered importable.
 			break
@@ -381,4 +379,9 @@ func (s *Service) WaitForCompletion() error {
 	case <-s.complete:
 		return nil
 	}
+}
+
+func (s *Service) downscorePeer(peerID peer.ID, reason string) {
+	newScore := s.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason, "newScore": newScore}).Debug("Downscore peer")
 }

--- a/beacon-chain/sync/backfill/service.go
+++ b/beacon-chain/sync/backfill/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type Service struct {
@@ -211,7 +212,9 @@ func (s *Service) importBatches(ctx context.Context) {
 		_, err := s.batchImporter(ctx, current, ib, s.store)
 		if err != nil {
 			log.WithError(err).WithFields(ib.logFields()).Debug("Backfill batch failed to import")
-			s.downscore(ib)
+			newScore := s.p2p.Peers().Scorers().BadResponsesScorer().Increment(ib.blockPid)
+			log.WithFields(logrus.Fields{"peerID": ib.blockPid, "reason": "backfillBatchImportError", "newScore": newScore}).Debug("Downscore peer")
+
 			s.batchSeq.update(ib.withState(batchErrRetryable))
 			// If a batch fails, the subsequent batches are no longer considered importable.
 			break
@@ -334,10 +337,6 @@ func (s *Service) initBatches() error {
 		s.pool.todo(b)
 	}
 	return nil
-}
-
-func (s *Service) downscore(b batch) {
-	s.p2p.Peers().Scorers().BadResponsesScorer().Increment(b.blockPid)
 }
 
 func (*Service) Stop() error {

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -339,11 +339,11 @@ func (q *blocksQueue) onDataReceivedEvent(ctx context.Context) eventHandlerFn {
 			}
 
 			if errors.Is(response.err, beaconsync.ErrInvalidFetchedData) {
-				newScore := q.blocksFetcher.p2p.Peers().Scorers().BadResponsesScorer().Increment(response.blocksFrom)
-				log.WithError(response.err).WithFields(logrus.Fields{"peerID": response.blocksFrom, "reason": "invalidBlocks", "newScore": newScore}).Debug("Downscore peer")
-			} else if errors.Is(response.err, verification.ErrBlobInvalid) {
-				newScore := q.blocksFetcher.p2p.Peers().Scorers().BadResponsesScorer().Increment(response.blobsFrom)
-				log.WithError(response.err).WithFields(logrus.Fields{"peerID": response.blobsFrom, "reason": "invalidBlobs", "newScore": newScore}).Debug("Downscore peer")
+				q.downscorePeer(response.blocksFrom, "invalidBlocks")
+			}
+
+			if errors.Is(response.err, verification.ErrBlobInvalid) {
+				q.downscorePeer(response.blobsFrom, "invalidBlobs")
 			}
 
 			return m.state, response.err
@@ -454,6 +454,11 @@ func (q *blocksQueue) onProcessSkippedEvent(ctx context.Context) eventHandlerFn 
 		}
 		return stateSkipped, q.resetFromSlot(ctx, startSlot)
 	}
+}
+
+func (q *blocksQueue) downscorePeer(peerID peer.ID, reason string) {
+	newScore := q.blocksFetcher.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason, "newScore": newScore}).Debug("Downscore peer")
 }
 
 // onCheckStaleEvent is an event that allows to mark stale epochs,

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -337,14 +337,15 @@ func (q *blocksQueue) onDataReceivedEvent(ctx context.Context) eventHandlerFn {
 					}
 				}
 			}
+
 			if errors.Is(response.err, beaconsync.ErrInvalidFetchedData) {
-				// Peer returned invalid data, penalize.
-				q.blocksFetcher.p2p.Peers().Scorers().BadResponsesScorer().Increment(response.blocksFrom)
-				log.WithField("pid", response.blocksFrom).Debug("Peer is penalized for invalid blocks")
+				newScore := q.blocksFetcher.p2p.Peers().Scorers().BadResponsesScorer().Increment(response.blocksFrom)
+				log.WithError(response.err).WithFields(logrus.Fields{"peerID": response.blocksFrom, "reason": "invalidBlocks", "newScore": newScore}).Debug("Downscore peer")
 			} else if errors.Is(response.err, verification.ErrBlobInvalid) {
-				q.blocksFetcher.p2p.Peers().Scorers().BadResponsesScorer().Increment(response.blobsFrom)
-				log.WithField("pid", response.blobsFrom).Debug("Peer is penalized for invalid blob response")
+				newScore := q.blocksFetcher.p2p.Peers().Scorers().BadResponsesScorer().Increment(response.blobsFrom)
+				log.WithError(response.err).WithFields(logrus.Fields{"peerID": response.blobsFrom, "reason": "invalidBlobs", "newScore": newScore}).Debug("Downscore peer")
 			}
+
 			return m.state, response.err
 		}
 		m.fetched = *response

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -522,7 +522,7 @@ func TestBlocksQueue_onDataReceivedEvent(t *testing.T) {
 		})
 		assert.ErrorContains(t, beaconsync.ErrInvalidFetchedData.Error(), err)
 		assert.Equal(t, stateScheduled, updatedState)
-		assert.LogsContain(t, hook, "msg=\"Peer is penalized for invalid blocks\" pid=ZiCa")
+		assert.LogsContain(t, hook, "Downscore peer")
 	})
 
 	t.Run("transition ok", func(t *testing.T) {

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/paulbellamy/ratecounter"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -345,11 +346,9 @@ func isPunishableError(err error) bool {
 func (s *Service) updatePeerScorerStats(data *blocksQueueFetchedData, count uint64, err error) {
 	if isPunishableError(err) {
 		if verification.IsBlobValidationFailure(err) {
-			newScore := s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(data.blobsFrom)
-			log.WithError(err).WithFields(logrus.Fields{"peerID": data.blobsFrom, "reason": "invalidBlobs", "newScore": newScore}).Debug("Downscore peer")
+			s.downscorePeer(data.blobsFrom, "invalidBlobs")
 		} else {
-			newScore := s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(data.blocksFrom)
-			log.WithError(err).WithFields(logrus.Fields{"peerID": data.blocksFrom, "reason": "invalidBlocks", "newScore": newScore}).Debug("Downscore peer")
+			s.downscorePeer(data.blocksFrom, "invalidBlocks")
 		}
 
 		// If the error is punishable, exit here so that we don't give them credit for providing bad blocks.
@@ -376,4 +375,9 @@ func (s *Service) isProcessedBlock(ctx context.Context, blk blocks.ROBlock) bool
 		return true
 	}
 	return false
+}
+
+func (s *Service) downscorePeer(peerID peer.ID, reason string) {
+	newScore := s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason, "newScore": newScore}).Debug("Downscore peer")
 }

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -345,12 +345,13 @@ func isPunishableError(err error) bool {
 func (s *Service) updatePeerScorerStats(data *blocksQueueFetchedData, count uint64, err error) {
 	if isPunishableError(err) {
 		if verification.IsBlobValidationFailure(err) {
-			log.WithError(err).WithField("peer_id", data.blobsFrom).Warn("Downscoring peer for invalid blobs")
-			s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(data.blobsFrom)
+			newScore := s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(data.blobsFrom)
+			log.WithError(err).WithFields(logrus.Fields{"peerID": data.blobsFrom, "reason": "invalidBlobs", "newScore": newScore}).Debug("Downscore peer")
 		} else {
-			log.WithError(err).WithField("peer_id", data.blocksFrom).Warn("Downscoring peer for invalid blocks")
-			s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(data.blocksFrom)
+			newScore := s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(data.blocksFrom)
+			log.WithError(err).WithFields(logrus.Fields{"peerID": data.blocksFrom, "reason": "invalidBlocks", "newScore": newScore}).Debug("Downscore peer")
 		}
+
 		// If the error is punishable, exit here so that we don't give them credit for providing bad blocks.
 		return
 	}

--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -122,7 +122,7 @@ func (l *limiter) validateRequest(stream network.Stream, amt uint64) error {
 
 	collector, err := l.retrieveCollector(topic)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "retrieve collector")
 	}
 
 	remaining := collector.Remaining(remotePeer.String())
@@ -131,7 +131,14 @@ func (l *limiter) validateRequest(stream network.Stream, amt uint64) error {
 		amt = 1
 	}
 	if amt > uint64(remaining) {
-		l.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		newScore := l.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{
+			"peerID":   remotePeer.String(),
+			"reason":   "rateLimitExceeded",
+			"newScore": newScore,
+			"topic":    topic,
+		}).Debug("Downscore peer")
+
 		writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrRateLimited.Error(), stream, l.p2p)
 		return p2ptypes.ErrRateLimited
 	}
@@ -140,21 +147,29 @@ func (l *limiter) validateRequest(stream network.Stream, amt uint64) error {
 
 // This is used to validate all incoming rpc streams from external peers.
 func (l *limiter) validateRawRpcRequest(stream network.Stream) error {
+	// Treat each request as a minimum of 1.
+	const amt = 1
+
 	l.RLock()
 	defer l.RUnlock()
 
-	topic := rpcLimiterTopic
-
-	collector, err := l.retrieveCollector(topic)
+	remotePeer := stream.Conn().RemotePeer()
+	collector, err := l.retrieveCollector(rpcLimiterTopic)
 	if err != nil {
 		return err
 	}
 	key := stream.Conn().RemotePeer().String()
 	remaining := collector.Remaining(key)
-	// Treat each request as a minimum of 1.
-	amt := int64(1)
+
 	if amt > remaining {
-		l.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+		newScore := l.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{
+			"peerID":   remotePeer.String(),
+			"reason":   "rawRateLimitExceeded",
+			"newScore": newScore,
+			"topic":    rpcLimiterTopic,
+		}).Debug("Downscore peer")
+
 		writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrRateLimited.Error(), stream, l.p2p)
 		return p2ptypes.ErrRateLimited
 	}

--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/trailofbits/go-mutexasserts"
@@ -131,14 +132,7 @@ func (l *limiter) validateRequest(stream network.Stream, amt uint64) error {
 		amt = 1
 	}
 	if amt > uint64(remaining) {
-		newScore := l.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{
-			"peerID":   remotePeer.String(),
-			"reason":   "rateLimitExceeded",
-			"newScore": newScore,
-			"topic":    topic,
-		}).Debug("Downscore peer")
-
+		l.downscorePeer(remotePeer, topic, "rateLimitExceeded")
 		writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrRateLimited.Error(), stream, l.p2p)
 		return p2ptypes.ErrRateLimited
 	}
@@ -162,14 +156,7 @@ func (l *limiter) validateRawRpcRequest(stream network.Stream) error {
 	remaining := collector.Remaining(key)
 
 	if amt > remaining {
-		newScore := l.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{
-			"peerID":   remotePeer.String(),
-			"reason":   "rawRateLimitExceeded",
-			"newScore": newScore,
-			"topic":    rpcLimiterTopic,
-		}).Debug("Downscore peer")
-
+		l.downscorePeer(remotePeer, rpcLimiterTopic, "rawRateLimitExceeded")
 		writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrRateLimited.Error(), stream, l.p2p)
 		return p2ptypes.ErrRateLimited
 	}
@@ -247,4 +234,14 @@ func (l *limiter) retrieveCollector(topic string) (*leakybucket.Collector, error
 
 func (_ *limiter) topicLogger(topic string) *logrus.Entry {
 	return log.WithField("rateLimiter", topic)
+}
+
+func (l *limiter) downscorePeer(peerID peer.ID, topic, reason string) {
+	newScore := l.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+	log.WithFields(logrus.Fields{
+		"peerID":   peerID.String(),
+		"reason":   reason,
+		"newScore": newScore,
+		"topic":    topic,
+	}).Debug("Downscore peer")
 }

--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -140,10 +140,7 @@ func (l *limiter) validateRequest(stream network.Stream, amt uint64) error {
 }
 
 // This is used to validate all incoming rpc streams from external peers.
-func (l *limiter) validateRawRpcRequest(stream network.Stream) error {
-	// Treat each request as a minimum of 1.
-	const amt = 1
-
+func (l *limiter) validateRawRpcRequest(stream network.Stream, amt uint64) error {
 	l.RLock()
 	defer l.RUnlock()
 
@@ -155,7 +152,7 @@ func (l *limiter) validateRawRpcRequest(stream network.Stream) error {
 	key := stream.Conn().RemotePeer().String()
 	remaining := collector.Remaining(key)
 
-	if amt > remaining {
+	if amt > uint64(remaining) {
 		l.downscorePeer(remotePeer, rpcLimiterTopic, "rawRateLimitExceeded")
 		writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrRateLimited.Error(), stream, l.p2p)
 		return p2ptypes.ErrRateLimited

--- a/beacon-chain/sync/rate_limiter_test.go
+++ b/beacon-chain/sync/rate_limiter_test.go
@@ -85,16 +85,16 @@ func TestRateLimiter_ExceedRawCapacity(t *testing.T) {
 	require.NoError(t, err, "could not create stream")
 
 	for i := 0; i < 2*defaultBurstLimit; i++ {
-		err = rlimiter.validateRawRpcRequest(stream)
+		err = rlimiter.validateRawRpcRequest(stream, 1)
 		rlimiter.addRawStream(stream)
 		require.NoError(t, err, "could not validate incoming request")
 	}
 	// Triggers rate limit error on burst.
-	assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream))
+	assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream, 1))
 
 	// Make Peer bad.
 	for i := 0; i < defaultBurstLimit; i++ {
-		assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream))
+		assert.ErrorContains(t, p2ptypes.ErrRateLimited.Error(), rlimiter.validateRawRpcRequest(stream, 1))
 	}
 	assert.NotNil(t, p1.Peers().IsBad(p2.PeerID()), "peer is not marked as a bad peer")
 	require.NoError(t, stream.Close(), "could not close stream")

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -249,7 +249,7 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 			return
 		}
 		// Validate request according to peer limits.
-		if err := s.rateLimiter.validateRawRpcRequest(stream); err != nil {
+		if err := s.rateLimiter.validateRawRpcRequest(stream, 1); err != nil {
 			log.WithError(err).Debug("Could not validate rpc request from peer")
 			return
 		}

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -305,10 +305,7 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
 				logStreamErrors(err, topic)
 				tracing.AnnotateError(span, err)
-
-				newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-				log.WithFields(logrus.Fields{"reason": "registerRpcError", "newScore": newScore}).Debug("Downscore peer")
-
+				s.downscorePeer(remotePeer, "registerRpcError")
 				return
 			}
 			if err := handle(ctx, msg, stream); err != nil {
@@ -328,10 +325,7 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
 				logStreamErrors(err, topic)
 				tracing.AnnotateError(span, err)
-
-				newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-				log.WithFields(logrus.Fields{"reason": "registerRpcError", "newScore": newScore}).Debug("Downscore peer")
-
+				s.downscorePeer(remotePeer, "registerRpcError")
 				return
 			}
 			if err := handle(ctx, nTyp.Elem().Interface(), stream); err != nil {

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/pkg/errors"
 	ssz "github.com/prysmaticlabs/fastssz"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -238,7 +239,7 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 		defer span.End()
 		span.SetAttributes(trace.StringAttribute("topic", topic))
 		span.SetAttributes(trace.StringAttribute("peer", remotePeer.String()))
-		log := log.WithField("peer", stream.Conn().RemotePeer().String()).WithField("topic", string(stream.Protocol()))
+		log := log.WithFields(logrus.Fields{"peer": remotePeer.String(), "topic": string(stream.Protocol())})
 
 		// Check before hand that peer is valid.
 		if err := s.cfg.p2p.Peers().IsBad(remotePeer); err != nil {
@@ -304,7 +305,10 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
 				logStreamErrors(err, topic)
 				tracing.AnnotateError(span, err)
-				s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+
+				newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+				log.WithFields(logrus.Fields{"reason": "registerRpcError", "newScore": newScore}).Debug("Downscore peer")
+
 				return
 			}
 			if err := handle(ctx, msg, stream); err != nil {
@@ -324,7 +328,10 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
 				logStreamErrors(err, topic)
 				tracing.AnnotateError(span, err)
-				s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+
+				newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+				log.WithFields(logrus.Fields{"reason": "registerRpcError", "newScore": newScore}).Debug("Downscore peer")
+
 				return
 			}
 			if err := handle(ctx, nTyp.Elem().Interface(), stream); err != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	libp2pcore "github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -43,10 +44,7 @@ func (s *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interfa
 	rp, err := validateRangeRequest(m, s.cfg.clock.CurrentSlot())
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "beaconBlocksByRangeRPCHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(remotePeer, "beaconBlocksByRangeRPCHandlerValidationError")
 		tracing.AnnotateError(span, err)
 		return err
 	}
@@ -203,4 +201,14 @@ func (s *Service) writeBlockBatchToStream(ctx context.Context, batch blockBatch,
 	}
 
 	return nil
+}
+
+func (s *Service) downscorePeer(peerID peer.ID, reason string, fields ...logrus.Fields) {
+	log := log
+	for _, field := range fields {
+		log = log.WithFields(field)
+	}
+
+	newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason, "newScore": newScore}).Debug("Downscore peer")
 }

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -43,7 +43,10 @@ func (s *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interfa
 	rp, err := validateRangeRequest(m, s.cfg.clock.CurrentSlot())
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "beaconBlocksByRangeRPCHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
+
 		tracing.AnnotateError(span, err)
 		return err
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -18,7 +18,6 @@ import (
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // sendBeaconBlocksRequest sends a recent beacon blocks request to a peer to get
@@ -97,9 +96,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 
 	currentEpoch := slots.ToEpoch(s.cfg.clock.CurrentSlot())
 	if uint64(len(blockRoots)) > params.MaxRequestBlock(currentEpoch) {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "beaconBlocksRootRPCHandlerTooManyRoots", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(remotePeer, "beaconBlocksRootRPCHandlerTooManyRoots")
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, "requested more than the max block limit", stream)
 		return errors.New("requested more than the max block limit")
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -18,6 +18,7 @@ import (
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // sendBeaconBlocksRequest sends a recent beacon blocks request to a peer to get
@@ -92,9 +93,13 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("no block roots provided")
 	}
 
+	remotePeer := stream.Conn().RemotePeer()
+
 	currentEpoch := slots.ToEpoch(s.cfg.clock.CurrentSlot())
 	if uint64(len(blockRoots)) > params.MaxRequestBlock(currentEpoch) {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "beaconBlocksRootRPCHandlerTooManyRoots", "newScore": newScore}).Debug("Downscore peer")
+
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, "requested more than the max block limit", stream)
 		return errors.New("requested more than the max block limit")
 	}

--- a/beacon-chain/sync/rpc_blob_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_range.go
@@ -16,7 +16,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func (s *Service) streamBlobBatch(ctx context.Context, batch blockBatch, wQuota uint64, stream libp2pcore.Stream) (uint64, error) {
@@ -81,10 +80,7 @@ func (s *Service) blobSidecarsByRangeRPCHandler(ctx context.Context, msg interfa
 	rp, err := validateBlobsByRange(r, s.cfg.chain.CurrentSlot())
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "blobSidecarsByRangeRpcHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(remotePeer, "blobSidecarsByRangeRpcHandlerValidationError")
 		tracing.AnnotateError(span, err)
 		return err
 	}

--- a/beacon-chain/sync/rpc_blob_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_range.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func (s *Service) streamBlobBatch(ctx context.Context, batch blockBatch, wQuota uint64, stream libp2pcore.Stream) (uint64, error) {
@@ -74,10 +75,16 @@ func (s *Service) blobSidecarsByRangeRPCHandler(ctx context.Context, msg interfa
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
 		return err
 	}
+
+	remotePeer := stream.Conn().RemotePeer()
+
 	rp, err := validateBlobsByRange(r, s.cfg.chain.CurrentSlot())
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "blobSidecarsByRangeRpcHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
+
 		tracing.AnnotateError(span, err)
 		return err
 	}
@@ -87,7 +94,7 @@ func (s *Service) blobSidecarsByRangeRPCHandler(ctx context.Context, msg interfa
 	defer ticker.Stop()
 	batcher, err := newBlockRangeBatcher(rp, s.cfg.beaconDB, s.rateLimiter, s.cfg.chain.IsCanonical, ticker)
 	if err != nil {
-		log.WithError(err).Info("error in BlobSidecarsByRange batch")
+		log.WithError(err).Error("Cannot create new block range batcher")
 		s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
 		tracing.AnnotateError(span, err)
 		return err
@@ -112,7 +119,7 @@ func (s *Service) blobSidecarsByRangeRPCHandler(ctx context.Context, msg interfa
 		}
 	}
 	if err := batch.error(); err != nil {
-		log.WithError(err).Debug("error in BlobSidecarsByRange batch")
+		log.WithError(err).Debug("Error in BlobSidecarsByRange batch")
 
 		// If a rate limit is hit, it means an error response has already been sent and the stream has been closed.
 		if !errors.Is(err, p2ptypes.ErrRateLimited) {

--- a/beacon-chain/sync/rpc_blob_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root.go
@@ -39,9 +39,7 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 	cs := s.cfg.clock.CurrentSlot()
 	remotePeer := stream.Conn().RemotePeer()
 	if err := validateBlobByRootRequest(blobIdents, cs); err != nil {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "blobSidecarsByRootRpcHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(remotePeer, "blobSidecarsByRootRpcHandlerValidationError")
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		return err
 	}

--- a/beacon-chain/sync/rpc_blob_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root.go
@@ -39,7 +39,9 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 	cs := s.cfg.clock.CurrentSlot()
 	remotePeer := stream.Conn().RemotePeer()
 	if err := validateBlobByRootRequest(blobIdents, cs); err != nil {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "blobSidecarsByRootRpcHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
+
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		return err
 	}

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
@@ -65,7 +65,10 @@ func (s *Service) dataColumnSidecarsByRangeRPCHandler(ctx context.Context, msg i
 	rangeParameters, err := validateDataColumnsByRange(request, s.cfg.chain.CurrentSlot())
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "dataColumnSidecarsByRangeRpcHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
+
 		tracing.AnnotateError(span, err)
 		return errors.Wrap(err, "validate data columns by range")
 	}

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_range.go
@@ -65,10 +65,7 @@ func (s *Service) dataColumnSidecarsByRangeRPCHandler(ctx context.Context, msg i
 	rangeParameters, err := validateDataColumnsByRange(request, s.cfg.chain.CurrentSlot())
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "dataColumnSidecarsByRangeRpcHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(remotePeer, "dataColumnSidecarsByRangeRpcHandlerValidationError")
 		tracing.AnnotateError(span, err)
 		return errors.Wrap(err, "validate data columns by range")
 	}

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -51,9 +51,7 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 
 	// Penalize peers that send invalid requests.
 	if err := validateDataColumnsByRootRequest(requestedColumnIdents); err != nil {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "dataColumnSidecarByRootRPCHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(remotePeer, "dataColumnSidecarByRootRPCHandlerValidationError")
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		return errors.Wrap(err, "validate data columns by root request")
 	}

--- a/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_data_column_sidecars_by_root.go
@@ -42,7 +42,7 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 	}
 
 	requestedColumnIdents := *ref
-	remotePeerId := stream.Conn().RemotePeer()
+	remotePeer := stream.Conn().RemotePeer()
 
 	ctx, cancel := context.WithTimeout(ctx, ttfbTimeout)
 	defer cancel()
@@ -51,7 +51,9 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 
 	// Penalize peers that send invalid requests.
 	if err := validateDataColumnsByRootRequest(requestedColumnIdents); err != nil {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeerId)
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "dataColumnSidecarByRootRPCHandlerValidationError", "newScore": newScore}).Debug("Downscore peer")
+
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		return errors.Wrap(err, "validate data columns by root request")
 	}
@@ -85,7 +87,7 @@ func (s *Service) dataColumnSidecarByRootRPCHandler(ctx context.Context, msg int
 	}
 
 	log := log.WithFields(logrus.Fields{
-		"peer":    remotePeerId,
+		"peer":    remotePeer,
 		"columns": requestedColumnsByRootLog,
 	})
 

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -89,7 +89,7 @@ func (s *Service) disconnectBadPeer(ctx context.Context, id peer.ID, badPeerErr 
 			"peerID": id,
 			"agent":  agentString(id, s.cfg.p2p.Host()),
 		}).
-		Debug("Sent peer disconnection")
+		Debug("Sent bad peer disconnection")
 }
 
 // A custom goodbye method that is used by our connection handler, in the

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -13,6 +13,7 @@ import (
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,22 +36,40 @@ var backOffTime = map[primitives.SSZUint64]time.Duration{
 
 // goodbyeRPCHandler reads the incoming goodbye rpc message from the peer.
 func (s *Service) goodbyeRPCHandler(_ context.Context, msg interface{}, stream libp2pcore.Stream) error {
+	const amount = 1
 	SetRPCStreamDeadlines(stream)
+	peerID := stream.Conn().RemotePeer()
 
 	m, ok := msg.(*primitives.SSZUint64)
 	if !ok {
 		return fmt.Errorf("wrong message type for goodbye, got %T, wanted *uint64", msg)
 	}
-	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		log.WithError(err).Debug("Goodbye message from rate-limited peer")
-	} else {
+
+	isRateLimitedPeer := false
+	if err := s.rateLimiter.validateRequest(stream, amount); err != nil {
+		if !errors.Is(err, p2ptypes.ErrRateLimited) {
+			return errors.Wrap(err, "validate request")
+		}
+		isRateLimitedPeer = true
+	}
+
+	if !isRateLimitedPeer {
 		s.rateLimiter.add(stream, 1)
 	}
-	log := log.WithField("Reason", goodbyeMessage(*m))
-	log.WithField("peer", stream.Conn().RemotePeer()).Trace("Peer has sent a goodbye message")
-	s.cfg.p2p.Peers().SetNextValidTime(stream.Conn().RemotePeer(), goodByeBackoff(*m))
-	// closes all streams with the peer
-	return s.cfg.p2p.Disconnect(stream.Conn().RemotePeer())
+
+	log.WithFields(logrus.Fields{
+		"peer":          peerID,
+		"reason":        goodbyeMessage(*m),
+		"isRateLimited": isRateLimitedPeer,
+	}).Debug("Received a goodbye message")
+
+	s.cfg.p2p.Peers().SetNextValidTime(peerID, goodByeBackoff(*m))
+
+	if err := s.cfg.p2p.Disconnect(peerID); err != nil {
+		return errors.Wrap(err, "disconnect")
+	}
+
+	return nil
 }
 
 // disconnectBadPeer checks whether peer is considered bad by some scorer, and tries to disconnect

--- a/beacon-chain/sync/rpc_light_client.go
+++ b/beacon-chain/sync/rpc_light_client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
 	eth "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	libp2pcore "github.com/libp2p/go-libp2p/core"
-	"github.com/sirupsen/logrus"
 )
 
 // lightClientBootstrapRPCHandler handles the /eth2/beacon_chain/req/light_client_bootstrap/1/ RPC request.
@@ -92,9 +91,7 @@ func (s *Service) lightClientUpdatesByRangeRPCHandler(ctx context.Context, msg i
 
 	if r.Count == 0 {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, "count is 0", stream)
-
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "lightClientUpdatesByRangeRPCHandlerCount0", "newScore": newScore}).Debug("Downscore peer")
+		s.downscorePeer(remotePeer, "lightClientUpdatesByRangeRPCHandlerCount0")
 
 		logger.Error("Count is 0")
 		return nil
@@ -107,10 +104,7 @@ func (s *Service) lightClientUpdatesByRangeRPCHandler(ctx context.Context, msg i
 	endPeriod, err := math.Add64(r.StartPeriod, r.Count-1)
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "lightClientUpdatesByRangeRPCHandlerEndPeriodOverflow", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(remotePeer, "lightClientUpdatesByRangeRPCHandlerEndPeriodOverflow")
 		tracing.AnnotateError(span, err)
 		logger.WithError(err).Error("End period overflows")
 		return err

--- a/beacon-chain/sync/rpc_light_client.go
+++ b/beacon-chain/sync/rpc_light_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
 	eth "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	libp2pcore "github.com/libp2p/go-libp2p/core"
+	"github.com/sirupsen/logrus"
 )
 
 // lightClientBootstrapRPCHandler handles the /eth2/beacon_chain/req/light_client_bootstrap/1/ RPC request.
@@ -26,7 +27,7 @@ func (s *Service) lightClientBootstrapRPCHandler(ctx context.Context, msg interf
 
 	SetRPCStreamDeadlines(stream)
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		logger.WithError(err).Error("s.rateLimiter.validateRequest")
+		logger.WithError(err).Error("Canno validate request")
 		return err
 	}
 	s.rateLimiter.add(stream, 1)
@@ -42,7 +43,7 @@ func (s *Service) lightClientBootstrapRPCHandler(ctx context.Context, msg interf
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 		tracing.AnnotateError(span, err)
-		logger.WithError(err).Error("s.cfg.beaconDB.LightClientBootstrap")
+		logger.WithError(err).Error("Cannot bootstrap light client")
 		return err
 	}
 	if bootstrap == nil {
@@ -74,10 +75,11 @@ func (s *Service) lightClientUpdatesByRangeRPCHandler(ctx context.Context, msg i
 	defer cancel()
 
 	logger := log.WithField("handler", p2p.LightClientUpdatesByRangeName[1:])
+	remotePeer := stream.Conn().RemotePeer()
 
 	SetRPCStreamDeadlines(stream)
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		logger.WithError(err).Error("s.rateLimiter.validateRequest")
+		logger.WithError(err).Error("Cannot validate request")
 		return err
 	}
 	s.rateLimiter.add(stream, 1)
@@ -90,7 +92,10 @@ func (s *Service) lightClientUpdatesByRangeRPCHandler(ctx context.Context, msg i
 
 	if r.Count == 0 {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, "count is 0", stream)
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "lightClientUpdatesByRangeRPCHandlerCount0", "newScore": newScore}).Debug("Downscore peer")
+
 		logger.Error("Count is 0")
 		return nil
 	}
@@ -102,7 +107,10 @@ func (s *Service) lightClientUpdatesByRangeRPCHandler(ctx context.Context, msg i
 	endPeriod, err := math.Add64(r.StartPeriod, r.Count-1)
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+		log.WithFields(logrus.Fields{"peerID": remotePeer.String(), "reason": "lightClientUpdatesByRangeRPCHandlerEndPeriodOverflow", "newScore": newScore}).Debug("Downscore peer")
+
 		tracing.AnnotateError(span, err)
 		logger.WithError(err).Error("End period overflows")
 		return err
@@ -114,7 +122,7 @@ func (s *Service) lightClientUpdatesByRangeRPCHandler(ctx context.Context, msg i
 	if err != nil {
 		s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 		tracing.AnnotateError(span, err)
-		logger.WithError(err).Error("s.cfg.beaconDB.LightClientUpdates")
+		logger.WithError(err).Error("Cannot retrieve light client updates")
 		return err
 	}
 
@@ -153,7 +161,7 @@ func (s *Service) lightClientFinalityUpdateRPCHandler(ctx context.Context, _ int
 
 	SetRPCStreamDeadlines(stream)
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		logger.WithError(err).Error("s.rateLimiter.validateRequest")
+		logger.WithError(err).Error("Cannot validate request")
 		return err
 	}
 	s.rateLimiter.add(stream, 1)
@@ -191,7 +199,7 @@ func (s *Service) lightClientOptimisticUpdateRPCHandler(ctx context.Context, _ i
 
 	SetRPCStreamDeadlines(stream)
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		logger.WithError(err).Error("s.rateLimiter.validateRequest")
+		logger.WithError(err).Error("Cannot validate request")
 		return err
 	}
 	s.rateLimiter.add(stream, 1)

--- a/beacon-chain/sync/rpc_light_client.go
+++ b/beacon-chain/sync/rpc_light_client.go
@@ -26,7 +26,7 @@ func (s *Service) lightClientBootstrapRPCHandler(ctx context.Context, msg interf
 
 	SetRPCStreamDeadlines(stream)
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		logger.WithError(err).Error("Canno validate request")
+		logger.WithError(err).Error("Cannot validate request")
 		return err
 	}
 	s.rateLimiter.add(stream, 1)

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -15,7 +15,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/sirupsen/logrus"
 )
 
 // metaDataHandler reads the incoming metadata RPC request from the peer.
@@ -173,16 +172,12 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, peerID peer.ID) (meta
 	// Read the METADATA response from the peer.
 	code, errMsg, err := ReadStatusCode(stream, s.cfg.p2p.Encoding())
 	if err != nil {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "MetadataReadStatusCodeError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(peerID, "MetadataReadStatusCodeError")
 		return nil, errors.Wrap(err, "read status code")
 	}
 
 	if code != 0 {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "NonNullMetadataReadStatusCode", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(peerID, "NonNullMetadataReadStatusCode")
 		return nil, errors.New(errMsg)
 	}
 
@@ -219,9 +214,7 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, peerID peer.ID) (meta
 
 	// Decode the metadata from the peer.
 	if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "MetadataDecodeError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(peerID, "MetadataDecodeError")
 		return nil, errors.Wrap(err, "decode with max length")
 	}
 

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/sirupsen/logrus"
 )
 
 // metaDataHandler reads the incoming metadata RPC request from the peer.
@@ -172,12 +173,16 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, peerID peer.ID) (meta
 	// Read the METADATA response from the peer.
 	code, errMsg, err := ReadStatusCode(stream, s.cfg.p2p.Encoding())
 	if err != nil {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "MetadataReadStatusCodeError", "newScore": newScore}).Debug("Downscore peer")
+
 		return nil, errors.Wrap(err, "read status code")
 	}
 
 	if code != 0 {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "NonNullMetadataReadStatusCode", "newScore": newScore}).Debug("Downscore peer")
+
 		return nil, errors.New(errMsg)
 	}
 
@@ -214,8 +219,10 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, peerID peer.ID) (meta
 
 	// Decode the metadata from the peer.
 	if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
-		return nil, err
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "MetadataDecodeError", "newScore": newScore}).Debug("Downscore peer")
+
+		return nil, errors.Wrap(err, "decode with max length")
 	}
 
 	return msg, nil

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -138,9 +138,7 @@ func (s *Service) sendPingRequest(ctx context.Context, peerID peer.ID) error {
 
 	// If the peer responded with an error, increment the bad responses scorer.
 	if code != 0 {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "NotNullPingReadStatusCode", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(peerID, "NotNullPingReadStatusCode")
 		return errors.Errorf("code: %d - %s", code, errMsg)
 	}
 
@@ -194,14 +192,10 @@ func (s *Service) isSequenceNumberUpToDate(incomingSequenceNumber uint64, peerID
 	// The peer's sequence number must be less than or equal to the sequence number we have in our store.
 	storedSequenceNumber := storedMetadata.SequenceNumber()
 	if storedSequenceNumber > incomingSequenceNumber {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-		log.WithFields(logrus.Fields{
-			"peerID":                 peerID.String(),
-			"reason":                 "pingInvalidSequenceNumber",
-			"newScore":               newScore,
+		s.downscorePeer(peerID, "pingInvalidSequenceNumber", logrus.Fields{
 			"storedSequenceNumber":   storedSequenceNumber,
 			"incomingSequenceNumber": incomingSequenceNumber,
-		}).Debug("Downscore peer")
+		})
 		return false, p2ptypes.ErrInvalidSequenceNum
 	}
 

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -28,6 +28,7 @@ func (s *Service) pingHandler(_ context.Context, msg interface{}, stream libp2pc
 	if !ok {
 		return fmt.Errorf("wrong message type for ping, got %T, wanted *uint64", msg)
 	}
+	sequenceNumber := uint64(*m)
 
 	// Validate the incoming request regarding rate limiting.
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
@@ -40,14 +41,9 @@ func (s *Service) pingHandler(_ context.Context, msg interface{}, stream libp2pc
 	peerID := stream.Conn().RemotePeer()
 
 	// Check if the peer sequence number is higher than the one we have in our store.
-	valid, err := s.validateSequenceNum(*m, peerID)
+	valid, err := s.isSequenceNumberUpToDate(sequenceNumber, peerID)
 	if err != nil {
-		// Downscore peer for giving us a bad sequence number.
-		if errors.Is(err, p2ptypes.ErrInvalidSequenceNum) {
-			newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-			log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "pingInvalidSequenceNumber", "newScore": newScore}).Debug("Downscore peer")
-		}
-
+		s.writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrInvalidSequenceNum.Error(), stream)
 		return errors.Wrap(err, "validate sequence number")
 	}
 
@@ -153,16 +149,11 @@ func (s *Service) sendPingRequest(ctx context.Context, peerID peer.ID) error {
 	if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
 		return errors.Wrap(err, "decode sequence number")
 	}
+	sequenceNumber := uint64(*msg)
 
 	// Determine if the peer's sequence number returned by the peer is higher than the one we have in our store.
-	valid, err := s.validateSequenceNum(*msg, peerID)
+	valid, err := s.isSequenceNumberUpToDate(sequenceNumber, peerID)
 	if err != nil {
-		// Descore peer for giving us a bad sequence number.
-		if errors.Is(err, p2ptypes.ErrInvalidSequenceNum) {
-			newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-			log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "pingInvalidSequenceNumber", "newScore": newScore}).Debug("Downscore peer")
-		}
-
 		return errors.Wrap(err, "validate sequence number")
 	}
 
@@ -184,27 +175,40 @@ func (s *Service) sendPingRequest(ctx context.Context, peerID peer.ID) error {
 	return nil
 }
 
-// validateSequenceNum validates the peer's sequence number.
-// - If the peer's sequence number is greater than the sequence number we have in our store for the peer, return false.
-// - If the peer's sequence number is equal to the sequence number we have in our store for the peer, return true.
-// - If the peer's sequence number is less than the sequence number we have in our store for the peer, return an error.
-func (s *Service) validateSequenceNum(seq primitives.SSZUint64, id peer.ID) (bool, error) {
+// isSequenceNumberUpToDate check if our internal sequence number for the peer is up to date wrt. the incoming one.
+// - If the incoming sequence number is greater than the sequence number we have in our store for the peer, return false.
+// - If the incoming sequence number is equal to the sequence number we have in our store for the peer, return true.
+// - If the incoming sequence number is less than the sequence number we have in our store for the peer, return an error.
+func (s *Service) isSequenceNumberUpToDate(incomingSequenceNumber uint64, peerID peer.ID) (bool, error) {
 	// Retrieve the metadata for the peer we got in our store.
-	md, err := s.cfg.p2p.Peers().Metadata(id)
+	storedMetadata, err := s.cfg.p2p.Peers().Metadata(peerID)
 	if err != nil {
-		return false, errors.Wrap(err, "get metadata")
+		return false, errors.Wrap(err, "peers metadata")
 	}
 
 	// If we have no metadata for the peer, return false.
-	if md == nil || md.IsNil() {
+	if storedMetadata == nil || storedMetadata.IsNil() {
 		return false, nil
 	}
 
 	// The peer's sequence number must be less than or equal to the sequence number we have in our store.
-	if md.SequenceNumber() > uint64(seq) {
+	storedSequenceNumber := storedMetadata.SequenceNumber()
+	if storedSequenceNumber > incomingSequenceNumber {
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		log.WithFields(logrus.Fields{
+			"peerID":                 peerID.String(),
+			"reason":                 "pingInvalidSequenceNumber",
+			"newScore":               newScore,
+			"storedSequenceNumber":   storedSequenceNumber,
+			"incomingSequenceNumber": incomingSequenceNumber,
+		}).Debug("Downscore peer")
 		return false, p2ptypes.ErrInvalidSequenceNum
 	}
 
-	// Return true if the peer's sequence number is equal to the sequence number we have in our store.
-	return md.SequenceNumber() == uint64(seq), nil
+	// If this is the case, our information about the peer is outdated.
+	if storedSequenceNumber < incomingSequenceNumber {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -13,6 +13,7 @@ import (
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // pingHandler reads the incoming ping rpc message from the peer.
@@ -41,10 +42,10 @@ func (s *Service) pingHandler(_ context.Context, msg interface{}, stream libp2pc
 	// Check if the peer sequence number is higher than the one we have in our store.
 	valid, err := s.validateSequenceNum(*m, peerID)
 	if err != nil {
-		// Descore peer for giving us a bad sequence number.
+		// Downscore peer for giving us a bad sequence number.
 		if errors.Is(err, p2ptypes.ErrInvalidSequenceNum) {
-			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
-			s.writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrInvalidSequenceNum.Error(), stream)
+			newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+			log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "pingInvalidSequenceNumber", "newScore": newScore}).Debug("Downscore peer")
 		}
 
 		return errors.Wrap(err, "validate sequence number")
@@ -141,7 +142,9 @@ func (s *Service) sendPingRequest(ctx context.Context, peerID peer.ID) error {
 
 	// If the peer responded with an error, increment the bad responses scorer.
 	if code != 0 {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+		log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "NotNullPingReadStatusCode", "newScore": newScore}).Debug("Downscore peer")
+
 		return errors.Errorf("code: %d - %s", code, errMsg)
 	}
 
@@ -156,7 +159,8 @@ func (s *Service) sendPingRequest(ctx context.Context, peerID peer.ID) error {
 	if err != nil {
 		// Descore peer for giving us a bad sequence number.
 		if errors.Is(err, p2ptypes.ErrInvalidSequenceNum) {
-			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+			newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+			log.WithFields(logrus.Fields{"peerID": peerID.String(), "reason": "pingInvalidSequenceNumber", "newScore": newScore}).Debug("Downscore peer")
 		}
 
 		return errors.Wrap(err, "validate sequence number")

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -169,6 +169,7 @@ func (s *Service) sendRPCStatusRequest(ctx context.Context, peer peer.ID) error 
 
 	code, errMsg, err := ReadStatusCode(stream, s.cfg.p2p.Encoding())
 	if err != nil {
+		log := log.WithError(err)
 		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peer)
 		log.WithFields(logrus.Fields{"reason": "statusRequestReadStatusCodeError", "newScore": newScore}).Debug("Downscore peer")
 

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -65,8 +65,7 @@ func (s *Service) maintainPeerStatuses() {
 
 				if prysmTime.Now().After(lastUpdated.Add(interval)) {
 					if err := s.reValidatePeer(s.ctx, id); err != nil {
-						newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(id)
-						log.WithFields(logrus.Fields{"reason": "reValidatePeerError", "newScore": newScore}).Debug("Downscore peer")
+						log.WithError(err).Debug("Cannot re-validate peer")
 					}
 				}
 			}(pid)
@@ -169,25 +168,18 @@ func (s *Service) sendRPCStatusRequest(ctx context.Context, peer peer.ID) error 
 
 	code, errMsg, err := ReadStatusCode(stream, s.cfg.p2p.Encoding())
 	if err != nil {
-		log := log.WithError(err)
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peer)
-		log.WithFields(logrus.Fields{"reason": "statusRequestReadStatusCodeError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(peer, "statusRequestReadStatusCodeError")
 		return errors.Wrap(err, "read status code")
 	}
 
 	if code != 0 {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peer)
-		log.WithFields(logrus.Fields{"reason": "statusRequestNonNullStatusCode", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(peer, "statusRequestNonNullStatusCode")
 		return errors.New(errMsg)
 	}
 
 	msg := &pb.Status{}
 	if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peer)
-		log.WithFields(logrus.Fields{"reason": "statusRequestDecodeError", "newScore": newScore}).Debug("Downscore peer")
-
+		s.downscorePeer(peer, "statusRequestDecodeError")
 		return errors.Wrap(err, "decode status message")
 	}
 
@@ -254,9 +246,7 @@ func (s *Service) statusRPCHandler(ctx context.Context, msg interface{}, stream 
 			return nil
 		default:
 			respCode = responseCodeInvalidRequest
-
-			newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
-			log.WithFields(logrus.Fields{"reason": "statusRpcHandlerInvalidMessage", "newScore": newScore}).Debug("Downscore peer")
+			s.downscorePeer(remotePeer, "statusRpcHandlerInvalidMessage")
 		}
 
 		originalErr := err

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -35,6 +35,9 @@ func (s *Service) maintainPeerStatuses() {
 			wg.Add(1)
 			go func(id peer.ID) {
 				defer wg.Done()
+
+				log := log.WithField("peer", id)
+
 				// If our peer status has not been updated correctly we disconnect over here
 				// and set the connection state over here instead.
 				if s.cfg.p2p.Host().Network().Connectedness(id) != network.Connected {
@@ -43,27 +46,27 @@ func (s *Service) maintainPeerStatuses() {
 						log.WithError(err).Debug("Error when disconnecting with peer")
 					}
 					s.cfg.p2p.Peers().SetConnectionState(id, peers.Disconnected)
-					log.WithFields(logrus.Fields{
-						"peer":   id,
-						"reason": "maintain peer statuses - peer is not connected",
-					}).Debug("Initiate peer disconnection")
+					log.WithField("reason", "maintainPeerStatusesNotConnectedPeer").Debug("Initiate peer disconnection")
 					return
 				}
+
 				// Disconnect from peers that are considered bad by any of the registered scorers.
 				if err := s.cfg.p2p.Peers().IsBad(id); err != nil {
 					s.disconnectBadPeer(s.ctx, id, err)
 					return
 				}
+
 				// If the status hasn't been updated in the recent interval time.
 				lastUpdated, err := s.cfg.p2p.Peers().ChainStateLastUpdated(id)
 				if err != nil {
 					// Peer has vanished; nothing to do.
 					return
 				}
+
 				if prysmTime.Now().After(lastUpdated.Add(interval)) {
 					if err := s.reValidatePeer(s.ctx, id); err != nil {
-						log.WithField("peer", id).WithError(err).Debug("Could not revalidate peer")
-						s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(id)
+						newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(id)
+						log.WithFields(logrus.Fields{"reason": "reValidatePeerError", "newScore": newScore}).Debug("Downscore peer")
 					}
 				}
 			}(pid)
@@ -128,19 +131,20 @@ func (s *Service) shouldReSync() bool {
 }
 
 // sendRPCStatusRequest for a given topic with an expected protobuf message type.
-func (s *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
+func (s *Service) sendRPCStatusRequest(ctx context.Context, peer peer.ID) error {
 	ctx, cancel := context.WithTimeout(ctx, respTimeout)
 	defer cancel()
 
 	headRoot, err := s.cfg.chain.HeadRoot(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "head root")
 	}
 
 	forkDigest, err := s.currentForkDigest()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "current fork digest")
 	}
+
 	cp := s.cfg.chain.FinalizedCheckpt()
 	resp := &pb.Status{
 		ForkDigest:     forkDigest[:],
@@ -149,37 +153,48 @@ func (s *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
 		HeadRoot:       headRoot,
 		HeadSlot:       s.cfg.chain.HeadSlot(),
 	}
+
+	log := log.WithField("peer", peer)
+
 	topic, err := p2p.TopicFromMessage(p2p.StatusMessageName, slots.ToEpoch(s.cfg.clock.CurrentSlot()))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "topic from message")
 	}
-	stream, err := s.cfg.p2p.Send(ctx, resp, topic, id)
+
+	stream, err := s.cfg.p2p.Send(ctx, resp, topic, peer)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "send p2p message")
 	}
 	defer closeStream(stream, log)
 
 	code, errMsg, err := ReadStatusCode(stream, s.cfg.p2p.Encoding())
 	if err != nil {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
-		return err
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peer)
+		log.WithFields(logrus.Fields{"reason": "statusRequestReadStatusCodeError", "newScore": newScore}).Debug("Downscore peer")
+
+		return errors.Wrap(err, "read status code")
 	}
 
 	if code != 0 {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(id)
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peer)
+		log.WithFields(logrus.Fields{"reason": "statusRequestNonNullStatusCode", "newScore": newScore}).Debug("Downscore peer")
+
 		return errors.New(errMsg)
 	}
+
 	msg := &pb.Status{}
 	if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
-		return err
+		newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(peer)
+		log.WithFields(logrus.Fields{"reason": "statusRequestDecodeError", "newScore": newScore}).Debug("Downscore peer")
+
+		return errors.Wrap(err, "decode status message")
 	}
 
 	// If validation fails, validation error is logged, and peer status scorer will mark peer as bad.
 	err = s.validateStatusMessage(ctx, msg)
-	s.cfg.p2p.Peers().Scorers().PeerStatusScorer().SetPeerStatus(id, msg, err)
-	if err := s.cfg.p2p.Peers().IsBad(id); err != nil {
-		s.disconnectBadPeer(s.ctx, id, err)
+	s.cfg.p2p.Peers().Scorers().PeerStatusScorer().SetPeerStatus(peer, msg, err)
+	if err := s.cfg.p2p.Peers().IsBad(peer); err != nil {
+		s.disconnectBadPeer(s.ctx, peer, err)
 	}
 	return err
 }
@@ -238,7 +253,9 @@ func (s *Service) statusRPCHandler(ctx context.Context, msg interface{}, stream 
 			return nil
 		default:
 			respCode = responseCodeInvalidRequest
-			s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+
+			newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(remotePeer)
+			log.WithFields(logrus.Fields{"reason": "statusRpcHandlerInvalidMessage", "newScore": newScore}).Debug("Downscore peer")
 		}
 
 		originalErr := err

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -290,7 +290,7 @@ func (s *Service) Stop() error {
 	// Say goodbye to all peers.
 	for _, peerID := range s.cfg.p2p.Peers().Connected() {
 		if s.cfg.p2p.Host().Network().Connectedness(peerID) == network.Connected {
-			if err := s.sendGoodByeAndDisconnect(context.TODO(), p2ptypes.GoodbyeCodeClientShutdown, peerID); err != nil {
+			if err := s.sendGoodByeAndDisconnect(s.ctx, p2ptypes.GoodbyeCodeClientShutdown, peerID); err != nil {
 				log.WithError(err).WithField("peerID", peerID).Error("Failed to send goodbye message")
 			}
 		}

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -278,6 +278,8 @@ func (s *Service) Start() {
 // Stop the regular sync service.
 func (s *Service) Stop() error {
 	defer func() {
+		s.cancel()
+
 		if s.rateLimiter != nil {
 			s.rateLimiter.free()
 		}
@@ -286,11 +288,12 @@ func (s *Service) Stop() error {
 	for _, p := range s.cfg.p2p.Host().Mux().Protocols() {
 		s.cfg.p2p.Host().RemoveStreamHandler(p)
 	}
+
 	// Deregister Topic Subscribers.
 	for _, t := range s.cfg.p2p.PubSub().GetTopics() {
 		s.unSubscribeFromTopic(t)
 	}
-	defer s.cancel()
+
 	return nil
 }
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -11,10 +11,12 @@ import (
 
 	lightClient "github.com/OffchainLabs/prysm/v6/beacon-chain/core/light-client"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
+	p2ptypes "github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/types"
 	"github.com/OffchainLabs/prysm/v6/crypto/rand"
 	lru "github.com/hashicorp/golang-lru"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	libp2pcore "github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	gcache "github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
@@ -284,6 +286,16 @@ func (s *Service) Stop() error {
 			s.rateLimiter.free()
 		}
 	}()
+
+	// Say goodbye to all peers.
+	for _, peerID := range s.cfg.p2p.Peers().Connected() {
+		if s.cfg.p2p.Host().Network().Connectedness(peerID) == network.Connected {
+			if err := s.sendGoodByeAndDisconnect(context.TODO(), p2ptypes.GoodbyeCodeClientShutdown, peerID); err != nil {
+				log.WithError(err).WithField("peerID", peerID).Error("Failed to send goodbye message")
+			}
+		}
+	}
+
 	// Removing RPC Stream handlers.
 	for _, p := range s.cfg.p2p.Host().Mux().Protocols() {
 		s.cfg.p2p.Host().RemoveStreamHandler(p)

--- a/changelog/manu-peer-ban-at-restart.md
+++ b/changelog/manu-peer-ban-at-restart.md
@@ -1,0 +1,2 @@
+### Fixed 
+- Fixed various reasons why a node is banned by its peers when it stops.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR fixes various reasons why a node is downscored by its peers when stopping (and consequently banned by its peers when restarting).

**Other notes for review**
Please read commit by commit with commit messages.
It is not strictly a peerDAS PR, however, peerDAS, because of stricter peers selection **and** mandatory fix node identity, enhances this issue. 

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
