### PR TITLE
Add serialization for Gloas block

### DIFF
--- a/beacon-chain/state/state-native/hasher.go
+++ b/beacon-chain/state/state-native/hasher.go
@@ -247,13 +247,22 @@ func ComputeFieldRootsWithHasher(ctx context.Context, state *BeaconState) ([][]b
 		fieldRoots[types.LatestExecutionPayloadHeaderCapella.RealPosition()] = executionPayloadRoot[:]
 	}
 
-	if state.version >= version.Deneb {
+	if state.version >= version.Deneb && state.version < version.Gloas {
 		// Execution payload root.
 		executionPayloadRoot, err := state.latestExecutionPayloadHeaderDeneb.HashTreeRoot()
 		if err != nil {
 			return nil, err
 		}
 		fieldRoots[types.LatestExecutionPayloadHeaderDeneb.RealPosition()] = executionPayloadRoot[:]
+	}
+
+	if state.version >= version.Gloas {
+		// Execution payload root.
+		executionPayloadRoot, err := state.latestExecutionPayloadHeaderGloas.HashTreeRoot()
+		if err != nil {
+			return nil, err
+		}
+		fieldRoots[types.LatestExecutionPayloadHeaderGloas.RealPosition()] = executionPayloadRoot[:]
 	}
 
 	if state.version >= version.Capella {

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -199,6 +199,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	BeaconStateDenebFieldCount:     28,
 	BeaconStateElectraFieldCount:   37,
 	BeaconStateFuluFieldCount:      38,
+	BeaconStateGloasFieldCount:     38,
 
 	// Slasher related values.
 	WeakSubjectivityPeriod:          54000,

--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -46,6 +46,8 @@ func NewWrappedExecutionData(v proto.Message) (interfaces.ExecutionData, error) 
 		return WrappedExecutionPayloadDeneb(pbStruct.Payload)
 	case *enginev1.ExecutionBundleFulu:
 		return WrappedExecutionPayloadDeneb(pbStruct.Payload)
+	case *enginev1.ExecutionBundleGloas:
+		return WrappedExecutionPayloadGloas(pbStruct.Payload)
 	default:
 		return nil, errors.Wrapf(ErrUnsupportedVersion, "type %T", pbStruct)
 	}

--- a/consensus-types/blocks/factory.go
+++ b/consensus-types/blocks/factory.go
@@ -693,13 +693,13 @@ func BuildSignedBeaconBlockFromExecutionPayload(blk interfaces.ReadOnlySignedBea
 			return nil, err
 		}
 
-		fullBlock = &eth.SignedBeaconBlockFulu{
-			Block: &eth.BeaconBlockElectra{
+		fullBlock = &eth.SignedBeaconBlockGloas{
+			Block: &eth.BeaconBlockGloas{
 				Slot:          b.Slot(),
 				ProposerIndex: b.ProposerIndex(),
 				ParentRoot:    parentRoot[:],
 				StateRoot:     stateRoot[:],
-				Body: &eth.BeaconBlockBodyElectra{
+				Body: &eth.BeaconBlockBodyGloas{
 					RandaoReveal:      randaoReveal[:],
 					Eth1Data:          b.Body().Eth1Data(),
 					Graffiti:          graffiti[:],
@@ -709,24 +709,25 @@ func BuildSignedBeaconBlockFromExecutionPayload(blk interfaces.ReadOnlySignedBea
 					Deposits:          b.Body().Deposits(),
 					VoluntaryExits:    b.Body().VoluntaryExits(),
 					SyncAggregate:     syncAgg,
-					ExecutionPayload: &enginev1.ExecutionPayloadDeneb{
-						ParentHash:    p.ParentHash,
-						FeeRecipient:  p.FeeRecipient,
-						StateRoot:     p.StateRoot,
-						ReceiptsRoot:  p.ReceiptsRoot,
-						LogsBloom:     p.LogsBloom,
-						PrevRandao:    p.PrevRandao,
-						BlockNumber:   p.BlockNumber,
-						GasLimit:      p.GasLimit,
-						GasUsed:       p.GasUsed,
-						Timestamp:     p.Timestamp,
-						ExtraData:     p.ExtraData,
-						BaseFeePerGas: p.BaseFeePerGas,
-						BlockHash:     p.BlockHash,
-						Transactions:  p.Transactions,
-						Withdrawals:   p.Withdrawals,
-						BlobGasUsed:   p.BlobGasUsed,
-						ExcessBlobGas: p.ExcessBlobGas,
+					ExecutionPayload: &enginev1.ExecutionPayloadGloas{
+						ParentHash:      p.ParentHash,
+						FeeRecipient:    p.FeeRecipient,
+						StateRoot:       p.StateRoot,
+						ReceiptsRoot:    p.ReceiptsRoot,
+						LogsBloom:       p.LogsBloom,
+						PrevRandao:      p.PrevRandao,
+						BlockNumber:     p.BlockNumber,
+						GasLimit:        p.GasLimit,
+						GasUsed:         p.GasUsed,
+						Timestamp:       p.Timestamp,
+						ExtraData:       p.ExtraData,
+						BaseFeePerGas:   p.BaseFeePerGas,
+						BlockHash:       p.BlockHash,
+						Transactions:    p.Transactions,
+						Withdrawals:     p.Withdrawals,
+						BlobGasUsed:     p.BlobGasUsed,
+						ExcessBlobGas:   p.ExcessBlobGas,
+						BlockAccessList: p.BlockAccessList,
 					},
 					BlsToExecutionChanges: blsToExecutionChanges,
 					BlobKzgCommitments:    commitments,

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -1250,6 +1250,9 @@ func (b *BeaconBlock) AsSignRequestObject() (validatorpb.SignRequestObject, erro
 		}
 		return &validatorpb.SignRequest_BlockFulu{BlockFulu: pb.(*eth.BeaconBlockElectra)}, nil
 	case version.Gloas:
+		if b.IsBlinded() {
+			return &validatorpb.SignRequest_BlindedBlockFulu{BlindedBlockFulu: pb.(*eth.BlindedBeaconBlockFulu)}, nil
+		}
 		return &validatorpb.SignRequest_BlockGloas{BlockGloas: pb.(*eth.BeaconBlockGloas)}, nil
 	default:
 		return nil, errIncorrectBlockVersion
@@ -1427,6 +1430,11 @@ func (b *BeaconBlockBody) HashTreeRoot() ([field_params.RootLength]byte, error) 
 			return pb.(*eth.BlindedBeaconBlockBodyElectra).HashTreeRoot()
 		}
 		return pb.(*eth.BeaconBlockBodyElectra).HashTreeRoot()
+	case version.Gloas:
+		if b.IsBlinded() {
+			return pb.(*eth.BlindedBeaconBlockBodyElectra).HashTreeRoot()
+		}
+		return pb.(*eth.BeaconBlockBodyGloas).HashTreeRoot()
 	default:
 		return [field_params.RootLength]byte{}, errIncorrectBodyVersion
 	}

--- a/consensus-types/blocks/proto.go
+++ b/consensus-types/blocks/proto.go
@@ -1544,43 +1544,6 @@ func initBlindedBlockFromProtoFulu(pb *eth.BlindedBeaconBlockFulu) (*BeaconBlock
 	return b, nil
 }
 
-func initSignedBlockFromProtoGloas(pb *eth.SignedBeaconBlockGloas) (*SignedBeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	block, err := initBlockFromProtoGloas(pb.Block)
-	if err != nil {
-		return nil, err
-	}
-	b := &SignedBeaconBlock{
-		version:   version.Gloas,
-		block:     block,
-		signature: bytesutil.ToBytes96(pb.Signature),
-	}
-	return b, nil
-}
-
-func initBlockFromProtoGloas(pb *eth.BeaconBlockGloas) (*BeaconBlock, error) {
-	if pb == nil {
-		return nil, errNilBlock
-	}
-
-	body, err := initBlockBodyFromProtoGloas(pb.Body)
-	if err != nil {
-		return nil, err
-	}
-	b := &BeaconBlock{
-		version:       version.Gloas,
-		slot:          pb.Slot,
-		proposerIndex: pb.ProposerIndex,
-		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
-		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
-		body:          body,
-	}
-	return b, nil
-}
-
 func initBlockBodyFromProtoFulu(pb *eth.BeaconBlockBodyElectra) (*BeaconBlockBody, error) {
 	if pb == nil {
 		return nil, errNilBlockBody
@@ -1643,6 +1606,47 @@ func initBlindedBlockBodyFromProtoFulu(pb *eth.BlindedBeaconBlockBodyElectra) (*
 		blsToExecutionChanges:    pb.BlsToExecutionChanges,
 		blobKzgCommitments:       pb.BlobKzgCommitments,
 		executionRequests:        er,
+	}
+	return b, nil
+}
+
+// ----------------------------------------------------------------------------
+// Gloas
+// ----------------------------------------------------------------------------
+
+func initSignedBlockFromProtoGloas(pb *eth.SignedBeaconBlockGloas) (*SignedBeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	block, err := initBlockFromProtoGloas(pb.Block)
+	if err != nil {
+		return nil, err
+	}
+	b := &SignedBeaconBlock{
+		version:   version.Gloas,
+		block:     block,
+		signature: bytesutil.ToBytes96(pb.Signature),
+	}
+	return b, nil
+}
+
+func initBlockFromProtoGloas(pb *eth.BeaconBlockGloas) (*BeaconBlock, error) {
+	if pb == nil {
+		return nil, errNilBlock
+	}
+
+	body, err := initBlockBodyFromProtoGloas(pb.Body)
+	if err != nil {
+		return nil, err
+	}
+	b := &BeaconBlock{
+		version:       version.Gloas,
+		slot:          pb.Slot,
+		proposerIndex: pb.ProposerIndex,
+		parentRoot:    bytesutil.ToBytes32(pb.ParentRoot),
+		stateRoot:     bytesutil.ToBytes32(pb.StateRoot),
+		body:          body,
 	}
 	return b, nil
 }

--- a/proto/engine/v1/BUILD.bazel
+++ b/proto/engine/v1/BUILD.bazel
@@ -83,6 +83,7 @@ go_library(
         "execution_engine.go",
         "fulu.go",
         "json_marshal_unmarshal.go",
+        "gloas.go",
         ":ssz_generated_files",  # keep
     ],
     embed = [

--- a/proto/engine/v1/gloas.go
+++ b/proto/engine/v1/gloas.go
@@ -1,0 +1,43 @@
+package enginev1
+
+import (
+	"github.com/pkg/errors"
+)
+
+func (ebe *ExecutionBundleGloas) GetDecodedExecutionRequests(limits ExecutionRequestLimits) (*ExecutionRequests, error) {
+	requests := &ExecutionRequests{}
+	var prevTypeNum *uint8
+	for i := range ebe.ExecutionRequests {
+		requestType, requestListInSSZBytes, err := decodeExecutionRequest(ebe.ExecutionRequests[i])
+		if err != nil {
+			return nil, err
+		}
+		if prevTypeNum != nil && *prevTypeNum >= requestType {
+			return nil, errors.New("invalid execution request type order or duplicate requests, requests should be in sorted order and unique")
+		}
+		prevTypeNum = &requestType
+		switch requestType {
+		case DepositRequestType:
+			drs, err := unmarshalDeposits(requestListInSSZBytes, limits.Deposits)
+			if err != nil {
+				return nil, err
+			}
+			requests.Deposits = drs
+		case WithdrawalRequestType:
+			wrs, err := unmarshalWithdrawals(requestListInSSZBytes, limits.Withdrawals)
+			if err != nil {
+				return nil, err
+			}
+			requests.Withdrawals = wrs
+		case ConsolidationRequestType:
+			crs, err := unmarshalConsolidations(requestListInSSZBytes, limits.Consolidations)
+			if err != nil {
+				return nil, err
+			}
+			requests.Consolidations = crs
+		default:
+			return nil, errors.Errorf("unsupported request type %d", requestType)
+		}
+	}
+	return requests, nil
+}

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -313,6 +313,14 @@ type GetPayloadV5ResponseJson struct {
 	ExecutionRequests     []hexutil.Bytes            `json:"executionRequests"`
 }
 
+type GetPayloadV6ResponseJson struct {
+	ExecutionPayload      *ExecutionPayloadGloasJSON `json:"executionPayload"`
+	BlockValue            string                     `json:"blockValue"`
+	BlobsBundle           *BlobBundleV2JSON          `json:"blobsBundle"`
+	ShouldOverrideBuilder bool                       `json:"shouldOverrideBuilder"`
+	ExecutionRequests     []hexutil.Bytes            `json:"executionRequests"`
+}
+
 // ExecutionPayloadBody represents the engine API ExecutionPayloadV1 or ExecutionPayloadV2 type.
 type ExecutionPayloadBody struct {
 	Transactions          []hexutil.Bytes          `json:"transactions"`
@@ -340,6 +348,27 @@ type ExecutionPayloadDenebJSON struct {
 	BlockHash     *common.Hash    `json:"blockHash"`
 	Transactions  []hexutil.Bytes `json:"transactions"`
 	Withdrawals   []*Withdrawal   `json:"withdrawals"`
+}
+
+type ExecutionPayloadGloasJSON struct {
+	ParentHash      *common.Hash    `json:"parentHash"`
+	FeeRecipient    *common.Address `json:"feeRecipient"`
+	StateRoot       *common.Hash    `json:"stateRoot"`
+	ReceiptsRoot    *common.Hash    `json:"receiptsRoot"`
+	LogsBloom       *hexutil.Bytes  `json:"logsBloom"`
+	PrevRandao      *common.Hash    `json:"prevRandao"`
+	BlockNumber     *hexutil.Uint64 `json:"blockNumber"`
+	GasLimit        *hexutil.Uint64 `json:"gasLimit"`
+	GasUsed         *hexutil.Uint64 `json:"gasUsed"`
+	Timestamp       *hexutil.Uint64 `json:"timestamp"`
+	ExtraData       hexutil.Bytes   `json:"extraData"`
+	BaseFeePerGas   string          `json:"baseFeePerGas"`
+	BlobGasUsed     *hexutil.Uint64 `json:"blobGasUsed"`
+	ExcessBlobGas   *hexutil.Uint64 `json:"excessBlobGas"`
+	BlockHash       *common.Hash    `json:"blockHash"`
+	Transactions    []hexutil.Bytes `json:"transactions"`
+	Withdrawals     []*Withdrawal   `json:"withdrawals"`
+	BlockAccessList *hexutil.Bytes  `json:"blockAccessList"`
 }
 
 // WithdrawalRequestV1 represents an execution engine WithdrawalRequestV1 value
@@ -912,6 +941,54 @@ func (e *ExecutionPayloadDeneb) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (e *ExecutionPayloadGloas) MarshalJSON() ([]byte, error) {
+	transactions := make([]hexutil.Bytes, len(e.Transactions))
+	for i, tx := range e.Transactions {
+		transactions[i] = tx
+	}
+	baseFee := new(big.Int).SetBytes(bytesutil.ReverseByteOrder(e.BaseFeePerGas))
+	baseFeeHex := hexutil.EncodeBig(baseFee)
+	pHash := common.BytesToHash(e.ParentHash)
+	sRoot := common.BytesToHash(e.StateRoot)
+	recRoot := common.BytesToHash(e.ReceiptsRoot)
+	prevRan := common.BytesToHash(e.PrevRandao)
+	bHash := common.BytesToHash(e.BlockHash)
+	blockNum := hexutil.Uint64(e.BlockNumber)
+	gasLimit := hexutil.Uint64(e.GasLimit)
+	gasUsed := hexutil.Uint64(e.GasUsed)
+	timeStamp := hexutil.Uint64(e.Timestamp)
+	recipient := common.BytesToAddress(e.FeeRecipient)
+	logsBloom := hexutil.Bytes(e.LogsBloom)
+	withdrawals := e.Withdrawals
+	if withdrawals == nil {
+		withdrawals = make([]*Withdrawal, 0)
+	}
+	blobGasUsed := hexutil.Uint64(e.BlobGasUsed)
+	excessBlobGas := hexutil.Uint64(e.ExcessBlobGas)
+	blockAccessList := hexutil.Bytes(e.BlockAccessList)
+
+	return json.Marshal(ExecutionPayloadGloasJSON{
+		ParentHash:      &pHash,
+		FeeRecipient:    &recipient,
+		StateRoot:       &sRoot,
+		ReceiptsRoot:    &recRoot,
+		LogsBloom:       &logsBloom,
+		PrevRandao:      &prevRan,
+		BlockNumber:     &blockNum,
+		GasLimit:        &gasLimit,
+		GasUsed:         &gasUsed,
+		Timestamp:       &timeStamp,
+		ExtraData:       e.ExtraData,
+		BaseFeePerGas:   baseFeeHex,
+		BlobGasUsed:     &blobGasUsed,
+		ExcessBlobGas:   &excessBlobGas,
+		BlockHash:       &bHash,
+		Transactions:    transactions,
+		Withdrawals:     withdrawals,
+		BlockAccessList: &blockAccessList,
+	})
+}
+
 func JsonDepositRequestsToProto(j []DepositRequestV1) ([]*DepositRequest, error) {
 	reqs := make([]*DepositRequest, len(j))
 
@@ -1405,6 +1482,141 @@ func (e *ExecutionBundleFulu) UnmarshalJSON(enc []byte) error {
 	}
 
 	e.ExecutionRequests = requests
+
+	return nil
+}
+
+func (e *ExecutionBundleGloas) UnmarshalJSON(enc []byte) error {
+	dec := GetPayloadV6ResponseJson{}
+	if err := json.Unmarshal(enc, &dec); err != nil {
+		return err
+	}
+
+	if dec.ExecutionPayload == nil || dec.ExecutionPayload.ParentHash == nil {
+		return errors.New("missing required field 'parentHash' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.FeeRecipient == nil {
+		return errors.New("missing required field 'feeRecipient' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.StateRoot == nil {
+		return errors.New("missing required field 'stateRoot' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.ReceiptsRoot == nil {
+		return errors.New("missing required field 'receiptsRoot' for ExecutableDataV1")
+	}
+	if dec.ExecutionPayload.LogsBloom == nil {
+		return errors.New("missing required field 'logsBloom' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.PrevRandao == nil {
+		return errors.New("missing required field 'prevRandao' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.ExtraData == nil {
+		return errors.New("missing required field 'extraData' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.BlockHash == nil {
+		return errors.New("missing required field 'blockHash' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.Transactions == nil {
+		return errors.New("missing required field 'transactions' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.BlockNumber == nil {
+		return errors.New("missing required field 'blockNumber' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.Timestamp == nil {
+		return errors.New("missing required field 'timestamp' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.GasUsed == nil {
+		return errors.New("missing required field 'gasUsed' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.GasLimit == nil {
+		return errors.New("missing required field 'gasLimit' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.BlobGasUsed == nil {
+		return errors.New("missing required field 'blobGasUsed' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.ExcessBlobGas == nil {
+		return errors.New("missing required field 'excessBlobGas' for ExecutionPayload")
+	}
+	if dec.ExecutionPayload.BlockAccessList == nil {
+		return errors.New("missing required field 'blockAccessList' for ExecutionPayload")
+	}
+
+	*e = ExecutionBundleGloas{Payload: &ExecutionPayloadGloas{}}
+	e.Payload.ParentHash = dec.ExecutionPayload.ParentHash.Bytes()
+	e.Payload.FeeRecipient = dec.ExecutionPayload.FeeRecipient.Bytes()
+	e.Payload.StateRoot = dec.ExecutionPayload.StateRoot.Bytes()
+	e.Payload.ReceiptsRoot = dec.ExecutionPayload.ReceiptsRoot.Bytes()
+	e.Payload.LogsBloom = *dec.ExecutionPayload.LogsBloom
+	e.Payload.PrevRandao = dec.ExecutionPayload.PrevRandao.Bytes()
+	e.Payload.BlockNumber = uint64(*dec.ExecutionPayload.BlockNumber)
+	e.Payload.GasLimit = uint64(*dec.ExecutionPayload.GasLimit)
+	e.Payload.GasUsed = uint64(*dec.ExecutionPayload.GasUsed)
+	e.Payload.Timestamp = uint64(*dec.ExecutionPayload.Timestamp)
+	e.Payload.ExtraData = dec.ExecutionPayload.ExtraData
+
+	baseFee, err := hexutil.DecodeBig(dec.ExecutionPayload.BaseFeePerGas)
+	if err != nil {
+		return err
+	}
+	e.Payload.BaseFeePerGas = bytesutil.PadTo(bytesutil.ReverseByteOrder(baseFee.Bytes()), fieldparams.RootLength)
+
+	e.Payload.ExcessBlobGas = uint64(*dec.ExecutionPayload.ExcessBlobGas)
+	e.Payload.BlobGasUsed = uint64(*dec.ExecutionPayload.BlobGasUsed)
+	e.Payload.BlockHash = dec.ExecutionPayload.BlockHash.Bytes()
+
+	txs := make([][]byte, len(dec.ExecutionPayload.Transactions))
+	for i, tx := range dec.ExecutionPayload.Transactions {
+		txs[i] = tx
+	}
+	e.Payload.Transactions = txs
+	if dec.ExecutionPayload.Withdrawals == nil {
+		dec.ExecutionPayload.Withdrawals = make([]*Withdrawal, 0)
+	}
+	e.Payload.Withdrawals = dec.ExecutionPayload.Withdrawals
+
+	e.Payload.BlockAccessList = *dec.ExecutionPayload.BlockAccessList
+
+	v, err := hexutil.DecodeBig(dec.BlockValue)
+	if err != nil {
+		return err
+	}
+	e.Value = bytesutil.PadTo(bytesutil.ReverseByteOrder(v.Bytes()), fieldparams.RootLength)
+
+	if dec.BlobsBundle != nil {
+		e.BlobsBundle = &BlobsBundleV2{}
+
+		commitments := make([][]byte, len(dec.BlobsBundle.Commitments))
+		for i, kzg := range dec.BlobsBundle.Commitments {
+			k := kzg
+			commitments[i] = bytesutil.PadTo(k[:], fieldparams.BLSPubkeyLength)
+		}
+		e.BlobsBundle.KzgCommitments = commitments
+
+		proofs := make([][]byte, len(dec.BlobsBundle.Proofs))
+		for i, proof := range dec.BlobsBundle.Proofs {
+			p := proof
+			proofs[i] = bytesutil.PadTo(p[:], fieldparams.BLSPubkeyLength)
+		}
+		e.BlobsBundle.Proofs = proofs
+
+		blobs := make([][]byte, len(dec.BlobsBundle.Blobs))
+		for i, blob := range dec.BlobsBundle.Blobs {
+			b := make([]byte, fieldparams.BlobLength)
+			copy(b, blob)
+			blobs[i] = b
+		}
+		e.BlobsBundle.Blobs = blobs
+	}
+
+	e.ShouldOverrideBuilder = dec.ShouldOverrideBuilder
+
+	reqs := make([][]byte, len(dec.ExecutionRequests))
+	for i, r := range dec.ExecutionRequests {
+		b := make([]byte, len(r))
+		copy(b, r)
+		reqs[i] = b
+	}
+	e.ExecutionRequests = reqs
 
 	return nil
 }

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -153,6 +153,12 @@ func (v *validator) ProposeBlock(ctx context.Context, slot primitives.Slot, pubK
 				log.WithError(err).Error("Failed to build generic signed block")
 				return
 			}
+		case version.Gloas:
+			genericSignedBlock, err = buildGenericSignedBlockGloasWithBlobs(pb, b)
+			if err != nil {
+				log.WithError(err).Error("Failed to build generic signed block")
+				return
+			}
 		default:
 			log.Errorf("Unsupported block version %s", version.String(blk.Version()))
 		}
@@ -286,6 +292,22 @@ func buildGenericSignedBlockFuluWithBlobs(pb proto.Message, b *ethpb.GenericBeac
 				Block:     fuluBlock,
 				KzgProofs: b.GetFulu().KzgProofs,
 				Blobs:     b.GetFulu().Blobs,
+			},
+		},
+	}, nil
+}
+
+func buildGenericSignedBlockGloasWithBlobs(pb proto.Message, b *ethpb.GenericBeaconBlock) (*ethpb.GenericSignedBeaconBlock, error) {
+	gloasBlock, ok := pb.(*ethpb.SignedBeaconBlockGloas)
+	if !ok {
+		return nil, errors.New("could cast to gloas block")
+	}
+	return &ethpb.GenericSignedBeaconBlock{
+		Block: &ethpb.GenericSignedBeaconBlock_Gloas{
+			Gloas: &ethpb.SignedBeaconBlockContentsGloas{
+				Block:     gloasBlock,
+				KzgProofs: b.GetGloas().KzgProofs,
+				Blobs:     b.GetGloas().Blobs,
 			},
 		},
 	}, nil


### PR DESCRIPTION
This PR adds Gloas block serialization. When the EL sends `blockAccessList == nil`, it will return an error `missing required field 'blockAccessList' for ExecutionPayload`. Otherwise, it will crash as it currently doesn't have Gloas blinded block. Once it's added, it should be able to successfully unmarshal it.

This PR is tested with an ad-hoc version of Geth that doesn't check PayloadVersion when `GetPayloadV6` is called and always returns nil `blockAccessList`. It's also tested with another version with BALs turned off, spotting the absence of Gloas blinded block, which is a known issue.