### PR TITLE
attempting to improve duties v2

### DIFF
--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -399,7 +399,6 @@ func CommitteeAssignments(ctx context.Context, state state.BeaconState, epoch pr
 	ctx, span := trace.StartSpan(ctx, "helpers.CommitteeAssignments")
 	defer span.End()
 
-	// Verify if the epoch is valid for assignment based on the provided state.
 	if err := VerifyAssignmentEpoch(epoch, state); err != nil {
 		return nil, err
 	}
@@ -407,12 +406,15 @@ func CommitteeAssignments(ctx context.Context, state state.BeaconState, epoch pr
 	if err != nil {
 		return nil, err
 	}
-	vals := make(map[primitives.ValidatorIndex]struct{})
+
+	// Deduplicate and make set for O(1) membership checks.
+	vals := make(map[primitives.ValidatorIndex]struct{}, len(validators))
 	for _, v := range validators {
 		vals[v] = struct{}{}
 	}
-	assignments := make(map[primitives.ValidatorIndex]*CommitteeAssignment)
-	// Compute committee assignments for each slot in the epoch.
+	remaining := len(vals)
+
+	assignments := make(map[primitives.ValidatorIndex]*CommitteeAssignment, len(vals))
 	for slot := startSlot; slot < startSlot+params.BeaconConfig().SlotsPerEpoch; slot++ {
 		committees, err := BeaconCommittees(ctx, state, slot)
 		if err != nil {
@@ -420,15 +422,21 @@ func CommitteeAssignments(ctx context.Context, state state.BeaconState, epoch pr
 		}
 		for j, committee := range committees {
 			for _, vIndex := range committee {
-				if _, ok := vals[vIndex]; !ok { // Skip if the validator is not in the provided validators slice.
+				if _, ok := vals[vIndex]; !ok {
 					continue
 				}
 				if _, ok := assignments[vIndex]; !ok {
-					assignments[vIndex] = &CommitteeAssignment{}
+					assignments[vIndex] = &CommitteeAssignment{
+						Committee:      committee,
+						AttesterSlot:   slot,
+						CommitteeIndex: primitives.CommitteeIndex(j),
+					}
+					delete(vals, vIndex)
+					remaining--
+					if remaining == 0 {
+						return assignments, nil // early exit
+					}
 				}
-				assignments[vIndex].Committee = committee
-				assignments[vIndex].AttesterSlot = slot
-				assignments[vIndex].CommitteeIndex = primitives.CommitteeIndex(j)
 			}
 		}
 	}

--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -426,16 +426,15 @@ func CommitteeAssignments(ctx context.Context, state state.BeaconState, epoch pr
 					continue
 				}
 				if _, ok := assignments[vIndex]; !ok {
-					assignments[vIndex] = &CommitteeAssignment{
-						Committee:      committee,
-						AttesterSlot:   slot,
-						CommitteeIndex: primitives.CommitteeIndex(j),
-					}
-					delete(vals, vIndex)
-					remaining--
-					if remaining == 0 {
-						return assignments, nil // early exit
-					}
+					assignments[vIndex] = &CommitteeAssignment{}
+				}
+				assignments[vIndex].Committee = committee
+				assignments[vIndex].AttesterSlot = slot
+				assignments[vIndex].CommitteeIndex = primitives.CommitteeIndex(j)
+				delete(vals, vIndex)
+				remaining--
+				if remaining == 0 {
+					return assignments, nil // early exit
 				}
 			}
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
@@ -345,11 +345,9 @@ func (vs *Server) buildValidatorDuty(
 			}
 			nextDuty.IsSyncCommittee = nextInSync
 			if nextInSync {
-				go func() {
-					if err := core.RegisterSyncSubnetNextPeriodProto(s, reqEpoch, pubKey, statusEnum); err != nil {
-						log.WithError(err).Warn("Could not register sync subnet next period")
-					}
-				}()
+				if err := core.RegisterSyncSubnetNextPeriodProto(s, reqEpoch, pubKey, statusEnum); err != nil {
+					log.WithError(err).Warn("Could not register sync subnet next period")
+				}
 			}
 		}
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	// validatorLookupThreshold determines when to use full assignment map vs cached linear search.
-	// For requests with fewer validators, we use cached linear search to avoid the overhead
-	// of building a complete assignment map for all validators in the epoch.
+	// validatorLookupThreshold determines when to use PrecomputeCommittees vs CommitteeAssignments.
+	// For requests with fewer validators, we use CommitteeAssignments which only computes committees
+	// for the requested validators. For large amounts of validators, we precompute all committees
+	// and build a map for O(1) lookups.
 	validatorLookupThreshold = 3000
 )
 
@@ -60,7 +61,26 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 	span.SetAttributes(trace.Int64Attribute("num_pubkeys", int64(len(req.PublicKeys))))
 	defer span.End()
 
-	meta, err := loadDutiesMetadata(ctx, s, req.Epoch, len(req.PublicKeys))
+	// Collect validator indices from public keys and cache the lookups
+	type validatorInfo struct {
+		index primitives.ValidatorIndex
+		found bool
+	}
+	validatorLookup := make(map[string]validatorInfo, len(req.PublicKeys))
+	requestIndices := make([]primitives.ValidatorIndex, 0, len(req.PublicKeys))
+
+	for _, pubKey := range req.PublicKeys {
+		key := string(pubKey)
+		if _, exists := validatorLookup[key]; !exists {
+			idx, ok := s.ValidatorIndexByPubkey(bytesutil.ToBytes48(pubKey))
+			validatorLookup[key] = validatorInfo{index: idx, found: ok}
+			if ok {
+				requestIndices = append(requestIndices, idx)
+			}
+		}
+	}
+
+	meta, err := loadDutiesMetadata(ctx, s, req.Epoch, requestIndices)
 	if err != nil {
 		return nil, err
 	}
@@ -68,14 +88,14 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 	validatorAssignments := make([]*ethpb.DutiesV2Response_Duty, 0, len(req.PublicKeys))
 	nextValidatorAssignments := make([]*ethpb.DutiesV2Response_Duty, 0, len(req.PublicKeys))
 
-	// start loop for assignments for current and next epochs
+	// Build duties using cached validator index lookups
 	for _, pubKey := range req.PublicKeys {
 		if ctx.Err() != nil {
 			return nil, status.Errorf(codes.Aborted, "Could not continue fetching assignments: %v", ctx.Err())
 		}
 
-		validatorIndex, ok := s.ValidatorIndexByPubkey(bytesutil.ToBytes48(pubKey))
-		if !ok {
+		info := validatorLookup[string(pubKey)]
+		if !info.found {
 			unknownDuty := &ethpb.DutiesV2Response_Duty{
 				PublicKey: pubKey,
 				Status:    ethpb.ValidatorStatus_UNKNOWN_STATUS,
@@ -85,16 +105,15 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 			continue
 		}
 
-		meta.current.liteAssignment = vs.getValidatorAssignment(meta.current, validatorIndex)
+		currentAssignment := vs.getValidatorAssignment(meta.current, info.index)
+		nextAssignment := vs.getValidatorAssignment(meta.next, info.index)
 
-		meta.next.liteAssignment = vs.getValidatorAssignment(meta.next, validatorIndex)
-
-		assignment, nextAssignment, err := vs.buildValidatorDuty(pubKey, validatorIndex, s, req.Epoch, meta)
+		assignment, nextDuty, err := vs.buildValidatorDuty(pubKey, info.index, s, req.Epoch, meta, currentAssignment, nextAssignment)
 		if err != nil {
 			return nil, err
 		}
 		validatorAssignments = append(validatorAssignments, assignment)
-		nextValidatorAssignments = append(nextValidatorAssignments, nextAssignment)
+		nextValidatorAssignments = append(nextValidatorAssignments, nextDuty)
 	}
 
 	// Dependent roots for fork choice
@@ -147,18 +166,18 @@ type dutiesMetadata struct {
 }
 
 type metadata struct {
-	committeesAtSlot       uint64
-	proposalSlots          map[primitives.ValidatorIndex][]primitives.Slot
-	startSlot              primitives.Slot
-	committeesBySlot       [][][]primitives.ValidatorIndex
-	validatorAssignmentMap map[primitives.ValidatorIndex]*helpers.LiteAssignment
-	liteAssignment         *helpers.LiteAssignment
+	committeesAtSlot     uint64
+	proposalSlots        map[primitives.ValidatorIndex][]primitives.Slot
+	startSlot            primitives.Slot
+	committeesBySlot     [][][]primitives.ValidatorIndex
+	validatorAssignments map[primitives.ValidatorIndex]*helpers.LiteAssignment
+	committeeAssignments map[primitives.ValidatorIndex]*helpers.CommitteeAssignment
 }
 
-func loadDutiesMetadata(ctx context.Context, s state.BeaconState, reqEpoch primitives.Epoch, numValidators int) (*dutiesMetadata, error) {
+func loadDutiesMetadata(ctx context.Context, s state.BeaconState, reqEpoch primitives.Epoch, requestIndices []primitives.ValidatorIndex) (*dutiesMetadata, error) {
 	meta := &dutiesMetadata{}
 	var err error
-	meta.current, err = loadMetadata(ctx, s, reqEpoch, numValidators)
+	meta.current, err = loadMetadata(ctx, s, reqEpoch, requestIndices)
 	if err != nil {
 		return nil, err
 	}
@@ -168,14 +187,14 @@ func loadDutiesMetadata(ctx context.Context, s state.BeaconState, reqEpoch primi
 		return nil, status.Errorf(codes.Internal, "Could not compute proposer slots: %v", err)
 	}
 
-	meta.next, err = loadMetadata(ctx, s, reqEpoch+1, numValidators)
+	meta.next, err = loadMetadata(ctx, s, reqEpoch+1, requestIndices)
 	if err != nil {
 		return nil, err
 	}
 	return meta, nil
 }
 
-func loadMetadata(ctx context.Context, s state.BeaconState, reqEpoch primitives.Epoch, numValidators int) (*metadata, error) {
+func loadMetadata(ctx context.Context, s state.BeaconState, reqEpoch primitives.Epoch, requestIndices []primitives.ValidatorIndex) (*metadata, error) {
 	meta := &metadata{}
 
 	if err := helpers.VerifyAssignmentEpoch(reqEpoch, s); err != nil {
@@ -193,13 +212,20 @@ func loadMetadata(ctx context.Context, s state.BeaconState, reqEpoch primitives.
 		return nil, err
 	}
 
-	meta.committeesBySlot, err = helpers.PrecomputeCommittees(ctx, s, meta.startSlot)
-	if err != nil {
-		return nil, err
-	}
-
-	if numValidators >= validatorLookupThreshold {
-		meta.validatorAssignmentMap = buildValidatorAssignmentMap(meta.committeesBySlot, meta.startSlot)
+	// Use different strategies based on request size
+	if len(requestIndices) >= validatorLookupThreshold {
+		// For large requests: precompute all committees and build a map for O(1) lookup
+		meta.committeesBySlot, err = helpers.PrecomputeCommittees(ctx, s, meta.startSlot)
+		if err != nil {
+			return nil, err
+		}
+		meta.validatorAssignments = buildValidatorAssignmentMap(meta.committeesBySlot, meta.startSlot)
+	} else {
+		// For small requests: use CommitteeAssignments which only computes for requested validators
+		meta.committeeAssignments, err = helpers.CommitteeAssignments(ctx, s, reqEpoch, requestIndices)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not compute committee assignments: %v", err)
+		}
 	}
 
 	return meta, nil
@@ -227,17 +253,42 @@ func buildValidatorAssignmentMap(
 	return validatorToAssignment
 }
 
+// findValidatorIndexInCommittee finds the position of a validator in a committee.
+func findValidatorIndexInCommittee(committee []primitives.ValidatorIndex, validatorIndex primitives.ValidatorIndex) uint64 {
+	for i, vIdx := range committee {
+		if vIdx == validatorIndex {
+			return uint64(i)
+		}
+	}
+	return 0
+}
+
 // getValidatorAssignment retrieves the assignment for a validator using either
-// the pre-built assignment map (for large requests) or linear search (for small requests).
+// the pre-built assignment map (for large requests) or CommitteeAssignments (for small requests).
 func (vs *Server) getValidatorAssignment(meta *metadata, validatorIndex primitives.ValidatorIndex) *helpers.LiteAssignment {
-	if meta.validatorAssignmentMap != nil {
-		if assignment, exists := meta.validatorAssignmentMap[validatorIndex]; exists {
+	// For large requests: use the pre-built assignment map
+	if meta.validatorAssignments != nil {
+		if assignment, exists := meta.validatorAssignments[validatorIndex]; exists {
 			return assignment
 		}
 		return &helpers.LiteAssignment{}
 	}
 
-	return helpers.AssignmentForValidator(meta.committeesBySlot, meta.startSlot, validatorIndex)
+	// For small requests: use CommitteeAssignments result
+	if meta.committeeAssignments != nil {
+		if assignment, exists := meta.committeeAssignments[validatorIndex]; exists {
+			return &helpers.LiteAssignment{
+				AttesterSlot:            assignment.AttesterSlot,
+				CommitteeIndex:          assignment.CommitteeIndex,
+				CommitteeLength:         uint64(len(assignment.Committee)),
+				ValidatorCommitteeIndex: findValidatorIndexInCommittee(assignment.Committee, validatorIndex),
+			}
+		}
+		return &helpers.LiteAssignment{}
+	}
+
+	// Fallback (shouldn't happen, but for safety)
+	return &helpers.LiteAssignment{}
 }
 
 // buildValidatorDuty builds both current‑epoch and next‑epoch V2 duty objects
@@ -248,21 +299,23 @@ func (vs *Server) buildValidatorDuty(
 	s state.BeaconState,
 	reqEpoch primitives.Epoch,
 	meta *dutiesMetadata,
+	currentAssignment *helpers.LiteAssignment,
+	nextAssignment *helpers.LiteAssignment,
 ) (*ethpb.DutiesV2Response_Duty, *ethpb.DutiesV2Response_Duty, error) {
 	assignment := &ethpb.DutiesV2Response_Duty{PublicKey: pubKey}
-	nextAssignment := &ethpb.DutiesV2Response_Duty{PublicKey: pubKey}
+	nextDuty := &ethpb.DutiesV2Response_Duty{PublicKey: pubKey}
 
 	statusEnum := assignmentStatus(s, idx)
 	assignment.ValidatorIndex = idx
 	assignment.Status = statusEnum
 	assignment.CommitteesAtSlot = meta.current.committeesAtSlot
 	assignment.ProposerSlots = meta.current.proposalSlots[idx]
-	populateCommitteeFields(assignment, meta.current.liteAssignment)
+	populateCommitteeFields(assignment, currentAssignment)
 
-	nextAssignment.ValidatorIndex = idx
-	nextAssignment.Status = statusEnum
-	nextAssignment.CommitteesAtSlot = meta.next.committeesAtSlot
-	populateCommitteeFields(nextAssignment, meta.next.liteAssignment)
+	nextDuty.ValidatorIndex = idx
+	nextDuty.Status = statusEnum
+	nextDuty.CommitteesAtSlot = meta.next.committeesAtSlot
+	populateCommitteeFields(nextDuty, nextAssignment)
 
 	// Sync committee flags
 	if coreTime.HigherEqualThanAltairVersionAndEpoch(s, reqEpoch) {
@@ -271,7 +324,7 @@ func (vs *Server) buildValidatorDuty(
 			return nil, nil, status.Errorf(codes.Internal, "Could not determine current epoch sync committee: %v", err)
 		}
 		assignment.IsSyncCommittee = inSync
-		nextAssignment.IsSyncCommittee = inSync
+		nextDuty.IsSyncCommittee = inSync
 		if inSync {
 			if err := core.RegisterSyncSubnetCurrentPeriodProto(s, reqEpoch, pubKey, statusEnum); err != nil {
 				return nil, nil, status.Errorf(codes.Internal, "Could not register sync subnet current period: %v", err)
@@ -290,7 +343,7 @@ func (vs *Server) buildValidatorDuty(
 			if err != nil {
 				return nil, nil, status.Errorf(codes.Internal, "Could not determine next epoch sync committee: %v", err)
 			}
-			nextAssignment.IsSyncCommittee = nextInSync
+			nextDuty.IsSyncCommittee = nextInSync
 			if nextInSync {
 				go func() {
 					if err := core.RegisterSyncSubnetNextPeriodProto(s, reqEpoch, pubKey, statusEnum); err != nil {
@@ -301,7 +354,7 @@ func (vs *Server) buildValidatorDuty(
 		}
 	}
 
-	return assignment, nextAssignment, nil
+	return assignment, nextDuty, nil
 }
 
 func populateCommitteeFields(duty *ethpb.DutiesV2Response_Duty, la *helpers.LiteAssignment) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-
 // GetDutiesV2 returns the duties assigned to a list of validators specified
 // in the request object.
 //

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
@@ -169,7 +169,6 @@ type metadata struct {
 	committeesAtSlot     uint64
 	proposalSlots        map[primitives.ValidatorIndex][]primitives.Slot
 	startSlot            primitives.Slot
-	committeesBySlot     [][][]primitives.ValidatorIndex
 	validatorAssignments map[primitives.ValidatorIndex]*helpers.LiteAssignment
 	committeeAssignments map[primitives.ValidatorIndex]*helpers.CommitteeAssignment
 }
@@ -215,11 +214,11 @@ func loadMetadata(ctx context.Context, s state.BeaconState, reqEpoch primitives.
 	// Use different strategies based on request size
 	if len(requestIndices) >= validatorLookupThreshold {
 		// For large requests: precompute all committees and build a map for O(1) lookup
-		meta.committeesBySlot, err = helpers.PrecomputeCommittees(ctx, s, meta.startSlot)
+		committeesBySlot, err := helpers.PrecomputeCommittees(ctx, s, meta.startSlot)
 		if err != nil {
 			return nil, err
 		}
-		meta.validatorAssignments = buildValidatorAssignmentMap(meta.committeesBySlot, meta.startSlot)
+		meta.validatorAssignments = buildValidatorAssignmentMap(committeesBySlot, meta.startSlot)
 	} else {
 		// For small requests: use CommitteeAssignments which only computes for requested validators
 		meta.committeeAssignments, err = helpers.CommitteeAssignments(ctx, s, reqEpoch, requestIndices)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
@@ -17,13 +17,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	// validatorLookupThreshold determines when to use PrecomputeCommittees vs CommitteeAssignments.
-	// For requests with fewer validators, we use CommitteeAssignments which only computes committees
-	// for the requested validators. For large amounts of validators, we precompute all committees
-	// and build a map for O(1) lookups.
-	validatorLookupThreshold = 3000
-)
 
 // GetDutiesV2 returns the duties assigned to a list of validators specified
 // in the request object.
@@ -168,8 +161,6 @@ type dutiesMetadata struct {
 type metadata struct {
 	committeesAtSlot     uint64
 	proposalSlots        map[primitives.ValidatorIndex][]primitives.Slot
-	startSlot            primitives.Slot
-	validatorAssignments map[primitives.ValidatorIndex]*helpers.LiteAssignment
 	committeeAssignments map[primitives.ValidatorIndex]*helpers.CommitteeAssignment
 }
 
@@ -206,50 +197,13 @@ func loadMetadata(ctx context.Context, s state.BeaconState, reqEpoch primitives.
 	}
 	meta.committeesAtSlot = helpers.SlotCommitteeCount(activeValidatorCount)
 
-	meta.startSlot, err = slots.EpochStart(reqEpoch)
+	// Use CommitteeAssignments which only computes committees for requested validators
+	meta.committeeAssignments, err = helpers.CommitteeAssignments(ctx, s, reqEpoch, requestIndices)
 	if err != nil {
-		return nil, err
-	}
-
-	// Use different strategies based on request size
-	if len(requestIndices) >= validatorLookupThreshold {
-		// For large requests: precompute all committees and build a map for O(1) lookup
-		committeesBySlot, err := helpers.PrecomputeCommittees(ctx, s, meta.startSlot)
-		if err != nil {
-			return nil, err
-		}
-		meta.validatorAssignments = buildValidatorAssignmentMap(committeesBySlot, meta.startSlot)
-	} else {
-		// For small requests: use CommitteeAssignments which only computes for requested validators
-		meta.committeeAssignments, err = helpers.CommitteeAssignments(ctx, s, reqEpoch, requestIndices)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not compute committee assignments: %v", err)
-		}
+		return nil, status.Errorf(codes.Internal, "Could not compute committee assignments: %v", err)
 	}
 
 	return meta, nil
-}
-
-// buildValidatorAssignmentMap creates a map from validator index to assignment for O(1) lookup.
-func buildValidatorAssignmentMap(
-	bySlot [][][]primitives.ValidatorIndex,
-	startSlot primitives.Slot,
-) map[primitives.ValidatorIndex]*helpers.LiteAssignment {
-	validatorToAssignment := make(map[primitives.ValidatorIndex]*helpers.LiteAssignment)
-
-	for relativeSlot, committees := range bySlot {
-		for cIdx, committee := range committees {
-			for pos, vIdx := range committee {
-				validatorToAssignment[vIdx] = &helpers.LiteAssignment{
-					AttesterSlot:            startSlot + primitives.Slot(relativeSlot),
-					CommitteeIndex:          primitives.CommitteeIndex(cIdx),
-					CommitteeLength:         uint64(len(committee)),
-					ValidatorCommitteeIndex: uint64(pos),
-				}
-			}
-		}
-	}
-	return validatorToAssignment
 }
 
 // findValidatorIndexInCommittee finds the position of a validator in a committee.
@@ -262,31 +216,16 @@ func findValidatorIndexInCommittee(committee []primitives.ValidatorIndex, valida
 	return 0
 }
 
-// getValidatorAssignment retrieves the assignment for a validator using either
-// the pre-built assignment map (for large requests) or CommitteeAssignments (for small requests).
+// getValidatorAssignment retrieves the assignment for a validator from CommitteeAssignments.
 func (vs *Server) getValidatorAssignment(meta *metadata, validatorIndex primitives.ValidatorIndex) *helpers.LiteAssignment {
-	// For large requests: use the pre-built assignment map
-	if meta.validatorAssignments != nil {
-		if assignment, exists := meta.validatorAssignments[validatorIndex]; exists {
-			return assignment
+	if assignment, exists := meta.committeeAssignments[validatorIndex]; exists {
+		return &helpers.LiteAssignment{
+			AttesterSlot:            assignment.AttesterSlot,
+			CommitteeIndex:          assignment.CommitteeIndex,
+			CommitteeLength:         uint64(len(assignment.Committee)),
+			ValidatorCommitteeIndex: findValidatorIndexInCommittee(assignment.Committee, validatorIndex),
 		}
-		return &helpers.LiteAssignment{}
 	}
-
-	// For small requests: use CommitteeAssignments result
-	if meta.committeeAssignments != nil {
-		if assignment, exists := meta.committeeAssignments[validatorIndex]; exists {
-			return &helpers.LiteAssignment{
-				AttesterSlot:            assignment.AttesterSlot,
-				CommitteeIndex:          assignment.CommitteeIndex,
-				CommitteeLength:         uint64(len(assignment.Committee)),
-				ValidatorCommitteeIndex: findValidatorIndexInCommittee(assignment.Committee, validatorIndex),
-			}
-		}
-		return &helpers.LiteAssignment{}
-	}
-
-	// Fallback (shouldn't happen, but for safety)
 	return &helpers.LiteAssignment{}
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
@@ -626,9 +626,9 @@ func TestGetValidatorAssignment_WithAssignmentMap(t *testing.T) {
 
 	// Test with pre-built assignment map (large request scenario)
 	meta := &metadata{
-		startSlot:              start,
-		committeesBySlot:       bySlot,
-		validatorAssignmentMap: buildValidatorAssignmentMap(bySlot, start),
+		startSlot:            start,
+		committeesBySlot:     bySlot,
+		validatorAssignments: buildValidatorAssignmentMap(bySlot, start),
 	}
 
 	vs := &Server{}
@@ -649,16 +649,20 @@ func TestGetValidatorAssignment_WithAssignmentMap(t *testing.T) {
 
 func TestGetValidatorAssignment_WithoutAssignmentMap(t *testing.T) {
 	start := primitives.Slot(100)
-	bySlot := [][][]primitives.ValidatorIndex{
-		{{1, 2, 3}},
-		{{4, 5, 6}},
+
+	// Test without assignment map (small request scenario using CommitteeAssignments)
+	committeeAssignments := map[primitives.ValidatorIndex]*helpers.CommitteeAssignment{
+		5: {
+			Committee:      []primitives.ValidatorIndex{4, 5, 6},
+			AttesterSlot:   start + 1,
+			CommitteeIndex: primitives.CommitteeIndex(0),
+		},
 	}
 
-	// Test without assignment map (small request scenario)
 	meta := &metadata{
-		startSlot:              start,
-		committeesBySlot:       bySlot,
-		validatorAssignmentMap: nil, // No map - should use linear search
+		startSlot:            start,
+		committeeAssignments: committeeAssignments,
+		validatorAssignments: nil, // No map - should use CommitteeAssignments
 	}
 
 	vs := &Server{}
@@ -682,47 +686,54 @@ func TestLoadMetadata_ThresholdBehavior(t *testing.T) {
 	epoch := primitives.Epoch(0)
 
 	tests := []struct {
-		name                string
-		numValidators       int
-		expectAssignmentMap bool
+		name                       string
+		numValidators              int
+		expectAssignmentMap        bool
+		expectCommitteeAssignments bool
 	}{
 		{
-			name:                "Small request - below threshold",
-			numValidators:       100,
-			expectAssignmentMap: false,
+			name:                       "Small request - below threshold",
+			numValidators:              100,
+			expectAssignmentMap:        false,
+			expectCommitteeAssignments: true,
 		},
 		{
-			name:                "Large request - at threshold",
-			numValidators:       validatorLookupThreshold,
-			expectAssignmentMap: true,
+			name:                       "Large request - at threshold",
+			numValidators:              validatorLookupThreshold,
+			expectAssignmentMap:        true,
+			expectCommitteeAssignments: false,
 		},
 		{
-			name:                "Large request - above threshold",
-			numValidators:       validatorLookupThreshold + 1000,
-			expectAssignmentMap: true,
+			name:                       "Large request - above threshold",
+			numValidators:              validatorLookupThreshold + 1000,
+			expectAssignmentMap:        true,
+			expectCommitteeAssignments: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			meta, err := loadMetadata(t.Context(), state, epoch, tt.numValidators)
+			// Create a slice of validator indices based on numValidators
+			requestIndices := make([]primitives.ValidatorIndex, tt.numValidators)
+			for i := 0; i < tt.numValidators && i < int(state.NumValidators()); i++ {
+				requestIndices[i] = primitives.ValidatorIndex(i)
+			}
+
+			meta, err := loadMetadata(t.Context(), state, epoch, requestIndices)
 			require.NoError(t, err)
 			require.NotNil(t, meta)
 
 			if tt.expectAssignmentMap {
-				require.NotNil(t, meta.validatorAssignmentMap, "Expected assignment map to be built for large requests")
-				assert.Equal(t, true, len(meta.validatorAssignmentMap) > 0, "Assignment map should not be empty")
-			} else {
-				// For small requests, the map should be nil (not initialized)
-				if meta.validatorAssignmentMap != nil {
-					t.Errorf("Expected no assignment map for small requests, got: %v", meta.validatorAssignmentMap)
-				}
+				require.NotNil(t, meta.validatorAssignments, "Expected assignment map to be built for large requests")
+				assert.Equal(t, true, len(meta.validatorAssignments) > 0, "Assignment map should not be empty")
+				require.IsNil(t, meta.committeeAssignments, "Expected no committee assignments for large requests")
+			} else if tt.expectCommitteeAssignments {
+				require.NotNil(t, meta.committeeAssignments, "Expected committee assignments for small requests")
+				require.IsNil(t, meta.validatorAssignments, "Expected no assignment map for small requests")
 			}
 
 			// Common fields should always be set
 			assert.Equal(t, true, meta.committeesAtSlot > 0)
-			require.NotNil(t, meta.committeesBySlot)
-			assert.Equal(t, true, len(meta.committeesBySlot) > 0)
 		})
 	}
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
@@ -627,7 +627,6 @@ func TestGetValidatorAssignment_WithAssignmentMap(t *testing.T) {
 	// Test with pre-built assignment map (large request scenario)
 	meta := &metadata{
 		startSlot:            start,
-		committeesBySlot:     bySlot,
 		validatorAssignments: buildValidatorAssignmentMap(bySlot, start),
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
@@ -560,96 +560,10 @@ func TestGetDutiesV2_SyncNotReady(t *testing.T) {
 	assert.ErrorContains(t, "Syncing to latest head", err)
 }
 
-func TestBuildValidatorAssignmentMap(t *testing.T) {
-	start := primitives.Slot(200)
-	bySlot := [][][]primitives.ValidatorIndex{
-		{{1, 2, 3}},        // slot 200, committee 0
-		{{7, 8, 9}},        // slot 201, committee 0
-		{{4, 5}, {10, 11}}, // slot 202, committee 0 & 1
-	}
-
-	assignmentMap := buildValidatorAssignmentMap(bySlot, start)
-
-	// Test validator 8 assignment (slot 201, committee 0, position 1)
-	vIdx := primitives.ValidatorIndex(8)
-	got, exists := assignmentMap[vIdx]
-	assert.Equal(t, true, exists)
-	require.NotNil(t, got)
-	assert.Equal(t, start+1, got.AttesterSlot)
-	assert.Equal(t, primitives.CommitteeIndex(0), got.CommitteeIndex)
-	assert.Equal(t, uint64(3), got.CommitteeLength)
-	assert.Equal(t, uint64(1), got.ValidatorCommitteeIndex)
-
-	// Test validator 1 assignment (slot 200, committee 0, position 0)
-	vIdx1 := primitives.ValidatorIndex(1)
-	got1, exists1 := assignmentMap[vIdx1]
-	assert.Equal(t, true, exists1)
-	require.NotNil(t, got1)
-	assert.Equal(t, start, got1.AttesterSlot)
-	assert.Equal(t, primitives.CommitteeIndex(0), got1.CommitteeIndex)
-	assert.Equal(t, uint64(3), got1.CommitteeLength)
-	assert.Equal(t, uint64(0), got1.ValidatorCommitteeIndex)
-
-	// Test validator 10 assignment (slot 202, committee 1, position 0)
-	vIdx10 := primitives.ValidatorIndex(10)
-	got10, exists10 := assignmentMap[vIdx10]
-	assert.Equal(t, true, exists10)
-	require.NotNil(t, got10)
-	assert.Equal(t, start+2, got10.AttesterSlot)
-	assert.Equal(t, primitives.CommitteeIndex(1), got10.CommitteeIndex)
-	assert.Equal(t, uint64(2), got10.CommitteeLength)
-	assert.Equal(t, uint64(0), got10.ValidatorCommitteeIndex)
-
-	// Test non-existent validator
-	_, exists99 := assignmentMap[primitives.ValidatorIndex(99)]
-	assert.Equal(t, false, exists99)
-
-	// Verify that we get the same results as the linear search
-	for _, committees := range bySlot {
-		for _, committee := range committees {
-			for _, validatorIdx := range committee {
-				linearResult := helpers.AssignmentForValidator(bySlot, start, validatorIdx)
-				mapResult, mapExists := assignmentMap[validatorIdx]
-				assert.Equal(t, true, mapExists)
-				require.DeepEqual(t, linearResult, mapResult)
-			}
-		}
-	}
-}
-
-func TestGetValidatorAssignment_WithAssignmentMap(t *testing.T) {
-	start := primitives.Slot(100)
-	bySlot := [][][]primitives.ValidatorIndex{
-		{{1, 2, 3}},
-		{{4, 5, 6}},
-	}
-
-	// Test with pre-built assignment map (large request scenario)
-	meta := &metadata{
-		startSlot:            start,
-		validatorAssignments: buildValidatorAssignmentMap(bySlot, start),
-	}
-
-	vs := &Server{}
-
-	// Test existing validator (validator 2 is at position 1 in the committee, not position 2)
-	assignment := vs.getValidatorAssignment(meta, primitives.ValidatorIndex(2))
-	require.NotNil(t, assignment)
-	assert.Equal(t, start, assignment.AttesterSlot)
-	assert.Equal(t, primitives.CommitteeIndex(0), assignment.CommitteeIndex)
-	assert.Equal(t, uint64(1), assignment.ValidatorCommitteeIndex)
-
-	// Test non-existent validator should return empty assignment
-	assignment = vs.getValidatorAssignment(meta, primitives.ValidatorIndex(99))
-	require.NotNil(t, assignment)
-	assert.Equal(t, primitives.Slot(0), assignment.AttesterSlot)
-	assert.Equal(t, primitives.CommitteeIndex(0), assignment.CommitteeIndex)
-}
-
-func TestGetValidatorAssignment_WithoutAssignmentMap(t *testing.T) {
+func TestGetValidatorAssignment(t *testing.T) {
 	start := primitives.Slot(100)
 
-	// Test without assignment map (small request scenario using CommitteeAssignments)
+	// Test using CommitteeAssignments
 	committeeAssignments := map[primitives.ValidatorIndex]*helpers.CommitteeAssignment{
 		5: {
 			Committee:      []primitives.ValidatorIndex{4, 5, 6},
@@ -659,9 +573,7 @@ func TestGetValidatorAssignment_WithoutAssignmentMap(t *testing.T) {
 	}
 
 	meta := &metadata{
-		startSlot:            start,
 		committeeAssignments: committeeAssignments,
-		validatorAssignments: nil, // No map - should use CommitteeAssignments
 	}
 
 	vs := &Server{}
@@ -678,61 +590,4 @@ func TestGetValidatorAssignment_WithoutAssignmentMap(t *testing.T) {
 	require.NotNil(t, assignment)
 	assert.Equal(t, primitives.Slot(0), assignment.AttesterSlot)
 	assert.Equal(t, primitives.CommitteeIndex(0), assignment.CommitteeIndex)
-}
-
-func TestLoadMetadata_ThresholdBehavior(t *testing.T) {
-	state, _ := util.DeterministicGenesisState(t, 128)
-	epoch := primitives.Epoch(0)
-
-	tests := []struct {
-		name                       string
-		numValidators              int
-		expectAssignmentMap        bool
-		expectCommitteeAssignments bool
-	}{
-		{
-			name:                       "Small request - below threshold",
-			numValidators:              100,
-			expectAssignmentMap:        false,
-			expectCommitteeAssignments: true,
-		},
-		{
-			name:                       "Large request - at threshold",
-			numValidators:              validatorLookupThreshold,
-			expectAssignmentMap:        true,
-			expectCommitteeAssignments: false,
-		},
-		{
-			name:                       "Large request - above threshold",
-			numValidators:              validatorLookupThreshold + 1000,
-			expectAssignmentMap:        true,
-			expectCommitteeAssignments: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a slice of validator indices based on numValidators
-			requestIndices := make([]primitives.ValidatorIndex, tt.numValidators)
-			for i := 0; i < tt.numValidators && i < int(state.NumValidators()); i++ {
-				requestIndices[i] = primitives.ValidatorIndex(i)
-			}
-
-			meta, err := loadMetadata(t.Context(), state, epoch, requestIndices)
-			require.NoError(t, err)
-			require.NotNil(t, meta)
-
-			if tt.expectAssignmentMap {
-				require.NotNil(t, meta.validatorAssignments, "Expected assignment map to be built for large requests")
-				assert.Equal(t, true, len(meta.validatorAssignments) > 0, "Assignment map should not be empty")
-				require.IsNil(t, meta.committeeAssignments, "Expected no committee assignments for large requests")
-			} else if tt.expectCommitteeAssignments {
-				require.NotNil(t, meta.committeeAssignments, "Expected committee assignments for small requests")
-				require.IsNil(t, meta.validatorAssignments, "Expected no assignment map for small requests")
-			}
-
-			// Common fields should always be set
-			assert.Equal(t, true, meta.committeesAtSlot > 0)
-		})
-	}
 }

--- a/changelog/james-prysm_improve-duties-v2.md
+++ b/changelog/james-prysm_improve-duties-v2.md
@@ -1,5 +1,3 @@
 ### Fixed
 
-- adding in improvements to getduties v2, calling helpers.PrecomputeCommittees() might be slow if used for not a lot of keys, so this implements hybrid strategy based on validatorLookupThreshold (3000)
-  - < 3000 validators: Uses helpers.CommitteeAssignments() - only computes for requested validators
-  - ≥ 3000 validators: Uses helpers.PrecomputeCommittees() + map for O(1) lookups
+- adding in improvements to getduties v2, replaces helpers.PrecomputeCommittees() ( exepensive ) with CommitteeAssignments

--- a/changelog/james-prysm_improve-duties-v2.md
+++ b/changelog/james-prysm_improve-duties-v2.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- adding in improvements to getduties v2, calling helpers.PrecomputeCommittees() might be slow if used for not a lot of keys, so this implements hybrid strategy based on validatorLookupThreshold (3000)
+  - < 3000 validators: Uses helpers.CommitteeAssignments() - only computes for requested validators
+  - ≥ 3000 validators: Uses helpers.PrecomputeCommittees() + map for O(1) lookups


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

There is a performance regression for nodes with few keys using get duties v2
GetDuties (v1) does not call helpers.PrecomputeCommittees. It uses helpers.CommitteeAssignments for only the requested validator indices. 

~~This PR implements hybrid strategy based on validatorLookupThreshold (3000):~~
    - ~~< 3000 validators: Uses helpers.CommitteeAssignments() - only computes for requested validators~~
    - ~~≥ 3000 validators: Uses helpers.PrecomputeCommittees() + map for O(1) lookups~~
    
 going to completely swap back to only using committeeAssignments
 
with precompute
- get all the committees in the epoch as a 3d array
- loop through build a map of validator index to assignment for every single validator  in that 3d array ( expensive)
- look up the validators we need from the built map based on the ids we requested
with helpers.CommitteeAssignments
- loop by slot and check each committee for assignments based on our request, exit early if all of our assignments are completed returning a map of validator to committee assignment map
- look up the validator by committee assignment and then loop through the committee assignment to find the position to return the validator assignment
 
 Benchmark Results (100k validators)

  | Request Size | CommitteeAssignments          | PrecomputeCommittees            | Winner                                               |
  |--------------|-------------------------------|---------------------------------|------------------------------------------------------|
  | 10           | 12.6ms / 11.8KB / 233 allocs  | 16.7ms / 7.9MB / 100,747 allocs | CommitteeAssignments (1.3x faster, 670x less memory) |
  | 100          | 13.3ms / 20KB / 323 allocs    | 17.0ms / 7.9MB / 100,747 allocs | CommitteeAssignments (1.3x faster, 395x less memory) |
  | 1000         | 12.7ms / 133KB / 1,227 allocs | 16.7ms / 7.9MB / 100,747 allocs | CommitteeAssignments (1.3x faster, 59x less memory)  |
  | 5000         | 13.8ms / 546KB / 5,251 allocs | 17.1ms / 7.9MB / 100,747 allocs | CommitteeAssignments (1.2x faster, 14x less memory)  |
    
```
func BenchmarkCommitteeStrategies_100k(b *testing.B) {
	numValidators := uint64(100_000)

	b.Logf("Creating state with %d validators...", numValidators)
	st := createLargeState(b, numValidators)
	b.Logf("State created successfully with %d validators", st.NumValidators())

	epoch := primitives.Epoch(0)

	// Test with different request sizes
	requestSizes := []int{10, 100, 1000, 5000}

	for _, requestSize := range requestSizes {
		requestIndices := make([]primitives.ValidatorIndex, requestSize)
		for i := 0; i < requestSize; i++ {
			requestIndices[i] = primitives.ValidatorIndex(i)
		}

		// Benchmark CommitteeAssignments approach
		b.Run(fmt.Sprintf("CommitteeAssignments_%d_validators", requestSize), func(b *testing.B) {
			for i := 0; i < b.N; i++ {
				ctx := context.Background()
				_, err := helpers.CommitteeAssignments(ctx, st, epoch, requestIndices)
				if err != nil {
					b.Fatal(err)
				}
			}
		})

		// Benchmark PrecomputeCommittees approach
		b.Run(fmt.Sprintf("PrecomputeCommittees_%d_validators", requestSize), func(b *testing.B) {
			for i := 0; i < b.N; i++ {
				ctx := context.Background()
				startSlot, err := slots.EpochStart(epoch)
				if err != nil {
					b.Fatal(err)
				}

				// Precompute all committees
				committeesBySlot, err := helpers.PrecomputeCommittees(ctx, st, startSlot)
				if err != nil {
					b.Fatal(err)
				}

				// Build validator assignment map
				validatorAssignments := buildValidatorAssignmentMap(committeesBySlot, startSlot)

				// Look up requested validators
				for _, idx := range requestIndices {
					_ = validatorAssignments[idx]
				}
			}
		})
	}
}

// createLargeState creates a beacon state with the specified number of validators
func createLargeState(b *testing.B, numValidators uint64) state.BeaconState {
	b.Helper()

	deposits, _, err := util.DeterministicDepositsAndKeys(numValidators)
	require.NoError(b, err)

	eth1Data, err := util.DeterministicEth1Data(len(deposits))
	require.NoError(b, err)

	st, err := util.GenesisBeaconState(context.Background(), deposits, 0, eth1Data)
	require.NoError(b, err)

	return st
}
```
**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
