### PR TITLE
Use reflect.TypeFor for proto.Message type token in SSZ equality

### DIFF
--- a/encoding/ssz/equality/deep_equal.go
+++ b/encoding/ssz/equality/deep_equal.go
@@ -320,6 +320,6 @@ func IsProto(item interface{}) bool {
 		return ok
 	}
 	elemTyp := typ.Elem()
-	modelType := reflect.TypeOf((*proto.Message)(nil)).Elem()
+	modelType := reflect.TypeFor[proto.Message]()
 	return elemTyp.Implements(modelType)
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -341,7 +341,7 @@ func (v *validator) SetTicker() {
 	// This means that sometimes we need to reset the ticker to avoid replaying old ticks on a slow consumer of the ticks.
 	// i.e.,
 	// 1. tick starts at 0
-	// 2. loop stops consuming on slot 10 due to accounts changed tigger with no active keys
+	// 2. loop stops consuming on slot 10 due to accounts changed trigger with no active keys
 	// 3. new active keys are added in slot 20 resolving wait for activation
 	// 4. new tick starts ticking from slot 20 instead of slot 10
 	if v.ticker != nil {


### PR DESCRIPTION
Replace reflect.TypeOf((proto.Message)(nil)).Elem() with reflect.TypeForproto.Message in encoding/ssz/equality/deep_equal.go. Cleaner and more idiomatic.