### PR TITLE
fix: correct typos and improve spelling consistency across codebase

### DIFF
--- a/beacon-chain/core/peerdas/info.go
+++ b/beacon-chain/core/peerdas/info.go
@@ -17,8 +17,8 @@ type info struct {
 }
 
 const (
-	nodeInfoCacheSize   = 200
-	nodeInfoCachKeySize = 32 + 8
+	nodeInfoCacheSize    = 200
+	nodeInfoCacheKeySize = 32 + 8
 )
 
 var (
@@ -99,8 +99,8 @@ func createInfoCacheIfNeeded() error {
 }
 
 // computeInfoCacheKey returns a unique key for a node and its custodyGroupCount.
-func computeInfoCacheKey(nodeID enode.ID, custodyGroupCount uint64) [nodeInfoCachKeySize]byte {
-	var key [nodeInfoCachKeySize]byte
+func computeInfoCacheKey(nodeID enode.ID, custodyGroupCount uint64) [nodeInfoCacheKeySize]byte {
+	var key [nodeInfoCacheKeySize]byte
 
 	copy(key[:32], nodeID[:])
 	binary.BigEndian.PutUint64(key[32:], custodyGroupCount)

--- a/beacon-chain/core/peerdas/reconstruction.go
+++ b/beacon-chain/core/peerdas/reconstruction.go
@@ -37,7 +37,7 @@ func ReconstructDataColumnSidecars(inVerifiedRoSidecars []blocks.VerifiedRODataC
 	// Safely retrieve the first sidecar as a reference.
 	referenceSidecar := inVerifiedRoSidecars[0]
 
-	// Check if all columns have the same length and are commmitted to the same block.
+	// Check if all columns have the same length and are committed to the same block.
 	blobCount := len(referenceSidecar.Column)
 	blockRoot := referenceSidecar.BlockRoot()
 	for _, sidecar := range inVerifiedRoSidecars[1:] {

--- a/beacon-chain/das/data_column_cache.go
+++ b/beacon-chain/das/data_column_cache.go
@@ -53,7 +53,7 @@ func (e *dataColumnCacheEntry) setDiskSummary(sum filesystem.DataColumnStorageSu
 
 // stash adds an item to the in-memory cache of DataColumnSidecars.
 // Only the first DataColumnSidecar of a given Index will be kept in the cache.
-// stash will return an error if the given data colunn is already in the cache, or if the Index is out of bounds.
+// stash will return an error if the given data column is already in the cache, or if the Index is out of bounds.
 func (e *dataColumnCacheEntry) stash(sc *blocks.RODataColumn) error {
 	if sc.Index >= fieldparams.NumberOfColumns {
 		return errors.Wrapf(errColumnIndexTooHigh, "index=%d", sc.Index)

--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -542,7 +542,7 @@ func (dcs *DataColumnStorage) prune() {
 		}
 
 		if period < highestPeriodToPrune {
-			// Remove everything lower thant highest period to prune.
+			// Remove everything lower than highest period to prune.
 			if err := dcs.fs.RemoveAll(periodStr); err != nil {
 				log.WithError(err).Error("Error encountered while removing period directory")
 			}

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -43,7 +43,7 @@ func (s *Store) getBlock(ctx context.Context, blockRoot [32]byte, tx *bolt.Tx) (
 		return v, nil
 	}
 	// This method allows the caller to pass in its tx if one is already open.
-	// Or if a nil value is used, a transaction will be managed intenally.
+	// Or if a nil value is used, a transaction will be managed internally.
 	if tx == nil {
 		var err error
 		tx, err = s.db.Begin(false)

--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -238,7 +238,7 @@ func (s *Service) AddDisconnectionHandler(handler func(ctx context.Context, id p
 
 				s.peers.SetConnectionState(peerID, peers.Disconnected)
 				if err := s.peerDisconnectionTime.Add(peerID.String(), time.Now(), cache.DefaultExpiration); err != nil {
-					// The `DisconnectedF` funcition already called for this peer less than `cache.DefaultExpiration` ago. Skip.
+					// The `DisconnectedF` function already called for this peer less than `cache.DefaultExpiration` ago. Skip.
 					// (Very probably a bug in libp2p.)
 					log.WithError(err).Trace("Failed to set peer disconnection time")
 					return

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -685,7 +685,7 @@ func byteCount(bitCount int) int {
 	return numOfBytes
 }
 
-// interesect intersects two maps and returns a new map containing only the keys
+// intersect intersects two maps and returns a new map containing only the keys
 // that are present in both maps.
 func intersect(left map[uint64]int, right map[uint64]bool) map[uint64]bool {
 	result := make(map[uint64]bool, min(len(left), len(right)))

--- a/beacon-chain/p2p/types/types.go
+++ b/beacon-chain/p2p/types/types.go
@@ -120,7 +120,7 @@ func (m *ErrorMessage) UnmarshalSSZ(buf []byte) error {
 	bufLen := len(buf)
 	maxLength := maxErrorLength
 	if bufLen > maxLength {
-		return errors.Errorf("expected buffer with length of upto %d but received length %d", maxLength, bufLen)
+		return errors.Errorf("expected buffer with length of up to %d but received length %d", maxLength, bufLen)
 	}
 	errMsg := make([]byte, bufLen)
 	copy(errMsg, buf)
@@ -250,7 +250,7 @@ func (d *DataColumnsByRootIdentifiers) UnmarshalSSZ(buf []byte) error {
 	}
 	valueStart := offsetEnd
 
-	// Decode the identifers.
+	// Decode the identifiers.
 	*d = make([]*eth.DataColumnsByRootIdentifier, count)
 	var start uint32
 	end := uint32(len(buf))

--- a/beacon-chain/p2p/types/types_test.go
+++ b/beacon-chain/p2p/types/types_test.go
@@ -299,7 +299,7 @@ func TestDataColumnSidecarsByRootReq_MarshalUnmarshal(t *testing.T) {
 				in = append(in, byte(0))
 				return in
 			},
-			unmarshalErr: "a is not evenly divisble by b",
+			unmarshalErr: "a is not evenly divisible by b",
 		},
 		{
 			name: "size too big",

--- a/beacon-chain/state/state-native/setters_misc.go
+++ b/beacon-chain/state/state-native/setters_misc.go
@@ -40,7 +40,7 @@ import (
 const (
 	// This specifies the limit till which we process all dirty indices for a certain field.
 	// If we have more dirty indices than the threshold, then we rebuild the whole trie. This
-	// comes due to the fact that O(alogn) > O(n) beyond a certain value of a.
+	// comes due to the fact that O(a log n) > O(n) beyond a certain value of a.
 	indicesLimit = 20000
 )
 

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -52,9 +52,9 @@ func TestColumnSatisfyRequirement(t *testing.T) {
 	parentRoot := [fieldparams.RootLength]byte{}
 
 	columns := GenerateTestDataColumns(t, parentRoot, columnSlot, blobCount)
-	intializer := Initializer{}
+	initializer := Initializer{}
 
-	v := intializer.NewDataColumnsVerifier(columns, GossipDataColumnSidecarRequirements)
+	v := initializer.NewDataColumnsVerifier(columns, GossipDataColumnSidecarRequirements)
 	require.Equal(t, false, v.results.executed(RequireValidProposerSignature))
 	v.SatisfyRequirement(RequireValidProposerSignature)
 	require.Equal(t, true, v.results.executed(RequireValidProposerSignature))
@@ -672,19 +672,19 @@ func TestDataColumnsSidecarDescendsFromFinalized(t *testing.T) {
 
 func TestDataColumnsSidecarInclusionProven(t *testing.T) {
 	testCases := []struct {
-		name     string
-		alterate bool
-		isError  bool
+		name      string
+		alternate bool
+		isError   bool
 	}{
 		{
-			name:     "Inclusion proven",
-			alterate: false,
-			isError:  false,
+			name:      "Inclusion proven",
+			alternate: false,
+			isError:   false,
 		},
 		{
-			name:     "Inclusion not proven",
-			alterate: true,
-			isError:  true,
+			name:      "Inclusion not proven",
+			alternate: true,
+			isError:   true,
 		},
 	}
 
@@ -697,7 +697,7 @@ func TestDataColumnsSidecarInclusionProven(t *testing.T) {
 
 			parentRoot := [fieldparams.RootLength]byte{}
 			columns := GenerateTestDataColumns(t, parentRoot, columnSlot, blobCount)
-			if tc.alterate {
+			if tc.alternate {
 				firstColumn := columns[0]
 				byte0 := firstColumn.SignedBlockHeader.Header.BodyRoot[0]
 				firstColumn.SignedBlockHeader.Header.BodyRoot[0] = byte0 ^ 255

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -315,12 +315,12 @@ func startNode(ctx *cli.Context, cancel context.CancelFunc) error {
 		backfill.BeaconNodeOptions,
 	}
 	for _, of := range optFuncs {
-		ofo, err := of(ctx)
+		optsFromFunc, err := of(ctx)
 		if err != nil {
 			return err
 		}
-		if ofo != nil {
-			opts = append(opts, ofo...)
+		if optsFromFunc != nil {
+			opts = append(opts, optsFromFunc...)
 		}
 	}
 

--- a/encoding/bytesutil/hex.go
+++ b/encoding/bytesutil/hex.go
@@ -23,7 +23,7 @@ func IsHex(b []byte) bool {
 // and validates whether the string is a hex and has the correct length.
 func DecodeHexWithLength(s string, length int) ([]byte, error) {
 	if len(s) > 2*length+2 {
-		return nil, fmt.Errorf("%s is greather than length %d bytes", s, length)
+		return nil, fmt.Errorf("%s is greater than length %d bytes", s, length)
 	}
 	bytes, err := hexutil.Decode(s)
 	if err != nil {

--- a/encoding/ssz/htrutils_test.go
+++ b/encoding/ssz/htrutils_test.go
@@ -283,7 +283,7 @@ func TestWithdrawalRoot(t *testing.T) {
 	}
 }
 
-func TestWithrawalSliceRoot(t *testing.T) {
+func TestWithdrawalSliceRoot(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []*enginev1.Withdrawal

--- a/genesis/embedded_test.go
+++ b/genesis/embedded_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 )
 
-func TestEmbededGenesisDataMatchesMainnet(t *testing.T) {
+func TestEmbeddedGenesisDataMatchesMainnet(t *testing.T) {
 	st, err := embedded.ByName(params.MainnetName)
 	require.NoError(t, err)
 	gvr := st.GenesisValidatorsRoot()

--- a/genesis/providers.go
+++ b/genesis/providers.go
@@ -35,7 +35,7 @@ func NewAPIProvider(beaconNodeHost string) (*APIProvider, error) {
 	return &APIProvider{c: c}, nil
 }
 
-// Genesis satisfies the Provider interface by retrieving the genesis state from the beacon node API and unmarshaling it into a phase0 beacon state.
+// Genesis satisfies the Provider interface by retrieving the genesis state from the beacon node API and unmarshalling it into a phase0 beacon state.
 func (dl *APIProvider) Genesis(ctx context.Context) (state.BeaconState, error) {
 	sb, err := dl.c.GetState(ctx, beacon.IdGenesis)
 	if err != nil {
@@ -60,7 +60,7 @@ func NewFileProvider(statePath string) (*FileProvider, error) {
 	return &FileProvider{statePath: statePath}, nil
 }
 
-// Genesis satisfies the Provider interface by reading the genesis state from a file and unmarshaling it.
+// Genesis satisfies the Provider interface by reading the genesis state from a file and unmarshalling it.
 func (fi *FileProvider) Genesis(_ context.Context) (state.BeaconState, error) {
 	return stateFromFile(fi.statePath)
 }

--- a/io/logs/logutil_test.go
+++ b/io/logs/logutil_test.go
@@ -27,7 +27,7 @@ func TestMaskCredentialsLogging(t *testing.T) {
 	}
 }
 
-func TestConfigurePersistantLogging(t *testing.T) {
+func TestConfigurePersistentLogging(t *testing.T) {
 	testParentDir := t.TempDir()
 
 	// 1. Test creation of file in an existing parent directory

--- a/validator/client/runner_test.go
+++ b/validator/client/runner_test.go
@@ -380,7 +380,7 @@ func TestRunnerPushesProposerSettings_ValidContext(t *testing.T) {
 	defer cancel()
 
 	// This test is meant to ensure that PushProposerSettings is called successfully on a next slot event.
-	// This is a regresion test for PR 15369, however the same methodology of context checking is applied
+	// This is a regression test for PR 15369, however the same methodology of context checking is applied
 	// to many other methods as well.
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -340,7 +340,7 @@ func (v *validator) SetTicker() {
 	// This means that sometimes we need to reset the ticker to avoid replaying old ticks on a slow consumer of the ticks.
 	// i.e.,
 	// 1. tick starts at 0
-	// 2. loop stops consuming on slot 10 due to accounts changed tigger with no active keys
+	// 2. loop stops consuming on slot 10 due to accounts changed trigger with no active keys
 	// 3. new active keys are added in slot 20 resolving wait for activation
 	// 4. new tick starts ticking from slot 20 instead of slot 10
 	if v.ticker != nil {


### PR DESCRIPTION
This PR fixes multiple typos, spelling mistakes, and minor naming inconsistencies across the codebase and tests.  
Examples include:
- Fixed misspellings like `CachKeySize` → `CacheKeySize`, `intenally` → `internally`, `funcition` → `function`.  
- Corrected grammar issues: `upto` → `up to`, `divisble` → `divisible`, `thant` → `than`.  
- Renamed mis-typed variables: `intializer` → `initializer`, `alterate` → `alternate`.  
- Adjusted test and log function names for clarity and correctness.

**Other notes for review**

- Changes are non-functional and limited to typos, spelling, and readability improvements.  
- No logic or behavior changes introduced.  
