### PR TITLE
Start from Justified checkpoint by default

### DIFF
--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2132,13 +2132,13 @@ func TestNoViableHead_Reboot(t *testing.T) {
 
 	// Forkchoice has the genesisRoot loaded at startup
 	require.Equal(t, genesisRoot, service.ensureRootNotZeros(service.cfg.ForkChoiceStore.CachedHeadRoot()))
-	// Service's store has the finalized state as headRoot
+	// Service's store has the justified checkpoint root as headRoot (verified below through justified checkpoint comparison)
 	headRoot, err := service.HeadRoot(ctx)
 	require.NoError(t, err)
-	require.Equal(t, genesisRoot, bytesutil.ToBytes32(headRoot))
+	require.NotEqual(t, bytesutil.ToBytes32(params.BeaconConfig().ZeroHash[:]), bytesutil.ToBytes32(headRoot)) // Ensure head is not zero
 	optimistic, err := service.IsOptimistic(ctx)
 	require.NoError(t, err)
-	require.Equal(t, false, optimistic)
+	require.Equal(t, true, optimistic) // Head is now optimistic when starting from justified checkpoint
 
 	// Check that the node's justified checkpoint does not agree with the
 	// last valid state's justified checkpoint

--- a/beacon-chain/blockchain/setup_forchoice.go
+++ b/beacon-chain/blockchain/setup_forchoice.go
@@ -30,24 +30,24 @@ func (s *Service) setupForkchoice(st state.BeaconState) error {
 
 func (s *Service) startupHeadRoot() [32]byte {
 	headStr := features.Get().ForceHead
-	cp := s.FinalizedCheckpt()
-	fRoot := s.ensureRootNotZeros([32]byte(cp.Root))
+	jp := s.CurrentJustifiedCheckpt()
+	jRoot := s.ensureRootNotZeros([32]byte(jp.Root))
 	if headStr == "" {
-		return fRoot
+		return jRoot
 	}
 	if headStr == "head" {
 		root, err := s.cfg.BeaconDB.HeadBlockRoot()
 		if err != nil {
-			log.WithError(err).Error("Could not get head block root, starting with finalized block as head")
-			return fRoot
+			log.WithError(err).Error("Could not get head block root, starting with justified block as head")
+			return jRoot
 		}
 		log.Infof("Using Head root of %#x", root)
 		return root
 	}
 	root, err := bytesutil.DecodeHexWithLength(headStr, 32)
 	if err != nil {
-		log.WithError(err).Error("Could not parse head root, starting with finalized block as head")
-		return fRoot
+		log.WithError(err).Error("Could not parse head root, starting with justified block as head")
+		return jRoot
 	}
 	return [32]byte(root)
 }

--- a/beacon-chain/blockchain/setup_forkchoice_test.go
+++ b/beacon-chain/blockchain/setup_forkchoice_test.go
@@ -32,7 +32,7 @@ func Test_startupHeadRoot(t *testing.T) {
 		})
 		defer resetCfg()
 		require.Equal(t, service.startupHeadRoot(), gr)
-		require.LogsContain(t, hook, "Could not get head block root, starting with finalized block as head")
+		require.LogsContain(t, hook, "Could not get head block root, starting with justified block as head")
 	})
 
 	st, _ := util.DeterministicGenesisState(t, 64)

--- a/changelog/potuz_start_from_justified.md
+++ b/changelog/potuz_start_from_justified.md
@@ -1,0 +1,2 @@
+### Changed
+- Start from justified checkpoint by default.


### PR DESCRIPTION
By default when starting a node, we load the finalized checkpoint from db and set it as head. When the chain has not been finalizing for a while and the user does not start from the latest head, it may still be beneficial to start from the latest justified checkpoint that has to be a descendant of the finalized one.