### PR TITLE
fix(kv): boundary in TestStore_IsFinalizedBlock non-finalized rang

### DIFF
--- a/beacon-chain/db/kv/finalized_block_roots_test.go
+++ b/beacon-chain/db/kv/finalized_block_roots_test.go
@@ -50,7 +50,7 @@ func TestStore_IsFinalizedBlock(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, true, db.IsFinalizedBlock(ctx, root), "Block at index %d was not considered finalized in the index", i)
 	}
-	for i := slotsPerEpoch * 3; i < uint64(len(blks)); i++ {
+	for i := slotsPerEpoch * 2; i < uint64(len(blks)); i++ {
 		root, err := blks[i].Block().HashTreeRoot()
 		require.NoError(t, err)
 		assert.Equal(t, false, db.IsFinalizedBlock(ctx, root), "Block at index %d was considered finalized in the index, but should not have", i)

--- a/changelog/Forostovec
+++ b/changelog/Forostovec
@@ -1,0 +1,2 @@
+## Fixed
+- fix boundary in TestStore_IsFinalizedBlock non-finalized range (#15675)

--- a/changelog/Forostovec_finalized-index-test-boundary
+++ b/changelog/Forostovec_finalized-index-test-boundary
@@ -1,2 +1,3 @@
-## Fixed
+### Fixed
+
 - fix boundary in TestStore_IsFinalizedBlock non-finalized range (#15675)


### PR DESCRIPTION
Adjust the second loop in TestStore_IsFinalizedBlock to start at slotsPerEpoch2 instead of slotsPerEpoch3. With cp.Epoch=1 and three epochs of blocks, epochs 0–1 must be indexed as finalized while epoch 2 must not. The previous bound started at len(blks), so the non-finalized assertions never executed. This change makes the test validate the intended behavior of the finalized block roots index.