### PR TITLE
Do not compare liveness response with LH

### DIFF
--- a/changelog/radek_do-not-compare-liveness.md
+++ b/changelog/radek_do-not-compare-liveness.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Do not compare liveness response with LH in e2e Beacon API evaluator.

--- a/testing/endtoend/evaluators/beaconapi/requests.go
+++ b/testing/endtoend/evaluators/beaconapi/requests.go
@@ -322,6 +322,7 @@ var (
 			}())),
 		"/validator/liveness/{param1}": newMetadata[structs.GetLivenessResponse](
 			v1PathTemplate,
+			withSanityCheckOnly(),
 			withParams(func(currentEpoch primitives.Epoch) []string {
 				return []string{fmt.Sprintf("%v", currentEpoch)}
 			}),


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The Beacon API e2e evaluator is very flaky because we compare Prysm and Lighthouse responses of `/validator/liveness`. This endpoint is not guaranteed to produce consistent results across nodes and each client is free to implement the endpoint based on individual logic.

> It is important to note that the values returned by the beacon node are not canonical; they are best-effort and based upon a subjective view of the network.

This PR changes the evaluator so that we only check that the API call is successful

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
