### PR TITLE
Refactor attestation cache key generation outside critical section

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -146,6 +146,12 @@ func (s *Service) processAggregate(ctx context.Context, aggregate ethpb.SignedAg
 func (s *Service) processAtt(ctx context.Context, att ethpb.Att) {
 	data := att.GetData()
 
+	// Generate cache key for unaggregated attestation tracking
+	attKey, err := generateUnaggregatedAttCacheKey(att)
+	if err != nil {
+		log.Debug("Could not generate cache key for attestation tracking")
+	}
+
 	// This is an important validation before retrieving attestation pre state to defend against
 	// attestation's target intentionally referencing a checkpoint that's long ago.
 	if !s.cfg.chain.InForkchoice(bytesutil.ToBytes32(data.BeaconBlockRoot)) {
@@ -225,7 +231,9 @@ func (s *Service) processAtt(ctx context.Context, att ethpb.Att) {
 			}
 		}
 
-		s.setSeenUnaggregatedAtt(att)
+		if err == nil {
+			s.setSeenUnaggregatedAtt(attKey)
+		}
 
 		valCount, err := helpers.ActiveValidatorCount(ctx, preState, slots.ToEpoch(data.Slot))
 		if err != nil {

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -146,12 +146,6 @@ func (s *Service) processAggregate(ctx context.Context, aggregate ethpb.SignedAg
 func (s *Service) processAtt(ctx context.Context, att ethpb.Att) {
 	data := att.GetData()
 
-	// Generate cache key for unaggregated attestation tracking
-	attKey, err := generateUnaggregatedAttCacheKey(att)
-	if err != nil {
-		log.Debug("Could not generate cache key for attestation tracking")
-	}
-
 	// This is an important validation before retrieving attestation pre state to defend against
 	// attestation's target intentionally referencing a checkpoint that's long ago.
 	if !s.cfg.chain.InForkchoice(bytesutil.ToBytes32(data.BeaconBlockRoot)) {
@@ -231,7 +225,10 @@ func (s *Service) processAtt(ctx context.Context, att ethpb.Att) {
 			}
 		}
 
-		if err == nil {
+		attKey, err := generateUnaggregatedAttCacheKey(att)
+		if err != nil {
+			log.WithError(err).Error("Could not generate cache key for attestation tracking")
+		} else {
 			s.setSeenUnaggregatedAtt(attKey)
 		}
 

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -91,11 +91,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	// Generate cache key for unaggregated attestation tracking
 	attKey, err := generateUnaggregatedAttCacheKey(att)
 	if err != nil {
-		if att.Version() >= version.Electra {
-			log.Debug("Called hasSeenUnaggregatedAtt with a non-single Electra attestation")
-		} else {
-			log.Debug("Attestation does not have exactly 1 bit set")
-		}
+		log.WithError(err).Error("Could not generate cache key for attestation tracking")
 		return pubsub.ValidationIgnore, nil
 	}
 

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -88,9 +88,20 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 
 	committeeIndex := att.GetCommitteeIndex()
 
+	// Generate cache key for unaggregated attestation tracking
+	attKey, err := generateUnaggregatedAttCacheKey(att)
+	if err != nil {
+		if att.Version() >= version.Electra {
+			log.Debug("Called hasSeenUnaggregatedAtt with a non-single Electra attestation")
+		} else {
+			log.Debug("Attestation does not have exactly 1 bit set")
+		}
+		return pubsub.ValidationIgnore, nil
+	}
+
 	if !s.slasherEnabled {
 		// Verify this the first attestation received for the participating validator for the slot.
-		if s.hasSeenUnaggregatedAtt(att) {
+		if s.hasSeenUnaggregatedAtt(attKey) {
 			return pubsub.ValidationIgnore, nil
 		}
 		// Reject an attestation if it references an invalid block.
@@ -209,7 +220,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		Data: eventData,
 	})
 
-	s.setSeenUnaggregatedAtt(att)
+	s.setSeenUnaggregatedAtt(attKey)
 
 	// Attach final validated attestation to the message for further pipeline use
 	msg.ValidatorData = attForValidation
@@ -339,23 +350,18 @@ func validateAttestingIndex(
 	return pubsub.ValidationAccept, nil
 }
 
-// Returns true if the attestation was already seen for the participating validator for the slot.
-func (s *Service) hasSeenUnaggregatedAtt(att eth.Att) bool {
-	s.seenUnAggregatedAttestationLock.RLock()
-	defer s.seenUnAggregatedAttestationLock.RUnlock()
-
+// generateUnaggregatedAttCacheKey generates the cache key for unaggregated attestation tracking.
+func generateUnaggregatedAttCacheKey(att eth.Att) (string, error) {
 	var attester uint64
 	if att.Version() >= version.Electra {
 		if !att.IsSingle() {
-			log.Debug("Called hasSeenUnaggregatedAtt with a non-single Electra attestation")
-			return false
+			return "", errors.New("non-single Electra attestation")
 		}
 		attester = uint64(att.GetAttestingIndex())
 	} else {
 		aggBits := att.GetAggregationBits()
 		if aggBits.Count() != 1 {
-			log.Debug("Attestation does not have exactly 1 bit set")
-			return false
+			return "", errors.New("attestation does not have exactly 1 bit set")
 		}
 		attester = uint64(att.GetAggregationBits().BitIndices()[0])
 	}
@@ -364,36 +370,24 @@ func (s *Service) hasSeenUnaggregatedAtt(att eth.Att) bool {
 	binary.LittleEndian.PutUint64(b, uint64(att.GetData().Slot))
 	binary.LittleEndian.PutUint64(b[8:16], uint64(att.GetCommitteeIndex()))
 	binary.LittleEndian.PutUint64(b[16:], attester)
-	_, seen := s.seenUnAggregatedAttestationCache.Get(string(b))
+	return string(b), nil
+}
+
+// Returns true if the attestation was already seen for the participating validator for the slot.
+func (s *Service) hasSeenUnaggregatedAtt(key string) bool {
+	s.seenUnAggregatedAttestationLock.RLock()
+	defer s.seenUnAggregatedAttestationLock.RUnlock()
+
+	_, seen := s.seenUnAggregatedAttestationCache.Get(key)
 	return seen
 }
 
 // Set an incoming attestation as seen for the participating validator for the slot.
-func (s *Service) setSeenUnaggregatedAtt(att eth.Att) {
+func (s *Service) setSeenUnaggregatedAtt(key string) {
 	s.seenUnAggregatedAttestationLock.Lock()
 	defer s.seenUnAggregatedAttestationLock.Unlock()
 
-	var attester uint64
-	if att.Version() >= version.Electra {
-		if !att.IsSingle() {
-			log.Debug("Called setSeenUnaggregatedAtt with a non-single Electra attestation. It will not be marked as seen")
-			return
-		}
-		attester = uint64(att.GetAttestingIndex())
-	} else {
-		aggBits := att.GetAggregationBits()
-		if aggBits.Count() != 1 {
-			log.Debug("Attestation does not have exactly 1 bit set. It will not be marked as seen")
-			return
-		}
-		attester = uint64(att.GetAggregationBits().BitIndices()[0])
-	}
-
-	b := make([]byte, 24)
-	binary.LittleEndian.PutUint64(b, uint64(att.GetData().Slot))
-	binary.LittleEndian.PutUint64(b[8:16], uint64(att.GetCommitteeIndex()))
-	binary.LittleEndian.PutUint64(b[16:], attester)
-	s.seenUnAggregatedAttestationCache.Add(string(b), true)
+	s.seenUnAggregatedAttestationCache.Add(key, true)
 }
 
 // hasBlockAndState returns true if the beacon node knows about a block and associated state in the

--- a/changelog/ttsao_fix-attestation-cache-key.md
+++ b/changelog/ttsao_fix-attestation-cache-key.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Improved sync unaggregated attestation cache key outside of lock path


### PR DESCRIPTION
Today we do:
* **Check if attestation is seen**: lock → generate key → check cache → unlock
* **Mark attestation as seen**: lock → generate key → set cache → unlock

Key generation should not be inside the lock path.This change moves key generation outside the lock path:
* Generate key
* **Check if attestation is seen**: lock → check cache → unlock
* **Mark attestation as seen**: lock → set cache → unlock

**Benchmarks**
* Original: `200.0 ns/op  2 B/op  0 allocs/op`
* KeyGen outside: `35.3 ns/op  8 B/op  0 allocs/op`