### PR TITLE
don't use gzip handler for sse

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -1138,7 +1138,6 @@ func (s *Service) eventsEndpoints() []endpoint {
 			name:     namespace + ".StreamEvents",
 			middleware: []middleware.Middleware{
 				middleware.AcceptHeaderHandler([]string{api.EventStreamMediaType}),
-				middleware.AcceptEncodingHeaderHandler(),
 			},
 			handler: server.StreamEvents,
 			methods: []string{http.MethodGet},

--- a/changelog/kasey_gzip-skip-sse.md
+++ b/changelog/kasey_gzip-skip-sse.md
@@ -1,0 +1,2 @@
+### Fixed
+- Do not apply the gzip middleware to the event stream API.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

The event stream beacon api implementation is not compatible with the gzip middleware. After quite a bit of debugging I'm still not exactly sure why this is the case, but I realized it was easy to just manually remove the middleware from this one handler, which unblocks the release.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
