### PR TITLE
Add debug logging for 'invalid data returned from peer' errors

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -450,7 +450,12 @@ func (f *blocksFetcher) fetchBlocksFromPeer(
 	for _, p := range peers {
 		blocks, err := f.requestBlocks(ctx, req, p)
 		if err != nil {
-			log.WithField("peer", p).WithError(err).Debug("Could not request blocks by range from peer")
+			log.WithFields(logrus.Fields{
+				"peer":      p,
+				"startSlot": req.StartSlot,
+				"count":     req.Count,
+				"step":      req.Step,
+			}).WithError(err).Debug("Could not request blocks by range from peer")
 			continue
 		}
 		f.p2p.Peers().Scorers().BlockProviderScorer().Touch(p)

--- a/changelog/pvl-debug-log.md
+++ b/changelog/pvl-debug-log.md
@@ -1,0 +1,3 @@
+### Added 
+
+- Added more metadata for debug logs when initial sync requests fail for "invalid data returned from peer" errors


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

When peers return invalid data during initial sync, log the specific validation failure reason. This helps identify:
- Whether peer exceeded requested block count
- Whether peer exceeded MAX_REQUEST_BLOCKS protocol limit
- Whether blocks are outside the requested slot range
- Whether blocks are out of order (not increasing or wrong step)

Each log includes the specific condition that failed, making it easier to debug whether the issue is with peer implementations or request validation logic.

**Which issues(s) does this PR fix?**

The debug logging when "invalid data returned from peer" is received is lacking sufficient metadata to understand why this error was returned. 

**Other notes for review**

**Acknowledgements**

-  [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
