### PR TITLE
fix e2e noise from a goroutine exits after test cleanup

### DIFF
--- a/changelog/kasey_fix-e2e-panic.md
+++ b/changelog/kasey_fix-e2e-panic.md
@@ -1,0 +1,2 @@
+### Ignored
+- Fix a panic in e2e that is caused by poor context management leading to error assertions being called after test cleanup.

--- a/testing/endtoend/components/eth1/depositor.go
+++ b/testing/endtoend/components/eth1/depositor.go
@@ -170,7 +170,7 @@ func (d *Depositor) SendAndMine(ctx context.Context, offset, nvals int, batch ty
 
 	// This is the "AndMine" part of the function. WaitForBlocks will spam transactions to/from the given key
 	// to advance the EL chain and until the chain has advanced the requested amount.
-	if err = WaitForBlocks(d.Client, d.Key, params.BeaconConfig().Eth1FollowDistance); err != nil {
+	if err = WaitForBlocks(ctx, d.Client, d.Key, params.BeaconConfig().Eth1FollowDistance); err != nil {
 		return fmt.Errorf("failed to mine blocks %w", err)
 	}
 	return nil
@@ -210,7 +210,7 @@ func (d *Depositor) SendAndMineByBatch(ctx context.Context, offset, nvals, batch
 		}
 		// This is the "AndMine" part of the function. WaitForBlocks will spam transactions to/from the given key
 		// to advance the EL chain and until the chain has advanced the requested amount.
-		if err = WaitForBlocks(d.Client, d.Key, 1); err != nil {
+		if err = WaitForBlocks(ctx, d.Client, d.Key, 1); err != nil {
 			return fmt.Errorf("failed to mine blocks %w", err)
 		}
 	}
@@ -226,7 +226,7 @@ func (d *Depositor) SendAndMineByBatch(ctx context.Context, offset, nvals, batch
 	}
 	// This is the "AndMine" part of the function. WaitForBlocks will spam transactions to/from the given key
 	// to advance the EL chain and until the chain has advanced the requested amount.
-	if err = WaitForBlocks(d.Client, d.Key, 1); err != nil {
+	if err = WaitForBlocks(ctx, d.Client, d.Key, 1); err != nil {
 		return fmt.Errorf("failed to mine blocks %w", err)
 	}
 	return nil

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -232,7 +232,10 @@ func (r *testRunner) testDepositsAndTx(ctx context.Context, g *errgroup.Group,
 				// for further deposit testing.
 				err := r.depositor.SendAndMine(ctx, minGenesisActiveCount, int(e2e.DepositCount), e2etypes.PostGenesisDepositBatch, false)
 				if err != nil {
-					r.t.Error(err)
+					// prevent noisy panic if this goroutine exits after test cleanup
+					if r.t.Context().Err() == nil {
+						r.t.Error(errors.Wrap(err, "depositor.SendAndMine failed"))
+					}
 				}
 			}
 			r.testTxGeneration(ctx, g, keystorePath, []e2etypes.ComponentRunner{})


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Sometimes the tx generator keeps running and generates an error after the test context has been cleaned up. This is passed to t.Error() which causes the go testing stdlib to panic. This PR address this panic in the following ways:
- plumbs through ctx to a few places that support context cancellation in this code path that were not getting the test context
- some extra ctx checks
- does not call t.Error in the goroutine where this has been observed to happen if the `testing.T` context is canceled.

Here's an example of the panic this fixes:
```

FAIL: TestEndToEnd_MinimalConfig (110.15s)
--
  | --- PASS: TestEndToEnd_MinimalConfig/chain_started (0.50s)
  | --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_0 (0.00s)
  | --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_0 (0.00s)
  | --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_0 (0.00s)
  | --- FAIL: TestEndToEnd_MinimalConfig/validator_sync_participation_0 (0.01s)
  | --- PASS: TestEndToEnd_MinimalConfig/peers_connect_epoch_0 (0.11s)
  | === RUN   TestEndToEnd_SlasherSimulator
  | time="2025-09-17T01:50:03Z" level=info msg="Starting slasher simulator" func="github.com/OffchainLabs/prysm/v6/testing/slasher/simulator.(*Simulator).Start" file="testing/slasher/simulator/simulator.go:128" attesterSlashingProbab=0.3 numEpochs=4 numValidators=256 prefix=simulator proposerSlashingProbab=0.3 secondsPerSlot=10
  | panic: Fail in goroutine after TestEndToEnd_MinimalConfig has completed
  |  
  | goroutine 482 [running]:
  | testing.(*common).Fail(0xc0005a4700)
  | GOROOT/src/testing/testing.go:988 +0xcb
  | testing.(*common).Error(0xc0005a4700, {0xc011c59fc0?, 0xc0005a1040?, 0x100?})
  | GOROOT/src/testing/testing.go:1104 +0x54
  | testing/endtoend/go_default_test.(*testRunner).testDepositsAndTx.func1.1()
  | testing/endtoend/endtoend_test.go:235 +0x11c
  | created by testing/endtoend/go_default_test.(*testRunner).testDepositsAndTx.func1 in goroutine 444
  | testing/endtoend/endtoend_test.go:227 +0x18c


```
**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
