### PR TITLE
Fix link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2993,7 +2993,7 @@ There are two known issues with this release:
 
 ### Added
 
-- Web3Signer support. See the [documentation](https://docs.prylabs.network/docs/next/wallet/web3signer) for more
+- Web3Signer support. See the [documentation](https://prysm.offchainlabs.com/docs/manage-wallet/web3signer/) for more
   details.
 - Bellatrix support. See [kiln testnet instructions](https://hackmd.io/OqIoTiQvS9KOIataIFksBQ?view)
 - Weak subjectivity sync / checkpoint sync. This is an experimental feature and may have unintended side effects for

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 
 Prysm is go project with many complicated dependencies, including some c++ based libraries. There
 are two parts to Prysm's dependency management. Go modules and bazel managed dependencies. Be sure 
-to read [Why Bazel?](https://github.com/OffchainLabs/documentation/issues/138) to fully
+to read [Why Bazel?](https://prysm.offchainlabs.com/docs/install-prysm/install-with-bazel/#why-bazel) to fully
 understand the reasoning behind an additional layer of build tooling via Bazel rather than a pure
 "go build" project.
 

--- a/changelog/2025-08-25-docs-links.md
+++ b/changelog/2025-08-25-docs-links.md
@@ -1,0 +1,2 @@
+### Changed
+- Updated outdated documentation links for Web3Signer and Why Bazel.


### PR DESCRIPTION
**What type of PR is this?**

> Documentation

**What does this PR do? Why is it needed?**

This PR updates outdated documentation links to improve clarity and developer experience:

* Updated `DEPENDENCIES.md` to replace the old GitHub issue reference with the official docs link to **[[Why Bazel?](https://prysm.offchainlabs.com/docs/install-prysm/install-with-bazel/#why-bazel)](https://prysm.offchainlabs.com/docs/install-prysm/install-with-bazel/#why-bazel)**.
* Updated `CHANGELOG.md` to point to the correct Web3Signer documentation.

These fixes ensure contributors and users are directed to the right resources.

**Which issues(s) does this PR fix?**

No tracking issue required (documentation improvement).

**Other notes for review**

* A changelog fragment file has been added:
  `changelog/2025-08-25-docs-links.md`

  ```markdown
  ### Changed
  - Updated outdated documentation links for Web3Signer and Why Bazel.
  ```

**Acknowledgements**

* [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md)
* [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd)
* [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.

