### PR TITLE
Return zero value for `Eth-Consensus-Block-Value` on error

### DIFF
--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -118,8 +118,9 @@ func (s *Server) produceBlockV3(ctx context.Context, w http.ResponseWriter, r *h
 	consensusBlockValue, httpError := getConsensusBlockValue(ctx, s.BlockRewardFetcher, v1alpha1resp.Block)
 	if httpError != nil {
 		log.WithError(httpError).Debug("Failed to get consensus block value")
-		// Having the consensus block value is not critical to block production
-		consensusBlockValue = ""
+		// Having the consensus block value is not critical to block production.
+		// We set it to zero to satisfy the specification, which requires a numeric value.
+		consensusBlockValue = "0"
 	}
 
 	w.Header().Set(api.ExecutionPayloadBlindedHeader, fmt.Sprintf("%v", v1alpha1resp.IsBlinded))

--- a/changelog/radek_consensus-value-unavailable.md
+++ b/changelog/radek_consensus-value-unavailable.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Return zero value for `Eth-Consensus-Block-Value` on error to avoid missed block proposals.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Whenever calculating the consensus block value results in an error, we return an empty string in the `Eth-Consensus-Block-Value` header. This is against the spec which requires it to be a number, and clients can miss a proposal if they fail to parse the header.

**Which issues(s) does this PR fix?**

This is a hacky workaround to https://github.com/OffchainLabs/prysm/issues/15174. The main question of why sometimes we fail to calculate the block value is still unresolved.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
