### PR TITLE
fix: remove redundant ZeroHash filter in requestBodiesByHash

### DIFF
--- a/beacon-chain/execution/payload_body.go
+++ b/beacon-chain/execution/payload_body.go
@@ -179,9 +179,6 @@ func (r *blindedBlockReconstructor) requestBodiesByHash(ctx context.Context, cli
 	}
 	hashes := make([]common.Hash, 0, len(batch))
 	for h := range batch {
-		if h == params.BeaconConfig().ZeroHash {
-			continue
-		}
 		hashes = append(hashes, h)
 	}
 	result := make([]*pb.ExecutionPayloadBody, 0)

--- a/changelog/GarmashAlex_fix-execution-remove-redundant-zerohash-filter
+++ b/changelog/GarmashAlex_fix-execution-remove-redundant-zerohash-filter
@@ -1,0 +1,3 @@
+### Fixed
+
+- remove redundant ZeroHash filter in requestBodiesByHash (#15781)


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Remove duplicate ZeroHash check when building the hashes slice in requestBodiesByHash, as ZeroHash is already excluded in addToBatch.
Keeps other ZeroHash checks intact where they have distinct semantics (e.g., empty payload handling).

