### PR TITLE
Fix #15738

### DIFF
--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"fmt"
+
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
@@ -46,6 +48,7 @@ func (s *Service) registerForUpcomingFork(currentEpoch primitives.Epoch) error {
 	}
 
 	if s.subHandler.digestExists(nextEntry.ForkDigest) {
+		log.WithField("digest", fmt.Sprintf("%#x", nextEntry.ForkDigest)).Debug("Already subscribed to fork")
 		return nil
 	}
 

--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -14,7 +14,6 @@ import (
 // Is a background routine that observes for new incoming forks. Depending on the epoch
 // it will be in charge of subscribing/unsubscribing the relevant topics at the fork boundaries.
 func (s *Service) forkWatcher() {
-	<-s.initialSyncComplete
 	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
 	for {
 		select {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -413,6 +413,8 @@ func (s *Service) startDiscoveryAndSubscriptions() {
 		return
 	}
 
+	s.registeredNetworkEntry = params.GetNetworkScheduleEntry(currentEpoch)
+
 	// Register respective pubsub handlers at state synced event.
 	s.registerSubscribers(currentEpoch, forkDigest)
 

--- a/changelog/manu-fix-#15738.md
+++ b/changelog/manu-fix-#15738.md
@@ -1,0 +1,2 @@
+### Fixed
+- [#15738](https://github.com/OffchainLabs/prysm/issues/15738)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix


**Which issues(s) does this PR fix?**
Fixes
- #15738

**Other notes for review**
Please read commit by commit.

This pull requests ensures that the `registerForUpcomingFork` function already knows what is the current `s.registeredNetworkEntry` before running, to avoid double subscription.

Independently of this bug, this pull request ensures that `forkWatcher` runs even during the initial sync, to ensure optimal behavior (for example, the ability to respond to the correct Req/Resp requests) even if the initial sync starts before a hard fork epoch and continues after the hard fork epoch.

**Alternative proposals:**
- https://github.com/OffchainLabs/prysm/pull/15769
- https://github.com/OffchainLabs/prysm/pull/15771
- https://github.com/OffchainLabs/prysm/pull/15779

**Cons of this solution:**
This solution avoids `registerSubscribers` to be called concurrently.
However, if, in the future, an other part of the code starts again to call `registerSubscribers` concurrently, then the same issue will happen again.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
