### PR TITLE
Change insertchain

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -247,7 +247,7 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []consensusblocks.ROBlo
 		args := &forkchoicetypes.BlockAndCheckpoints{Block: b,
 			JustifiedCheckpoint: jCheckpoints[i],
 			FinalizedCheckpoint: fCheckpoints[i]}
-		pendingNodes[len(blks)-i-1] = args
+		pendingNodes[i] = args
 		if err := s.saveInitSyncBlock(ctx, root, b); err != nil {
 			tracing.AnnotateError(span, err)
 			return err
@@ -284,13 +284,9 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []consensusblocks.ROBlo
 	if err := s.cfg.StateGen.SaveState(ctx, lastBR, preState); err != nil {
 		return err
 	}
-	// Insert all nodes but the last one to forkchoice
+	// Insert all nodes to forkchoice
 	if err := s.cfg.ForkChoiceStore.InsertChain(ctx, pendingNodes); err != nil {
 		return errors.Wrap(err, "could not insert batch to forkchoice")
-	}
-	// Insert the last block to forkchoice
-	if err := s.cfg.ForkChoiceStore.InsertNode(ctx, preState, lastB); err != nil {
-		return errors.Wrap(err, "could not insert last block in batch to forkchoice")
 	}
 	// Set their optimistic status
 	if isValidPayload {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed"
@@ -402,11 +403,8 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, signed inte
 	if root != s.ensureRootNotZeros(finalized.Root) && !s.cfg.ForkChoiceStore.HasNode(root) {
 		return ErrNotDescendantOfFinalized
 	}
-	orderedNodes := make([]*forkchoicetypes.BlockAndCheckpoints, 0, len(pendingNodes))
-	for i := len(pendingNodes) - 1; i >= 0; i-- {
-		orderedNodes = append(orderedNodes, pendingNodes[i])
-	}
-	return s.cfg.ForkChoiceStore.InsertChain(ctx, orderedNodes)
+	slices.Reverse(pendingNodes)
+	return s.cfg.ForkChoiceStore.InsertChain(ctx, pendingNodes)
 }
 
 // inserts finalized deposits into our finalized deposit trie, needs to be

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -376,15 +376,8 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, signed inte
 	if err != nil {
 		return err
 	}
-	// The first block can have a bogus root since the block is not inserted in forkchoice
-	roblock, err := consensus_blocks.NewROBlockWithRoot(signed, [32]byte{})
-	if err != nil {
-		return err
-	}
-	pendingNodes = append(pendingNodes, &forkchoicetypes.BlockAndCheckpoints{Block: roblock,
-		JustifiedCheckpoint: jCheckpoint, FinalizedCheckpoint: fCheckpoint})
+	root := signed.Block().ParentRoot()
 	// As long as parent node is not in fork choice store, and parent node is in DB.
-	root := roblock.Block().ParentRoot()
 	for !s.cfg.ForkChoiceStore.HasNode(root) && s.cfg.BeaconDB.HasBlock(ctx, root) {
 		b, err := s.getBlock(ctx, root)
 		if err != nil {
@@ -403,13 +396,17 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, signed inte
 			FinalizedCheckpoint: fCheckpoint}
 		pendingNodes = append(pendingNodes, args)
 	}
-	if len(pendingNodes) == 1 {
+	if len(pendingNodes) == 0 {
 		return nil
 	}
 	if root != s.ensureRootNotZeros(finalized.Root) && !s.cfg.ForkChoiceStore.HasNode(root) {
 		return ErrNotDescendantOfFinalized
 	}
-	return s.cfg.ForkChoiceStore.InsertChain(ctx, pendingNodes)
+	orderedNodes := make([]*forkchoicetypes.BlockAndCheckpoints, 0, len(pendingNodes))
+	for i := len(pendingNodes) - 1; i >= 0; i-- {
+		orderedNodes = append(orderedNodes, pendingNodes[i])
+	}
+	return s.cfg.ForkChoiceStore.InsertChain(ctx, orderedNodes)
 }
 
 // inserts finalized deposits into our finalized deposit trie, needs to be

--- a/beacon-chain/blockchain/setup_forkchoice.go
+++ b/beacon-chain/blockchain/setup_forkchoice.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"slices"
 
 	forkchoicetypes "github.com/OffchainLabs/prysm/v6/beacon-chain/forkchoice/types"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
@@ -112,11 +113,8 @@ func (s *Service) buildForkchoiceChain(ctx context.Context, head interfaces.Read
 			return nil, errors.New("head block is not a descendant of the finalized checkpoint")
 		}
 	}
-	ret := make([]*forkchoicetypes.BlockAndCheckpoints, 0, len(chain))
-	for i := len(chain) - 1; i >= 0; i-- {
-		ret = append(ret, chain[i])
-	}
-	return ret, nil
+	slices.Reverse(chain)
+	return chain, nil
 }
 
 func (s *Service) setupForkchoiceRoot(st state.BeaconState) error {

--- a/beacon-chain/blockchain/setup_forkchoice.go
+++ b/beacon-chain/blockchain/setup_forkchoice.go
@@ -78,10 +78,7 @@ func (s *Service) setupForkchoiceTree(st state.BeaconState) error {
 	}
 	s.cfg.ForkChoiceStore.Lock()
 	defer s.cfg.ForkChoiceStore.Unlock()
-	if err := s.cfg.ForkChoiceStore.InsertChain(s.ctx, chain); err != nil {
-		return errors.Wrap(err, "could not insert forkchoice chain")
-	}
-	return s.cfg.ForkChoiceStore.InsertNode(s.ctx, st, chain[0].Block)
+	return s.cfg.ForkChoiceStore.InsertChain(s.ctx, chain)
 }
 
 func (s *Service) buildForkchoiceChain(ctx context.Context, head interfaces.ReadOnlySignedBeaconBlock) ([]*forkchoicetypes.BlockAndCheckpoints, error) {
@@ -115,7 +112,11 @@ func (s *Service) buildForkchoiceChain(ctx context.Context, head interfaces.Read
 			return nil, errors.New("head block is not a descendant of the finalized checkpoint")
 		}
 	}
-	return chain, nil
+	ret := make([]*forkchoicetypes.BlockAndCheckpoints, 0, len(chain))
+	for i := len(chain) - 1; i >= 0; i-- {
+		ret = append(ret, chain[i])
+	}
+	return ret, nil
 }
 
 func (s *Service) setupForkchoiceRoot(st state.BeaconState) error {

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -630,14 +630,15 @@ func TestStore_InsertChain(t *testing.T) {
 			FinalizedCheckpoint: &ethpb.Checkpoint{Epoch: 1, Root: params.BeaconConfig().ZeroHash[:]},
 		})
 	}
-	args := make([]*forkchoicetypes.BlockAndCheckpoints, 10)
-	for i := 0; i < len(blks); i++ {
-		args[i] = blks[10-i-1]
-	}
-	require.NoError(t, f.InsertChain(t.Context(), args))
+	// InsertChain now expects blocks in increasing slot order
+	require.NoError(t, f.InsertChain(t.Context(), blks))
 
+	// Test partial insertion: first insert the foundation blocks, then a subset
 	f = setup(1, 1)
-	require.NoError(t, f.InsertChain(t.Context(), args[2:]))
+	// Insert first 2 blocks to establish a chain from genesis
+	require.NoError(t, f.InsertChain(t.Context(), blks[:2]))
+	// Then insert the remaining blocks
+	require.NoError(t, f.InsertChain(t.Context(), blks[2:]))
 }
 
 func TestForkChoice_UpdateCheckpoints(t *testing.T) {

--- a/changelog/potuz_change_insertchain.md
+++ b/changelog/potuz_change_insertchain.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Change InsertChain to use be increasingly ordered and insert the last block of the chain. 


### PR DESCRIPTION
    InsertChain uses `ROBlock` since #14571, this allows it to insert the
    last block of the chain as well. We change the semantics of InsertChain
    to include all blocks and take them in increasing order.