### PR TITLE
Update cc-debian11 to latest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -190,7 +190,7 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 # A multi-arch base image
 oci_pull(
     name = "linux_debian11_multiarch_base",  # Debian bullseye
-    digest = "sha256:b82f113425c5b5c714151aaacd8039bc141821cdcd3c65202d42bdf9c43ae60b",  # 2023-12-12
+    digest = "sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf",
     image = "gcr.io/prysmaticlabs/distroless/cc-debian11",
     platforms = [
         "linux/amd64",

--- a/changelog/pvl-update-cc-debian11.md
+++ b/changelog/pvl-update-cc-debian11.md
@@ -1,0 +1,3 @@
+### Security
+
+- Updated distroless/cc-debian11 to latest to resolve CVE-2024-2961.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Updates cc-debian11 base image to the latest available tag from gcr.io/distroless. The purpose is to explicitly fix CVE-2024-2961. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

We mirror this in our old prysmaticlabs project to minimize the risk that distroless deletes the image. They have deprecated debian11 support and it will be removed at some point.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
