### PR TITLE
slasherkv: Set a 1 minute timeout on PruneAttestationOnEpoch operations

### DIFF
--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
@@ -13,8 +14,13 @@ import (
 // PruneAttestationsAtEpoch deletes all attestations from the slasher DB with target epoch
 // less than or equal to the specified epoch.
 func (s *Store) PruneAttestationsAtEpoch(
-	_ context.Context, maxEpoch primitives.Epoch,
+	ctx context.Context, maxEpoch primitives.Epoch,
 ) (numPruned uint, err error) {
+	// In some cases, pruning may take a very long time and consume significant memory in the open
+	// open Update transaction. Therefore, we impose a 1 minute timeout on this operation.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
 	// We can prune everything less than the current epoch - history length.
 	encodedEndPruneEpoch := make([]byte, 8)
 	binary.BigEndian.PutUint64(encodedEndPruneEpoch, uint64(maxEpoch))
@@ -55,6 +61,11 @@ func (s *Store) PruneAttestationsAtEpoch(
 
 		// We begin a pruning iteration starting from the first item in the bucket.
 		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if ctx.Err() != nil {
+				// Exit the routine if the context has expired.
+				log.WithError(ctx.Err()).Warn("Aborting pruning routine")
+				return nil
+			}
 			// We check the epoch from the current key in the database.
 			// If we have hit an epoch that is greater than the end epoch of the pruning process,
 			// we then completely exit the process as we are done.

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -8,15 +8,18 @@ import (
 
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
+	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
+
+var errTimeOut = errors.New("operation timed out")
 
 // PruneAttestationsAtEpoch deletes all attestations from the slasher DB with target epoch
 // less than or equal to the specified epoch.
 func (s *Store) PruneAttestationsAtEpoch(
 	ctx context.Context, maxEpoch primitives.Epoch,
 ) (numPruned uint, err error) {
-	// In some cases, pruning may take a very long time and consume significant memory in the open
+	// In some cases, pruning may take a very long time and consume significant memory in the
 	// open Update transaction. Therefore, we impose a 1 minute timeout on this operation.
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
@@ -54,7 +57,7 @@ func (s *Store) PruneAttestationsAtEpoch(
 		return
 	}
 
-	if err = s.db.Update(func(tx *bolt.Tx) error {
+	err = s.db.Update(func(tx *bolt.Tx) error {
 		signingRootsBkt := tx.Bucket(attestationDataRootsBucket)
 		attRecordsBkt := tx.Bucket(attestationRecordsBucket)
 		c := signingRootsBkt.Cursor()
@@ -63,9 +66,9 @@ func (s *Store) PruneAttestationsAtEpoch(
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			if ctx.Err() != nil {
 				// Exit the routine if the context has expired.
-				log.WithError(ctx.Err()).Warn("Aborting pruning routine")
-				return nil
+				return errTimeOut
 			}
+
 			// We check the epoch from the current key in the database.
 			// If we have hit an epoch that is greater than the end epoch of the pruning process,
 			// we then completely exit the process as we are done.
@@ -78,18 +81,27 @@ func (s *Store) PruneAttestationsAtEpoch(
 			// so it is possible we have a few adjacent objects that have the same slot, such as
 			//  (target_epoch = 3 ++ _) => encode(attestation)
 			if err := signingRootsBkt.Delete(k); err != nil {
-				return err
+				return errors.Wrap(err, "delete attestation signing root")
 			}
 			if err := attRecordsBkt.Delete(v); err != nil {
-				return err
+				return errors.Wrap(err, "delete attestation record")
 			}
 			slasherAttestationsPrunedTotal.Inc()
 			numPruned++
 		}
 		return nil
-	}); err != nil {
+	})
+
+	if errors.Is(err, errTimeOut) {
+		log.Warning("Aborting pruning routine")
 		return
 	}
+
+	if err != nil {
+		log.WithError(err).Error("Failed to prune attestations")
+		return
+	}
+
 	return
 }
 

--- a/changelog/pvl-slasherkv-timeout.md
+++ b/changelog/pvl-slasherkv-timeout.md
@@ -1,0 +1,2 @@
+### Added
+- Added a 1 minute timeout on PruneAttestationOnEpoch operations to prevent very large bolt transactions


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

In some cases, the slasher kv may attempt to prune a very large part of a fully saturated slasherkv database. This can create very large bbolt transactions which use significant memory. This PR addresses this by saving the progress of the transaction after a one minute timeout is exceeded. 

**Which issues(s) does this PR fix?**

If a slasher has been offline for an extended period of time, then attempts to prune slashing data can result in OOM issues.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
