### PR TITLE
PeerDAS: Modify the reconstruction and reseed process.

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -723,7 +723,8 @@ func (c *ChainService) ReceiveDataColumn(dc blocks.VerifiedRODataColumn) error {
 }
 
 // ReceiveDataColumns implements the same method in chain service
-func (*ChainService) ReceiveDataColumns(_ []blocks.VerifiedRODataColumn) error {
+func (c *ChainService) ReceiveDataColumns(dcs []blocks.VerifiedRODataColumn) error {
+	c.DataColumns = append(c.DataColumns, dcs...)
 	return nil
 }
 

--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -259,7 +259,6 @@ func (dcs *DataColumnStorage) Summary(root [fieldparams.RootLength]byte) DataCol
 }
 
 // Save saves data column sidecars into the database and asynchronously performs pruning.
-// The returned channel is closed when the pruning is complete.
 func (dcs *DataColumnStorage) Save(dataColumnSidecars []blocks.VerifiedRODataColumn) error {
 	startTime := time.Now()
 

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -154,6 +154,7 @@ go_library(
         "@com_github_trailofbits_go_mutexasserts//:go_default_library",
         "@io_opentelemetry_go_otel_trace//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
         "@org_golang_x_sync//singleflight:go_default_library",
     ],
 )

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -116,12 +116,9 @@ func (s *Service) shouldReconstruct(root [fieldparams.RootLength]byte) bool {
 	storedDataColumns := s.cfg.dataColumnStorage.Summary(root)
 	storedColumnsCount := storedDataColumns.Count()
 
-	// Do not reconstruct if we don't have enough columns or if we already have all columns.
-	if storedColumnsCount < peerdas.MinimumColumnCountToReconstruct() || storedColumnsCount == numberOfColumns {
-		return false
-	}
-
-	return true
+	// Reconstruct only if we have at least the minimum number of columns to reconstruct, but not all the columns.
+	// (If we have not enough columns, reconstruction is impossible. If we have all the columns, reconstruction is unnecessary.)
+	return storedColumnsCount >= peerdas.MinimumColumnCountToReconstruct() && storedColumnsCount != numberOfColumns
 }
 
 // computeRandomDelay computes a random delay duration to wait before reconstructing data column sidecars.

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -47,7 +47,7 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(ctx context.Context
 	}
 
 	// Retrieve column indices to sample.
-	custodyColumns, err := s.columnIndicesToSample()
+	columnIndicesToSample, err := s.columnIndicesToSample()
 	if err != nil {
 		return errors.Wrap(err, "column indices to sample")
 	}
@@ -65,9 +65,9 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(ctx context.Context
 	}
 
 	// Filter reconstructed sidecars to save.
-	toSaveSidecars := make([]blocks.VerifiedRODataColumn, 0, len(custodyColumns))
+	toSaveSidecars := make([]blocks.VerifiedRODataColumn, 0, len(columnIndicesToSample))
 	for _, sidecar := range reconstructedSidecars {
-		if custodyColumns[sidecar.Index] {
+		if columnIndicesToSample[sidecar.Index] {
 			toSaveSidecars = append(toSaveSidecars, sidecar)
 		}
 	}

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -27,7 +27,6 @@ const (
 // (but reconstructed) sidecars.
 func (s *Service) reconstructSaveBroadcastDataColumnSidecars(ctx context.Context, sidecar blocks.VerifiedRODataColumn) error {
 	startTime := time.Now()
-	samplesPerSlot := params.BeaconConfig().SamplesPerSlot
 
 	root := sidecar.BlockRoot()
 	slot := sidecar.Slot()
@@ -47,17 +46,10 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(ctx context.Context
 		return nil
 	}
 
-	// Retrieve our local node info.
-	nodeID := s.cfg.p2p.NodeID()
-	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount()
+	// Retrieve column indices to sample.
+	custodyColumns, err := s.columnIndicesToSample()
 	if err != nil {
-		return errors.Wrap(err, "custody group count")
-	}
-
-	samplingSize := max(custodyGroupCount, samplesPerSlot)
-	localNodeInfo, _, err := peerdas.Info(nodeID, samplingSize)
-	if err != nil {
-		return errors.Wrap(err, "peer info")
+		return errors.Wrap(err, "column indices to sample")
 	}
 
 	// Load all the possible data column sidecars, to minimize reconstruction time.
@@ -73,7 +65,6 @@ func (s *Service) reconstructSaveBroadcastDataColumnSidecars(ctx context.Context
 	}
 
 	// Filter reconstructed sidecars to save.
-	custodyColumns := localNodeInfo.CustodyColumns
 	toSaveSidecars := make([]blocks.VerifiedRODataColumn, 0, len(custodyColumns))
 	for _, sidecar := range reconstructedSidecars {
 		if custodyColumns[sidecar.Index] {

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // processDataColumnSidecarsFromReconstruction, after a random delay, attempts to reconstruct,
@@ -84,34 +85,20 @@ func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Contex
 				return
 			}
 
-			// Compute sidecars we need to broadcast and receive.
-			unseenSidecars := make([]blocks.VerifiedRODataColumn, 0, len(reconstructedSidecars))
-			for _, sidecar := range reconstructedSidecars {
-				// Skip already seen data column sidecars.
-				if s.hasSeenDataColumnIndex(slot, proposerIndex, sidecar.Index) {
-					continue
-				}
-
-				if columnIndicesToSample[sidecar.Index] {
-					unseenSidecars = append(unseenSidecars, sidecar)
-				}
-			}
-
-			// Broadcast all the data column sidecars we reconstructed but did not see via gossip.
-			for _, sidecar := range unseenSidecars {
-				// Compute the subnet for this data column sidecar.
-				subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index)
-
-				// Broadcast the data column sidecar.
-				if err := s.cfg.p2p.BroadcastDataColumnSidecar(subnet, sidecar); err != nil {
-					log.WithError(err).Error("Broadcast data column")
-				}
-			}
-
-			// Receive data column sidecars.
-			if err := s.receiveDataColumnSidecars(ctx, unseenSidecars); err != nil {
-				log.WithError(err).Error("Failed to receive data column sidecars")
+			unseenIndices, err := s.broadcastAndReceiveUnseenDataColumnSidecars(ctx, slot, proposerIndex, columnIndicesToSample, reconstructedSidecars)
+			if err != nil {
+				log.WithError(err).Error("Failed to broadcast and receive unseen data column sidecars")
 				return
+			}
+
+			if len(unseenIndices) > 0 {
+				log.WithFields(logrus.Fields{
+					"root":          fmt.Sprintf("%#x", root),
+					"slot":          slot,
+					"proposerIndex": proposerIndex,
+					"count":         len(unseenIndices),
+					"indices":       sortedSliceFromMap(unseenIndices),
+				}).Debug("Reconstructed data column sidecars")
 			}
 		})
 

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -21,8 +21,6 @@ import (
 func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Context, sidecar blocks.VerifiedRODataColumn) error {
 	key := fmt.Sprintf("%#x", sidecar.BlockRoot())
 	if _, err, _ := s.reconstructionSingleFlight.Do(key, func() (interface{}, error) {
-		const maxReconstructionDelaySec = 2.
-
 		var wg sync.WaitGroup
 
 		root := sidecar.BlockRoot()
@@ -41,8 +39,7 @@ func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Contex
 		}
 
 		// Randomly choose value before starting reconstruction.
-		randFloat := s.reconstructionRandGen.Float64()
-		timeIntoSlot := time.Duration(maxReconstructionDelaySec*randFloat) * time.Second
+		timeIntoSlot := s.computeRandomDelay(slotStartTime)
 		broadcastTime := slotStartTime.Add(timeIntoSlot)
 		waitingTime := time.Until(broadcastTime)
 
@@ -125,4 +122,13 @@ func (s *Service) shouldReconstruct(root [fieldparams.RootLength]byte) bool {
 	}
 
 	return true
+}
+
+// computeRandomDelay computes a random delay duration to wait before reconstructing data column sidecars.
+func (s *Service) computeRandomDelay(slotStartTime time.Time) time.Duration {
+	const maxReconstructionDelaySec = 2.
+
+	randFloat := s.reconstructionRandGen.Float64()
+	timeIntoSlot := time.Duration(maxReconstructionDelaySec * randFloat * float64(time.Second))
+	return timeIntoSlot
 }

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -72,7 +72,8 @@ func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Contex
 				return
 			}
 
-			dataColumnReconstructionHistogram.Observe(float64(time.Since(startTime).Milliseconds()))
+			duration := time.Since(startTime)
+			dataColumnReconstructionHistogram.Observe(float64(duration.Milliseconds()))
 			dataColumnReconstructionCounter.Add(float64(len(reconstructedSidecars) - len(verifiedSidecars)))
 
 			// Retrieve indices of data column sidecars to sample.
@@ -95,6 +96,7 @@ func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Contex
 					"proposerIndex": proposerIndex,
 					"count":         len(unseenIndices),
 					"indices":       sortedSliceFromMap(unseenIndices),
+					"duration":      duration,
 				}).Debug("Reconstructed data column sidecars")
 			}
 		})

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -3,210 +3,139 @@ package sync
 import (
 	"context"
 	"fmt"
-	"slices"
+	"sync"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
-const (
-	broadcastMissingDataColumnsTimeIntoSlotMin = 1 * time.Second
-	broadcastMissingDataColumnsSlack           = 2 * time.Second
-)
+// processDataColumnSidecarsFromReconstruction, after a random delay, attempts to reconstruct,
+// broadcast and receive missing data column sidecars for the given block root.
+// https:github.com/ethereum/consensus-specs/blob/master/specs/fulu/das-core.md#reconstruction-and-cross-seeding
+func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Context, sidecar blocks.VerifiedRODataColumn) error {
+	key := fmt.Sprintf("%#x", sidecar.BlockRoot())
+	if _, err, _ := s.reconstructionSingleFlight.Do(key, func() (interface{}, error) {
+		const maxReconstructionDelaySec = 2.
 
-// reconstructSaveBroadcastDataColumnSidecars reconstructs, if possible,
-// all data column sidecars. Then, it saves missing sidecars to the store.
-// After a delay, it broadcasts in the background not seen via gossip
-// (but reconstructed) sidecars.
-func (s *Service) reconstructSaveBroadcastDataColumnSidecars(ctx context.Context, sidecar blocks.VerifiedRODataColumn) error {
-	startTime := time.Now()
+		var wg sync.WaitGroup
 
-	root := sidecar.BlockRoot()
-	slot := sidecar.Slot()
-	proposerIndex := sidecar.ProposerIndex()
+		root := sidecar.BlockRoot()
+		slot := sidecar.Slot()
+		proposerIndex := sidecar.ProposerIndex()
 
-	// Lock to prevent concurrent reconstructions.
-	s.reconstructionLock.Lock()
-	defer s.reconstructionLock.Unlock()
+		// Return early if reconstruction is not needed.
+		if !s.shouldReconstruct(root) {
+			return nil, nil
+		}
+
+		// Compute the slot start time.
+		slotStartTime, err := slots.StartTime(s.cfg.clock.GenesisTime(), slot)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to calculate slot start time")
+		}
+
+		// Randomly choose value before starting reconstruction.
+		randFloat := s.reconstructionRandGen.Float64()
+		timeIntoSlot := time.Duration(maxReconstructionDelaySec*randFloat) * time.Second
+		broadcastTime := slotStartTime.Add(timeIntoSlot)
+		waitingTime := time.Until(broadcastTime)
+
+		wg.Add(1)
+		time.AfterFunc(waitingTime, func() {
+			defer wg.Done()
+
+			// Return early if the context was canceled during the waiting time.
+			if err := ctx.Err(); err != nil {
+				return
+			}
+
+			// Return early if reconstruction is not needed anymore.
+			if !s.shouldReconstruct(root) {
+				return
+			}
+
+			// Load all the stored data column sidecars for this root.
+			verifiedSidecars, err := s.cfg.dataColumnStorage.Get(root, nil)
+			if err != nil {
+				log.WithError(err).Error("Failed to get data column sidecars")
+				return
+			}
+
+			// Reconstruct all the data column sidecars.
+			startTime := time.Now()
+			reconstructedSidecars, err := peerdas.ReconstructDataColumnSidecars(verifiedSidecars)
+			if err != nil {
+				log.WithError(err).Error("Failed to reconstruct data column sidecars")
+				return
+			}
+
+			dataColumnReconstructionHistogram.Observe(float64(time.Since(startTime).Milliseconds()))
+			dataColumnReconstructionCounter.Add(float64(len(reconstructedSidecars) - len(verifiedSidecars)))
+
+			// Retrieve indices of data column sidecars to sample.
+			columnIndicesToSample, err := s.columnIndicesToSample()
+			if err != nil {
+				log.WithError(err).Error("Failed to get column indices to sample")
+				return
+			}
+
+			// Compute sidecars we need to broadcast and receive.
+			unseenSidecars := make([]blocks.VerifiedRODataColumn, 0, len(reconstructedSidecars))
+			for _, sidecar := range reconstructedSidecars {
+				// Skip already seen data column sidecars.
+				if s.hasSeenDataColumnIndex(slot, proposerIndex, sidecar.Index) {
+					continue
+				}
+
+				if columnIndicesToSample[sidecar.Index] {
+					unseenSidecars = append(unseenSidecars, sidecar)
+				}
+			}
+
+			// Broadcast all the data column sidecars we reconstructed but did not see via gossip.
+			for _, sidecar := range unseenSidecars {
+				// Compute the subnet for this data column sidecar.
+				subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index)
+
+				// Broadcast the data column sidecar.
+				if err := s.cfg.p2p.BroadcastDataColumnSidecar(subnet, sidecar); err != nil {
+					log.WithError(err).Error("Broadcast data column")
+				}
+			}
+
+			// Receive data column sidecars.
+			if err := s.receiveDataColumnSidecars(ctx, unseenSidecars); err != nil {
+				log.WithError(err).Error("Failed to receive data column sidecars")
+				return
+			}
+		})
+
+		wg.Wait()
+		return nil, nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// shouldReconstruct returns true if we should attempt to reconstruct the data columns for the given block root.
+func (s *Service) shouldReconstruct(root [fieldparams.RootLength]byte) bool {
+	numberOfColumns := params.BeaconConfig().NumberOfColumns
 
 	// Get the columns we store.
 	storedDataColumns := s.cfg.dataColumnStorage.Summary(root)
 	storedColumnsCount := storedDataColumns.Count()
-	numberOfColumns := params.BeaconConfig().NumberOfColumns
 
-	// If reconstruction is not possible or if all columns are already stored, exit early.
+	// Do not reconstruct if we don't have enough columns or if we already have all columns.
 	if storedColumnsCount < peerdas.MinimumColumnCountToReconstruct() || storedColumnsCount == numberOfColumns {
-		return nil
+		return false
 	}
 
-	// Retrieve column indices to sample.
-	columnIndicesToSample, err := s.columnIndicesToSample()
-	if err != nil {
-		return errors.Wrap(err, "column indices to sample")
-	}
-
-	// Load all the possible data column sidecars, to minimize reconstruction time.
-	verifiedSidecars, err := s.cfg.dataColumnStorage.Get(root, nil)
-	if err != nil {
-		return errors.Wrap(err, "get data column sidecars")
-	}
-
-	// Reconstruct all the data column sidecars.
-	reconstructedSidecars, err := peerdas.ReconstructDataColumnSidecars(verifiedSidecars)
-	if err != nil {
-		return errors.Wrap(err, "reconstruct data column sidecars")
-	}
-
-	// Filter reconstructed sidecars to save.
-	toSaveSidecars := make([]blocks.VerifiedRODataColumn, 0, len(columnIndicesToSample))
-	for _, sidecar := range reconstructedSidecars {
-		if columnIndicesToSample[sidecar.Index] {
-			toSaveSidecars = append(toSaveSidecars, sidecar)
-		}
-	}
-
-	// Save the data column sidecars to the database.
-	// Note: We do not call `receiveDataColumn`, because it will ignore
-	// incoming data columns via gossip while we did not broadcast (yet) the reconstructed data columns.
-	if err := s.cfg.dataColumnStorage.Save(toSaveSidecars); err != nil {
-		return errors.Wrap(err, "save data column sidecars")
-	}
-
-	slotStartTime, err := slots.StartTime(s.cfg.clock.GenesisTime(), slot)
-	if err != nil {
-		return errors.Wrap(err, "failed to calculate slot start time")
-	}
-	log.WithFields(logrus.Fields{
-		"root":                          fmt.Sprintf("%#x", root),
-		"slot":                          slot,
-		"fromColumnsCount":              storedColumnsCount,
-		"sinceSlotStartTime":            time.Since(slotStartTime),
-		"reconstructionAndSaveDuration": time.Since(startTime),
-	}).Debug("Data columns reconstructed and saved")
-
-	// Update reconstruction metrics.
-	dataColumnReconstructionHistogram.Observe(float64(time.Since(startTime).Milliseconds()))
-	dataColumnReconstructionCounter.Add(float64(len(reconstructedSidecars) - len(verifiedSidecars)))
-
-	// Schedule the broadcast.
-	if err := s.scheduleMissingDataColumnSidecarsBroadcast(ctx, root, proposerIndex, slot); err != nil {
-		return errors.Wrap(err, "schedule reconstructed data columns broadcast")
-	}
-
-	return nil
-}
-
-// scheduleMissingDataColumnSidecarsBroadcast schedules the broadcast of missing
-// (aka. not seen via gossip but reconstructed) sidecars.
-func (s *Service) scheduleMissingDataColumnSidecarsBroadcast(
-	ctx context.Context,
-	root [fieldparams.RootLength]byte,
-	proposerIndex primitives.ValidatorIndex,
-	slot primitives.Slot,
-) error {
-	log := log.WithFields(logrus.Fields{
-		"root": fmt.Sprintf("%x", root),
-		"slot": slot,
-	})
-
-	// Get the time corresponding to the start of the slot.
-	genesisTime := s.cfg.clock.GenesisTime()
-	slotStartTime, err := slots.StartTime(genesisTime, slot)
-	if err != nil {
-		return errors.Wrap(err, "failed to calculate slot start time")
-	}
-
-	// Compute the waiting time. This could be negative. In such a case, broadcast immediately.
-	randFloat := s.reconstructionRandGen.Float64()
-	timeIntoSlot := broadcastMissingDataColumnsTimeIntoSlotMin + time.Duration(float64(broadcastMissingDataColumnsSlack)*randFloat)
-	broadcastTime := slotStartTime.Add(timeIntoSlot)
-	waitingTime := time.Until(broadcastTime)
-	time.AfterFunc(waitingTime, func() {
-		// Return early if the context was canceled during the waiting time.
-		if err := ctx.Err(); err != nil {
-			return
-		}
-
-		if err := s.broadcastMissingDataColumnSidecars(slot, proposerIndex, root, timeIntoSlot); err != nil {
-			log.WithError(err).Error("Failed to broadcast missing data column sidecars")
-		}
-	})
-
-	return nil
-}
-
-func (s *Service) broadcastMissingDataColumnSidecars(
-	slot primitives.Slot,
-	proposerIndex primitives.ValidatorIndex,
-	root [fieldparams.RootLength]byte,
-	timeIntoSlot time.Duration,
-) error {
-	// Get the node ID.
-	nodeID := s.cfg.p2p.NodeID()
-
-	// Retrieve the local node info.
-	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount()
-	if err != nil {
-		return errors.Wrap(err, "custody group count")
-	}
-
-	localNodeInfo, _, err := peerdas.Info(nodeID, custodyGroupCount)
-	if err != nil {
-		return errors.Wrap(err, "peerdas info")
-	}
-
-	// Compute the missing data columns (data columns we should custody but we did not received via gossip.)
-	missingColumns := make([]uint64, 0, len(localNodeInfo.CustodyColumns))
-	for column := range localNodeInfo.CustodyColumns {
-		if !s.hasSeenDataColumnIndex(slot, proposerIndex, column) {
-			missingColumns = append(missingColumns, column)
-		}
-	}
-
-	// Return early if there are no missing data columns.
-	if len(missingColumns) == 0 {
-		return nil
-	}
-
-	// Load from the store the non received but reconstructed data column.
-	verifiedRODataColumnSidecars, err := s.cfg.dataColumnStorage.Get(root, missingColumns)
-	if err != nil {
-		return errors.Wrap(err, "data column storage get")
-	}
-
-	broadcastedColumns := make([]uint64, 0, len(verifiedRODataColumnSidecars))
-	for _, verifiedRODataColumn := range verifiedRODataColumnSidecars {
-		broadcastedColumns = append(broadcastedColumns, verifiedRODataColumn.Index)
-		// Compute the subnet for this column.
-		subnet := peerdas.ComputeSubnetForDataColumnSidecar(verifiedRODataColumn.Index)
-
-		// Broadcast the missing data column.
-		if err := s.cfg.p2p.BroadcastDataColumnSidecar(subnet, verifiedRODataColumn); err != nil {
-			log.WithError(err).Error("Broadcast data column")
-		}
-
-		// Now, we can set the data column as seen.
-		s.setSeenDataColumnIndex(slot, proposerIndex, verifiedRODataColumn.Index)
-	}
-
-	if logrus.GetLevel() >= logrus.DebugLevel {
-		// Sort for nice logging.
-		slices.Sort(broadcastedColumns)
-		slices.Sort(missingColumns)
-
-		log.WithFields(logrus.Fields{
-			"timeIntoSlot":   timeIntoSlot,
-			"missingColumns": missingColumns,
-			"broadcasted":    broadcastedColumns,
-		}).Debug("Start broadcasting not seen via gossip but reconstructed data columns")
-	}
-
-	return nil
+	return true
 }

--- a/beacon-chain/sync/data_columns_reconstruct_test.go
+++ b/beacon-chain/sync/data_columns_reconstruct_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db/filesystem"
 	p2ptest "github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/testing"
 	"github.com/OffchainLabs/prysm/v6/config/params"
-	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/OffchainLabs/prysm/v6/testing/util"
 )
 
-func TestReconstructDataColumns(t *testing.T) {
+func TestProcessDataColumnSidecarsFromReconstruction(t *testing.T) {
 	const blobCount = 4
 	numberOfColumns := params.BeaconConfig().NumberOfColumns
 
@@ -35,7 +34,7 @@ func TestReconstructDataColumns(t *testing.T) {
 		require.NoError(t, err)
 
 		service := NewService(ctx, WithP2P(p2ptest.NewTestP2P(t)), WithDataColumnStorage(storage))
-		err = service.reconstructSaveBroadcastDataColumnSidecars(ctx, verifiedRoDataColumns[0])
+		err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
 		require.NoError(t, err)
 	})
 
@@ -45,7 +44,7 @@ func TestReconstructDataColumns(t *testing.T) {
 		require.NoError(t, err)
 
 		service := NewService(ctx, WithP2P(p2ptest.NewTestP2P(t)), WithDataColumnStorage(storage))
-		err = service.reconstructSaveBroadcastDataColumnSidecars(ctx, verifiedRoDataColumns[0])
+		err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
 		require.NoError(t, err)
 	})
 
@@ -57,19 +56,39 @@ func TestReconstructDataColumns(t *testing.T) {
 		// However, for the needs of this test, this is perfectly fine.
 		const cgc = 8
 
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
-		minimumCount := peerdas.MinimumColumnCountToReconstruct()
-		err := storage.Save(verifiedRoDataColumns[:minimumCount])
 		require.NoError(t, err)
+
+		chainService := &mockChain.ChainService{}
+		p2p := p2ptest.NewTestP2P(t)
+		storage := filesystem.NewEphemeralDataColumnStorage(t)
 
 		service := NewService(
 			ctx,
-			WithP2P(p2ptest.NewTestP2P(t)),
+			WithP2P(p2p),
 			WithDataColumnStorage(storage),
-			WithChainService(&mockChain.ChainService{}),
+			WithChainService(chainService),
+			WithOperationNotifier(chainService.OperationNotifier()),
 		)
 
-		err = service.reconstructSaveBroadcastDataColumnSidecars(ctx, verifiedRoDataColumns[0])
+		minimumCount := peerdas.MinimumColumnCountToReconstruct()
+		receivedBeforeReconstruction := verifiedRoDataColumns[:minimumCount]
+
+		err = service.receiveDataColumnSidecars(ctx, receivedBeforeReconstruction)
+		require.NoError(t, err)
+
+		err = storage.Save(receivedBeforeReconstruction)
+		require.NoError(t, err)
+
+		require.Equal(t, false, p2p.BroadcastCalled.Load())
+
+		// Check received indices before reconstruction.
+		require.Equal(t, minimumCount, uint64(len(chainService.DataColumns)))
+		for i, actual := range chainService.DataColumns {
+			require.Equal(t, uint64(i), actual.Index)
+		}
+
+		// Run the reconstruction.
+		err = service.processDataColumnSidecarsFromReconstruction(ctx, verifiedRoDataColumns[0])
 		require.NoError(t, err)
 
 		expected := make(map[uint64]bool, minimumCount+cgc)
@@ -78,95 +97,18 @@ func TestReconstructDataColumns(t *testing.T) {
 		}
 
 		// The node should custody these indices.
-		for _, i := range [...]uint64{1, 17, 19, 42, 75, 87, 102, 117} {
+		for _, i := range [...]uint64{75, 87, 102, 117} {
 			expected[i] = true
 		}
 
-		summary := storage.Summary(roBlock.Root())
-		actual := summary.Stored()
+		block := roBlock.Block()
+		slot := block.Slot()
+		proposerIndex := block.ProposerIndex()
 
-		require.Equal(t, len(expected), len(actual))
-		for index := range expected {
-			require.Equal(t, true, actual[index])
-		}
-	})
-}
-
-func TestBroadcastMissingDataColumnSidecars(t *testing.T) {
-	const (
-		cgc          = 8
-		blobCount    = 4
-		timeIntoSlot = 0
-	)
-
-	numberOfColumns := params.BeaconConfig().NumberOfColumns
-	ctx := t.Context()
-
-	// Start the trusted setup.
-	err := kzg.Start()
-	require.NoError(t, err)
-
-	roBlock, _, verifiedRoDataColumns := util.GenerateTestFuluBlockWithSidecars(t, blobCount)
-	require.Equal(t, numberOfColumns, uint64(len(verifiedRoDataColumns)))
-
-	root, block := roBlock.Root(), roBlock.Block()
-	slot, proposerIndex := block.Slot(), block.ProposerIndex()
-
-	t.Run("no missing sidecars", func(t *testing.T) {
-		service := NewService(
-			ctx,
-			WithP2P(p2ptest.NewTestP2P(t)),
-		)
-
-		for _, index := range [...]uint64{1, 17, 19, 42, 75, 87, 102, 117} {
-			key := computeCacheKey(slot, proposerIndex, index)
-			service.seenDataColumnCache.Add(slot, key, true)
-		}
-
-		err := service.broadcastMissingDataColumnSidecars(slot, proposerIndex, root, timeIntoSlot)
-		require.NoError(t, err)
-	})
-
-	t.Run("some missing sidecars", func(t *testing.T) {
-		toSave := make([]blocks.VerifiedRODataColumn, 0, 2)
-		for _, index := range [...]uint64{42, 87} {
-			toSave = append(toSave, verifiedRoDataColumns[index])
-		}
-
-		p2p := p2ptest.NewTestP2P(t)
-		storage := filesystem.NewEphemeralDataColumnStorage(t)
-		err := storage.Save(toSave)
-		require.NoError(t, err)
-
-		service := NewService(
-			ctx,
-			WithP2P(p2p),
-			WithDataColumnStorage(storage),
-		)
-		_, _, err = service.cfg.p2p.UpdateCustodyInfo(0, cgc)
-		require.NoError(t, err)
-
-		for _, index := range [...]uint64{1, 17, 19, 102, 117} { // 42, 75 and 87 are missing
-			key := computeCacheKey(slot, proposerIndex, index)
-			service.seenDataColumnCache.Add(slot, key, true)
-		}
-
-		for _, index := range [...]uint64{42, 75, 87} {
-			seen := service.hasSeenDataColumnIndex(slot, proposerIndex, index)
-			require.Equal(t, false, seen)
-		}
-
-		require.Equal(t, false, p2p.BroadcastCalled.Load())
-
-		err = service.broadcastMissingDataColumnSidecars(slot, proposerIndex, root, timeIntoSlot)
-		require.NoError(t, err)
-
-		seen := service.hasSeenDataColumnIndex(slot, proposerIndex, 75)
-		require.Equal(t, false, seen)
-
-		for _, index := range [...]uint64{42, 87} {
-			seen := service.hasSeenDataColumnIndex(slot, proposerIndex, index)
-			require.Equal(t, true, seen)
+		require.Equal(t, len(expected), len(chainService.DataColumns))
+		for _, actual := range chainService.DataColumns {
+			require.Equal(t, true, expected[actual.Index])
+			require.Equal(t, true, service.hasSeenDataColumnIndex(slot, proposerIndex, actual.Index))
 		}
 
 		require.Equal(t, true, p2p.BroadcastCalled.Load())

--- a/beacon-chain/sync/data_columns_reconstruct_test.go
+++ b/beacon-chain/sync/data_columns_reconstruct_test.go
@@ -1,7 +1,11 @@
 package sync
 
 import (
+	"fmt"
 	"testing"
+	"time"
+
+	"math/rand"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain/kzg"
 	mockChain "github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain/testing"
@@ -113,4 +117,22 @@ func TestProcessDataColumnSidecarsFromReconstruction(t *testing.T) {
 
 		require.Equal(t, true, p2p.BroadcastCalled.Load())
 	})
+}
+
+func TestComputeRandomDelay(t *testing.T) {
+	const (
+		seed     = 42
+		expected = 746056722 * time.Nanosecond // = 0.746056722 seconds
+	)
+	slotStartTime := time.Date(2020, 12, 30, 0, 0, 0, 0, time.UTC)
+
+	service := NewService(
+		t.Context(),
+		WithP2P(p2ptest.NewTestP2P(t)),
+		WithReconstructionRandGen(rand.New(rand.NewSource(seed))),
+	)
+
+	waitingTime := service.computeRandomDelay(slotStartTime)
+	fmt.Print(waitingTime)
+	require.Equal(t, expected, waitingTime)
 }

--- a/beacon-chain/sync/options.go
+++ b/beacon-chain/sync/options.go
@@ -20,6 +20,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stategen"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/sync/backfill/coverage"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v6/crypto/rand"
 )
 
 type Option func(s *Service) error
@@ -226,6 +227,14 @@ func WithLightClientStore(lcs *lightClient.Store) Option {
 func WithBatchVerifierLimit(limit int) Option {
 	return func(s *Service) error {
 		s.cfg.batchVerifierLimit = limit
+		return nil
+	}
+}
+
+// WithReconstructionRandGen sets the random generator for reconstruction delays.
+func WithReconstructionRandGen(rg *rand.Rand) Option {
+	return func(s *Service) error {
+		s.reconstructionRandGen = rg
 		return nil
 	}
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -172,8 +172,8 @@ type Service struct {
 	newBlobVerifier                  verification.NewBlobVerifier
 	newColumnsVerifier               verification.NewDataColumnsVerifier
 	columnSidecarsExecSingleFlight   singleflight.Group
+	reconstructionSingleFlight       singleflight.Group
 	availableBlocker                 coverage.AvailableBlocker
-	reconstructionLock               sync.Mutex
 	reconstructionRandGen            *rand.Rand
 	trackedValidatorsCache           *cache.TrackedValidatorsCache
 	ctxMap                           ContextByteVersions

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -214,34 +214,9 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, so
 				return nil, errors.Errorf("reconstruct data column sidecars returned %d sidecars, expected %d - should never happen", sidecarCount, numberOfColumns)
 			}
 
-			// Compute sidecars we need to broadcast and receive.
-			unseenSidecars := make([]blocks.VerifiedRODataColumn, 0, len(constructedSidecars))
-			unseenIndices := make(map[uint64]bool, len(constructedSidecars))
-			for _, sidecar := range constructedSidecars {
-				// Skip already seen data column sidecars.
-				if s.hasSeenDataColumnIndex(source.Slot(), source.ProposerIndex(), sidecar.Index) {
-					continue
-				}
-
-				if columnIndicesToSample[sidecar.Index] {
-					unseenSidecars = append(unseenSidecars, sidecar)
-				}
-			}
-
-			// Broadcast all the data column sidecars we reconstructed but did not see via gossip.
-			for _, sidecar := range unseenSidecars {
-				// Compute the subnet for this data column sidecar.
-				subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index)
-
-				// Broadcast the data column sidecar.
-				if err := s.cfg.p2p.BroadcastDataColumnSidecar(subnet, sidecar); err != nil {
-					log.WithError(err).Error("Broadcast data column")
-				}
-			}
-
-			// Receive data column sidecars.
-			if err := s.receiveDataColumnSidecars(ctx, unseenSidecars); err != nil {
-				return nil, errors.Wrap(err, "receive data column sidecars")
+			unseenIndices, err := s.broadcastAndReceiveUnseenDataColumnSidecars(ctx, source.Slot(), source.ProposerIndex(), columnIndicesToSample, constructedSidecars)
+			if err != nil {
+				return nil, errors.Wrap(err, "broadcast and receive unseen data column sidecars")
 			}
 
 			if len(unseenIndices) > 0 {
@@ -263,6 +238,52 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, so
 	}
 
 	return nil
+}
+
+// broadcastAndReceiveUnseenDataColumnSidecars broadcasts and receives unseen data column sidecars.
+func (s *Service) broadcastAndReceiveUnseenDataColumnSidecars(
+	ctx context.Context,
+	slot primitives.Slot,
+	proposerIndex primitives.ValidatorIndex,
+	neededIndices map[uint64]bool,
+	sidecars []blocks.VerifiedRODataColumn,
+) (map[uint64]bool, error) {
+	// Compute sidecars we need to broadcast and receive.
+	unseenSidecars := make([]blocks.VerifiedRODataColumn, 0, len(sidecars))
+	unseenIndices := make(map[uint64]bool, len(sidecars))
+	for _, sidecar := range sidecars {
+		// Skip data column sidecars we don't need.
+		if !neededIndices[sidecar.Index] {
+			continue
+		}
+
+		// Skip already seen data column sidecars.
+		if s.hasSeenDataColumnIndex(slot, proposerIndex, sidecar.Index) {
+			continue
+		}
+
+		unseenSidecars = append(unseenSidecars, sidecar)
+		unseenIndices[sidecar.Index] = true
+	}
+
+	// Broadcast all the data column sidecars we reconstructed but did not see via gossip.
+	for _, sidecar := range unseenSidecars {
+		// Compute the subnet for this data column sidecar.
+		subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index)
+
+		// Broadcast the data column sidecar.
+		if err := s.cfg.p2p.BroadcastDataColumnSidecar(subnet, sidecar); err != nil {
+			// Don't return on error on broadcast failure, just log it.
+			log.WithError(err).Error("Broadcast data column")
+		}
+	}
+
+	// Receive data column sidecars.
+	if err := s.receiveDataColumnSidecars(ctx, unseenSidecars); err != nil {
+		return nil, errors.Wrap(err, "receive data column sidecars")
+	}
+
+	return unseenIndices, nil
 }
 
 // haveAllSidecarsBeenSeen checks if all sidecars for the given slot, proposer index, and data column indices have been seen.

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -178,7 +178,7 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, so
 		}
 
 		// Retrieve the indices of sidecars we should sample.
-		indicesToSample, err := s.columnIndicesToSample()
+		columnIndicesToSample, err := s.columnIndicesToSample()
 		if err != nil {
 			return nil, errors.Wrap(err, "column indices to sample")
 		}
@@ -188,18 +188,18 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, so
 
 		for iteration := uint64(0); ; /*no stop condition*/ iteration++ {
 			// Exit early if all sidecars to sample have been seen.
-			if s.haveAllSidecarsBeenSeen(source.Slot(), source.ProposerIndex(), indicesToSample) {
+			if s.haveAllSidecarsBeenSeen(source.Slot(), source.ProposerIndex(), columnIndicesToSample) {
 				return nil, nil
 			}
 
-			// Try to reconstruct data column sidecars from the execution client.
-			sidecars, err := s.cfg.executionReconstructor.ConstructDataColumnSidecars(ctx, source)
+			// Try to reconstruct data column constructedSidecars from the execution client.
+			constructedSidecars, err := s.cfg.executionReconstructor.ConstructDataColumnSidecars(ctx, source)
 			if err != nil {
 				return nil, errors.Wrap(err, "reconstruct data column sidecars")
 			}
 
 			// No sidecars are retrieved from the EL, retry later
-			sidecarCount := uint64(len(sidecars))
+			sidecarCount := uint64(len(constructedSidecars))
 			if sidecarCount == 0 {
 				if ctx.Err() != nil {
 					return nil, ctx.Err()
@@ -214,40 +214,45 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, so
 				return nil, errors.Errorf("reconstruct data column sidecars returned %d sidecars, expected %d - should never happen", sidecarCount, numberOfColumns)
 			}
 
-			// Broadcast and save data column sidecars to custody but not yet received.
-			reconstructedIndices := make(map[uint64]bool, len(indicesToSample))
-			for index := range indicesToSample {
-				if index >= sidecarCount {
-					return nil, errors.Errorf("data column index %d >= sidecar count %d - should never happen", index, sidecarCount)
-				}
-
-				// This sidecar has been received in the meantime, skip it.
-				if s.hasSeenDataColumnIndex(source.Slot(), source.ProposerIndex(), index) {
+			// Compute sidecars we need to broadcast and receive.
+			unseenSidecars := make([]blocks.VerifiedRODataColumn, 0, len(constructedSidecars))
+			unseenIndices := make(map[uint64]bool, len(constructedSidecars))
+			for _, sidecar := range constructedSidecars {
+				// Skip already seen data column sidecars.
+				if s.hasSeenDataColumnIndex(source.Slot(), source.ProposerIndex(), sidecar.Index) {
 					continue
 				}
 
-				sidecar := sidecars[index]
-
-				if err := s.cfg.p2p.BroadcastDataColumnSidecar(sidecar.Index, sidecar); err != nil {
-					return nil, errors.Wrap(err, "broadcast data column sidecar")
+				if columnIndicesToSample[sidecar.Index] {
+					unseenSidecars = append(unseenSidecars, sidecar)
 				}
-
-				if err := s.receiveDataColumnSidecar(ctx, sidecar); err != nil {
-					return nil, errors.Wrap(err, "receive data column sidecar")
-				}
-
-				reconstructedIndices[index] = true
 			}
 
-			if len(reconstructedIndices) > 0 {
+			// Broadcast all the data column sidecars we reconstructed but did not see via gossip.
+			for _, sidecar := range unseenSidecars {
+				// Compute the subnet for this data column sidecar.
+				subnet := peerdas.ComputeSubnetForDataColumnSidecar(sidecar.Index)
+
+				// Broadcast the data column sidecar.
+				if err := s.cfg.p2p.BroadcastDataColumnSidecar(subnet, sidecar); err != nil {
+					log.WithError(err).Error("Broadcast data column")
+				}
+			}
+
+			// Receive data column sidecars.
+			if err := s.receiveDataColumnSidecars(ctx, unseenSidecars); err != nil {
+				return nil, errors.Wrap(err, "receive data column sidecars")
+			}
+
+			if len(unseenIndices) > 0 {
 				log.WithFields(logrus.Fields{
 					"root":          fmt.Sprintf("%#x", source.Root()),
 					"slot":          source.Slot(),
 					"proposerIndex": source.ProposerIndex(),
 					"iteration":     iteration,
 					"type":          source.Type(),
-					"count":         len(reconstructedIndices),
-					"indices":       sortedSliceFromMap(reconstructedIndices),
+					"count":         len(unseenIndices),
+					"indices":       sortedSliceFromMap(unseenIndices),
 				}).Debug("Constructed data column sidecars from the execution client")
 			}
 

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -74,14 +74,7 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 // builds corresponding sidecars, save them to the storage, and broadcasts them over P2P if necessary.
 func (s *Service) processSidecarsFromExecutionFromBlock(ctx context.Context, roBlock blocks.ROBlock) {
 	if roBlock.Version() >= version.Fulu {
-		key := fmt.Sprintf("%#x", roBlock.Root())
-		if _, err, _ := s.columnSidecarsExecSingleFlight.Do(key, func() (interface{}, error) {
-			if err := s.processDataColumnSidecarsFromExecution(ctx, peerdas.PopulateFromBlock(roBlock)); err != nil {
-				return nil, err
-			}
-
-			return nil, nil
-		}); err != nil {
+		if err := s.processDataColumnSidecarsFromExecution(ctx, peerdas.PopulateFromBlock(roBlock)); err != nil {
 			log.WithError(err).Error("Failed to process data column sidecars from execution")
 			return
 		}
@@ -167,97 +160,104 @@ func (s *Service) processBlobSidecarsFromExecution(ctx context.Context, block in
 // processDataColumnSidecarsFromExecution retrieves (if available) data column sidecars data from the execution client,
 // builds corresponding sidecars, save them to the storage, and broadcasts them over P2P if necessary.
 func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, source peerdas.ConstructionPopulator) error {
-	const delay = 250 * time.Millisecond
-	secondsPerHalfSlot := time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second
+	key := fmt.Sprintf("%#x", source.Root())
+	if _, err, _ := s.columnSidecarsExecSingleFlight.Do(key, func() (interface{}, error) {
+		const delay = 250 * time.Millisecond
+		secondsPerHalfSlot := time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second
 
-	numberOfColumns := params.BeaconConfig().NumberOfColumns
+		numberOfColumns := params.BeaconConfig().NumberOfColumns
 
-	commitments, err := source.Commitments()
-	if err != nil {
-		return errors.Wrap(err, "blob kzg commitments")
-	}
-
-	// Exit early if there are no commitments.
-	if len(commitments) == 0 {
-		return nil
-	}
-
-	// Retrieve the indices of sidecars we should sample.
-	indicesToSample, err := s.columnIndicesToSample()
-	if err != nil {
-		return errors.Wrap(err, "column indices to sample")
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, secondsPerHalfSlot)
-	defer cancel()
-
-	for iteration := uint64(0); ; /*no stop condition*/ iteration++ {
-		// Exit early if all sidecars to sample have been seen.
-		if s.haveAllSidecarsBeenSeen(source.Slot(), source.ProposerIndex(), indicesToSample) {
-			return nil
-		}
-
-		// Try to reconstruct data column sidecars from the execution client.
-		sidecars, err := s.cfg.executionReconstructor.ConstructDataColumnSidecars(ctx, source)
+		commitments, err := source.Commitments()
 		if err != nil {
-			return errors.Wrap(err, "reconstruct data column sidecars")
+			return nil, errors.Wrap(err, "blob kzg commitments")
 		}
 
-		// No sidecars are retrieved from the EL, retry later
-		sidecarCount := uint64(len(sidecars))
-		if sidecarCount == 0 {
-			if ctx.Err() != nil {
-				return ctx.Err()
+		// Exit early if there are no commitments.
+		if len(commitments) == 0 {
+			return nil, nil
+		}
+
+		// Retrieve the indices of sidecars we should sample.
+		indicesToSample, err := s.columnIndicesToSample()
+		if err != nil {
+			return nil, errors.Wrap(err, "column indices to sample")
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, secondsPerHalfSlot)
+		defer cancel()
+
+		for iteration := uint64(0); ; /*no stop condition*/ iteration++ {
+			// Exit early if all sidecars to sample have been seen.
+			if s.haveAllSidecarsBeenSeen(source.Slot(), source.ProposerIndex(), indicesToSample) {
+				return nil, nil
 			}
 
-			time.Sleep(delay)
-			continue
-		}
-
-		// Boundary check.
-		if sidecarCount != numberOfColumns {
-			return errors.Errorf("reconstruct data column sidecars returned %d sidecars, expected %d - should never happen", sidecarCount, numberOfColumns)
-		}
-
-		// Broadcast and save data column sidecars to custody but not yet received.
-		reconstructedIndices := make(map[uint64]bool, len(indicesToSample))
-		for index := range indicesToSample {
-			if index >= sidecarCount {
-				return errors.Errorf("data column index %d >= sidecar count %d - should never happen", index, sidecarCount)
+			// Try to reconstruct data column sidecars from the execution client.
+			sidecars, err := s.cfg.executionReconstructor.ConstructDataColumnSidecars(ctx, source)
+			if err != nil {
+				return nil, errors.Wrap(err, "reconstruct data column sidecars")
 			}
 
-			// This sidecar has been received in the meantime, skip it.
-			if s.hasSeenDataColumnIndex(source.Slot(), source.ProposerIndex(), index) {
+			// No sidecars are retrieved from the EL, retry later
+			sidecarCount := uint64(len(sidecars))
+			if sidecarCount == 0 {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+
+				time.Sleep(delay)
 				continue
 			}
 
-			sidecar := sidecars[index]
-
-			if err := s.cfg.p2p.BroadcastDataColumnSidecar(sidecar.Index, sidecar); err != nil {
-				return errors.Wrap(err, "broadcast data column sidecar")
+			// Boundary check.
+			if sidecarCount != numberOfColumns {
+				return nil, errors.Errorf("reconstruct data column sidecars returned %d sidecars, expected %d - should never happen", sidecarCount, numberOfColumns)
 			}
 
-			if err := s.receiveDataColumnSidecar(ctx, sidecar); err != nil {
-				return errors.Wrap(err, "receive data column sidecar")
+			// Broadcast and save data column sidecars to custody but not yet received.
+			reconstructedIndices := make(map[uint64]bool, len(indicesToSample))
+			for index := range indicesToSample {
+				if index >= sidecarCount {
+					return nil, errors.Errorf("data column index %d >= sidecar count %d - should never happen", index, sidecarCount)
+				}
+
+				// This sidecar has been received in the meantime, skip it.
+				if s.hasSeenDataColumnIndex(source.Slot(), source.ProposerIndex(), index) {
+					continue
+				}
+
+				sidecar := sidecars[index]
+
+				if err := s.cfg.p2p.BroadcastDataColumnSidecar(sidecar.Index, sidecar); err != nil {
+					return nil, errors.Wrap(err, "broadcast data column sidecar")
+				}
+
+				if err := s.receiveDataColumnSidecar(ctx, sidecar); err != nil {
+					return nil, errors.Wrap(err, "receive data column sidecar")
+				}
+
+				reconstructedIndices[index] = true
 			}
 
-			reconstructedIndices[index] = true
-		}
+			if len(reconstructedIndices) > 0 {
+				log.WithFields(logrus.Fields{
+					"root":          fmt.Sprintf("%#x", source.Root()),
+					"slot":          source.Slot(),
+					"proposerIndex": source.ProposerIndex(),
+					"iteration":     iteration,
+					"type":          source.Type(),
+					"count":         len(reconstructedIndices),
+					"indices":       sortedSliceFromMap(reconstructedIndices),
+				}).Debug("Constructed data column sidecars from the execution client")
+			}
 
-		if len(reconstructedIndices) > 0 {
-			log.WithFields(logrus.Fields{
-				"root":          fmt.Sprintf("%#x", source.Root()),
-				"slot":          source.Slot(),
-				"proposerIndex": source.ProposerIndex(),
-				"iteration":     iteration,
-				"type":          source.Type(),
-				"count":         len(reconstructedIndices),
-				"indices":       sortedSliceFromMap(reconstructedIndices),
-			}).Debug("Constructed data column sidecars from the execution client")
+			return nil, nil
 		}
-
-		return nil
+	}); err != nil {
+		return err
 	}
+
+	return nil
 }
 
 // haveAllSidecarsBeenSeen checks if all sidecars for the given slot, proposer index, and data column indices have been seen.

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// dataColumnSubscriber is the subscriber function for data column sidecars.
 func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) error {
 	sidecar, ok := msg.(blocks.VerifiedRODataColumn)
 	if !ok {
@@ -28,11 +29,9 @@ func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) e
 		return errors.Wrap(err, "reconstruct/save/broadcast data column sidecars")
 	}
 
-	source := peerdas.PopulateFromSidecar(sidecar)
-
 	key := fmt.Sprintf("%#x", sidecar.BlockRoot())
 	if _, err, _ := s.columnSidecarsExecSingleFlight.Do(key, func() (interface{}, error) {
-		if err := s.processDataColumnSidecarsFromExecution(ctx, source); err != nil {
+		if err := s.processDataColumnSidecarsFromExecution(ctx, peerdas.PopulateFromSidecar(sidecar)); err != nil {
 			return nil, err
 		}
 

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -44,23 +44,34 @@ func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) e
 	return nil
 }
 
+// receiveDataColumnSidecar receives a single data column sidecar: marks it as seen and saves it to the chain.
+// Do not loop over this function to receive multiple sidecars, use receiveDataColumnSidecars instead.
 func (s *Service) receiveDataColumnSidecar(ctx context.Context, sidecar blocks.VerifiedRODataColumn) error {
-	slot := sidecar.SignedBlockHeader.Header.Slot
-	proposerIndex := sidecar.SignedBlockHeader.Header.ProposerIndex
-	columnIndex := sidecar.Index
+	return s.receiveDataColumnSidecars(ctx, []blocks.VerifiedRODataColumn{sidecar})
+}
 
-	s.setSeenDataColumnIndex(slot, proposerIndex, columnIndex)
+// receiveDataColumnSidecars receives multiple data column sidecars: marks them as seen and saves them to the chain.
+func (s *Service) receiveDataColumnSidecars(ctx context.Context, sidecars []blocks.VerifiedRODataColumn) error {
+	for _, sidecar := range sidecars {
+		slot := sidecar.SignedBlockHeader.Header.Slot
+		proposerIndex := sidecar.SignedBlockHeader.Header.ProposerIndex
+		columnIndex := sidecar.Index
 
-	if err := s.cfg.chain.ReceiveDataColumn(sidecar); err != nil {
+		s.setSeenDataColumnIndex(slot, proposerIndex, columnIndex)
+	}
+
+	if err := s.cfg.chain.ReceiveDataColumns(sidecars); err != nil {
 		return errors.Wrap(err, "receive data column")
 	}
 
-	s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
-		Type: opfeed.DataColumnSidecarReceived,
-		Data: &opfeed.DataColumnSidecarReceivedData{
-			DataColumn: &sidecar,
-		},
-	})
+	for _, sidecar := range sidecars {
+		s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
+			Type: opfeed.DataColumnSidecarReceived,
+			Data: &opfeed.DataColumnSidecarReceivedData{
+				DataColumn: &sidecar,
+			},
+		})
+	}
 
 	return nil
 }

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -29,15 +29,8 @@ func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) e
 		return errors.Wrap(err, "reconstruct/save/broadcast data column sidecars")
 	}
 
-	key := fmt.Sprintf("%#x", sidecar.BlockRoot())
-	if _, err, _ := s.columnSidecarsExecSingleFlight.Do(key, func() (interface{}, error) {
-		if err := s.processDataColumnSidecarsFromExecution(ctx, peerdas.PopulateFromSidecar(sidecar)); err != nil {
-			return nil, err
-		}
-
-		return nil, nil
-	}); err != nil {
-		return errors.Wrap(err, "process data column sidecars from execution from sidecar")
+	if err := s.processDataColumnSidecarsFromExecution(ctx, peerdas.PopulateFromSidecar(sidecar)); err != nil {
+		return errors.Wrap(err, "process data column sidecars from execution")
 	}
 
 	return nil

--- a/beacon-chain/sync/subscriber_data_column_sidecar.go
+++ b/beacon-chain/sync/subscriber_data_column_sidecar.go
@@ -11,11 +11,14 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 )
 
 // dataColumnSubscriber is the subscriber function for data column sidecars.
 func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) error {
+	var wg errgroup.Group
+
 	sidecar, ok := msg.(blocks.VerifiedRODataColumn)
 	if !ok {
 		return fmt.Errorf("message was not type blocks.VerifiedRODataColumn, type=%T", msg)
@@ -25,12 +28,24 @@ func (s *Service) dataColumnSubscriber(ctx context.Context, msg proto.Message) e
 		return errors.Wrap(err, "receive data column sidecar")
 	}
 
-	if err := s.reconstructSaveBroadcastDataColumnSidecars(ctx, sidecar); err != nil {
-		return errors.Wrap(err, "reconstruct/save/broadcast data column sidecars")
-	}
+	wg.Go(func() error {
+		if err := s.processDataColumnSidecarsFromReconstruction(ctx, sidecar); err != nil {
+			return errors.Wrap(err, "process data column sidecars from reconstruction")
+		}
 
-	if err := s.processDataColumnSidecarsFromExecution(ctx, peerdas.PopulateFromSidecar(sidecar)); err != nil {
-		return errors.Wrap(err, "process data column sidecars from execution")
+		return nil
+	})
+
+	wg.Go(func() error {
+		if err := s.processDataColumnSidecarsFromExecution(ctx, peerdas.PopulateFromSidecar(sidecar)); err != nil {
+			return errors.Wrap(err, "process data column sidecars from execution")
+		}
+
+		return nil
+	})
+
+	if err := wg.Wait(); err != nil {
+		return err
 	}
 
 	return nil

--- a/changelog/manu-peerdas-reconstruction-delay.md
+++ b/changelog/manu-peerdas-reconstruction-delay.md
@@ -1,0 +1,2 @@
+### Changed 
+- PeerDAS: Wait for a random delay, then reconstruct data column sidecars and immediately reseed instead of immediately reconstructing, waiting and then reseeding.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this PR, when enough data column sidecars were received via gossip to enable reconstruction, Prysm:
1. started to reconstruct immediately,
2. waited for a random time, and
3. re-seeded reconstructed but not seen data column sidecars on the gossip network.

This it quite inefficient because it creates useless CPU stress on all nodes subscribed to at least 64 data column subets.
This implementation is also not correct according to [the specification](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#reconstruction-and-cross-seeding).

> If the node obtains 50%+ of all the columns, it SHOULD reconstruct the full data matrix via the `recover_matrix` helper. Nodes MAY delay this reconstruction allowing time for other columns to arrive over the network. If delaying reconstruction, nodes may use a random delay in order to desynchronize reconstruction among nodes, thus reducing overall CPU load.

After this PR, when enough data column sidecars were received via gossip to enable reconstruction, Prysm:
1. waits for a random time,
2. starts to reconstruct **if needed**, and 
3. re-seeded reconstructed but not seen data column sidecars on the gossip network.

Note: the random wait ensures not all Prysm nodes on the network start reconstructing at the same time.

**Other notes for review**
Please read commit by commit, with commit messages.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
