### PR TITLE
Downscore peers when they give invalid responses during initial sync

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -457,7 +457,7 @@ func (f *blocksFetcher) fetchBlocksFromPeer(
 				"step":      req.Step,
 			}).WithError(err).Debug("Could not request blocks by range from peer")
 			if errors.Is(err, prysmsync.ErrInvalidFetchedData) {
-				f.p2p.Peers().Scorers().BadResponsesScorer().Increment(p)
+				f.downscorePeer(p, err)
 			}
 			continue
 		}
@@ -877,6 +877,12 @@ func dedupPeers(peers []peer.ID) []peer.ID {
 		peerExists[peers[i]] = true
 	}
 	return newPeerList
+}
+
+// downscorePeer increments the bad responses score for the peer and logs the event.
+func (f *blocksFetcher) downscorePeer(peerID peer.ID, reason error) {
+	newScore := f.p2p.Peers().Scorers().BadResponsesScorer().Increment(peerID)
+	log.WithFields(logrus.Fields{"peerID": peerID, "reason": reason, "newScore": newScore}).Debug("Downscore peer")
 }
 
 // findFirstFuluIndex returns the index of the first block with a version >= Fulu.

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -456,6 +456,9 @@ func (f *blocksFetcher) fetchBlocksFromPeer(
 				"count":     req.Count,
 				"step":      req.Step,
 			}).WithError(err).Debug("Could not request blocks by range from peer")
+			if errors.Is(err, prysmsync.ErrInvalidFetchedData) {
+				f.p2p.Peers().Scorers().BadResponsesScorer().Increment(p)
+			}
 			continue
 		}
 		f.p2p.Peers().Scorers().BlockProviderScorer().Touch(p)

--- a/changelog/pvl-downscore-init-sync.md
+++ b/changelog/pvl-downscore-init-sync.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Prysm will now downscore peers that return invalid block_by_range responses.


### PR DESCRIPTION
**What type of PR is this?**

Feature


**What does this PR do? Why is it needed?**

This PR implements a change where block by range requests that fail due to an invalid response from the peer will now result in the peer being downscored. 

**Which issues(s) does this PR fix?**

An example is a block by range request in which prysm requests 64 blocks from a peer, but the peer returns 65 blocks is considered an invalid response and the entire response is discarded. This is bad behavior from a peer and they should be downscored for this response.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
