### PR TITLE
fix(genesis): cache embedded state in package var during lazy load

### DIFF
--- a/changelog/MozirDmitriy_genesis-embedded-state-caching
+++ b/changelog/MozirDmitriy_genesis-embedded-state-caching
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cache embedded genesis state on first lazy load by writing it back to the package variable. This prevents repeated decompression/unmarshal on subsequent `State()` calls and ensures consistency between `State()`, `ValidatorsRoot()`, and `Time()` when using embedded genesis, including the uninitialized path. (#15673)

--- a/genesis/storage.go
+++ b/genesis/storage.go
@@ -43,7 +43,16 @@ func stateInternal() (state.BeaconState, error) {
 		// If the state is not explicitly initialized, try to load embedded states if available.
 		name := params.BeaconConfig().ConfigName
 		if ed, ok := embeddedGenesisData[name]; ok {
-			return ed.embeddedState()
+			st, err := ed.embeddedState()
+			if err != nil {
+				return nil, errors.Wrap(err, "load embedded genesis state")
+			}
+			if !state.IsNil(st) {
+				ed.State = st
+				setPkgVar(ed, true)
+				return st, nil
+			}
+			return nil, ErrGenesisStateNotInitialized
 		}
 		return nil, ErrGenesisStateNotInitialized
 	}
@@ -57,6 +66,7 @@ func stateInternal() (state.BeaconState, error) {
 		}
 		if !state.IsNil(st) {
 			gd.State = st
+			setPkgVar(gd, true)
 			return gd.State, nil
 		}
 	}


### PR DESCRIPTION
- Fix lazy-load path to write loaded embedded state back to the package variable using setPkgVar, ensuring subsequent State() calls do not re-decompress/re-unmarshal.
- In the uninitialized path, when an embedded genesis exists, load it once, set ed.State, and set the package variable so ValidatorsRoot/Time and State() are consistent.
- This prevents repeated expensive loads and removes inconsistency where State() could succeed while ValidatorsRoot/Time remained zero due to missing initialization.