### PR TITLE
Omit non blob fields

### DIFF
--- a/changelog/kasey_omit-non-blob-fields.md
+++ b/changelog/kasey_omit-non-blob-fields.md
@@ -1,0 +1,2 @@
+### Ignored
+- omits non-standard blob schedule entry struct fields from marshaling.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -348,13 +348,13 @@ func (b *BeaconChainConfig) ExecutionRequestLimits() enginev1.ExecutionRequestLi
 }
 
 type NetworkScheduleEntry struct {
-	ForkVersion      [fieldparams.VersionLength]byte
-	ForkDigest       [4]byte
-	MaxBlobsPerBlock uint64           `yaml:"MAX_BLOBS_PER_BLOCK" json:"MAX_BLOBS_PER_BLOCK"`
-	Epoch            primitives.Epoch `yaml:"EPOCH" json:"EPOCH"`
-	BPOEpoch         primitives.Epoch
-	VersionEnum      int
-	isFork           bool
+	ForkVersion      [fieldparams.VersionLength]byte `yaml:"-" json:"-"`
+	ForkDigest       [4]byte                         `yaml:"-" json:"-"`
+	MaxBlobsPerBlock uint64                          `yaml:"MAX_BLOBS_PER_BLOCK" json:"MAX_BLOBS_PER_BLOCK"`
+	Epoch            primitives.Epoch                `yaml:"EPOCH" json:"EPOCH"`
+	BPOEpoch         primitives.Epoch                `yaml:"-" json:"-"`
+	VersionEnum      int                             `yaml:"-" json:"-"`
+	isFork           bool                            `yaml:"-" json:"-"`
 }
 
 func (e NetworkScheduleEntry) LogFields() log.Fields {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Since our BlobScheduleEntries are lowkey NetworkScheduleEntries they wind up serializing a bunch of extra fields, like this:
```
BLOB_SCHEDULE": [
      {
        "BPOEpoch": "0",
        "EPOCH": "512",
        "ForkDigest": "0x00000000",
        "ForkVersion": "0x00000000",
        "MAX_BLOBS_PER_BLOCK": "12",
        "VersionEnum": "0"
      },
...
    ],
```

This PR tags the fields aside from `EPOCH` and `MAX_BLOBS_PER_BLOCK` with `json:"-"` so that they won't get marshaled.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
