### PR TITLE
Fix prysm.sh to handle offline scenarios gracefully

### DIFF
--- a/changelog/augment_fix-prysm-offline-mode.md
+++ b/changelog/augment_fix-prysm-offline-mode.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed prysm.sh script to handle offline scenarios gracefully by using existing local binaries when internet connection is unavailable, preventing systemd restart loops and "Start request repeated too quickly" errors.

--- a/prysm.sh
+++ b/prysm.sh
@@ -107,14 +107,48 @@ mkdir -p "$wrapper_dir"
 
 function get_prysm_version() {
     if [[ -n ${USE_PRYSM_VERSION:-} ]]; then
-        readonly reason="specified in \$USE_PRYSM_VERSION"
-        readonly prysm_version="${USE_PRYSM_VERSION}"
+        reason="specified in \$USE_PRYSM_VERSION"
+        prysm_version="${USE_PRYSM_VERSION}"
     else
         # Find the latest Prysm version available for download.
-        readonly reason="automatically selected latest available version"
-        prysm_version=$(curl -f -s https://prysmaticlabs.com/releases/latest) || (color "31" "Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can download the beacon chain and validator executables from our releases page on Github here https://github.com/OffchainLabs/prysm/releases/" && exit 1)
-        readonly prysm_version
+        prysm_version=$(curl -f -s https://prysmaticlabs.com/releases/latest 2>/dev/null)
+
+        if [[ -n "$prysm_version" ]]; then
+            reason="automatically selected latest available version"
+        else
+            # No internet connection, try to find existing binaries
+            color "33" "Unable to fetch latest version (no internet connection). Checking for existing binaries..."
+
+            # Look for existing binaries in the dist directory
+            local existing_binaries=()
+            if [[ -d "$wrapper_dir" ]]; then
+                # Find all beacon-chain binaries and extract versions
+                while IFS= read -r -d '' binary; do
+                    if [[ -x "$binary" ]]; then
+                        # Extract version from filename (e.g., beacon-chain-v4.0.0-linux-amd64)
+                        local basename=$(basename "$binary")
+                        if [[ $basename =~ beacon-chain-(.+)-${system}-${arch}$ ]]; then
+                            existing_binaries+=("${BASH_REMATCH[1]}")
+                        elif [[ $basename =~ beacon-chain-(.+)-modern-${system}-${arch}$ ]]; then
+                            existing_binaries+=("${BASH_REMATCH[1]}")
+                        fi
+                    fi
+                done < <(find "$wrapper_dir" -name "beacon-chain-*-${system}-${arch}" -print0 2>/dev/null)
+            fi
+
+            if [[ ${#existing_binaries[@]} -gt 0 ]]; then
+                # Use the most recent version (assuming semantic versioning)
+                prysm_version=$(printf '%s\n' "${existing_binaries[@]}" | sort -V | tail -n1)
+                reason="using existing local binary (offline mode)"
+                color "33" "Using existing binary version: $prysm_version"
+            else
+                color "31" "Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can download the beacon chain and validator executables from our releases page on Github here https://github.com/OffchainLabs/prysm/releases/"
+                exit 1
+            fi
+        fi
     fi
+    readonly reason
+    readonly prysm_version
 }
 
 function verify() {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR fixes the prysm.sh script to handle offline scenarios gracefully by using existing local binaries when internet connection is unavailable. 

**Problem:** When there's no internet connection, the script immediately exits with status 1 when trying to fetch the latest version, causing systemd to repeatedly restart the service until it hits the restart limit and shows "Start request repeated too quickly" errors.

**Solution:** Modified the `get_prysm_version()` function to:
- First try to fetch the latest version online (normal behavior)
- If that fails (no internet), check for existing binaries in the dist directory  
- If existing binaries are found, use the most recent version available locally
- Only exit if no internet connection AND no local binaries are available

This allows Prysm to continue running with existing binaries during power outages or internet connectivity issues, similar to how Geth handles such scenarios.

**Which issues(s) does this PR fix?**

Fixes #10468

**Other notes for review**

- Maintains full backward compatibility - all existing functionality works as before
- Adds appropriate user feedback messages for offline mode detection
- Uses semantic versioning to select the most recent local binary when multiple versions exist
- Thoroughly tested with multiple scenarios:
  -  Online mode: Works normally, fetches latest version
  -  Offline mode with existing binaries: Successfully uses local binaries
  -  Offline mode without binaries: Shows appropriate error message
  -  USE_PRYSM_VERSION environment variable: Still works as expected

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.