### PR TITLE
keystore: Stop serializing private key in JSON; add backward-compatible Unmarshal

### DIFF
--- a/crypto/keystore/key.go
+++ b/crypto/keystore/key.go
@@ -109,7 +109,7 @@ func (k *Key) UnmarshalJSON(j []byte) (err error) {
 
 	// Try to unmarshal the public-only form first
 	var pkOnly publicKeyOnlyJSON
-	if err = json.Unmarshal(j, &pkOnly); err == nil && pkOnly.PublicKey != "" {
+	if err = json.Unmarshal(j, &pkOnly); err == nil && pkOnly.PublicKey != "" && pkOnly.ID != "" {
 		idStr = pkOnly.ID
 		pubStr = pkOnly.PublicKey
 	} else {

--- a/crypto/keystore/key.go
+++ b/crypto/keystore/key.go
@@ -50,7 +50,7 @@ type Key struct {
 
 	PublicKey bls.PublicKey // Represents the public key of the user.
 
-	SecretKey bls.SecretKey // Represents the private key of the user.
+	SecretKey bls.SecretKey `json:"-"` // Represents the private key of the user.
 }
 
 type keyStore interface {
@@ -65,6 +65,11 @@ type keyStore interface {
 type plainKeyJSON struct {
 	PublicKey string `json:"address"`
 	SecretKey string `json:"privatekey"`
+	ID        string `json:"id"`
+}
+
+type publicKeyOnlyJSON struct {
+	PublicKey string `json:"address"`
 	ID        string `json:"id"`
 }
 
@@ -89,9 +94,8 @@ type cipherparamsJSON struct {
 
 // MarshalJSON marshals a key struct into a JSON blob.
 func (k *Key) MarshalJSON() (j []byte, err error) {
-	jStruct := plainKeyJSON{
+	jStruct := publicKeyOnlyJSON{
 		hex.EncodeToString(k.PublicKey.Marshal()),
-		hex.EncodeToString(k.SecretKey.Marshal()),
 		k.ID.String(),
 	}
 	j, err = json.Marshal(jStruct)
@@ -100,32 +104,37 @@ func (k *Key) MarshalJSON() (j []byte, err error) {
 
 // UnmarshalJSON unmarshals a blob into a key struct.
 func (k *Key) UnmarshalJSON(j []byte) (err error) {
-	keyJSON := new(plainKeyJSON)
-	err = json.Unmarshal(j, &keyJSON)
-	if err != nil {
-		return err
+	var idStr string
+	var pubStr string
+
+	// Try to unmarshal the public-only form first
+	var pkOnly publicKeyOnlyJSON
+	if err = json.Unmarshal(j, &pkOnly); err == nil && pkOnly.PublicKey != "" {
+		idStr = pkOnly.ID
+		pubStr = pkOnly.PublicKey
+	} else {
+		// Fallback to legacy plain form that included private key; ignore the secret key
+		var legacy plainKeyJSON
+		if err2 := json.Unmarshal(j, &legacy); err2 != nil {
+			return err
+		}
+		idStr = legacy.ID
+		pubStr = legacy.PublicKey
 	}
 
 	u := new(uuid.UUID)
-	*u = uuid.Parse(keyJSON.ID)
+	*u = uuid.Parse(idStr)
 	k.ID = *u
-	pubkey, err := hex.DecodeString(keyJSON.PublicKey)
-	if err != nil {
-		return err
-	}
-	seckey, err := hex.DecodeString(keyJSON.SecretKey)
+	pubkeyBytes, err := hex.DecodeString(pubStr)
 	if err != nil {
 		return err
 	}
 
-	k.PublicKey, err = bls.PublicKeyFromBytes(pubkey)
+	k.PublicKey, err = bls.PublicKeyFromBytes(pubkeyBytes)
 	if err != nil {
 		return err
 	}
-	k.SecretKey, err = bls.SecretKeyFromBytes(seckey)
-	if err != nil {
-		return err
-	}
+	// Intentionally do not accept or set SecretKey from JSON
 	return nil
 }
 


### PR DESCRIPTION
Removed private key from JSON output in `crypto/keystore/key.go`. `MarshalJSON` now emits only `public key` and `id`; added `publicKeyOnlyJSON`. `SecretKey` marked `json:"-"`. `UnmarshalJSON` supports both the new format and the legacy one (ignores private key if present).
- **Why**: Prevent accidental leakage of private keys via logs, debug dumps, or APIs.
- **Security**: Eliminates a real risk of secret exposure through JSON marshaling.
- **Compatibility**: Backward-compatible on read; legacy JSON with `privatekey` still parses, but the private key is ignored.
