### PR TITLE
Fulu: Safegard against accidential out of bounds array access in dataColumnSidecars method

### DIFF
--- a/beacon-chain/core/peerdas/das_core.go
+++ b/beacon-chain/core/peerdas/das_core.go
@@ -223,6 +223,14 @@ func dataColumnsSidecars(
 			cellsForRow := cellsAndProofs[rowIndex].Cells
 			proofsForRow := cellsAndProofs[rowIndex].Proofs
 
+			// Validate that we have enough cells and proofs for this column index
+			if columnIndex >= uint64(len(cellsForRow)) {
+				return nil, errors.Errorf("column index %d exceeds cells length %d for blob %d", columnIndex, len(cellsForRow), rowIndex)
+			}
+			if columnIndex >= uint64(len(proofsForRow)) {
+				return nil, errors.Errorf("column index %d exceeds proofs length %d for blob %d", columnIndex, len(proofsForRow), rowIndex)
+			}
+
 			cell := cellsForRow[columnIndex]
 			column = append(column, cell)
 

--- a/changelog/pvl-fulu-prevent-datacolumns-oob.md
+++ b/changelog/pvl-fulu-prevent-datacolumns-oob.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Safeguard against accidental out of bounds array access in dataColumnSidecars method.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This adds a smiple validation that could prevent a panic if the code were misused or run in an unusual/impossible scenario.

**Which issues(s) does this PR fix?**

No known issues. Data columns are in fulu which has not occurred in any testnet or mainnet yet.

**Other notes for review**



**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
