### PR TITLE
Add default HTTP client timeout (30s)

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -33,7 +34,7 @@ func NewClient(host string, opts ...ClientOpt) (*Client, error) {
 		return nil, err
 	}
 	c := &Client{
-		hc:          &http.Client{},
+		hc:          &http.Client{Timeout: 30 * time.Second}, // Default client timeout to prevent indefinite hangs
 		baseURL:     u,
 		maxBodySize: MaxBodySize,
 	}


### PR DESCRIPTION


This PR sets a 30s default timeout on the internal HTTP client in `api/client/client.go` to prevent requests from hanging indefinitely under network issues or unresponsive peers, while preserving existing behavior by allowing callers to override the value via `WithTimeout(...)`; the change is low risk, improves reliability, and does not alter the public API.