### PR TITLE
Builder: fix builder bid version compatibility to support Electra bids with Fulu blocks

### DIFF
--- a/changelog/fix-fulu-bid-compatibility.md
+++ b/changelog/fix-fulu-bid-compatibility.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix builder bid version compatibility to support Electra bids with Fulu blocks


### PR DESCRIPTION
This PR implements version compatibility logic to allow Electra builder bids with Fulu blocks and simplifies fork version validation logic by removing string comparisons