### PR TITLE
 Use RLock for read-only ProposerBoost()

### DIFF
--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@ -71,8 +71,8 @@ func (s *Service) NewSlot(ctx context.Context, slot primitives.Slot) error {
 
 // ProposerBoost wraps the corresponding method from forkchoice
 func (s *Service) ProposerBoost() [32]byte {
-	s.cfg.ForkChoiceStore.Lock()
-	defer s.cfg.ForkChoiceStore.Unlock()
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
 	return s.cfg.ForkChoiceStore.ProposerBoost()
 }
 


### PR DESCRIPTION

## What / Why

`ProposerBoost()` only reads a `[32]byte` value from the fork-choice store, yet it’s currently guarded with `RWMutex.Lock`, which **serializes concurrent readers**. Switching to `RLock` restores **read parallelism** with **no behavior change** and aligns with Prysm’s existing read-only pattern (e.g., `ROForkChoice`).

## Change (Option A, minimal & panic-safe)

```diff
--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@
 func (s *Service) ProposerBoost() [32]byte {
-    s.cfg.ForkChoiceStore.Lock()
-    defer s.cfg.ForkChoiceStore.Unlock()
-    return s.cfg.ForkChoiceStore.ProposerBoost()
+    s.cfg.ForkChoiceStore.RLock()
+    defer s.cfg.ForkChoiceStore.RUnlock() // panic-safety
+    return s.cfg.ForkChoiceStore.ProposerBoost()
 }
```


## Technical validity

* **Pure getter:** `ProposerBoost()` returns a `[32]byte` value; no writes or nested locks (see `beacon-chain/forkchoice/doubly-linked-tree/proposer_boost.go`).
* **Value semantics:** `[32]byte` is returned **by value**, so use-after-unlock is safe.
* **Consistency:** Other read-only methods already use `RLock()` (e.g., `CachedHeadRoot()`, `GetProposerHead()`, `ChainHeads()`), and `ROForkChoice.ProposerBoost()` uses `RLock()` internally (see `beacon-chain/forkchoice/ro.go`).


## Safety

* Getter-only: no writes, no nested locks, no lock “upgrade” path.
* Tiny critical section; return value is a `[32]byte` copy.
* **Writer progress:** Go `RWMutex` blocks new readers when a writer is queued → writer starvation is not introduced.
* **Panic-safety:** keep `defer RUnlock()` so a panic cannot leak a read lock.

## Potential risks / notes

* **Sync pattern divergence (current state):** `Service.ProposerBoost()` previously used `Lock()` while `ROForkChoice.ProposerBoost()` used `RLock()`. This PR removes that inconsistency for this method.
* **Future lock-upgrade risk:** Not observed now, but we recommend keeping call sites simple (avoid acquiring `Lock()` on the same `RWMutex` while this `RLock()` is held).
*

## Follow-up recommendations (non-blocking)

* Consider a small audit to **unify read-only synchronization** between `Service` and `ROForkChoice` code paths.
* Add/expand a concurrency test that issues many concurrent `ProposerBoost()` reads interleaved with writers to quantify tail latency improvements.

## Pre-flight checks (mechanical)

1. **Getter purity:** `ForkChoiceStore.ProposerBoost()` performs no writes and acquires no extra locks.
2. **Return by value:** the result is **`[32]byte`** (not `[]byte` or `*[32]byte`).
3. **No lock upgrade path:** no code acquires `Lock()` on the same `RWMutex` while this `RLock()` is held.

## Why no new tests?

* This is a `Lock`→`RLock` swap for a read-only getter; **no behavior change** is intended.
* Existing suites already cover fork-choice semantics; CI will validate as usual.
* (Optional) We can add a dedicated concurrency micro-bench in a follow-up to measure p95/p99 lock-wait reduction.



### Notes

* No user-facing change → no CHANGELOG entry.
* No new dependencies.
* Base branch: `develop`.
