### PR TITLE
fix getBlockAttestationsV2 to return nil data

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -334,26 +334,26 @@ func (s *Server) GetBlockAttestationsV2(w http.ResponseWriter, r *http.Request) 
 	consensusAtts := blk.Block().Body().Attestations()
 
 	v := blk.Block().Version()
-	var attStructs []interface{}
+	attStructs := make([]interface{}, len(consensusAtts))
 	if v >= version.Electra {
-		for _, att := range consensusAtts {
+		for index, att := range consensusAtts {
 			a, ok := att.(*eth.AttestationElectra)
 			if !ok {
 				httputil.HandleError(w, fmt.Sprintf("unable to convert consensus attestations electra of type %T", att), http.StatusInternalServerError)
 				return
 			}
 			attStruct := structs.AttElectraFromConsensus(a)
-			attStructs = append(attStructs, attStruct)
+			attStructs[index] = attStruct
 		}
 	} else {
-		for _, att := range consensusAtts {
+		for index, att := range consensusAtts {
 			a, ok := att.(*eth.Attestation)
 			if !ok {
 				httputil.HandleError(w, fmt.Sprintf("unable to convert consensus attestation of type %T", att), http.StatusInternalServerError)
 				return
 			}
 			attStruct := structs.AttFromConsensus(a)
-			attStructs = append(attStructs, attStruct)
+			attStructs[index] = attStruct
 		}
 	}
 

--- a/changelog/muzry_fix_get_block_attestation_v2.md
+++ b/changelog/muzry_fix_get_block_attestation_v2.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix getBlockAttestationsV2 to return [] instead of null when data is empty


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Ensure getBlockAttestationsV2 returns an empty array [] instead of null 
When no attestations exist, matching the Beacon-API spec and other CL clients.

**Which issues(s) does this PR fix?**

Fixes #15647 

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
