### PR TITLE
Add fork choice check to pending attestations processing

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -68,7 +68,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 		attestations := s.blkRootToPendingAtts[bRoot]
 		s.pendingAttsLock.RUnlock()
 		// has the pending attestation's missing block arrived and the node processed block yet?
-		if s.cfg.beaconDB.HasBlock(ctx, bRoot) && (s.cfg.beaconDB.HasState(ctx, bRoot) || s.cfg.beaconDB.HasStateSummary(ctx, bRoot)) {
+		if s.cfg.beaconDB.HasBlock(ctx, bRoot) && (s.cfg.beaconDB.HasState(ctx, bRoot) || s.cfg.beaconDB.HasStateSummary(ctx, bRoot)) && s.cfg.chain.InForkchoice(bRoot) {
 			s.processAttestations(ctx, attestations)
 			log.WithFields(logrus.Fields{
 				"blockRoot":        hex.EncodeToString(bytesutil.Trunc(bRoot[:])),

--- a/changelog/tt_check_pending_att.md
+++ b/changelog/tt_check_pending_att.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Check pending block is in forkchoice before importing pending attestation.


### PR DESCRIPTION
We should not processing a pending attestation if its block is not in fork choice even though the block exists in DB. We have seen time to time again, pending attestations failed to process because its missing its block in fork choice store