### PR TITLE
Optimize validator assignment lookups with hybrid O(1) approach for large requests

### DIFF
--- a/changelog/tt_opt-val-lookup.md
+++ b/changelog/tt_opt-val-lookup.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Beacon api optimize validator lookup for large batch request size.


### PR DESCRIPTION
The GetDutiesV2 RPC endpoint experieces slow performance for large validator duty requests due to O(slots × committees × committee_size) linear search complexity. This PR implements a  hybrid optimization approach that:
  1. Small requests (< 3000 validators): Continue using the existing linear search (`AssignmentForValidator`) to avoid unnecessary overhead
  2. Large requests (≥ 3000 validators): Build a complete O(1) reverse index map from validator index to assignment, then perform constant-time lookups

Note to the reviewer: 3000 is just an arbitrary number I picked, it could be any value in the range of 2000 to 4000. In my original test, we saw O(1) perform better above 2000, but below that it doesn't due to a one-time fixed setup cost.

```
Before optimization:
  Batch Size   Duration   Status     Response Size
  100          0.044s     SUCCESS    64,494
  200          0.071s     SUCCESS    129,132
  500          0.157s     SUCCESS    323,096
  1,000        0.297s     SUCCESS    646,761
  2,000        0.579s     SUCCESS    1,294,874
  5,000        1.424s     SUCCESS    3,239,538
  10,000       2.984s     SUCCESS    6,488,034
  20,000       5.708s     SUCCESS    12,991,052
  30,000       8.744s     SUCCESS    19,497,854

After optimization:
  Batch Size   Duration   Status     Response Size
  100          0.045s     SUCCESS    64,631
  200          0.071s     SUCCESS    129,324
  500          0.147s     SUCCESS    323,009
  1,000        0.291s     SUCCESS    646,620
  2,000        0.570s     SUCCESS    1,294,539
  5,000        0.460s     SUCCESS    3,238,859       ← 67% faster
  10,000       0.440s     SUCCESS    6,487,949       ← 85% faster
  20,000       0.630s     SUCCESS    12,990,391      ← 89% faster
  30,000       0.807s     SUCCESS    19,495,046      ← 91% faster
```
