### PR TITLE
`createLocalNode`: Wait before retrying to retrieve the custody group count if not present.

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -614,6 +614,7 @@ func (s *Service) createLocalNode(
 			custodyGroupCount, err = s.CustodyGroupCount()
 			if errors.Is(err, errNoCustodyInfo) {
 				log.WithField("delay", delay).Debug("No custody info available yet, retrying later")
+				time.Sleep(delay)
 				continue
 			}
 

--- a/changelog/manu-wait.md
+++ b/changelog/manu-wait.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `createLocalNode`: Wait before retrying to retrieve the custody group count if not present.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
All in the title.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
