### PR TITLE
fix: correct Toggle() method to return value before inverting

### DIFF
--- a/async/abool/abool.go
+++ b/async/abool/abool.go
@@ -55,7 +55,7 @@ func (ab *AtomicBool) SetTo(yes bool) {
 
 // Toggle inverts the Boolean then returns the value before inverting.
 func (ab *AtomicBool) Toggle() bool {
-	return atomic.AddInt32((*int32)(ab), 1)&1 == 0
+	return atomic.AddInt32((*int32)(ab), 1)&1 == 1
 }
 
 // SetToIf sets the Boolean to new only if the Boolean matches the old.


### PR DESCRIPTION
Fix Toggle() method to return value before inverting

The method was returning the new value instead of the old value,
violating the API contract. Changed comparison from == 0 to == 1
to correctly return the previous boolean state.