### PR TITLE
Remove unused parameter from LC functions

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -171,15 +171,7 @@ func (s *Service) processLightClientUpdate(cfg *postBlockProcessConfig) error {
 		return errors.Wrapf(err, "could not get finalized block for root %#x", finalizedRoot)
 	}
 
-	update, err := lightclient.NewLightClientUpdateFromBeaconState(
-		cfg.ctx,
-		s.CurrentSlot(),
-		cfg.postState,
-		cfg.roblock,
-		attestedState,
-		attestedBlock,
-		finalizedBlock,
-	)
+	update, err := lightclient.NewLightClientUpdateFromBeaconState(cfg.ctx, cfg.postState, cfg.roblock, attestedState, attestedBlock, finalizedBlock)
 	if err != nil {
 		return errors.Wrapf(err, "could not create light client update")
 	}
@@ -221,15 +213,7 @@ func (s *Service) processLightClientFinalityUpdate(
 		return errors.Wrapf(err, "could not get finalized block for root %#x", finalizedRoot)
 	}
 
-	newUpdate, err := lightclient.NewLightClientFinalityUpdateFromBeaconState(
-		ctx,
-		postState.Slot(),
-		postState,
-		signed,
-		attestedState,
-		attestedBlock,
-		finalizedBlock,
-	)
+	newUpdate, err := lightclient.NewLightClientFinalityUpdateFromBeaconState(ctx, postState, signed, attestedState, attestedBlock, finalizedBlock)
 
 	if err != nil {
 		return errors.Wrap(err, "could not create light client finality update")
@@ -267,14 +251,7 @@ func (s *Service) processLightClientOptimisticUpdate(ctx context.Context, signed
 		return errors.Wrapf(err, "could not get attested state for root %#x", attestedRoot)
 	}
 
-	newUpdate, err := lightclient.NewLightClientOptimisticUpdateFromBeaconState(
-		ctx,
-		postState.Slot(),
-		postState,
-		signed,
-		attestedState,
-		attestedBlock,
-	)
+	newUpdate, err := lightclient.NewLightClientOptimisticUpdateFromBeaconState(ctx, postState, signed, attestedState, attestedBlock)
 
 	if err != nil {
 		if strings.Contains(err.Error(), lightclient.ErrNotEnoughSyncCommitteeBits) {

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -3179,14 +3179,7 @@ func TestProcessLightClientOptimisticUpdate(t *testing.T) {
 					lOld, cfgOld := setupLightClientTestRequirements(ctx, t, s, testVersion, tc.oldOptions...)
 					require.NoError(t, s.processLightClientOptimisticUpdate(cfgOld.ctx, cfgOld.roblock, cfgOld.postState))
 
-					oldActualUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(
-						lOld.Ctx,
-						lOld.State.Slot(),
-						lOld.State,
-						lOld.Block,
-						lOld.AttestedState,
-						lOld.AttestedBlock,
-					)
+					oldActualUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(lOld.Ctx, lOld.State, lOld.Block, lOld.AttestedState, lOld.AttestedBlock)
 					require.NoError(t, err)
 
 					// check that the old update is saved
@@ -3200,14 +3193,7 @@ func TestProcessLightClientOptimisticUpdate(t *testing.T) {
 				lNew, cfgNew := setupLightClientTestRequirements(ctx, t, s, testVersion, tc.newOptions...)
 				require.NoError(t, s.processLightClientOptimisticUpdate(cfgNew.ctx, cfgNew.roblock, cfgNew.postState))
 
-				newActualUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(
-					lNew.Ctx,
-					lNew.State.Slot(),
-					lNew.State,
-					lNew.Block,
-					lNew.AttestedState,
-					lNew.AttestedBlock,
-				)
+				newActualUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lNew.Ctx, lNew.State, lNew.Block, lNew.AttestedState, lNew.AttestedBlock)
 				require.NoError(t, err)
 
 				require.DeepNotEqual(t, newActualUpdate, oldActualUpdate, "new update should not be equal to old update")
@@ -3335,15 +3321,7 @@ func TestProcessLightClientFinalityUpdate(t *testing.T) {
 					require.NoError(t, s.processLightClientFinalityUpdate(cfgOld.ctx, cfgOld.roblock, cfgOld.postState))
 
 					// check that the old update is saved
-					actualOldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(
-						ctx,
-						cfgOld.postState.Slot(),
-						cfgOld.postState,
-						cfgOld.roblock,
-						lOld.AttestedState,
-						lOld.AttestedBlock,
-						lOld.FinalizedBlock,
-					)
+					actualOldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(ctx, cfgOld.postState, cfgOld.roblock, lOld.AttestedState, lOld.AttestedBlock, lOld.FinalizedBlock)
 					require.NoError(t, err)
 					oldUpdate := s.lcStore.LastFinalityUpdate()
 					require.DeepEqual(t, actualOldUpdate, oldUpdate)
@@ -3354,15 +3332,7 @@ func TestProcessLightClientFinalityUpdate(t *testing.T) {
 				require.NoError(t, s.processLightClientFinalityUpdate(cfgNew.ctx, cfgNew.roblock, cfgNew.postState))
 
 				// check that the actual old update and the actual new update are different
-				actualNewUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(
-					ctx,
-					cfgNew.postState.Slot(),
-					cfgNew.postState,
-					cfgNew.roblock,
-					lNew.AttestedState,
-					lNew.AttestedBlock,
-					lNew.FinalizedBlock,
-				)
+				actualNewUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(ctx, cfgNew.postState, cfgNew.roblock, lNew.AttestedState, lNew.AttestedBlock, lNew.FinalizedBlock)
 				require.NoError(t, err)
 				require.DeepNotEqual(t, actualOldUpdate, actualNewUpdate)
 

--- a/beacon-chain/core/light-client/lightclient.go
+++ b/beacon-chain/core/light-client/lightclient.go
@@ -26,14 +26,12 @@ const ErrNotEnoughSyncCommitteeBits = "sync committee bits count is less than re
 
 func NewLightClientFinalityUpdateFromBeaconState(
 	ctx context.Context,
-	currentSlot primitives.Slot,
 	state state.BeaconState,
 	block interfaces.ReadOnlySignedBeaconBlock,
 	attestedState state.BeaconState,
 	attestedBlock interfaces.ReadOnlySignedBeaconBlock,
-	finalizedBlock interfaces.ReadOnlySignedBeaconBlock,
-) (interfaces.LightClientFinalityUpdate, error) {
-	update, err := NewLightClientUpdateFromBeaconState(ctx, currentSlot, state, block, attestedState, attestedBlock, finalizedBlock)
+	finalizedBlock interfaces.ReadOnlySignedBeaconBlock) (interfaces.LightClientFinalityUpdate, error) {
+	update, err := NewLightClientUpdateFromBeaconState(ctx, state, block, attestedState, attestedBlock, finalizedBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -43,13 +41,11 @@ func NewLightClientFinalityUpdateFromBeaconState(
 
 func NewLightClientOptimisticUpdateFromBeaconState(
 	ctx context.Context,
-	currentSlot primitives.Slot,
 	state state.BeaconState,
 	block interfaces.ReadOnlySignedBeaconBlock,
 	attestedState state.BeaconState,
-	attestedBlock interfaces.ReadOnlySignedBeaconBlock,
-) (interfaces.LightClientOptimisticUpdate, error) {
-	update, err := NewLightClientUpdateFromBeaconState(ctx, currentSlot, state, block, attestedState, attestedBlock, nil)
+	attestedBlock interfaces.ReadOnlySignedBeaconBlock) (interfaces.LightClientOptimisticUpdate, error) {
+	update, err := NewLightClientUpdateFromBeaconState(ctx, state, block, attestedState, attestedBlock, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +62,6 @@ func NewLightClientOptimisticUpdateFromBeaconState(
 //     if locally available (may be unavailable, e.g., when using checkpoint sync, or if it was pruned locally)
 func NewLightClientUpdateFromBeaconState(
 	ctx context.Context,
-	currentSlot primitives.Slot,
 	state state.BeaconState,
 	block interfaces.ReadOnlySignedBeaconBlock,
 	attestedState state.BeaconState,
@@ -520,9 +515,9 @@ func ComputeWithdrawalsRoot(payload interfaces.ExecutionData) ([]byte, error) {
 
 func BlockToLightClientHeader(
 	ctx context.Context,
-	attestedBlockVersion int, // this is the version that the light client header should be in, based on the attested block.
+	attestedBlockVersion int,                   // this is the version that the light client header should be in, based on the attested block.
 	block interfaces.ReadOnlySignedBeaconBlock, // this block is either the attested block, or the finalized block.
-	// in case of the latter, we might need to upgrade it to the attested block's version.
+// in case of the latter, we might need to upgrade it to the attested block's version.
 ) (interfaces.LightClientHeader, error) {
 	if block.Version() > attestedBlockVersion {
 		return nil, errors.Errorf("block version %s is greater than attested block version %s", version.String(block.Version()), version.String(attestedBlockVersion))
@@ -778,7 +773,7 @@ func IsBetterFinalityUpdate(newUpdate, oldUpdate interfaces.LightClientFinalityU
 	return true
 }
 
-func IsBetterOptimisticUpdate(newUpdate interfaces.LightClientOptimisticUpdate, oldUpdate interfaces.LightClientOptimisticUpdate) bool {
+func IsBetterOptimisticUpdate(newUpdate, oldUpdate interfaces.LightClientOptimisticUpdate) bool {
 	if oldUpdate == nil {
 		return true
 	}

--- a/beacon-chain/core/light-client/lightclient.go
+++ b/beacon-chain/core/light-client/lightclient.go
@@ -515,9 +515,8 @@ func ComputeWithdrawalsRoot(payload interfaces.ExecutionData) ([]byte, error) {
 
 func BlockToLightClientHeader(
 	ctx context.Context,
-	attestedBlockVersion int,                   // this is the version that the light client header should be in, based on the attested block.
-	block interfaces.ReadOnlySignedBeaconBlock, // this block is either the attested block, or the finalized block.
-// in case of the latter, we might need to upgrade it to the attested block's version.
+	attestedBlockVersion int, // this is the version that the light client header should be in, based on the attested block.
+	block interfaces.ReadOnlySignedBeaconBlock, // this block is either the attested block, or the finalized block. in case of the latter, we might need to upgrade it to the attested block's version.
 ) (interfaces.LightClientHeader, error) {
 	if block.Version() > attestedBlockVersion {
 		return nil, errors.Errorf("block version %s is greater than attested block version %s", version.String(block.Version()), version.String(attestedBlockVersion))

--- a/beacon-chain/core/light-client/lightclient_test.go
+++ b/beacon-chain/core/light-client/lightclient_test.go
@@ -34,7 +34,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	t.Run("Altair", func(t *testing.T) {
 		l := util.NewTestLightClient(t, version.Altair)
 
-		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
 		require.NotNil(t, update, "update is nil")
 		require.Equal(t, l.Block.Block().Slot(), update.SignatureSlot(), "Signature slot is not equal")
@@ -46,7 +46,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	t.Run("Capella", func(t *testing.T) {
 		l := util.NewTestLightClient(t, version.Capella)
 
-		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
 		require.NotNil(t, update, "update is nil")
 
@@ -59,7 +59,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	t.Run("Deneb", func(t *testing.T) {
 		l := util.NewTestLightClient(t, version.Deneb)
 
-		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
 		require.NotNil(t, update, "update is nil")
 
@@ -72,7 +72,7 @@ func TestLightClient_NewLightClientOptimisticUpdateFromBeaconState(t *testing.T)
 	t.Run("Electra", func(t *testing.T) {
 		l := util.NewTestLightClient(t, version.Electra)
 
-		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+		update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 		require.NoError(t, err)
 		require.NotNil(t, update, "update is nil")
 
@@ -97,7 +97,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 		l := util.NewTestLightClient(t, version.Altair)
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
 
@@ -132,7 +132,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
 			l := util.NewTestLightClient(t, version.Capella)
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
 
@@ -206,7 +206,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 
 		t.Run("FinalizedBlock In Previous Fork", func(t *testing.T) {
 			l := util.NewTestLightClient(t, version.Capella, util.WithFinalizedCheckpointInPrevFork())
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
 
@@ -240,7 +240,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
 			l := util.NewTestLightClient(t, version.Deneb)
 
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
 
@@ -315,7 +315,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 		t.Run("FinalizedBlock In Previous Fork", func(t *testing.T) {
 			l := util.NewTestLightClient(t, version.Deneb, util.WithFinalizedCheckpointInPrevFork())
 
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
 
@@ -392,7 +392,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 		t.Run("FinalizedBlock Not Nil", func(t *testing.T) {
 			l := util.NewTestLightClient(t, version.Electra)
 
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
 
@@ -467,7 +467,7 @@ func TestLightClient_NewLightClientFinalityUpdateFromBeaconState(t *testing.T) {
 		t.Run("FinalizedBlock In Previous Fork", func(t *testing.T) {
 			l := util.NewTestLightClient(t, version.Electra, util.WithFinalizedCheckpointInPrevFork())
 
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 			require.NotNil(t, update, "update is nil")
 

--- a/beacon-chain/core/light-client/store_test.go
+++ b/beacon-chain/core/light-client/store_test.go
@@ -25,18 +25,18 @@ func TestLightClientStore(t *testing.T) {
 
 	// Create test light client updates for Capella and Deneb
 	lCapella := util.NewTestLightClient(t, version.Capella)
-	opUpdateCapella, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lCapella.Ctx, lCapella.State.Slot(), lCapella.State, lCapella.Block, lCapella.AttestedState, lCapella.AttestedBlock)
+	opUpdateCapella, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lCapella.Ctx, lCapella.State, lCapella.Block, lCapella.AttestedState, lCapella.AttestedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, opUpdateCapella, "OptimisticUpdateCapella is nil")
-	finUpdateCapella, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(lCapella.Ctx, lCapella.State.Slot(), lCapella.State, lCapella.Block, lCapella.AttestedState, lCapella.AttestedBlock, lCapella.FinalizedBlock)
+	finUpdateCapella, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(lCapella.Ctx, lCapella.State, lCapella.Block, lCapella.AttestedState, lCapella.AttestedBlock, lCapella.FinalizedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, finUpdateCapella, "FinalityUpdateCapella is nil")
 
 	lDeneb := util.NewTestLightClient(t, version.Deneb)
-	opUpdateDeneb, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lDeneb.Ctx, lDeneb.State.Slot(), lDeneb.State, lDeneb.Block, lDeneb.AttestedState, lDeneb.AttestedBlock)
+	opUpdateDeneb, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(lDeneb.Ctx, lDeneb.State, lDeneb.Block, lDeneb.AttestedState, lDeneb.AttestedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, opUpdateDeneb, "OptimisticUpdateDeneb is nil")
-	finUpdateDeneb, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(lDeneb.Ctx, lDeneb.State.Slot(), lDeneb.State, lDeneb.Block, lDeneb.AttestedState, lDeneb.AttestedBlock, lDeneb.FinalizedBlock)
+	finUpdateDeneb, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(lDeneb.Ctx, lDeneb.State, lDeneb.Block, lDeneb.AttestedState, lDeneb.AttestedBlock, lDeneb.FinalizedBlock)
 	require.NoError(t, err)
 	require.NotNil(t, finUpdateDeneb, "FinalityUpdateDeneb is nil")
 

--- a/beacon-chain/p2p/broadcaster_test.go
+++ b/beacon-chain/p2p/broadcaster_test.go
@@ -547,7 +547,7 @@ func TestService_BroadcastLightClientOptimisticUpdate(t *testing.T) {
 	}
 
 	l := util.NewTestLightClient(t, version.Altair)
-	msg, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+	msg, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 	require.NoError(t, err)
 
 	GossipTypeMapping[reflect.TypeOf(msg)] = LightClientOptimisticUpdateTopicFormat
@@ -614,7 +614,7 @@ func TestService_BroadcastLightClientFinalityUpdate(t *testing.T) {
 	}
 
 	l := util.NewTestLightClient(t, version.Altair)
-	msg, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+	msg, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 	require.NoError(t, err)
 
 	GossipTypeMapping[reflect.TypeOf(msg)] = LightClientFinalityUpdateTopicFormat

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -660,7 +660,7 @@ func TestLightClientHandler_GetLightClientFinalityUpdate(t *testing.T) {
 			ctx := t.Context()
 
 			l := util.NewTestLightClient(t, testVersion)
-			update, err := lightclient.NewLightClientFinalityUpdateFromBeaconState(ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightclient.NewLightClientFinalityUpdateFromBeaconState(ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 
 			s := &Server{LCStore: &lightclient.Store{}}
@@ -685,7 +685,7 @@ func TestLightClientHandler_GetLightClientFinalityUpdate(t *testing.T) {
 			ctx := t.Context()
 
 			l := util.NewTestLightClient(t, testVersion)
-			update, err := lightclient.NewLightClientFinalityUpdateFromBeaconState(ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightclient.NewLightClientFinalityUpdateFromBeaconState(ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 
 			s := &Server{LCStore: &lightclient.Store{}}
@@ -740,7 +740,7 @@ func TestLightClientHandler_GetLightClientOptimisticUpdate(t *testing.T) {
 		t.Run(version.String(testVersion), func(t *testing.T) {
 			ctx := t.Context()
 			l := util.NewTestLightClient(t, testVersion)
-			update, err := lightclient.NewLightClientOptimisticUpdateFromBeaconState(ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+			update, err := lightclient.NewLightClientOptimisticUpdateFromBeaconState(ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 			require.NoError(t, err)
 
 			s := &Server{LCStore: &lightclient.Store{}}
@@ -764,7 +764,7 @@ func TestLightClientHandler_GetLightClientOptimisticUpdate(t *testing.T) {
 		t.Run(version.String(testVersion)+" SSZ", func(t *testing.T) {
 			ctx := t.Context()
 			l := util.NewTestLightClient(t, testVersion)
-			update, err := lightclient.NewLightClientOptimisticUpdateFromBeaconState(ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+			update, err := lightclient.NewLightClientOptimisticUpdateFromBeaconState(ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 			require.NoError(t, err)
 
 			s := &Server{LCStore: &lightclient.Store{}}

--- a/beacon-chain/sync/rpc_light_client_test.go
+++ b/beacon-chain/sync/rpc_light_client_test.go
@@ -199,7 +199,7 @@ func TestRPC_LightClientOptimisticUpdate(t *testing.T) {
 		t.Run(version.String(i), func(t *testing.T) {
 			l := util.NewTestLightClient(t, i)
 
-			update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+			update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 			require.NoError(t, err)
 
 			r.lcStore.SetLastOptimisticUpdate(update)
@@ -319,7 +319,7 @@ func TestRPC_LightClientFinalityUpdate(t *testing.T) {
 		t.Run(version.String(i), func(t *testing.T) {
 			l := util.NewTestLightClient(t, i)
 
-			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+			update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 			require.NoError(t, err)
 
 			r.lcStore.SetLastFinalityUpdate(update)
@@ -439,7 +439,7 @@ func TestRPC_LightClientUpdatesByRange(t *testing.T) {
 		t.Run(version.String(i), func(t *testing.T) {
 			for j := 0; j < 5; j++ {
 				l := util.NewTestLightClient(t, i, util.WithIncreasedAttestedSlot(uint64(j)))
-				update, err := lightClient.NewLightClientUpdateFromBeaconState(ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+				update, err := lightClient.NewLightClientUpdateFromBeaconState(ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 				require.NoError(t, err)
 				require.NoError(t, r.cfg.beaconDB.SaveLightClientUpdate(ctx, uint64(j), update))
 			}

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -703,7 +703,7 @@ func TestSubscribe_ReceivesLCOptimisticUpdate(t *testing.T) {
 	r.markForChainStart()
 
 	l := util.NewTestLightClient(t, version.Altair, util.WithSupermajority())
-	update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+	update, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 	require.NoError(t, err, "Error generating light client optimistic update")
 
 	p2pService.ReceivePubSub(topic, update.Proto())
@@ -770,7 +770,7 @@ func TestSubscribe_ReceivesLCFinalityUpdate(t *testing.T) {
 	r.markForChainStart()
 
 	l := util.NewTestLightClient(t, version.Altair, util.WithSupermajority())
-	update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+	update, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 	require.NoError(t, err, "Error generating light client finality update")
 
 	p2pService.ReceivePubSub(topic, update.Proto())

--- a/beacon-chain/sync/validate_light_client_test.go
+++ b/beacon-chain/sync/validate_light_client_test.go
@@ -108,14 +108,14 @@ func TestValidateLightClientOptimisticUpdate(t *testing.T) {
 				var err error
 				if test.oldUpdateOptions != nil {
 					l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
-					oldUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+					oldUpdate, err = lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 					require.NoError(t, err)
 
 					s.lcStore.SetLastOptimisticUpdate(oldUpdate)
 				}
 
 				l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
-				newUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock)
+				newUpdate, err := lightClient.NewLightClientOptimisticUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock)
 				require.NoError(t, err)
 				buf := new(bytes.Buffer)
 				_, err = p.Encoding().EncodeGossip(buf, newUpdate)
@@ -248,14 +248,14 @@ func TestValidateLightClientFinalityUpdate(t *testing.T) {
 				var err error
 				if test.oldUpdateOptions != nil {
 					l := util.NewTestLightClient(t, v, test.oldUpdateOptions...)
-					oldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+					oldUpdate, err = lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 					require.NoError(t, err)
 
 					s.lcStore.SetLastFinalityUpdate(oldUpdate)
 				}
 
 				l := util.NewTestLightClient(t, v, test.newUpdateOptions...)
-				newUpdate, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State.Slot(), l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
+				newUpdate, err := lightClient.NewLightClientFinalityUpdateFromBeaconState(l.Ctx, l.State, l.Block, l.AttestedState, l.AttestedBlock, l.FinalizedBlock)
 				require.NoError(t, err)
 				buf := new(bytes.Buffer)
 				_, err = p.Encoding().EncodeGossip(buf, newUpdate)

--- a/changelog/bastin_remove-unused.md
+++ b/changelog/bastin_remove-unused.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Remove unused parameter `currentSlot` from LC functions.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR removes the unused parameter `currentSlot` from 3 functions in `core/light-client/lightclient.go`:
- `NewLightClientUpdateFromBeaconState`
- `NewLightClientOptimisticUpdateFromBeaconState`
- `NewLightClientFinalityUpdateFromBeaconState`