### PR TITLE
fix: typos in documentation files

### DIFF
--- a/beacon-chain/core/peerdas/reconstruction.go
+++ b/beacon-chain/core/peerdas/reconstruction.go
@@ -37,7 +37,7 @@ func ReconstructDataColumnSidecars(inVerifiedRoSidecars []blocks.VerifiedRODataC
 	// Safely retrieve the first sidecar as a reference.
 	referenceSidecar := inVerifiedRoSidecars[0]
 
-	// Check if all columns have the same length and are commmitted to the same block.
+	// Check if all columns have the same length and are committed to the same block.
 	blobCount := len(referenceSidecar.Column)
 	blockRoot := referenceSidecar.BlockRoot()
 	for _, sidecar := range inVerifiedRoSidecars[1:] {

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -43,7 +43,7 @@ func (s *Store) getBlock(ctx context.Context, blockRoot [32]byte, tx *bolt.Tx) (
 		return v, nil
 	}
 	// This method allows the caller to pass in its tx if one is already open.
-	// Or if a nil value is used, a transaction will be managed intenally.
+	// Or if a nil value is used, a transaction will be managed internally.
 	if tx == nil {
 		var err error
 		tx, err = s.db.Begin(false)

--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -238,7 +238,7 @@ func (s *Service) AddDisconnectionHandler(handler func(ctx context.Context, id p
 
 				s.peers.SetConnectionState(peerID, peers.Disconnected)
 				if err := s.peerDisconnectionTime.Add(peerID.String(), time.Now(), cache.DefaultExpiration); err != nil {
-					// The `DisconnectedF` funcition already called for this peer less than `cache.DefaultExpiration` ago. Skip.
+					// The `DisconnectedF` function already called for this peer less than `cache.DefaultExpiration` ago. Skip.
 					// (Very probably a bug in libp2p.)
 					log.WithError(err).Trace("Failed to set peer disconnection time")
 					return

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -700,7 +700,7 @@ func byteCount(bitCount int) int {
 	return numOfBytes
 }
 
-// interesect intersects two maps and returns a new map containing only the keys
+// intersect intersects two maps and returns a new map containing only the keys
 // that are present in both maps.
 func intersect(left map[uint64]int, right map[uint64]bool) map[uint64]bool {
 	result := make(map[uint64]bool, min(len(left), len(right)))

--- a/beacon-chain/p2p/types/types.go
+++ b/beacon-chain/p2p/types/types.go
@@ -250,7 +250,7 @@ func (d *DataColumnsByRootIdentifiers) UnmarshalSSZ(buf []byte) error {
 	}
 	valueStart := offsetEnd
 
-	// Decode the identifers.
+	// Decode the identifiers.
 	*d = make([]*eth.DataColumnsByRootIdentifier, count)
 	var start uint32
 	end := uint32(len(buf))

--- a/beacon-chain/p2p/types/types_test.go
+++ b/beacon-chain/p2p/types/types_test.go
@@ -299,7 +299,7 @@ func TestDataColumnSidecarsByRootReq_MarshalUnmarshal(t *testing.T) {
 				in = append(in, byte(0))
 				return in
 			},
-			unmarshalErr: "a is not evenly divisble by b",
+			unmarshalErr: "a is not evenly divisible by b",
 		},
 		{
 			name: "size too big",

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -52,9 +52,9 @@ func TestColumnSatisfyRequirement(t *testing.T) {
 	parentRoot := [fieldparams.RootLength]byte{}
 
 	columns := GenerateTestDataColumns(t, parentRoot, columnSlot, blobCount)
-	intializer := Initializer{}
+	initializer := Initializer{}
 
-	v := intializer.NewDataColumnsVerifier(columns, GossipDataColumnSidecarRequirements)
+	v := initializer.NewDataColumnsVerifier(columns, GossipDataColumnSidecarRequirements)
 	require.Equal(t, false, v.results.executed(RequireValidProposerSignature))
 	v.SatisfyRequirement(RequireValidProposerSignature)
 	require.Equal(t, true, v.results.executed(RequireValidProposerSignature))

--- a/changelog/James-prysm_parallel-goodbyes.md
+++ b/changelog/James-prysm_parallel-goodbyes.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- when shutting down the sync service we now send p2p goodbye messages in parallel to maxmimize changes of propogating goodbyes to all peers before an unsafe shutdown. 
+- when shutting down the sync service we now send p2p goodbye messages in parallel to maxmimize changes of propagating goodbyes to all peers before an unsafe shutdown. 

--- a/changelog/james-prysm_move-ticker.md
+++ b/changelog/james-prysm_move-ticker.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Fixes edge case starting validator client with new validator keys starts the slot ticker too early resulting in replayed slots in the main runner loop. Fixes edge case of replayed slots when waiting for account acivations. 
+- Fixes edge case starting validator client with new validator keys starts the slot ticker too early resulting in replayed slots in the main runner loop. Fixes edge case of replayed slots when waiting for account activations. 

--- a/changelog/manu-peerdas-beacon-api.md
+++ b/changelog/manu-peerdas-beacon-api.md
@@ -1,2 +1,2 @@
 ### Added 
-- Implement beacon API blob sidecar enpoint for Fulu.
+- Implement beacon API blob sidecar endpoint for Fulu.

--- a/changelog/tt_sushi.md
+++ b/changelog/tt_sushi.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- Optimize proposer inclusion proof calcuation by pre caching subtries
+- Optimize proposer inclusion proof calculation by pre caching subtries

--- a/validator/client/runner_test.go
+++ b/validator/client/runner_test.go
@@ -380,7 +380,7 @@ func TestRunnerPushesProposerSettings_ValidContext(t *testing.T) {
 	defer cancel()
 
 	// This test is meant to ensure that PushProposerSettings is called successfully on a next slot event.
-	// This is a regresion test for PR 15369, however the same methodology of context checking is applied
+	// This is a regression test for PR 15369, however the same methodology of context checking is applied
 	// to many other methods as well.
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -341,7 +341,7 @@ func (v *validator) SetTicker() {
 	// This means that sometimes we need to reset the ticker to avoid replaying old ticks on a slow consumer of the ticks.
 	// i.e.,
 	// 1. tick starts at 0
-	// 2. loop stops consuming on slot 10 due to accounts changed tigger with no active keys
+	// 2. loop stops consuming on slot 10 due to accounts changed trigger with no active keys
 	// 3. new active keys are added in slot 20 resolving wait for activation
 	// 4. new tick starts ticking from slot 20 instead of slot 10
 	if v.ticker != nil {


### PR DESCRIPTION

This pull request contains changes to improve clarity, correctness and structure.

Corrected `commmitted` → `committed`
Corrected `intenally` → `internally`
Corrected `funcition` → `function`
Corrected `interesect` → `intersect`
Corrected `identifers` → `identifiers`
Corrected `divisble` → `divisible`
Corrected `intializer` → `initializer`
Corrected `propogating` → `propagating`
Corrected `acivations` → `activations`
Corrected `enpoint` → `endpoint`
Corrected `calcuation` → `calculation`
Corrected `regresion` → `regression `
Corrected `tigger` → `trigger`
