### PR TITLE
enforce schedule alignment when next_fork_epoch matches

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -195,7 +195,6 @@ go_test(
         "@com_github_multiformats_go_multiaddr//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -89,7 +89,7 @@ func createTestNodeWithID(t *testing.T, id string) *enode.LocalNode {
 	localNode.SetStaticIP(net.ParseIP("127.0.0.1"))
 	localNode.Set(enr.TCP(3000))
 	localNode.Set(enr.UDP(3000))
-	localNode.Set(enr.WithEntry(eth2ENRKey, make([]byte, 16)))
+	localNode.Set(enr.WithEntry(eth2EnrKey, make([]byte, 16)))
 
 	return localNode
 }
@@ -108,7 +108,7 @@ func createTestNodeRandom(t *testing.T) *enode.LocalNode {
 	localNode.SetStaticIP(net.ParseIP("127.0.0.1"))
 	localNode.Set(enr.TCP(3000))
 	localNode.Set(enr.UDP(3000))
-	localNode.Set(enr.WithEntry(eth2ENRKey, make([]byte, 16)))
+	localNode.Set(enr.WithEntry(eth2EnrKey, make([]byte, 16)))
 
 	return localNode
 }
@@ -318,7 +318,7 @@ func TestCreateLocalNode(t *testing.T) {
 
 			// Check fork is set.
 			fork := new([]byte)
-			require.NoError(t, localNode.Node().Record().Load(enr.WithEntry(eth2ENRKey, fork)))
+			require.NoError(t, localNode.Node().Record().Load(enr.WithEntry(eth2EnrKey, fork)))
 			require.NotEmpty(t, *fork)
 
 			// Check att subnets.

--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -99,7 +99,7 @@ func compareForkENR(self, peer *enr.Record) error {
 	// or a Blob-Parameters-Only fork. This new entry MUST be added once FULU_FORK_EPOCH is assigned
 	// any value other than FAR_FUTURE_EPOCH. Adding this entry prior to the Fulu fork will not
 	// impact peering as nodes will ignore unknown ENR entries and nfd mismatches do not cause
-	// disconnnects.
+	// disconnects.
 	// When discovering and interfacing with peers, nodes MUST evaluate nfd alongside their existing
 	// consideration of the ENRForkID::next_* fields under the eth2 key, to form a more accurate
 	// view of the peer's intended next fork for the purposes of sustained peering. If there is a

--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -87,11 +87,6 @@ func compareForkENR(self, peer *enr.Record) error {
 			peerString, peerEntry.NextForkVersion, selfEntry.NextForkVersion)
 	}
 
-	// Don't consider nfd if the fulu fork epoch is not set.
-	if params.BeaconConfig().FuluForkEpoch == params.BeaconConfig().FarFutureEpoch {
-		return nil
-	}
-
 	// Fulu adds the following to the spec:
 	// ---
 	// A new entry is added to the ENR under the key nfd, short for next fork digest. This entry
@@ -117,6 +112,9 @@ func compareForkENR(self, peer *enr.Record) error {
 	// don't match.
 	//
 	// Given that the next_fork_epoch matches, we will require the next_fork_digest to match.
+	if !params.FuluEnabled() {
+		return nil
+	}
 	peerNFD, selfNFD := nfd(peer), nfd(self)
 	if peerNFD != selfNFD {
 		return errors.Wrapf(errNextDigestMismatch,

--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -13,10 +13,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var errEth2ENRDigestMismatch = errors.New("fork digest of peer does not match local value")
+var (
+	errForkScheduleMismatch  = errors.New("peer fork schedule incompatible")
+	errCurrentDigestMismatch = errors.Wrap(errForkScheduleMismatch, "current_fork_digest mismatch")
+	errNextVersionMismatch   = errors.Wrap(errForkScheduleMismatch, "next_fork_version mismatch")
+	errNextDigestMismatch    = errors.Wrap(errForkScheduleMismatch, "nfd (next fork digest) mismatch")
+)
 
-// ENR key used for Ethereum consensus-related fork data.
-var eth2ENRKey = params.BeaconNetworkConfig().ETH2Key
+const (
+	eth2EnrKey = "eth2" // The `eth2` ENR entry advertizes the node's view of the fork schedule with an ssz-encoded ENRForkID value.
+	nfdEnrKey  = "nfd"  // The `nfd` ENR entry separately advertizes the "next fork digest" aspect of the fork schedule.
+)
 
 // ForkDigest returns the current fork digest of
 // the node according to the local clock.
@@ -33,44 +40,88 @@ func (s *Service) currentForkDigest() ([4]byte, error) {
 // Compares fork ENRs between an incoming peer's record and our node's
 // local record values for current and next fork version/epoch.
 func compareForkENR(self, peer *enr.Record) error {
-	peerForkENR, err := forkEntry(peer)
+	peerEntry, err := forkEntry(peer)
 	if err != nil {
 		return err
 	}
-	currentForkENR, err := forkEntry(self)
+	selfEntry, err := forkEntry(self)
 	if err != nil {
 		return err
 	}
-	enrString, err := SerializeENR(peer)
+	peerString, err := SerializeENR(peer)
 	if err != nil {
 		return err
 	}
 	// Clients SHOULD connect to peers with current_fork_digest, next_fork_version,
 	// and next_fork_epoch that match local values.
-	if !bytes.Equal(peerForkENR.CurrentForkDigest, currentForkENR.CurrentForkDigest) {
-		return errors.Wrapf(errEth2ENRDigestMismatch,
+	if !bytes.Equal(peerEntry.CurrentForkDigest, selfEntry.CurrentForkDigest) {
+		return errors.Wrapf(errCurrentDigestMismatch,
 			"fork digest of peer with ENR %s: %v, does not match local value: %v",
-			enrString,
-			peerForkENR.CurrentForkDigest,
-			currentForkENR.CurrentForkDigest,
+			peerString,
+			peerEntry.CurrentForkDigest,
+			selfEntry.CurrentForkDigest,
 		)
 	}
+
 	// Clients MAY connect to peers with the same current_fork_version but a
 	// different next_fork_version/next_fork_epoch. Unless ENRForkID is manually
 	// updated to matching prior to the earlier next_fork_epoch of the two clients,
 	// these type of connecting clients will be unable to successfully interact
 	// starting at the earlier next_fork_epoch.
-	if peerForkENR.NextForkEpoch != currentForkENR.NextForkEpoch {
+	if peerEntry.NextForkEpoch != selfEntry.NextForkEpoch {
 		log.WithFields(logrus.Fields{
-			"peerNextForkEpoch": peerForkENR.NextForkEpoch,
-			"peerENR":           enrString,
+			"peerNextForkEpoch":   peerEntry.NextForkEpoch,
+			"peerNextForkVersion": peerEntry.NextForkVersion,
+			"peerENR":             peerString,
 		}).Trace("Peer matches fork digest but has different next fork epoch")
+		// We allow the connection because we have a different view of the next fork epoch. This
+		// could be due to peers that have no upgraded ahead of a fork or BPO schedule change, so
+		// we allow the connection to continue until the fork boundary.
+		return nil
 	}
-	if !bytes.Equal(peerForkENR.NextForkVersion, currentForkENR.NextForkVersion) {
-		log.WithFields(logrus.Fields{
-			"peerNextForkVersion": peerForkENR.NextForkVersion,
-			"peerENR":             enrString,
-		}).Trace("Peer matches fork digest but has different next fork version")
+
+	// Since we agree on the next fork epoch, we require next fork version to also be in agreement.
+	if !bytes.Equal(peerEntry.NextForkVersion, selfEntry.NextForkVersion) {
+		return errors.Wrapf(errNextVersionMismatch,
+			"next fork version of peer with ENR %s: %#x, does not match local value: %#x",
+			peerString, peerEntry.NextForkVersion, selfEntry.NextForkVersion)
+	}
+
+	// Don't consider nfd if the fulu fork epoch is not set.
+	if params.BeaconConfig().FuluForkEpoch == params.BeaconConfig().FarFutureEpoch {
+		return nil
+	}
+
+	// Fulu adds the following to the spec:
+	// ---
+	// A new entry is added to the ENR under the key nfd, short for next fork digest. This entry
+	// communicates the digest of the next scheduled fork, regardless of whether it is a regular
+	// or a Blob-Parameters-Only fork. This new entry MUST be added once FULU_FORK_EPOCH is assigned
+	// any value other than FAR_FUTURE_EPOCH. Adding this entry prior to the Fulu fork will not
+	// impact peering as nodes will ignore unknown ENR entries and nfd mismatches do not cause
+	// disconnnects.
+	// When discovering and interfacing with peers, nodes MUST evaluate nfd alongside their existing
+	// consideration of the ENRForkID::next_* fields under the eth2 key, to form a more accurate
+	// view of the peer's intended next fork for the purposes of sustained peering. If there is a
+	// mismatch, the node MUST NOT disconnect before the fork boundary, but it MAY disconnect
+	// at/after the fork boundary.
+
+	// Nodes unprepared to follow the Fulu fork will be unaware of nfd entries. However, their
+	// existing comparison of eth2 entries (concretely next_fork_epoch) is sufficient to detect
+	// upcoming divergence.
+	// ---
+
+	// Because this is a new in-bound connection, we lean into the pre-fulu point that clients
+	// MAY connect to peers with the same current_fork_version but a different
+	// next_fork_version/next_fork_epoch, which implies we can chose to not connect to them when these
+	// don't match.
+	//
+	// Given that the next_fork_epoch matches, we will require the next_fork_digest to match.
+	peerNFD, selfNFD := nfd(peer), nfd(self)
+	if peerNFD != selfNFD {
+		return errors.Wrapf(errNextDigestMismatch,
+			"next fork digest of peer with ENR %s: %v, does not match local value: %v",
+			peerString, peerNFD, selfNFD)
 	}
 	return nil
 }
@@ -102,7 +153,7 @@ func updateENR(node *enode.LocalNode, entry, next params.NetworkScheduleEntry) e
 	if err != nil {
 		return err
 	}
-	forkEntry := enr.WithEntry(eth2ENRKey, enc)
+	forkEntry := enr.WithEntry(eth2EnrKey, enc)
 	node.Set(forkEntry)
 	return nil
 }
@@ -111,7 +162,7 @@ func updateENR(node *enode.LocalNode, entry, next params.NetworkScheduleEntry) e
 // under the Ethereum consensus EnrKey
 func forkEntry(record *enr.Record) (*pb.ENRForkID, error) {
 	sszEncodedForkEntry := make([]byte, 16)
-	entry := enr.WithEntry(eth2ENRKey, &sszEncodedForkEntry)
+	entry := enr.WithEntry(eth2EnrKey, &sszEncodedForkEntry)
 	err := record.Load(entry)
 	if err != nil {
 		return nil, err
@@ -121,4 +172,16 @@ func forkEntry(record *enr.Record) (*pb.ENRForkID, error) {
 		return nil, err
 	}
 	return forkEntry, nil
+}
+
+// nfd retrieves the value of the `nfd` ("next fork digest") key from an ENR record.
+func nfd(record *enr.Record) [4]byte {
+	digest := [4]byte{}
+	entry := enr.WithEntry(nfdEnrKey, &digest)
+	if err := record.Load(entry); err != nil {
+		// Treat a missing nfd entry as an empty digest.
+		// We do this to avoid errors when checking peers that have not upgraded for fulu.
+		return [4]byte{}
+	}
+	return digest
 }

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -27,8 +27,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 )
 
-const nfdEnrKey = "nfd" // The ENR record key for "nfd" (Next Fork Digest).
-
 var (
 	attestationSubnetCount = params.BeaconConfig().AttestationSubnetCount
 	syncCommsSubnetCount   = params.BeaconConfig().SyncCommitteeSubnetCount

--- a/changelog/kasey_reject-mismatched-schedules.md
+++ b/changelog/kasey_reject-mismatched-schedules.md
@@ -1,0 +1,2 @@
+### Changed
+- Reject incoming connections when the fork schedule of the connecting peer (parsed from their ENR) has a matching next_fork_epoch, but mismatched next_fork_version or nfd (next fork digest).

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -34,7 +34,6 @@ const (
 )
 
 var mainnetNetworkConfig = &NetworkConfig{
-	ETH2Key:                    "eth2",
 	AttSubnetKey:               "attnets",
 	SyncCommsSubnetKey:         "syncnets",
 	CustodyGroupCountKey:       "cgc",

--- a/config/params/network_config.go
+++ b/config/params/network_config.go
@@ -8,7 +8,6 @@ import (
 // NetworkConfig defines the spec based network parameters.
 type NetworkConfig struct {
 	// DiscoveryV5 Config
-	ETH2Key                    string // ETH2Key is the ENR key of the Ethereum consensus object.
 	AttSubnetKey               string // AttSubnetKey is the ENR key of the subnet bitfield.
 	SyncCommsSubnetKey         string // SyncCommsSubnetKey is the ENR key of the sync committee subnet bitfield.
 	CustodyGroupCountKey       string // CustodyGroupsCountKey is the ENR key of the custody group count.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR changes the behavior of connection filtering where the fork schedule of incoming peers is compared to our own.

### Current behavior:
we refuse connections when there is a mismatch in current_fork_digest
if there is a mismatch in next_fork_epoch or next_fork_version, we emit a trace log, but we do allow the connection to proceed.

### Relevant spec commentary:
```
	// Clients MAY connect to peers with the same current_fork_version but a
	// different next_fork_version/next_fork_epoch. Unless ENRForkID is manually
	// updated to matching prior to the earlier next_fork_epoch of the two clients,
	// these type of connecting clients will be unable to successfully interact
	// starting at the earlier next_fork_epoch.
```
**Fulu adds**:
```
A new entry is added to the ENR under the key nfd, short for next fork digest. This entry communicates the digest of the next scheduled fork, regardless of whether it is a regular or a Blob-Parameters-Only fork. This new entry MUST be added once FULU_FORK_EPOCH is assigned any value other than FAR_FUTURE_EPOCH. Adding this entry prior to the Fulu fork will not impact peering as nodes will ignore unknown ENR entries and nfd mismatches do not cause disconnnects.
When discovering and interfacing with peers, nodes MUST evaluate nfd alongside their existing consideration of the ENRForkID::next_* fields under the eth2 key, to form a more accurate view of the peer's intended next fork for the purposes of sustained peering. If there is a mismatch, the node MUST NOT disconnect before the fork boundary, but it MAY disconnect at/after the fork boundary.
```

```
Nodes unprepared to follow the Fulu fork will be unaware of nfd entries. However, their existing comparison of eth2 entries (concretely next_fork_epoch) is sufficient to detect upcoming divergence.
```

### Proposed change 

(*note that this only impacts where we establish new connections*, peer scoring gracefully drops existing peers over time if their eth2 ENR record updates show us that they are headed for a different view of the digest schedule.)

- *unchanged* we refuse connections when there is a mismatch in current_fork_digest
- if there is a mismatch in next_fork_epoch
  - log the mismatch
  - add log fields for next_fork_version and next_fork_digest
- If we agree on the next_fork_epoch (and it's < FAR_FUTURE_EPOCH) we can be more strict. It means our peer is actually misconfigured, not just in need of an upgrade
  - only connect if next_fork_version and next_fork_digest are both correct

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
