### PR TITLE
Update go.mod to v1.25.1.

### DIFF
--- a/.github/actions/gomodtidy/Dockerfile
+++ b/.github/actions/gomodtidy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine
+FROM golang:1.25.1-alpine
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.23.5'
+          go-version: '1.25.1'
       - id: list
         uses: shogo82148/actions-go-fuzz/list@v0
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.23.5'
+          go-version: '1.25.1'
       - uses: shogo82148/actions-go-fuzz/run@v0
         with:
           packages: ${{ matrix.package }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,12 +44,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go 1.25.1
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.25.1'
-          id: go
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go 1.24
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.0'
+          go-version: '1.25.1'
       - name: Run Gosec Security Scanner
         run: | # https://github.com/securego/gosec/issues/469
           export PATH=$PATH:$(go env GOPATH)/bin
@@ -45,26 +45,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.24
+      - name: Set up Go 1.25.1
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.0'
+          go-version: '1.25.1'
           id: go
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.5
-          args: --config=.golangci.yml --out-${NO_FUTURE}format colored-line-number
+          version: v2.4
+          only-new-issues: true
 
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
+      - name: Set up Go 1.25.1
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.0'
+          go-version: '1.25.1'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,9 @@
+version: "2"
 run:
-  timeout: 10m
-  go: '1.23.5'
-
-issues:
-  exclude-files:
-    - validator/web/site_data.go
-    - .*_test.go
-  exclude-dirs:
-    - proto
-    - tools/analyzers
-
+  go: 1.23.5
 linters:
-  enable-all: true
+  default: all
   disable:
-    # Deprecated linters:
-    - govet
-
-    # Disabled for now:
     - asasalint
     - bodyclose
     - containedctx
@@ -26,14 +13,13 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errname
     - err113
+    - errname
     - exhaustive
     - exhaustruct
     - forbidigo
     - forcetypeassert
     - funlen
-    - gci
     - gochecknoglobals
     - gochecknoinits
     - goconst
@@ -41,9 +27,9 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofumpt
     - gomoddirectives
     - gosec
+    - govet
     - inamedparam
     - interfacebloat
     - intrange
@@ -58,6 +44,7 @@ linters:
     - nilnil
     - nlreturn
     - noctx
+    - noinlineerr
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
@@ -70,7 +57,6 @@ linters:
     - revive
     - spancheck
     - staticcheck
-    - stylecheck
     - tagalign
     - tagliatelle
     - thelper
@@ -79,12 +65,35 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
-
-linters-settings:
-  gocognit:
-    # TODO: We should target for < 50
-    min-complexity: 65
-
-output:
-  print-issued-lines: true
-  sort-results: true
+  settings:
+    gocognit:
+      min-complexity: 65
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - validator/web/site_data.go
+      - .*_test.go
+      - proto
+      - tools/analyzers
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - validator/web/site_data.go
+      - .*_test.go
+      - proto
+      - tools/analyzers
+      - third_party$
+      - builtin$
+      - examples$

--- a/changelog/manu-go-1.25.1.md
+++ b/changelog/manu-go-1.25.1.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Updated go.mod to v1.25.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OffchainLabs/prysm/v6
 
-go 1.24.5
+go 1.25.1
 
 require (
 	github.com/MariusVanDerWijden/FuzzyVM v0.0.0-20240516070431-7828990cad7d


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This change was done in the following PR
- https://github.com/OffchainLabs/prysm/pull/15641

but not in the `go.mod` file.

I had to update `golangci-lint` to `v2.4.0` because [it's the first version supporting golang `1.25`](https://golangci-lint.run/docs/product/changelog/#v240).

Some new errors are detected by this new version of `golangci-lint`.

==> I added the usage [only-new-issues](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#only-new-issues)
```yaml
      - name: Golangci-lint
       ...
        with:
          ...
          only-new-issues: true
```



meaning that errors detected by this new version of `golangci-lint` (and not by the previous one) **but** already existing in the codebase won't be showed.
**However, errors detected by this new version of `golangci-lint` (and not by the previous one) and introduced after this commit will be shown.**

Regarding the `golangci.yaml` file:
- The vast majority of changes are due to the run of the `golangci-lint migrate` command (needed to comply with this new version of `golangci-lint`).
- I also added the [`noinlineerr`](https://golangci-lint.run/docs/linters/configuration/#noinlineerr) option in the `disable` section of `golangci-lint`,  because I don't agree with it.



**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
