### PR TITLE
adding user agent validator beacon client

### DIFF
--- a/changelog/user-agent-addition-validator-outbound.md
+++ b/changelog/user-agent-addition-validator-outbound.md
@@ -1,4 +1,4 @@
 ### Added
 
-- All outbound HTTP requests from the validator client now include a custom `User-Agent` header in the format `PrysmVC/<name>/<version>`. This enhances observability and enables upstream systems to correctly identify Prysm validator clients by their name and version.
+- All outbound HTTP requests from the validator client now include a custom `User-Agent` header in the format `Prysm/<name>/<version>`. This enhances observability and enables upstream systems to correctly identify Prysm validator clients by their name and version.
 - Fixes [#15435](https://github.com/OffchainLabs/prysm/issues/15435).

--- a/changelog/user-agent-addition-validator-outbound.md
+++ b/changelog/user-agent-addition-validator-outbound.md
@@ -1,0 +1,4 @@
+### Added
+
+- All outbound HTTP requests from the validator client now include a custom `User-Agent` header in the format `PrysmVC/<name>/<version>`. This enhances observability and enables upstream systems to correctly identify Prysm validator clients by their name and version.
+- Fixes [#15435](https://github.com/OffchainLabs/prysm/issues/15435).

--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -47,3 +47,16 @@ func BuildData() string {
 	}
 	return fmt.Sprintf("Prysm/%s/%s", gitTag, gitCommit)
 }
+
+func BuildValidatorData() string {
+	// if doing a local build, these values are not interpolated
+	if gitCommit == "{STABLE_GIT_COMMIT}" {
+		commit, err := exec.Command("git", "rev-parse", "HEAD").Output()
+		if err != nil {
+			log.Println(err)
+		} else {
+			gitCommit = strings.TrimRight(string(commit), "\r\n")
+		}
+	}
+	return fmt.Sprintf("PrismValidator/%s/%s", gitTag, gitCommit)
+}

--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -47,16 +47,3 @@ func BuildData() string {
 	}
 	return fmt.Sprintf("Prysm/%s/%s", gitTag, gitCommit)
 }
-
-func BuildValidatorData() string {
-	// if doing a local build, these values are not interpolated
-	if gitCommit == "{STABLE_GIT_COMMIT}" {
-		commit, err := exec.Command("git", "rev-parse", "HEAD").Output()
-		if err != nil {
-			log.Println(err)
-		} else {
-			gitCommit = strings.TrimRight(string(commit), "\r\n")
-		}
-	}
-	return fmt.Sprintf("PrysmVC/%s/%s", gitTag, gitCommit)
-}

--- a/runtime/version/version.go
+++ b/runtime/version/version.go
@@ -58,5 +58,5 @@ func BuildValidatorData() string {
 			gitCommit = strings.TrimRight(string(commit), "\r\n")
 		}
 	}
-	return fmt.Sprintf("PrismValidator/%s/%s", gitTag, gitCommit)
+	return fmt.Sprintf("PrysmVC/%s/%s", gitTag, gitCommit)
 }

--- a/validator/client/beacon-api/rest_handler_client.go
+++ b/validator/client/beacon-api/rest_handler_client.go
@@ -75,7 +75,7 @@ func (c *BeaconApiRestHandler) Get(ctx context.Context, endpoint string, resp in
 	if err != nil {
 		return errors.Wrapf(err, "failed to create request for endpoint %s", url)
 	}
-	req.Header.Set("User-Agent", version.BuildValidatorData())
+	req.Header.Set("User-Agent", version.BuildData())
 	httpResp, err := c.client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to perform request for endpoint %s", url)
@@ -105,7 +105,7 @@ func (c *BeaconApiRestHandler) GetSSZ(ctx context.Context, endpoint string) ([]b
 		o(req)
 	}
 
-	req.Header.Set("User-Agent", version.BuildValidatorData())
+	req.Header.Set("User-Agent", version.BuildData())
 	httpResp, err := c.client.Do(req)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to perform request for endpoint %s", url)
@@ -165,7 +165,7 @@ func (c *BeaconApiRestHandler) Post(
 		req.Header.Set(headerKey, headerValue)
 	}
 	req.Header.Set("Content-Type", api.JsonMediaType)
-	req.Header.Set("User-Agent", version.BuildValidatorData())
+	req.Header.Set("User-Agent", version.BuildData())
 	httpResp, err := c.client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to perform request for endpoint %s", url)

--- a/validator/client/beacon-api/rest_handler_client.go
+++ b/validator/client/beacon-api/rest_handler_client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/api/apiutil"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/network/httputil"
+	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -74,6 +75,7 @@ func (c *BeaconApiRestHandler) Get(ctx context.Context, endpoint string, resp in
 	if err != nil {
 		return errors.Wrapf(err, "failed to create request for endpoint %s", url)
 	}
+	req.Header.Set("User-Agent", version.BuildValidatorData())
 	httpResp, err := c.client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to perform request for endpoint %s", url)
@@ -103,6 +105,7 @@ func (c *BeaconApiRestHandler) GetSSZ(ctx context.Context, endpoint string) ([]b
 		o(req)
 	}
 
+	req.Header.Set("User-Agent", version.BuildValidatorData())
 	httpResp, err := c.client.Do(req)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to perform request for endpoint %s", url)
@@ -162,7 +165,7 @@ func (c *BeaconApiRestHandler) Post(
 		req.Header.Set(headerKey, headerValue)
 	}
 	req.Header.Set("Content-Type", api.JsonMediaType)
-
+	req.Header.Set("User-Agent", version.BuildValidatorData())
 	httpResp, err := c.client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to perform request for endpoint %s", url)

--- a/validator/client/beacon-api/rest_handler_client_test.go
+++ b/validator/client/beacon-api/rest_handler_client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/api/server/structs"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/network/httputil"
+	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/OffchainLabs/prysm/v6/testing/assert"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/pkg/errors"
@@ -36,7 +37,7 @@ func TestGet(t *testing.T) {
 	mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 		marshalledJson, err := json.Marshal(genesisJson)
 		require.NoError(t, err)
-		assert.Equal(t, "PrysmVC/Unknown/Local build", r.Header.Get("User-Agent"))
+		assert.Equal(t, version.BuildData(), r.Header.Get("User-Agent"))
 		w.Header().Set("Content-Type", api.JsonMediaType)
 		_, err = w.Write(marshalledJson)
 		require.NoError(t, err)
@@ -70,7 +71,7 @@ func TestGetSSZ(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 			assert.StringContains(t, api.OctetStreamMediaType, r.Header.Get("Accept"))
-			assert.Equal(t, "PrysmVC/Unknown/Local build", r.Header.Get("User-Agent"))
+			assert.Equal(t, version.BuildData(), r.Header.Get("User-Agent"))
 			w.Header().Set("Content-Type", api.OctetStreamMediaType)
 			_, err := w.Write(expectedBody)
 			require.NoError(t, err)
@@ -183,7 +184,7 @@ func TestPost(t *testing.T) {
 	mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 		// Make sure the request headers have been set
 		assert.Equal(t, "bar", r.Header.Get("foo"))
-		assert.Equal(t, "PrysmVC/Unknown/Local build", r.Header.Get("User-Agent"))
+		assert.Equal(t, version.BuildData(), r.Header.Get("User-Agent"))
 		assert.Equal(t, api.JsonMediaType, r.Header.Get("Content-Type"))
 
 		// Make sure the data matches

--- a/validator/client/beacon-api/rest_handler_client_test.go
+++ b/validator/client/beacon-api/rest_handler_client_test.go
@@ -36,7 +36,7 @@ func TestGet(t *testing.T) {
 	mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 		marshalledJson, err := json.Marshal(genesisJson)
 		require.NoError(t, err)
-
+		assert.Equal(t, "PrysmVC/Unknown/Local build", r.Header.Get("User-Agent"))
 		w.Header().Set("Content-Type", api.JsonMediaType)
 		_, err = w.Write(marshalledJson)
 		require.NoError(t, err)
@@ -70,6 +70,7 @@ func TestGetSSZ(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 			assert.StringContains(t, api.OctetStreamMediaType, r.Header.Get("Accept"))
+			assert.Equal(t, "PrysmVC/Unknown/Local build", r.Header.Get("User-Agent"))
 			w.Header().Set("Content-Type", api.OctetStreamMediaType)
 			_, err := w.Write(expectedBody)
 			require.NoError(t, err)
@@ -182,6 +183,7 @@ func TestPost(t *testing.T) {
 	mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 		// Make sure the request headers have been set
 		assert.Equal(t, "bar", r.Header.Get("foo"))
+		assert.Equal(t, "PrysmVC/Unknown/Local build", r.Header.Get("User-Agent"))
 		assert.Equal(t, api.JsonMediaType, r.Header.Get("Content-Type"))
 
 		// Make sure the data matches


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR sets a custom User-Agent header for all outbound HTTP requests made by the validator client. The User-Agent will now correctly identify the Prysm validator client name and version, using the canonical format `PrismValidator/<name>/<version>` (e.g., `PrismValidator/prysm/2.0.0`), instead of the default `Go-http-client/1.1`. This improves observability and allows upstream middleware and monitoring systems to distinguish Prysm VC from other validator clients.

**Which issues(s) does this PR fix?**

Fixes #15435

**Other notes for review**

- Ensures User-Agent uses the canonical format: `PrismValidator/<gittag>/<gitcommit>`
- The name and version are retrieved from the validator client, for example using the `runtime/version` package for version.
- All outbound HTTP requests from the validator client now include the header.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.