### PR TITLE
Fix panic in blob cache when scs array is empty or shorter than commitments

### DIFF
--- a/beacon-chain/das/blob_cache.go
+++ b/beacon-chain/das/blob_cache.go
@@ -104,7 +104,7 @@ func (e *blobCacheEntry) filter(root [32]byte, kc [][]byte, slot primitives.Slot
 		if i < uint64(len(e.scs)) {
 			sidecar = e.scs[i]
 		}
-		
+
 		if kc[i] == nil {
 			if sidecar != nil {
 				return nil, errors.Wrapf(errCommitmentMismatch, "root=%#x, index=%#x, commitment=%#x, no block commitment", root, i, sidecar.KzgCommitment)

--- a/beacon-chain/das/blob_cache.go
+++ b/beacon-chain/das/blob_cache.go
@@ -99,20 +99,26 @@ func (e *blobCacheEntry) filter(root [32]byte, kc [][]byte, slot primitives.Slot
 		if e.diskSummary.HasIndex(i) {
 			continue
 		}
+		// Check if e.scs has this index before accessing
+		var sidecar *blocks.ROBlob
+		if i < uint64(len(e.scs)) {
+			sidecar = e.scs[i]
+		}
+		
 		if kc[i] == nil {
-			if e.scs[i] != nil {
-				return nil, errors.Wrapf(errCommitmentMismatch, "root=%#x, index=%#x, commitment=%#x, no block commitment", root, i, e.scs[i].KzgCommitment)
+			if sidecar != nil {
+				return nil, errors.Wrapf(errCommitmentMismatch, "root=%#x, index=%#x, commitment=%#x, no block commitment", root, i, sidecar.KzgCommitment)
 			}
 			continue
 		}
 
-		if e.scs[i] == nil {
+		if sidecar == nil {
 			return nil, errors.Wrapf(errMissingSidecar, "root=%#x, index=%#x", root, i)
 		}
-		if !bytes.Equal(kc[i], e.scs[i].KzgCommitment) {
-			return nil, errors.Wrapf(errCommitmentMismatch, "root=%#x, index=%#x, commitment=%#x, block commitment=%#x", root, i, e.scs[i].KzgCommitment, kc[i])
+		if !bytes.Equal(kc[i], sidecar.KzgCommitment) {
+			return nil, errors.Wrapf(errCommitmentMismatch, "root=%#x, index=%#x, commitment=%#x, block commitment=%#x", root, i, sidecar.KzgCommitment, kc[i])
 		}
-		scs = append(scs, *e.scs[i])
+		scs = append(scs, *sidecar)
 	}
 
 	return scs, nil

--- a/changelog/pvl-blob-cache-panic.md
+++ b/changelog/pvl-blob-cache-panic.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a condition where the blob cache could panic when there were less than or no sidecars in the cache entry.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Prevents a panic on the condition that the entry has no sidecars or less than the commitments. The panic was an out of bounds exception.

**Which issues(s) does this PR fix?**

Found testing in fusaka-devnet-4.

**Other notes for review**

Not sure if it is a realistic scenario but it happened to me in an incomplete implementation of fulu.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
