### PR TITLE
Move reconstruction lock to prevent unnecessary work

### DIFF
--- a/beacon-chain/core/peerdas/reconstruction.go
+++ b/beacon-chain/core/peerdas/reconstruction.go
@@ -123,7 +123,7 @@ func ReconstructDataColumnSidecars(inVerifiedRoSidecars []blocks.VerifiedRODataC
 
 // ConstructDataColumnSidecars constructs data column sidecars from a block, (un-extended) blobs and
 // cell proofs corresponding the extended blobs. The main purpose of this function is to
-// construct data columns sidecars from data obtained from the execution client via:
+// construct data column sidecars from data obtained from the execution client via:
 // - `engine_getBlobsV2` - https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#engine_getblobsv2, or
 // - `engine_getPayloadV5` - https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#engine_getpayloadv5
 // Note: In this function, to stick with the `BlobsBundleV2` format returned by the execution client in `engine_getPayloadV5`,
@@ -222,8 +222,8 @@ func ReconstructBlobs(block blocks.ROBlock, verifiedDataColumnSidecars []blocks.
 	// Check if the data column sidecars are aligned with the block.
 	dataColumnSidecars := make([]blocks.RODataColumn, 0, len(verifiedDataColumnSidecars))
 	for _, verifiedDataColumnSidecar := range verifiedDataColumnSidecars {
-		dataColumnSicecar := verifiedDataColumnSidecar.RODataColumn
-		dataColumnSidecars = append(dataColumnSidecars, dataColumnSicecar)
+		dataColumnSidecar := verifiedDataColumnSidecar.RODataColumn
+		dataColumnSidecars = append(dataColumnSidecars, dataColumnSidecar)
 	}
 
 	if err := DataColumnsAlignWithBlock(block, dataColumnSidecars); err != nil {
@@ -241,7 +241,7 @@ func ReconstructBlobs(block blocks.ROBlock, verifiedDataColumnSidecars []blocks.
 		return blobSidecars, nil
 	}
 
-	// We need to reconstruct the blobs.
+	// We need to reconstruct the data column sidecars.
 	reconstructedDataColumnSidecars, err := ReconstructDataColumnSidecars(verifiedDataColumnSidecars)
 	if err != nil {
 		return nil, errors.Wrap(err, "reconstruct data column sidecars")

--- a/beacon-chain/core/peerdas/reconstruction_test.go
+++ b/beacon-chain/core/peerdas/reconstruction_test.go
@@ -196,6 +196,26 @@ func TestReconstructBlobs(t *testing.T) {
 		require.ErrorIs(t, err, peerdas.ErrDataColumnSidecarsNotSortedByIndex)
 	})
 
+	t.Run("consecutive duplicates", func(t *testing.T) {
+		_, _, verifiedRoSidecars := util.GenerateTestFuluBlockWithSidecars(t, 3)
+
+		// [0, 1, 1, 3, 4, ...]
+		verifiedRoSidecars[2] = verifiedRoSidecars[1]
+
+		_, err := peerdas.ReconstructBlobs(emptyBlock, verifiedRoSidecars, []int{0})
+		require.ErrorIs(t, err, peerdas.ErrDataColumnSidecarsNotSortedByIndex)
+	})
+
+	t.Run("non-consecutive duplicates", func(t *testing.T) {
+		_, _, verifiedRoSidecars := util.GenerateTestFuluBlockWithSidecars(t, 3)
+
+		// [0, 1, 2, 1, 4, ...]
+		verifiedRoSidecars[3] = verifiedRoSidecars[1]
+
+		_, err := peerdas.ReconstructBlobs(emptyBlock, verifiedRoSidecars, []int{0})
+		require.ErrorIs(t, err, peerdas.ErrDataColumnSidecarsNotSortedByIndex)
+	})
+
 	t.Run("not enough columns", func(t *testing.T) {
 		_, _, verifiedRoSidecars := util.GenerateTestFuluBlockWithSidecars(t, 3)
 

--- a/beacon-chain/db/filesystem/doc.go
+++ b/beacon-chain/db/filesystem/doc.go
@@ -20,7 +20,7 @@ File organisation
   The remaining 7 bits (from 0 to 127) represent the index of the data column.
   This sentinel bit is needed to distinguish between the column with index 0 and no column.
   Example: If the column with index 5 is in the 3th position in the file, then indices[5] = 0x80 + 0x03 = 0x83.
-- The rest of the file is a repeat of the SSZ encoded data columns sidecars.
+- The rest of the file is a repeat of the SSZ encoded data column sidecars.
 
 
 |------------------------------------------|------------------------------------------------------------------------------------|

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -135,7 +135,7 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, ro
 	blockSlot := block.Slot()
 	proposerIndex := block.ProposerIndex()
 
-	// Broadcast and save data columns sidecars to custody but not yet received.
+	// Broadcast and save data column sidecars to custody but not yet received.
 	sidecarCount := uint64(len(sidecars))
 	for columnIndex := range info.CustodyColumns {
 		log := log.WithField("columnIndex", columnIndex)

--- a/changelog/jtraglia_move-reconstruction-lock.md
+++ b/changelog/jtraglia_move-reconstruction-lock.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Moved reconstruction lock to prevent unnecessary work.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR moves the `reconstructionLock.Lock()` call above the initialization for `storedColumnsCount`. The way I understand it, reconstruction will begin the first time 50% of sidecars available. Subsequent calls will be stopped by the lock and should return without doing any real work because all of the sidecars are now stored to the database. The issue is that `storedColumnsCount` will still use the old count (from before the lock) so it thinks reconstruction is still necessary.

And also:

* Add two reconstruction tests with duplicates.
* Fix a few comments (accuracy, punctuation, clarity).
* Replace "data columns sidecars" with "data column sidecars".

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
