### PR TITLE
refactor to using runtime.Cleanup

### DIFF
--- a/beacon-chain/state/state-native/multi_value_slices.go
+++ b/beacon-chain/state/state-native/multi_value_slices.go
@@ -47,7 +47,7 @@ func NewMultiValueRandaoMixes(mixes [][]byte) *MultiValueRandaoMixes {
 	mv := &MultiValueRandaoMixes{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.RandaoMixes.String()).Inc()
-	runtime.SetFinalizer(mv, randaoMixesFinalizer)
+	runtime.AddCleanup(mv, randaoMixesCleanup, 0)
 	return mv
 }
 
@@ -63,7 +63,7 @@ func NewMultiValueBlockRoots(roots [][]byte) *MultiValueBlockRoots {
 	mv := &MultiValueBlockRoots{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.BlockRoots.String()).Inc()
-	runtime.SetFinalizer(mv, blockRootsFinalizer)
+	runtime.AddCleanup(mv, blockRootsCleanup, 0)
 	return mv
 }
 
@@ -79,7 +79,7 @@ func NewMultiValueStateRoots(roots [][]byte) *MultiValueStateRoots {
 	mv := &MultiValueStateRoots{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.StateRoots.String()).Inc()
-	runtime.SetFinalizer(mv, stateRootsFinalizer)
+	runtime.AddCleanup(mv, stateRootsCleanup, 0)
 	return mv
 }
 
@@ -93,7 +93,7 @@ func NewMultiValueBalances(balances []uint64) *MultiValueBalances {
 	mv := &MultiValueBalances{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.Balances.String()).Inc()
-	runtime.SetFinalizer(mv, balancesFinalizer)
+	runtime.AddCleanup(mv, balancesCleanup, 0)
 	return mv
 }
 
@@ -107,7 +107,7 @@ func NewMultiValueInactivityScores(scores []uint64) *MultiValueInactivityScores 
 	mv := &MultiValueInactivityScores{}
 	mv.Init(items)
 	multiValueCountGauge.WithLabelValues(types.InactivityScores.String()).Inc()
-	runtime.SetFinalizer(mv, inactivityScoresFinalizer)
+	runtime.AddCleanup(mv, inactivityScoresCleanup, 0)
 	return mv
 }
 
@@ -119,7 +119,7 @@ func NewMultiValueValidators(vals []*ethpb.Validator) *MultiValueValidators {
 	mv := &MultiValueValidators{}
 	mv.Init(vals)
 	multiValueCountGauge.WithLabelValues(types.Validators.String()).Inc()
-	runtime.SetFinalizer(mv, validatorsFinalizer)
+	runtime.AddCleanup(mv, validatorsCleanup, 0)
 	return mv
 }
 
@@ -133,65 +133,65 @@ func (b *BeaconState) Defragment() {
 		b.blockRootsMultiValue = b.blockRootsMultiValue.Reset(b)
 		initialMVslice.Detach(b)
 		multiValueCountGauge.WithLabelValues(types.BlockRoots.String()).Inc()
-		runtime.SetFinalizer(b.blockRootsMultiValue, blockRootsFinalizer)
+		runtime.AddCleanup(b.blockRootsMultiValue, blockRootsCleanup, 0)
 	}
 	if b.stateRootsMultiValue != nil && b.stateRootsMultiValue.IsFragmented() {
 		initialMVslice := b.stateRootsMultiValue
 		b.stateRootsMultiValue = b.stateRootsMultiValue.Reset(b)
 		initialMVslice.Detach(b)
 		multiValueCountGauge.WithLabelValues(types.StateRoots.String()).Inc()
-		runtime.SetFinalizer(b.stateRootsMultiValue, stateRootsFinalizer)
+		runtime.AddCleanup(b.stateRootsMultiValue, stateRootsCleanup, 0)
 	}
 	if b.randaoMixesMultiValue != nil && b.randaoMixesMultiValue.IsFragmented() {
 		initialMVslice := b.randaoMixesMultiValue
 		b.randaoMixesMultiValue = b.randaoMixesMultiValue.Reset(b)
 		initialMVslice.Detach(b)
 		multiValueCountGauge.WithLabelValues(types.RandaoMixes.String()).Inc()
-		runtime.SetFinalizer(b.randaoMixesMultiValue, randaoMixesFinalizer)
+		runtime.AddCleanup(b.randaoMixesMultiValue, randaoMixesCleanup, 0)
 	}
 	if b.balancesMultiValue != nil && b.balancesMultiValue.IsFragmented() {
 		initialMVslice := b.balancesMultiValue
 		b.balancesMultiValue = b.balancesMultiValue.Reset(b)
 		initialMVslice.Detach(b)
 		multiValueCountGauge.WithLabelValues(types.Balances.String()).Inc()
-		runtime.SetFinalizer(b.balancesMultiValue, balancesFinalizer)
+		runtime.AddCleanup(b.balancesMultiValue, balancesCleanup, 0)
 	}
 	if b.validatorsMultiValue != nil && b.validatorsMultiValue.IsFragmented() {
 		initialMVslice := b.validatorsMultiValue
 		b.validatorsMultiValue = b.validatorsMultiValue.Reset(b)
 		initialMVslice.Detach(b)
 		multiValueCountGauge.WithLabelValues(types.Validators.String()).Inc()
-		runtime.SetFinalizer(b.validatorsMultiValue, validatorsFinalizer)
+		runtime.AddCleanup(b.validatorsMultiValue, validatorsCleanup, 0)
 	}
 	if b.inactivityScoresMultiValue != nil && b.inactivityScoresMultiValue.IsFragmented() {
 		initialMVslice := b.inactivityScoresMultiValue
 		b.inactivityScoresMultiValue = b.inactivityScoresMultiValue.Reset(b)
 		initialMVslice.Detach(b)
 		multiValueCountGauge.WithLabelValues(types.InactivityScores.String()).Inc()
-		runtime.SetFinalizer(b.inactivityScoresMultiValue, inactivityScoresFinalizer)
+		runtime.AddCleanup(b.inactivityScoresMultiValue, inactivityScoresCleanup, 0)
 	}
 }
 
-func randaoMixesFinalizer(m *MultiValueRandaoMixes) {
+func randaoMixesCleanup(_ int) {
 	multiValueCountGauge.WithLabelValues(types.RandaoMixes.String()).Dec()
 }
 
-func blockRootsFinalizer(m *MultiValueBlockRoots) {
+func blockRootsCleanup(_ int) {
 	multiValueCountGauge.WithLabelValues(types.BlockRoots.String()).Dec()
 }
 
-func stateRootsFinalizer(m *MultiValueStateRoots) {
+func stateRootsCleanup(_ int) {
 	multiValueCountGauge.WithLabelValues(types.StateRoots.String()).Dec()
 }
 
-func balancesFinalizer(m *MultiValueBalances) {
+func balancesCleanup(_ int) {
 	multiValueCountGauge.WithLabelValues(types.Balances.String()).Dec()
 }
 
-func validatorsFinalizer(m *MultiValueValidators) {
+func validatorsCleanup(_ int) {
 	multiValueCountGauge.WithLabelValues(types.Validators.String()).Dec()
 }
 
-func inactivityScoresFinalizer(m *MultiValueInactivityScores) {
+func inactivityScoresCleanup(_ int) {
 	multiValueCountGauge.WithLabelValues(types.InactivityScores.String()).Dec()
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Other

## **Why `runtime.AddCleanup`?**

Go 1.23 introduced `runtime.AddCleanup` as a **simpler, safer, and lower-overhead alternative** to `runtime.SetFinalizer` for cases where you just want to run some cleanup code when an object becomes unreachable.

### **Problems with `runtime.SetFinalizer`**
1. **Complex semantics** –  
   `SetFinalizer` allows the finalizer function to access the object’s memory, which means the GC must keep the object alive until the finalizer finishes. This can:
   - Increase GC pressure  
   - Cause memory leaks if the finalizer accidentally keeps the object alive
   - Make GC timing and ordering more complicated

2. **Unpredictable execution** –  
   Finalizers run at an unspecified time, possibly much later than the object becomes unreachable.

3. **Misuse risk** –  
   Because you can still read/write the object in the finalizer, people sometimes use it for logic that depends on object state — which is fragile and can break if GC behavior changes.

---

### **What `runtime.AddCleanup` does differently**
- **No access to the object’s memory**  
  When the cleanup function runs, the object has already been collected or is about to be collected. You can’t dereference it.
  
- **Lower runtime overhead**  
  The GC doesn’t need to keep the object alive for the cleanup function, making cleanup cheaper.

- **Safer semantics**  
  Because you can’t touch the object, there’s no risk of accidentally resurrecting it or depending on its state.

- **Intended purpose**  
  It’s for releasing **external resources** (file descriptors, network connections, C handles, etc.) when an object is no longer used — not for inspecting object state.

---

### **Example**
```go
type Resource struct {
    fd int
}

func NewResource(fd int) *Resource {
    r := &Resource{fd: fd}
    runtime.AddCleanup(r, func() {
        fmt.Printf("Closing fd %d\n", fd)
        syscall.Close(fd)
    })
    return r
}
```
Here:
- We capture only the `fd` value in the closure.
- The cleanup runs when `*Resource` is unreachable.
- We never touch `r` itself in the cleanup.

---

### **Summary Table**

| Feature                | `SetFinalizer`                  | `AddCleanup`                |
|------------------------|----------------------------------|------------------------------|
| Can access object      | ✅ Yes                          | ❌ No                        |
| GC keeps object alive  | ✅ Yes                          | ❌ No                        |
| Overhead               | Higher                          | Lower                        |
| Safety                 | Risk of misuse                  | Safer                        |
| Intended use           | Complex GC-aware logic           | Simple resource cleanup      |

---

If you want, I can also give you a **migration guide** for turning your `SetFinalizer`-based code into `AddCleanup`-based code, with patterns for cases where you need to access object state.  

Do you want me to prepare that migration guide?

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
