### PR TITLE
fix: use v2 endpoint for blinded block submission post-Fulu

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -30,10 +30,11 @@ import (
 )
 
 const (
-	getExecHeaderPath          = "/eth/v1/builder/header/{{.Slot}}/{{.ParentHash}}/{{.Pubkey}}"
-	getStatus                  = "/eth/v1/builder/status"
-	postBlindedBeaconBlockPath = "/eth/v1/builder/blinded_blocks"
-	postRegisterValidatorPath  = "/eth/v1/builder/validators"
+	getExecHeaderPath            = "/eth/v1/builder/header/{{.Slot}}/{{.ParentHash}}/{{.Pubkey}}"
+	getStatus                    = "/eth/v1/builder/status"
+	postBlindedBeaconBlockPath   = "/eth/v1/builder/blinded_blocks"
+	postBlindedBeaconBlockV2Path = "/eth/v2/builder/blinded_blocks"
+	postRegisterValidatorPath    = "/eth/v1/builder/validators"
 )
 
 var (
@@ -512,7 +513,7 @@ func (c *Client) SubmitBlindedBlockPostFulu(ctx context.Context, sb interfaces.R
 	}
 
 	// Post the blinded block - the response should only contain a status code (no payload)
-	_, _, err = c.do(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body), http.StatusAccepted, postOpts)
+	_, _, err = c.do(ctx, http.MethodPost, postBlindedBeaconBlockV2Path, bytes.NewBuffer(body), http.StatusAccepted, postOpts)
 	if err != nil {
 		return errors.Wrap(err, "error posting the blinded block to the builder api post-Fulu")
 	}

--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -1561,7 +1561,7 @@ func TestSubmitBlindedBlockPostFulu(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		hc := &http.Client{
 			Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
-				require.Equal(t, postBlindedBeaconBlockPath, r.URL.Path)
+				require.Equal(t, postBlindedBeaconBlockV2Path, r.URL.Path)
 				require.Equal(t, "bellatrix", r.Header.Get("Eth-Consensus-Version"))
 				require.Equal(t, api.JsonMediaType, r.Header.Get("Content-Type"))
 				require.Equal(t, api.JsonMediaType, r.Header.Get("Accept"))
@@ -1586,7 +1586,7 @@ func TestSubmitBlindedBlockPostFulu(t *testing.T) {
 	t.Run("success_ssz", func(t *testing.T) {
 		hc := &http.Client{
 			Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
-				require.Equal(t, postBlindedBeaconBlockPath, r.URL.Path)
+				require.Equal(t, postBlindedBeaconBlockV2Path, r.URL.Path)
 				require.Equal(t, "bellatrix", r.Header.Get(api.VersionHeader))
 				require.Equal(t, api.OctetStreamMediaType, r.Header.Get("Content-Type"))
 				require.Equal(t, api.OctetStreamMediaType, r.Header.Get("Accept"))
@@ -1612,7 +1612,7 @@ func TestSubmitBlindedBlockPostFulu(t *testing.T) {
 	t.Run("error_response", func(t *testing.T) {
 		hc := &http.Client{
 			Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
-				require.Equal(t, postBlindedBeaconBlockPath, r.URL.Path)
+				require.Equal(t, postBlindedBeaconBlockV2Path, r.URL.Path)
 				require.Equal(t, "bellatrix", r.Header.Get("Eth-Consensus-Version"))
 				message := ErrorMessage{
 					Code:    400,

--- a/changelog/ttsao_fix-blinded-block-v2-endpoint.md
+++ b/changelog/ttsao_fix-blinded-block-v2-endpoint.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use v2 endpoint for blinded block submission post-Fulu


### PR DESCRIPTION
use correct path for submit blind block v2