### PR TITLE
PeerDAS: find data column peers when tracking validators

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -194,6 +194,7 @@ go_test(
         "slot_aware_cache_test.go",
         "subscriber_beacon_aggregate_proof_test.go",
         "subscriber_beacon_blocks_test.go",
+        "subscriber_data_column_sidecar_test.go",
         "subscriber_test.go",
         "subscription_topic_handler_test.go",
         "sync_fuzz_test.go",

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -225,11 +225,12 @@ func (s *Service) registerSubscribers(epoch primitives.Epoch, digest [4]byte) {
 	// New gossip topic in Fulu.
 	if params.BeaconConfig().FuluForkEpoch <= epoch {
 		s.subscribeWithParameters(subscribeParameters{
-			topicFormat:      p2p.DataColumnSubnetTopicFormat,
-			validate:         s.validateDataColumn,
-			handle:           s.dataColumnSubscriber,
-			digest:           digest,
-			getSubnetsToJoin: s.dataColumnSubnetIndices,
+			topicFormat:              p2p.DataColumnSubnetTopicFormat,
+			validate:                 s.validateDataColumn,
+			handle:                   s.dataColumnSubscriber,
+			digest:                   digest,
+			getSubnetsToJoin:         s.dataColumnSubnetIndices,
+			getSubnetsRequiringPeers: s.allDataColumnSubnets,
 		})
 	}
 }

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -58,7 +58,7 @@ func (s *Service) receiveDataColumnSidecar(ctx context.Context, sidecar blocks.V
 // allDataColumnSubnets returns the data column subnets for which we need to find peers
 // but don't need to subscribe to. This is used to ensure we have peers available in all subnets
 // when we are serving validators. When a validator proposes a block, they need to publish data
-// columns on all subnets. This method returns a nil map when there is no validators custody
+// column sidecars on all subnets. This method returns a nil map when there is no validators custody
 // requirement.
 func (s *Service) allDataColumnSubnets(_ primitives.Slot) map[uint64]bool {
 	validatorsCustodyRequirement, err := s.validatorsCustodyRequirement()

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed"
 	opfeed "github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed/operation"
+	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 )
@@ -51,4 +53,31 @@ func (s *Service) receiveDataColumnSidecar(ctx context.Context, sidecar blocks.V
 	})
 
 	return nil
+}
+
+// allDataColumnSubnets returns the data column subnets for which we need to find peers
+// but don't need to subscribe to. This is used to ensure we have peers available in all subnets
+// when we are serving validators. When a validator proposes a block, they need to publish data
+// columns on all subnets. This method returns a nil map when there is no validators custody
+// requirement.
+func (s *Service) allDataColumnSubnets(_ primitives.Slot) map[uint64]bool {
+	validatorsCustodyRequirement, err := s.validatorsCustodyRequirement()
+	if err != nil {
+		log.WithError(err).Debug("Could not retrieve validators custody requirement")
+		return nil
+	}
+
+	// If no validators are tracked, return early
+	if validatorsCustodyRequirement == 0 {
+		return nil
+	}
+
+	// When we have validators with custody requirements, we need peers in all subnets
+	// because validators need to be able to publish data columns to all subnets when proposing
+	allSubnets := make(map[uint64]bool)
+	for i := uint64(0); i < params.BeaconConfig().DataColumnSidecarSubnetCount; i++ {
+		allSubnets[i] = true
+	}
+
+	return allSubnets
 }

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -63,7 +63,7 @@ func (s *Service) receiveDataColumnSidecar(ctx context.Context, sidecar blocks.V
 func (s *Service) allDataColumnSubnets(_ primitives.Slot) map[uint64]bool {
 	validatorsCustodyRequirement, err := s.validatorsCustodyRequirement()
 	if err != nil {
-		log.WithError(err).Debug("Could not retrieve validators custody requirement")
+		log.WithError(err).Error("Could not retrieve validators custody requirement")
 		return nil
 	}
 

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -74,8 +74,9 @@ func (s *Service) allDataColumnSubnets(_ primitives.Slot) map[uint64]bool {
 
 	// When we have validators with custody requirements, we need peers in all subnets
 	// because validators need to be able to publish data columns to all subnets when proposing
-	allSubnets := make(map[uint64]bool)
-	for i := uint64(0); i < params.BeaconConfig().DataColumnSidecarSubnetCount; i++ {
+	dataColumnSidecarSubnetCount := params.BeaconConfig().DataColumnSidecarSubnetCount
+	allSubnets := make(map[uint64]bool, dataColumnSidecarSubnetCount)
+	for i := range dataColumnSidecarSubnetCount {
 		allSubnets[i] = true
 	}
 

--- a/beacon-chain/sync/subscriber_data_column_sidecar_test.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar_test.go
@@ -1,0 +1,84 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/cache"
+	dbtest "github.com/OffchainLabs/prysm/v6/beacon-chain/db/testing"
+	doublylinkedtree "github.com/OffchainLabs/prysm/v6/beacon-chain/forkchoice/doubly-linked-tree"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stategen"
+	"github.com/OffchainLabs/prysm/v6/config/params"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v6/testing/assert"
+	"github.com/OffchainLabs/prysm/v6/testing/require"
+	"github.com/OffchainLabs/prysm/v6/testing/util"
+)
+
+func TestDataColumnSubnets(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) *Service
+		test  func(t *testing.T, svc *Service)
+	}{
+		{
+			name: "allDataColumnSubnets returns nil when no validators tracked",
+			setup: func(t *testing.T) *Service {
+				// Service with no tracked validators
+				return &Service{
+					ctx:                    t.Context(),
+					trackedValidatorsCache: cache.NewTrackedValidatorsCache(),
+				}
+			},
+			test: func(t *testing.T, svc *Service) {
+				result := svc.allDataColumnSubnets(primitives.Slot(0))
+				assert.Equal(t, true, len(result) == 0, "Expected nil or empty map when no validators are tracked")
+			},
+		},
+		{
+			name: "allDataColumnSubnets returns all subnets logic test",
+			setup: func(t *testing.T) *Service {
+				params.SetupTestConfigCleanup(t)
+				ctx := t.Context()
+
+				db := dbtest.SetupDB(t)
+
+				// Create and save genesis state
+				genesisState, _ := util.DeterministicGenesisState(t, 64)
+				require.NoError(t, db.SaveGenesisData(ctx, genesisState))
+
+				// Create stategen and initialize with genesis state
+				stateGen := stategen.New(db, doublylinkedtree.New())
+				_, err := stateGen.Resume(ctx, genesisState)
+				require.NoError(t, err)
+
+				// At least one tracked validator.
+				tvc := cache.NewTrackedValidatorsCache()
+				tvc.Set(cache.TrackedValidator{Active: true, Index: 1})
+
+				return &Service{
+					ctx:                    ctx,
+					trackedValidatorsCache: tvc,
+					cfg: &config{
+						stateGen: stateGen,
+						beaconDB: db,
+					},
+				}
+			},
+			test: func(t *testing.T, svc *Service) {
+				result := svc.allDataColumnSubnets(0)
+				assert.Equal(t, params.BeaconConfig().DataColumnSidecarSubnetCount, uint64(len(result)))
+
+				for i := uint64(0); i < params.BeaconConfig().DataColumnSidecarSubnetCount; i++ {
+					assert.Equal(t, true, result[i])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := tt.setup(t)
+			tt.test(t, svc)
+		})
+	}
+}

--- a/beacon-chain/sync/subscriber_data_column_sidecar_test.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar_test.go
@@ -14,72 +14,52 @@ import (
 	"github.com/OffchainLabs/prysm/v6/testing/util"
 )
 
-func TestDataColumnSubnets(t *testing.T) {
-	tests := []struct {
-		name  string
-		setup func(t *testing.T) *Service
-		test  func(t *testing.T, svc *Service)
-	}{
-		{
-			name: "allDataColumnSubnets returns nil when no validators tracked",
-			setup: func(t *testing.T) *Service {
-				// Service with no tracked validators
-				return &Service{
-					ctx:                    t.Context(),
-					trackedValidatorsCache: cache.NewTrackedValidatorsCache(),
-				}
+func TestAllDataColumnSubnets(t *testing.T) {
+	t.Run("returns nil when no validators tracked", func(t *testing.T) {
+		// Service with no tracked validators
+		svc := &Service{
+			ctx:                    t.Context(),
+			trackedValidatorsCache: cache.NewTrackedValidatorsCache(),
+		}
+
+		result := svc.allDataColumnSubnets(primitives.Slot(0))
+		assert.Equal(t, true, len(result) == 0, "Expected nil or empty map when no validators are tracked")
+	})
+
+	t.Run("returns all subnets logic test", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		ctx := t.Context()
+
+		db := dbtest.SetupDB(t)
+
+		// Create and save genesis state
+		genesisState, _ := util.DeterministicGenesisState(t, 64)
+		require.NoError(t, db.SaveGenesisData(ctx, genesisState))
+
+		// Create stategen and initialize with genesis state
+		stateGen := stategen.New(db, doublylinkedtree.New())
+		_, err := stateGen.Resume(ctx, genesisState)
+		require.NoError(t, err)
+
+		// At least one tracked validator.
+		tvc := cache.NewTrackedValidatorsCache()
+		tvc.Set(cache.TrackedValidator{Active: true, Index: 1})
+
+		svc := &Service{
+			ctx:                    ctx,
+			trackedValidatorsCache: tvc,
+			cfg: &config{
+				stateGen: stateGen,
+				beaconDB: db,
 			},
-			test: func(t *testing.T, svc *Service) {
-				result := svc.allDataColumnSubnets(primitives.Slot(0))
-				assert.Equal(t, true, len(result) == 0, "Expected nil or empty map when no validators are tracked")
-			},
-		},
-		{
-			name: "allDataColumnSubnets returns all subnets logic test",
-			setup: func(t *testing.T) *Service {
-				params.SetupTestConfigCleanup(t)
-				ctx := t.Context()
+		}
 
-				db := dbtest.SetupDB(t)
+		dataColumnSidecarSubnetCount := params.BeaconConfig().DataColumnSidecarSubnetCount
+		result := svc.allDataColumnSubnets(0)
+		assert.Equal(t, dataColumnSidecarSubnetCount, uint64(len(result)))
 
-				// Create and save genesis state
-				genesisState, _ := util.DeterministicGenesisState(t, 64)
-				require.NoError(t, db.SaveGenesisData(ctx, genesisState))
-
-				// Create stategen and initialize with genesis state
-				stateGen := stategen.New(db, doublylinkedtree.New())
-				_, err := stateGen.Resume(ctx, genesisState)
-				require.NoError(t, err)
-
-				// At least one tracked validator.
-				tvc := cache.NewTrackedValidatorsCache()
-				tvc.Set(cache.TrackedValidator{Active: true, Index: 1})
-
-				return &Service{
-					ctx:                    ctx,
-					trackedValidatorsCache: tvc,
-					cfg: &config{
-						stateGen: stateGen,
-						beaconDB: db,
-					},
-				}
-			},
-			test: func(t *testing.T, svc *Service) {
-				dataColumnSidecarSubnetCount := params.BeaconConfig().DataColumnSidecarSubnetCount
-				result := svc.allDataColumnSubnets(0)
-				assert.Equal(t, dataColumnSidecarSubnetCount, uint64(len(result)))
-
-				for i := range dataColumnSidecarSubnetCount {
-					assert.Equal(t, true, result[i])
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svc := tt.setup(t)
-			tt.test(t, svc)
-		})
-	}
+		for i := range dataColumnSidecarSubnetCount {
+			assert.Equal(t, true, result[i])
+		}
+	})
 }

--- a/beacon-chain/sync/subscriber_data_column_sidecar_test.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar_test.go
@@ -65,10 +65,11 @@ func TestDataColumnSubnets(t *testing.T) {
 				}
 			},
 			test: func(t *testing.T, svc *Service) {
+				dataColumnSidecarSubnetCount := params.BeaconConfig().DataColumnSidecarSubnetCount
 				result := svc.allDataColumnSubnets(0)
-				assert.Equal(t, params.BeaconConfig().DataColumnSidecarSubnetCount, uint64(len(result)))
+				assert.Equal(t, dataColumnSidecarSubnetCount, uint64(len(result)))
 
-				for i := uint64(0); i < params.BeaconConfig().DataColumnSidecarSubnetCount; i++ {
+				for i := range dataColumnSidecarSubnetCount {
 					assert.Equal(t, true, result[i])
 				}
 			},

--- a/changelog/pvl-peerdas-peer-fanout.md
+++ b/changelog/pvl-peerdas-peer-fanout.md
@@ -1,0 +1,3 @@
+### Added 
+
+- Configured the beacon node to seek peers when we have validator custody requirements. If one or more validators are connected to the beacon node, then the beacon node should seek a diverse set of peers such that broadcasting to all data column subnets for a block proposal is more efficient.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

When a validator proposes a block, they need to broadcast data columns on all subnets. However, they do not need to be subscribed on all subnets all of the time. As such, we can use the `getSubnetsRequiringPeers` property to indicate that we want peers that are subscribed on these subnets such that we already have peers on all data column subnets when we publish a block to the network.

**Which issues(s) does this PR fix?**

Part of the PeerDAS effort.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
