### PR TITLE
Fix subnet peer discovery

### DIFF
--- a/changelog/pop_fix-subnet.md
+++ b/changelog/pop_fix-subnet.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix bug where stale computed value in closure excludes newly required (eg attestation) subscriptions.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

Currently `computeAllNeededSubnets` is called only once in `subscribeWithParameters`. It should have been called regularly because the subnets in which you are supposed to publish the attestation change regularly.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

1. I already talked to Kasey that the test will be done by the Prysm team.
2. You probably want to call `computeAllNeededSubnets` a few slots in advance instead of at the beginning of the slot so that you will have more time to find more peers.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
