### PR TITLE
Fix no custody info available at start

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -122,18 +122,18 @@ type BlobStorage struct {
 func (bs *BlobStorage) WarmCache() {
 	start := time.Now()
 	if bs.layoutName == LayoutNameFlat {
-		log.Info("Blob filesystem cache warm-up started. This may take a few minutes.")
+		log.Info("Blob filesystem cache warm-up started. This may take a few minutes")
 	} else {
-		log.Info("Blob filesystem cache warm-up started.")
+		log.Info("Blob filesystem cache warm-up started")
 	}
 
 	if err := warmCache(bs.layout, bs.cache); err != nil {
-		log.WithError(err).Error("Error encountered while warming up blob filesystem cache.")
+		log.WithError(err).Error("Error encountered while warming up blob filesystem cache")
 	}
 	if err := bs.migrateLayouts(); err != nil {
-		log.WithError(err).Error("Error encountered while migrating blob storage.")
+		log.WithError(err).Error("Error encountered while migrating blob storage")
 	}
-	log.WithField("elapsed", time.Since(start)).Info("Blob filesystem cache warm-up complete.")
+	log.WithField("elapsed", time.Since(start)).Info("Blob filesystem cache warm-up complete")
 }
 
 // If any blob storage directories are found for layouts besides the configured layout, migrate them.

--- a/beacon-chain/p2p/custody.go
+++ b/beacon-chain/p2p/custody.go
@@ -10,6 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var errNoCustodyInfo = errors.New("no custody info available")
+
 var _ CustodyManager = (*Service)(nil)
 
 // EarliestAvailableSlot returns the earliest available slot.
@@ -30,7 +32,7 @@ func (s *Service) CustodyGroupCount() (uint64, error) {
 	defer s.custodyInfoLock.Unlock()
 
 	if s.custodyInfo == nil {
-		return 0, errors.New("no custody info available")
+		return 0, errNoCustodyInfo
 	}
 
 	return s.custodyInfo.groupCount, nil

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -79,7 +79,7 @@ func (quicProtocol) ENRKey() string { return quickProtocolEnrKey }
 func newListener(listenerCreator func() (*discover.UDPv5, error)) (*listenerWrapper, error) {
 	rawListener, err := listenerCreator()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create new listener")
+		return nil, errors.Wrap(err, "create new listener")
 	}
 	return &listenerWrapper{
 		listener:        rawListener,
@@ -536,7 +536,7 @@ func (s *Service) createListener(
 		int(s.cfg.QUICPort),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create local node")
+		return nil, errors.Wrap(err, "create local node")
 	}
 
 	bootNodes := make([]*enode.Node, 0, len(s.cfg.Discv5BootStrapAddrs))
@@ -606,7 +606,7 @@ func (s *Service) createLocalNode(
 	if params.FuluEnabled() {
 		custodyGroupCount, err := s.CustodyGroupCount()
 		if err != nil {
-			return nil, errors.Wrap(err, "could not retrieve custody group count")
+			return nil, errors.Wrap(err, "retrieve custody group count")
 		}
 
 		custodyGroupCountEntry := peerdas.Cgc(custodyGroupCount)
@@ -652,7 +652,7 @@ func (s *Service) startDiscoveryV5(
 	}
 	wrappedListener, err := newListener(createListener)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create listener")
+		return nil, errors.Wrap(err, "create listener")
 	}
 	record := wrappedListener.Self()
 

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -604,13 +604,25 @@ func (s *Service) createLocalNode(
 	localNode = initializeSyncCommSubnets(localNode)
 
 	if params.FuluEnabled() {
-		custodyGroupCount, err := s.CustodyGroupCount()
-		if err != nil {
-			return nil, errors.Wrap(err, "retrieve custody group count")
-		}
+		const delay = 1 * time.Second
 
-		custodyGroupCountEntry := peerdas.Cgc(custodyGroupCount)
-		localNode.Set(custodyGroupCountEntry)
+		var custodyGroupCount uint64
+
+		err := errNoCustodyInfo
+		for errors.Is(err, errNoCustodyInfo) {
+			custodyGroupCount, err = s.CustodyGroupCount()
+			if errors.Is(err, errNoCustodyInfo) {
+				log.WithField("delay", delay).Debug("No custody info available yet, retrying later")
+				continue
+			}
+
+			if err != nil {
+				return nil, errors.Wrap(err, "retrieve custody group count")
+			}
+
+			custodyGroupCountEntry := peerdas.Cgc(custodyGroupCount)
+			localNode.Set(custodyGroupCountEntry)
+		}
 	}
 
 	if s.cfg != nil && s.cfg.HostAddress != "" {

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -604,6 +604,7 @@ func (s *Service) createLocalNode(
 	localNode = initializeSyncCommSubnets(localNode)
 
 	if params.FuluEnabled() {
+		// TODO: Replace this quick fix with a proper synchronization scheme (chan?)
 		const delay = 1 * time.Second
 
 		var custodyGroupCount uint64

--- a/changelog/manu-fix-cgc-not-initialized.md
+++ b/changelog/manu-fix-cgc-not-initialized.md
@@ -1,0 +1,2 @@
+### Fixed 
+- In P2P service start, wait for the custody info to be correctly initialized.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR aims at ensure, using a primitive sync mechanism, that the custody group count is set at the P2P service start.

**Other notes for review**
Please read commit by commit, with commit messages.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
