### PR TITLE
Avoid unnecessary calls to ExitInformation()

### DIFF
--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -62,6 +62,9 @@ func ProcessAttesterSlashing(
 	slashing ethpb.AttSlashing,
 	exitInfo *validators.ExitInfo,
 ) (state.BeaconState, error) {
+	if exitInfo == nil {
+		return nil, errors.New("exit info is required to process attester slashing")
+	}
 	if err := VerifyAttesterSlashing(ctx, beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify attester slashing")
 	}
@@ -70,9 +73,6 @@ func ProcessAttesterSlashing(
 		return slashableIndices[i] < slashableIndices[j]
 	})
 	currentEpoch := slots.ToEpoch(beaconState.Slot())
-	if exitInfo == nil {
-		return nil, errors.New("exit info is required to process attester slashing")
-	}
 	var err error
 	var slashedAny bool
 	var val state.ReadOnlyValidator

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -42,6 +42,9 @@ func ProcessAttesterSlashings(
 	slashings []ethpb.AttSlashing,
 	exitInfo *validators.ExitInfo,
 ) (state.BeaconState, error) {
+	if exitInfo == nil && len(slashings) > 0 {
+		return nil, errors.New("exit info required to process attester slashings")
+	}
 	var err error
 	for _, slashing := range slashings {
 		beaconState, err = ProcessAttesterSlashing(ctx, beaconState, slashing, exitInfo)
@@ -67,6 +70,9 @@ func ProcessAttesterSlashing(
 		return slashableIndices[i] < slashableIndices[j]
 	})
 	currentEpoch := slots.ToEpoch(beaconState.Slot())
+	if exitInfo == nil {
+		return nil, errors.New("exit info is required to process attester slashing")
+	}
 	var err error
 	var slashedAny bool
 	var val state.ReadOnlyValidator

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -55,6 +55,9 @@ func ProcessVoluntaryExits(
 	if len(exits) == 0 {
 		return beaconState, nil
 	}
+	if exitInfo == nil {
+		return nil, errors.New("exit info required to process voluntary exits")
+	}
 	for idx, exit := range exits {
 		if exit == nil || exit.Exit == nil {
 			return nil, errors.New("nil voluntary exit in block body")

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -51,6 +51,9 @@ func ProcessProposerSlashings(
 	slashings []*ethpb.ProposerSlashing,
 	exitInfo *validators.ExitInfo,
 ) (state.BeaconState, error) {
+	if exitInfo == nil && len(slashings) > 0 {
+		return nil, errors.New("exit info required to process proposer slashings")
+	}
 	var err error
 	for _, slashing := range slashings {
 		beaconState, err = ProcessProposerSlashing(ctx, beaconState, slashing, exitInfo)
@@ -74,6 +77,9 @@ func ProcessProposerSlashing(
 	}
 	if err = VerifyProposerSlashing(beaconState, slashing); err != nil {
 		return nil, errors.Wrap(err, "could not verify proposer slashing")
+	}
+	if exitInfo == nil {
+		return nil, errors.New("exit info is required to process proposer slashing")
 	}
 	beaconState, err = validators.SlashValidator(ctx, beaconState, slashing.Header_1.Header.ProposerIndex, exitInfo)
 	if err != nil {

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/electra"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/transition/interop"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	v "github.com/OffchainLabs/prysm/v6/beacon-chain/core/validators"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
@@ -379,8 +380,9 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var err error
 
 	hasSlashings := len(beaconBlock.Body().ProposerSlashings()) > 0 || len(beaconBlock.Body().AttesterSlashings()) > 0
-	hasExits := len(beaconBlock.Body().VoluntaryExits()) > 0
-	var exitInfo *v.ExitInfo
+	// exitInfo is only needed for voluntary exits pre Electra.
+	hasExits := st.Version() < version.Electra && len(beaconBlock.Body().VoluntaryExits()) > 0
+	exitInfo := &validators.ExitInfo{}
 	if hasSlashings || hasExits {
 		// ExitInformation is expensive to compute, only do it if we need it.
 		exitInfo = v.ExitInformation(st)

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -378,9 +378,15 @@ func ProcessBlockForStateRoot(
 func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
 	var err error
 
-	exitInfo := v.ExitInformation(st)
-	if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
-		return nil, errors.Wrap(err, "could not update total active balance cache")
+	hasSlashings := len(beaconBlock.Body().ProposerSlashings()) > 0 || len(beaconBlock.Body().AttesterSlashings()) > 0
+	hasExits := len(beaconBlock.Body().VoluntaryExits()) > 0
+	var exitInfo *v.ExitInfo
+	if hasSlashings || hasExits {
+		// ExitInformation is expensive to compute, only do it if we need it.
+		exitInfo = v.ExitInformation(st)
+		if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
+			return nil, errors.Wrap(err, "could not update total active balance cache")
+		}
 	}
 	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo)
 	if err != nil {
@@ -407,10 +413,15 @@ func altairOperations(ctx context.Context, st state.BeaconState, beaconBlock int
 // This calls phase 0 block operations.
 func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
 	var err error
-
-	exitInfo := v.ExitInformation(st)
-	if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
-		return nil, errors.Wrap(err, "could not update total active balance cache")
+	hasSlashings := len(beaconBlock.Body().ProposerSlashings()) > 0 || len(beaconBlock.Body().AttesterSlashings()) > 0
+	hasExits := len(beaconBlock.Body().VoluntaryExits()) > 0
+	var exitInfo *v.ExitInfo
+	if hasSlashings || hasExits {
+		// ExitInformation is expensive to compute, only do it if we need it.
+		exitInfo := v.ExitInformation(st)
+		if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
+			return nil, errors.Wrap(err, "could not update total active balance cache")
+		}
 	}
 	st, err = b.ProcessProposerSlashings(ctx, st, beaconBlock.Body().ProposerSlashings(), exitInfo)
 	if err != nil {

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -420,7 +420,7 @@ func phase0Operations(ctx context.Context, st state.BeaconState, beaconBlock int
 	var exitInfo *v.ExitInfo
 	if hasSlashings || hasExits {
 		// ExitInformation is expensive to compute, only do it if we need it.
-		exitInfo := v.ExitInformation(st)
+		exitInfo = v.ExitInformation(st)
 		if err := helpers.UpdateTotalActiveBalanceCache(st, exitInfo.TotalActiveBalance); err != nil {
 			return nil, errors.Wrap(err, "could not update total active balance cache")
 		}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -98,7 +98,9 @@ func InitiateValidatorExit(
 	if validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
 		return s, ErrValidatorAlreadyExited
 	}
-
+	if exitInfo == nil {
+		return nil, errors.New("exit info is required to process validator exit")
+	}
 	// Compute exit queue epoch.
 	if s.Version() < version.Electra {
 		if err = initiateValidatorExitPreElectra(ctx, s, exitInfo); err != nil {
@@ -177,6 +179,9 @@ func initiateValidatorExitPreElectra(ctx context.Context, s state.BeaconState, e
 	//	if exit_queue_churn >= get_validator_churn_limit(state):
 	//	    exit_queue_epoch += Epoch(1)
 	exitableEpoch := helpers.ActivationExitEpoch(time.CurrentEpoch(s))
+	if exitInfo == nil {
+		return errors.New("exit info is required to process validator exit")
+	}
 	if exitableEpoch > exitInfo.HighestExitEpoch {
 		exitInfo.HighestExitEpoch = exitableEpoch
 		exitInfo.Churn = 0
@@ -235,7 +240,9 @@ func SlashValidator(
 	exitInfo *ExitInfo,
 ) (state.BeaconState, error) {
 	var err error
-
+	if exitInfo == nil {
+		return nil, errors.New("exit info is required to slash validator")
+	}
 	s, err = InitiateValidatorExitForTotalBal(ctx, s, slashedIdx, exitInfo, primitives.Gwei(exitInfo.TotalActiveBalance))
 	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)

--- a/beacon-chain/rpc/eth/rewards/service.go
+++ b/beacon-chain/rpc/eth/rewards/service.go
@@ -68,7 +68,11 @@ func (rs *BlockRewardService) GetBlockRewardsData(ctx context.Context, blk inter
 			Code:    http.StatusInternalServerError,
 		}
 	}
-	exitInfo := validators.ExitInformation(st)
+	var exitInfo *validators.ExitInfo
+	if len(blk.Body().ProposerSlashings()) > 0 || len(blk.Body().AttesterSlashings()) > 0 {
+		// ExitInformation is expensive to compute, only do it if we need it.
+		exitInfo = validators.ExitInformation(st)
+	}
 	st, err = coreblocks.ProcessAttesterSlashings(ctx, st, blk.Body().AttesterSlashings(), exitInfo)
 	if err != nil {
 		return nil, &httputil.DefaultJsonError{

--- a/changelog/potuz_avoid_exit_info.md
+++ b/changelog/potuz_avoid_exit_info.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Avoid unnecessary calls to `ExitInformation()`.


### PR DESCRIPTION
ExitInformation runs a loop over the whole validator set. This is needed in case that there are slashings or exits to be processed in a block (we could be caching or avoid this entirely post-Electra though). This PR removes these calls on normal state transition to this function. h/t to @terencechain for finding out this bug.

In addition, on processing withdrawal requests and registry updates, we kept recomputing the exit information at the same time that the state is updated and the function that updates the state already takes care of tracking and updating the right exit information. So this PR removes the calls to compute this exit information on a loop. Notice that this bug has been present even before we had a function `ExitInformation()` so I will document here to help the reviewer

Our previous behavior is to do this in a loop

```
st, err = validators.InitiateValidatorExit(ctx, st, vIdx, validators.ExitInformation(st))
```

This is a bit problematic since `ExitInformation` loops over the whole validator set to compute the exit information (and the total active balance) and then the function `InitiateValidatorExit` actually recomputes the total active balance looping again over the whole validator set and overwriting the pointer returned by `ExitInformation`.

On the other hand, the funciton `InitiateValidatorExit` does mutate the state `st` itself. So each call to `ExitInformation(st)` may actually return a different pointer.

The function ExitInformation computes as follows

```
	err := s.ReadFromEveryValidator(func(idx int, val state.ReadOnlyValidator) error {
		e := val.ExitEpoch()
		if e != farFutureEpoch {
			if e > exitInfo.HighestExitEpoch {
				exitInfo.HighestExitEpoch = e
				exitInfo.Churn = 1
			} else if e == exitInfo.HighestExitEpoch {
				exitInfo.Churn++
			}
```

So it simply increases the churn for each validator that has epoch equal to the highest exit epoch.

The function `InitiateValidatorExit` mutates this pointer in the following way

if the state is post-electra, it disregards completely this pointer and computes the highest exit epoch and updates churn inconditionally, so the pointer `exitInfo.HighestExitEpoch` will always have the right value and is not even neded to be computed before. We could even avoid the fist loop even. If the state is pre-Electra then the function itself updates correctly the exit info for the next iteration.
