### PR TITLE
Add strip=always to release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,7 @@ build:minimal --@io_bazel_rules_go//go/config:tags=minimal
 build:release --compilation_mode=opt
 build:release --stamp
 build:release --define pgo_enabled=1
+build:release --strip=always
 
 # Build binary with cgo symbolizer for debugging / profiling.
 build:cgo_symbolizer --copt=-g

--- a/changelog/pvl-strip.md
+++ b/changelog/pvl-strip.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Bazel builds with `--config=release` now properly apply `--strip=always` to strip debug symbols from the release assets.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The original intention of release builds was to strip the debug assets and ship the compile time optimized binary. Adding `--strip=always` ensures the debug symbols are removed.

**Which issues(s) does this PR fix?**

Fixes #15760

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
