### PR TITLE
chore: Remove duplicated test case from TestCollector

### DIFF
--- a/changelog/Galoretka_fix-leakybucket-test-duplicate.md
+++ b/changelog/Galoretka_fix-leakybucket-test-duplicate.md
@@ -1,0 +1,2 @@
+## Ignored
+- Remove duplicate test case in `container/leaky-bucket/collector_test.go` to reduce redundancy. (#15672)

--- a/container/leaky-bucket/collector_test.go
+++ b/container/leaky-bucket/collector_test.go
@@ -142,7 +142,6 @@ func TestCollector(t *testing.T) {
 
 	tests := []testSet{
 		collectorSimple,
-		collectorSimple,
 		collectorVaried,
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The tests slice in container/leaky-bucket/collector_test.go included collectorSimple twice. This duplication did not exercise new code paths or provide additional coverage because each iteration constructs a fresh Collector and runKey already covers Remove, Prune, and Reset scenarios. Removing the duplicate reduces redundancy and test runtime while keeping behavior and coverage unchanged.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
