### PR TITLE
Don't submit duplicate `SignedContributionAndProof` messages

### DIFF
--- a/changelog/radek_duplicate-sync-aggregate.md
+++ b/changelog/radek_duplicate-sync-aggregate.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Don't submit duplicate `SignedContributionAndProof` messages.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

If a validator is selected multiple times for the sync committee and is a sync committee aggregator, the validator client will submit one `SignedContributionAndProof` message for each selection. However, multiple selections can happen for the same subcommittee in which case these messages will be identical. This PR adds subcommittee tracking in `SubmitSignedContributionAndProof` to avoid sending multiple messages for the same subcommittee.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
