### PR TITLE
Trigger payload attribute event on early blocks

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -174,6 +174,7 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 			"payloadID": fmt.Sprintf("%#x", bytesutil.Trunc(payloadID[:])),
 		}).Info("Forkchoice updated with payload attributes for proposal")
 		s.cfg.PayloadIDCache.Set(nextSlot, arg.headRoot, pId)
+		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), arg.headBlock, arg.headRoot, nextSlot)
 	} else if hasAttr && payloadID == nil && !features.Get().PrepareAllPayloads {
 		log.WithFields(logrus.Fields{
 			"blockHash": fmt.Sprintf("%#x", headPayload.BlockHash()),

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -102,8 +102,6 @@ func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, args *fcuCo
 		log.WithError(err).Error("Could not save head")
 	}
 
-	go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), args.headBlock, args.headRoot, s.CurrentSlot()+1)
-
 	// Only need to prune attestations from pool if the head has changed.
 	s.pruneAttsFromPool(s.ctx, args.headState, args.headBlock)
 	return nil

--- a/changelog/potuz_event_happy_path.md
+++ b/changelog/potuz_event_happy_path.md
@@ -1,0 +1,2 @@
+### Fixed
+- Trigger payload attribute event as soon as an early block is processed. 


### PR DESCRIPTION
Currently the payload attribute events is triggered on `forkchoiceUpdateWithExecution`. However when we import an early block, we do not call this function, we make two calls to FCU, the first one is on a locked path at the end of `postBlockProcess` and this call is made without any payload attributes to avoid updating the shuffling caches.

The second call is made on `handleSecondFCUCall` which calls directly `notifyForkchoiceUpdate` bypassing the call to
`forkchoiceUpdateWithExecution`, but this call is the one that actually computes the payload attributes. So the event handler is never called with the new attributes.

This PR moves the event trigger to the same place where we actually call FCU with the computed payload attributes.

Some considerations with forkchoice locking logic: since the calls are always in a go routine, anyway the routine will wait to forkchoice to be unlocked to proceed.


Here is a more detailed walkthrough of block processing. Assuming we receive a valid block early in the slot. This is the behavior in develop:
- the call to `getFCUArgs` in `postBlockProcess` returns with a nil payload attributes because of the check
```
	if slots.WithinVotingWindow(s.genesisTime, slot) {
		return nil
	}
```
- The subsequent call to `sendFCU` will therefore not send any payload attributes. 
- however, `sendFCU` calls `forkchoiceUpdateWithExecution` which will fire the Payload attributes event with nil payload attributes. 
- Later the deferred call to `handleSecondFCUCall` will indeed compute the payload attributes in the background in funciton `sendFCUWithAttributes` and then call `notifyForkchoiceUpdate`. At no point in this path there is a firing of the event stream. 

Here is the behavior with this PR:
- the call to `getFCUArgs` in `postBlockProcess` returns with a nil payload attributes because of the same check as above
- The subsequent call to `sendFCU` will therefore not send any payload attributes. 
- `sendFCU` still calls `forkchoiceUpdateWithExecution` but we no longer fire the event in this function
- Later the deferred call to `handleSecondFCUCall` will indeed compute the payload attributes in the background in funciton `sendFCUWithAttributes` and then call `notifyForkchoiceUpdate`, this function is called with non-nil payload attributes and therefore now the event feed is triggered with the right data. 
