### PR TITLE
Justin's suggestion to unwedge CI

### DIFF
--- a/changelog/kasey_unwedge-ethspecify.md
+++ b/changelog/kasey_unwedge-ethspecify.md
@@ -1,0 +1,2 @@
+### Ignored
+- Unwedge ethspecify.

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -3737,8 +3737,6 @@
   sources:
     - file: beacon-chain/core/validators/validator.go
       search: func InitiateValidatorExit(
-    - file: beacon-chain/core/validators/validator.go
-      search: if s.Version() < version.Electra {
   spec: |
     <spec fn="initiate_validator_exit" fork="phase0" hash="0483a058">
     def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

This loosens an excessively constrained ethspecify definition that is causing our CI check to fail.

**Other notes for review**

This suggestion came from @jtraglia 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
