### PR TITLE
Fix SMT parent layer resizing on Insert and align MerkleProof length mixin

### DIFF
--- a/beacon-chain/state/stateutil/trie_helpers.go
+++ b/beacon-chain/state/stateutil/trie_helpers.go
@@ -223,13 +223,16 @@ func recomputeRootFromLayerVariable(idx int, item [32]byte, layers [][]*[32]byte
 		root = parentHash
 
 		parentIdx := currentIndex / 2
-		if len(layers[i+1]) == 0 || parentIdx >= len(layers[i+1]) {
-			newItem := root
-			layers[i+1] = append(layers[i+1], &newItem)
-		} else {
-			newItem := root
-			layers[i+1][parentIdx] = &newItem
+		// Ensure parent layer has capacity up to parentIdx; pad with zerohashes for this level.
+		if parentIdx >= len(layers[i+1]) {
+			neededLen := parentIdx + 1
+			for len(layers[i+1]) < neededLen {
+				zerohash := trie.ZeroHashes[i+1]
+				layers[i+1] = append(layers[i+1], &zerohash)
+			}
 		}
+		newItem := root
+		layers[i+1][parentIdx] = &newItem
 		currentIndex = parentIdx
 	}
 	return root, layers, nil

--- a/changelog/radik-878_fix-smt-insert-layer-resize-and-mixin.md
+++ b/changelog/radik-878_fix-smt-insert-layer-resize-and-mixin.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix SMT parent layer resizing on Insert and align MerkleProof length mixin. (#15750)

--- a/container/trie/sparse_merkle.go
+++ b/container/trie/sparse_merkle.go
@@ -154,13 +154,16 @@ func (m *SparseMerkleTrie) Insert(item []byte, index int) error {
 			root = parentHash
 		}
 		parentIdx := currentIndex / 2
-		if len(m.branches[i+1]) == 0 || parentIdx >= len(m.branches[i+1]) {
-			newItem := root
-			m.branches[i+1] = append(m.branches[i+1], newItem[:])
-		} else {
-			newItem := root
-			m.branches[i+1][parentIdx] = newItem[:]
+		// Ensure the parent layer has capacity up to parentIdx by padding with
+		// appropriate zero hashes for this level before assigning at index.
+		if parentIdx >= len(m.branches[i+1]) {
+			neededLen := parentIdx + 1
+			for len(m.branches[i+1]) < neededLen {
+				m.branches[i+1] = append(m.branches[i+1], ZeroHashes[i+1][:])
+			}
 		}
+		newItem := root
+		m.branches[i+1][parentIdx] = newItem[:]
 		currentIndex = parentIdx
 	}
 	return nil
@@ -187,7 +190,11 @@ func (m *SparseMerkleTrie) MerkleProof(index int) ([][]byte, error) {
 		}
 	}
 	var enc [32]byte
-	binary.LittleEndian.PutUint64(enc[:], uint64(len(m.originalItems)))
+	depositCount := uint64(len(m.originalItems))
+	if len(m.originalItems) == 1 && bytes.Equal(m.originalItems[0], ZeroHashes[0][:]) {
+		depositCount = 0
+	}
+	binary.LittleEndian.PutUint64(enc[:], depositCount)
 	proof[len(proof)-1] = enc[:]
 	return proof, nil
 }


### PR DESCRIPTION
Problem:
- SparseMerkleTrie.Insert appended parent hashes at the end of layer i+1 when parentIdx >= len(layer), instead of writing at parentIdx. This broke layer indexing for far-right insertions (e.g., index 15), producing misaligned layers and potentially invalid proofs/roots.
- MerkleProof always mixed in len(originalItems); it didn’t mirror the empty-tree rule used by HashTreeRoot (single zero leaf → depositCount = 0).
- The same parent-layer append-at-end pattern existed in beacon-chain/state/stateutil/trie_helpers.go, affecting recompute paths.

Solution:
- During upward propagation, ensure layer i+1 capacity up to parentIdx by padding with ZeroHashes[i+1] and then assign at m.branches[i+1][parentIdx].
- Align MerkleProof to set depositCount = 0 when the trie represents an empty tree (single ZeroHashes[0] leaf), matching HashTreeRoot.
- Apply the same resizing-and-pad-by-index fix in stateutil’s trie_helpers recompute logic.

