### PR TITLE
Beacon api: fix proposer duty computation for fulu

### DIFF
--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -1029,8 +1029,8 @@ func (s *Server) GetProposerDuties(w http.ResponseWriter, r *http.Request) {
 			httputil.HandleError(w, fmt.Sprintf("Could not get head state: %v ", err), http.StatusInternalServerError)
 			return
 		}
-		// Advance state with empty transitions up to the requested epoch start slot.
-		if st.Slot() < epochStartSlot {
+		// Advance state with empty transitions up to the requested epoch start slot for pre fulu state only. Fulu state utilizes proposer look ahead field.
+		if st.Slot() < epochStartSlot && st.Version() != version.Fulu {
 			headRoot, err := s.HeadFetcher.HeadRoot(ctx)
 			if err != nil {
 				httputil.HandleError(w, fmt.Sprintf("Could not get head root: %v ", err), http.StatusInternalServerError)

--- a/changelog/tt_duty.md
+++ b/changelog/tt_duty.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Beacon-api proposer duty fulu computation


### PR DESCRIPTION
`GetProposerDuties` only accepts input epochs that are:
1. Old
2. Current
3. Current + 1

In the event that is current + 1, I dont think we should be advancing the state, we should be current state's cached look ahead cache if it's Fulu state.

Note to the reviewer: still working on unit test but want ack if this makes sense