### PR TITLE
Add a go sdk toolchain with nodwarf5 for windows builds

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -203,7 +203,7 @@ load("@prysm//tools:image_deps.bzl", "prysm_image_deps")
 
 prysm_image_deps()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies", "go_download_sdk")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -218,9 +218,9 @@ go_register_toolchains(
 # Go SDK for windows on go 1.25+ with an outdated gcc/zig sdk. See issue #15760.
 # This must be configured at build time --@io_bazel_rules_go//go/toolchain:sdk_name=go_sdk_nodwarf5
 go_download_sdk(
-  name = "go_sdk_nodwarf5",
-  version = GO_VERSION,
-  experiments =["nodwarf5"],
+    name = "go_sdk_nodwarf5",
+    experiments = ["nodwarf5"],
+    version = GO_VERSION,
 )
 
 load("//:distroless_deps.bzl", "distroless_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -203,13 +203,24 @@ load("@prysm//tools:image_deps.bzl", "prysm_image_deps")
 
 prysm_image_deps()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies", "go_download_sdk")
 
 go_rules_dependencies()
 
+GO_VERSION = "1.25.1"
+
+# Default toolchain.
 go_register_toolchains(
-    go_version = "1.25.1",
+    go_version = GO_VERSION,
     nogo = "@//:nogo",
+)
+
+# Go SDK for windows on go 1.25+ with an outdated gcc/zig sdk. See issue #15760.
+# This must be configured at build time --@io_bazel_rules_go//go/toolchain:sdk_name=go_sdk_nodwarf5
+go_download_sdk(
+  name = "go_sdk_nodwarf5",
+  version = GO_VERSION,
+  experiments =["nodwarf5"],
 )
 
 load("//:distroless_deps.bzl", "distroless_deps")

--- a/build/bazelrc/cross.bazelrc
+++ b/build/bazelrc/cross.bazelrc
@@ -25,6 +25,7 @@ build:osx_arm64 --cpu=aarch64
 build:windows_amd64 --config=cross
 build:windows_amd64 --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64_cgo
 build:windows_amd64 --compiler=mingw-w64
+build:windows_amd64 --@io_bazel_rules_go//go/toolchain:sdk_name=go_sdk_nodwarf5 # See issue #15760
 
 # linux_arm64 config for cross compiler toolchain
 build:linux_arm64 --config=cross

--- a/changelog/pvl-nodwarf5.md
+++ b/changelog/pvl-nodwarf5.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Windows builds use GOEXPERIMENT=nodwarf5


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Release v6.1.0 introduced go1.25.1 and was built with gcc using zig 0.12.0 which caused issues like https://github.com/golang/go/issues/75077. 

There are two resolutions here:
1) Use an updated gcc that meets the new minimum requirements for go 1.25 (https://github.com/uber/hermetic_cc_toolchain/pull/203, currently blocked?)
2) Use GOEXPERIMENT=nodwarf5 (suggested in https://github.com/golang/go/issues/75077)

**Which issues(s) does this PR fix?**

Fixes #15760

**Other notes for review**

I tested this in a windows VM. I confirmed the behavior reported in #15760 and then built a new windows binary with these changes and did not observe a failure to start. 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
