### PR TITLE
Replace deprecated gRPC insecure dial with `insecure.NewCredentials()`

### DIFF
--- a/cmd/prysmctl/p2p/client.go
+++ b/cmd/prysmctl/p2p/client.go
@@ -33,6 +33,7 @@ import (
 	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/go-bitfield"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -74,7 +75,7 @@ func newClient(beaconEndpoints []string, tcpPort, quicPort uint) (*client, error
 	if len(beaconEndpoints) == 0 {
 		return nil, errors.New("no specified beacon API endpoints")
 	}
-	conn, err := grpc.Dial(beaconEndpoints[0], grpc.WithInsecure())
+	conn, err := grpc.Dial(beaconEndpoints[0], grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


- **What**: Replace `grpc.WithInsecure()` with `grpc.WithTransportCredentials(insecure.NewCredentials())` in `cmd/prysmctl/p2p/client.go`.
- **Why**: Removes deprecated API usage, aligns with current gRPC recommendations, and improves forward compatibility.
- **Security**: Behavior remains intentionally insecure (no TLS) to match existing semantics. A follow-up can introduce TLS-by-default with an explicit `--insecure` flag.
