### PR TITLE
Improve logging of data column sidecars

### DIFF
--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "legacy.go",
         "metrics.go",
         "randao.go",
+        "ranges.go",
         "rewards_penalties.go",
         "shuffle.go",
         "sync_committee.go",
@@ -56,6 +57,7 @@ go_test(
         "private_access_fuzz_noop_test.go",  # keep
         "private_access_test.go",
         "randao_test.go",
+        "ranges_test.go",
         "rewards_penalties_test.go",
         "shuffle_test.go",
         "sync_committee_test.go",

--- a/beacon-chain/core/helpers/ranges.go
+++ b/beacon-chain/core/helpers/ranges.go
@@ -1,0 +1,62 @@
+package helpers
+
+import (
+	"fmt"
+	"slices"
+)
+
+// SortedSliceFromMap takes a map with uint64 keys and returns a sorted slice of the keys.
+func SortedSliceFromMap(toSort map[uint64]bool) []uint64 {
+	slice := make([]uint64, 0, len(toSort))
+	for key := range toSort {
+		slice = append(slice, key)
+	}
+
+	slices.Sort(slice)
+	return slice
+}
+
+// PrettySlice returns a pretty string representation of a sorted slice of uint64.
+// `sortedSlice` must be sorted in ascending order.
+// Example: [1,2,3,5,6,7,8,10] -> "1-3,5-8,10"
+func PrettySlice(sortedSlice []uint64) string {
+	if len(sortedSlice) == 0 {
+		return ""
+	}
+
+	var result string
+	start := sortedSlice[0]
+	end := sortedSlice[0]
+
+	for i := 1; i < len(sortedSlice); i++ {
+		if sortedSlice[i] == end+1 {
+			end = sortedSlice[i]
+			continue
+		}
+
+		if start == end {
+			result += fmt.Sprintf("%d,", start)
+			start = sortedSlice[i]
+			end = sortedSlice[i]
+			continue
+		}
+
+		result += fmt.Sprintf("%d-%d,", start, end)
+		start = sortedSlice[i]
+		end = sortedSlice[i]
+	}
+
+	if start == end {
+		result += fmt.Sprintf("%d", start)
+		return result
+	}
+
+	result += fmt.Sprintf("%d-%d", start, end)
+	return result
+}
+
+// SortedPrettySliceFromMap combines SortedSliceFromMap and PrettySlice to return a pretty string representation of the keys in a map.
+func SortedPrettySliceFromMap(toSort map[uint64]bool) string {
+	sorted := SortedSliceFromMap(toSort)
+	return PrettySlice(sorted)
+}

--- a/beacon-chain/core/helpers/ranges_test.go
+++ b/beacon-chain/core/helpers/ranges_test.go
@@ -1,0 +1,64 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
+	"github.com/OffchainLabs/prysm/v6/testing/require"
+)
+
+func TestSortedSliceFromMap(t *testing.T) {
+	input := map[uint64]bool{5: true, 3: true, 8: true, 1: true}
+	expected := []uint64{1, 3, 5, 8}
+
+	actual := helpers.SortedSliceFromMap(input)
+	require.Equal(t, len(expected), len(actual))
+
+	for i := range expected {
+		require.Equal(t, expected[i], actual[i])
+	}
+}
+
+func TestPrettySlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []uint64
+		expected string
+	}{
+		{
+			name:     "empty slice",
+			input:    []uint64{},
+			expected: "",
+		},
+		{
+			name:     "only distinct elements",
+			input:    []uint64{1, 3, 5, 7, 9},
+			expected: "1,3,5,7,9",
+		},
+		{
+			name:     "single range",
+			input:    []uint64{1, 2, 3, 4, 5},
+			expected: "1-5",
+		},
+		{
+			name:     "multiple ranges and distinct elements",
+			input:    []uint64{1, 2, 3, 5, 6, 7, 8, 10, 12, 13, 14},
+			expected: "1-3,5-8,10,12-14",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := helpers.PrettySlice(tt.input)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestSortedPrettySliceFromMap(t *testing.T) {
+	input := map[uint64]bool{5: true, 7: true, 8: true, 10: true}
+	expected := "5,7-8,10"
+
+	actual := helpers.SortedPrettySliceFromMap(input)
+	require.Equal(t, expected, actual)
+}

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -1007,13 +1007,6 @@ func TestCompareIndices(t *testing.T) {
 	require.Equal(t, true, compareIndices(left, right))
 }
 
-func TestSlortedSliceFromMap(t *testing.T) {
-	input := map[uint64]bool{54: true, 23: true, 35: true}
-	expected := []uint64{23, 35, 54}
-	actual := sortedSliceFromMap(input)
-	require.DeepEqual(t, expected, actual)
-}
-
 func TestComputeTotalCount(t *testing.T) {
 	input := map[[fieldparams.RootLength]byte]map[uint64]bool{
 		[fieldparams.RootLength]byte{1}: {1: true, 3: true},

--- a/beacon-chain/sync/data_columns_reconstruct.go
+++ b/beacon-chain/sync/data_columns_reconstruct.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v6/config/params"
@@ -95,7 +96,7 @@ func (s *Service) processDataColumnSidecarsFromReconstruction(ctx context.Contex
 					"slot":          slot,
 					"proposerIndex": proposerIndex,
 					"count":         len(unseenIndices),
-					"indices":       sortedSliceFromMap(unseenIndices),
+					"indices":       helpers.SortedPrettySliceFromMap(unseenIndices),
 					"duration":      duration,
 				}).Debug("Reconstructed data column sidecars")
 			}

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//beacon-chain/blockchain:go_default_library",
         "//beacon-chain/core/feed/block:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/peerdas:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/das:go_default_library",

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -3,12 +3,12 @@ package initialsync
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db/filesystem"
@@ -430,9 +430,9 @@ func (f *blocksFetcher) fetchSidecars(ctx context.Context, pid peer.ID, peers []
 	}
 
 	if len(missingIndicesByRoot) > 0 {
-		prettyMissingIndicesByRoot := make(map[string][]uint64, len(missingIndicesByRoot))
+		prettyMissingIndicesByRoot := make(map[string]string, len(missingIndicesByRoot))
 		for root, indices := range missingIndicesByRoot {
-			prettyMissingIndicesByRoot[fmt.Sprintf("%#x", root)] = sortedSliceFromMap(indices)
+			prettyMissingIndicesByRoot[fmt.Sprintf("%#x", root)] = helpers.SortedPrettySliceFromMap(indices)
 		}
 		return "", errors.Errorf("some sidecars are still missing after fetch: %v", prettyMissingIndicesByRoot)
 	}
@@ -725,17 +725,6 @@ func (f *blocksFetcher) fetchBlobsFromPeer(ctx context.Context, bwb []blocks.Blo
 		return p, err
 	}
 	return "", errNoPeersAvailable
-}
-
-// sortedSliceFromMap returns a sorted slice of keys from a map.
-func sortedSliceFromMap(m map[uint64]bool) []uint64 {
-	result := make([]uint64, 0, len(m))
-	for k := range m {
-		result = append(result, k)
-	}
-
-	slices.Sort(result)
-	return result
 }
 
 // requestBlocks is a wrapper for handling BeaconBlocksByRangeRequest requests/streams.

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -1349,14 +1349,6 @@ func TestBlockFetcher_HasSufficientBandwidth(t *testing.T) {
 	assert.Equal(t, 2, len(receivedPeers))
 }
 
-func TestSortedSliceFromMap(t *testing.T) {
-	m := map[uint64]bool{1: true, 3: true, 2: true, 4: true}
-	expected := []uint64{1, 2, 3, 4}
-
-	actual := sortedSliceFromMap(m)
-	require.DeepSSZEqual(t, expected, actual)
-}
-
 func TestFetchSidecars(t *testing.T) {
 	ctx := t.Context()
 	t.Run("No blocks", func(t *testing.T) {

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
 	blockfeed "github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed/block"
 	statefeed "github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed/state"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/das"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db"
@@ -479,7 +480,7 @@ func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock, delay ti
 		// Some sidecars are still missing.
 		log := log.WithFields(logrus.Fields{
 			"attempt":        attempt,
-			"missingIndices": sortedSliceFromMap(missingIndicesByRoot[root]),
+			"missingIndices": helpers.SortedPrettySliceFromMap(missingIndicesByRoot[root]),
 			"delay":          delay,
 		})
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db/filesystem"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/execution"
@@ -121,9 +122,9 @@ func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock)
 	}
 
 	if len(missingIndicesByRoot) > 0 {
-		prettyMissingIndicesByRoot := make(map[string][]uint64, len(missingIndicesByRoot))
+		prettyMissingIndicesByRoot := make(map[string]string, len(missingIndicesByRoot))
 		for root, indices := range missingIndicesByRoot {
-			prettyMissingIndicesByRoot[fmt.Sprintf("%#x", root)] = sortedSliceFromMap(indices)
+			prettyMissingIndicesByRoot[fmt.Sprintf("%#x", root)] = helpers.SortedPrettySliceFromMap(indices)
 		}
 		return errors.Errorf("some sidecars are still missing after fetch: %v", prettyMissingIndicesByRoot)
 	}

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/encoder"
 	p2ptypes "github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/types"
@@ -598,7 +599,7 @@ func isSidecarIndexRequested(request *ethpb.DataColumnSidecarsByRangeRequest) Da
 	return func(sidecar blocks.RODataColumn) error {
 		columnIndex := sidecar.Index
 		if !requestedIndices[columnIndex] {
-			requested := sortedSliceFromMap(requestedIndices)
+			requested := helpers.SortedPrettySliceFromMap(requestedIndices)
 			return errors.Errorf("data column sidecar index %d returned by the peer but not found in requested indices %v", columnIndex, requested)
 		}
 

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/transition/interop"
 	"github.com/OffchainLabs/prysm/v6/config/features"
@@ -227,7 +228,7 @@ func (s *Service) processDataColumnSidecarsFromExecution(ctx context.Context, so
 					"iteration":     iteration,
 					"type":          source.Type(),
 					"count":         len(unseenIndices),
-					"indices":       sortedSliceFromMap(unseenIndices),
+					"indices":       helpers.SortedPrettySliceFromMap(unseenIndices),
 				}).Debug("Constructed data column sidecars from the execution client")
 			}
 

--- a/changelog/manu-logs-datacolumns.md
+++ b/changelog/manu-logs-datacolumns.md
@@ -1,0 +1,2 @@
+## Changed
+- Improve logging of data column sidecars


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Before this PR, logging data column indices `[1, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 127]` was logged as... `[1, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 127]`, which is quite long when there is a lot of indices.

After this PR, the same set of columns is logged as `1, 3-9, 11-13, 127`, which reduces the line length.

**Other notes for review**
Please read commit by commit.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
