### PR TITLE
Fix timing attack vulnerability in authentication

### DIFF
--- a/validator/rpc/intercepter.go
+++ b/validator/rpc/intercepter.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -51,8 +52,8 @@ func (s *Server) AuthTokenHandler(next http.Handler) http.Handler {
 				return
 			}
 
-			token := tokenParts[1]
-			if strings.TrimSpace(token) != s.authToken || strings.TrimSpace(s.authToken) == "" {
+			token := strings.TrimSpace(tokenParts[1])
+			if s.authToken == "" || subtle.ConstantTimeCompare([]byte(token), []byte(s.authToken)) != 1 {
 				httputil.HandleError(w, "Forbidden: token value is invalid", http.StatusForbidden)
 				return
 			}
@@ -75,8 +76,8 @@ func (s *Server) authorize(ctx context.Context) error {
 	if len(authHeader) < 1 || !strings.Contains(authHeader[0], "Bearer ") {
 		return status.Error(codes.Unauthenticated, "Invalid auth header, needs Bearer {token}")
 	}
-	token := strings.Split(authHeader[0], "Bearer ")[1]
-	if strings.TrimSpace(token) != s.authToken || strings.TrimSpace(s.authToken) == "" {
+	token := strings.TrimSpace(strings.Split(authHeader[0], "Bearer ")[1])
+	if s.authToken == "" || subtle.ConstantTimeCompare([]byte(token), []byte(s.authToken)) != 1 {
 		return status.Errorf(codes.Unauthenticated, "Forbidden: token value is invalid")
 	}
 	return nil


### PR DESCRIPTION


**Problem:** The authentication token comparison in `validator/rpc/intercepter.go` was vulnerable to timing attacks due to non-constant-time string comparison.

**Vulnerability Details:**
- `strings.TrimSpace()` operations on both tokens created timing differences
- Attackers could measure response times to infer token length/content
- Inefficient repeated `strings.TrimSpace(s.authToken)` calls

**Solution:**
- Replaced `strings.TrimSpace(token) != s.authToken` with `subtle.ConstantTimeCompare()`
- Added `crypto/subtle` import for secure constant-time comparison
- Optimized check order (empty token check first)

**Files Changed:**
- `validator/rpc/intercepter.go` - Fixed both HTTP and gRPC authentication handlers

