### PR TITLE
test: add forkchoice locking to saveHead data race test

### DIFF
--- a/beacon-chain/blockchain/service_norace_test.go
+++ b/beacon-chain/blockchain/service_norace_test.go
@@ -2,6 +2,7 @@ package blockchain
 
 import (
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
@@ -20,8 +21,21 @@ func TestChainService_SaveHead_DataRace(t *testing.T) {
 	b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 	st, _ := util.DeterministicGenesisState(t, 1)
 	require.NoError(t, err)
+	
+	var wg sync.WaitGroup
+	wg.Add(2)
+
 	go func() {
-		require.NoError(t, s.saveHead(t.Context(), [32]byte{}, b, st))
+	    s.cfg.ForkChoiceStore.Lock()
+	    defer s.cfg.ForkChoiceStore.Unlock()
+	    require.NoError(t, s.saveHead(t.Context(), [32]byte{}, b, st))
+	    wg.Done()
 	}()
+
+	s.cfg.ForkChoiceStore.Lock()
 	require.NoError(t, s.saveHead(t.Context(), [32]byte{}, b, st))
+	s.cfg.ForkChoiceStore.Unlock()
+	wg.Done()
+
+	wg.Wait()
 }


### PR DESCRIPTION


---



## Description
This PR updates the `TestChainService_SaveHead_DataRace` test to properly acquire and release the forkchoice lock around each `saveHead` call.  
This change ensures the test matches the function contract and prevents potential data races.

- Added `sync.WaitGroup` for correct goroutine synchronization.
- Now the test reflects real-world usage and thread-safety requirements.

---