### PR TITLE
Process pending on block

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"sync"
+	"fmt"
 
-	"github.com/OffchainLabs/prysm/v6/async"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed/operation"
@@ -24,30 +23,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// This defines how often a node cleans up and processes pending attestations in the queue.
-var processPendingAttsPeriod = slots.DivideSlotBy(2 /* twice per slot */)
-var pendingAttsLimit = 10000
+var pendingAttsLimit = 32768
 
-// This processes pending attestation queues on every processPendingAttsPeriod.
-func (s *Service) runPendingAttsQueue() {
-	// Prevents multiple queue processing goroutines (invoked by RunEvery) from contending for data.
-	mutex := new(sync.Mutex)
-	async.RunEvery(s.ctx, processPendingAttsPeriod, func() {
-		mutex.Lock()
-		if err := s.processPendingAtts(s.ctx); err != nil {
-			log.WithError(err).Debug("Could not process pending attestation")
-		}
-		mutex.Unlock()
-	})
-}
-
-// This defines how pending attestations are processed. It contains features:
-// 1. Clean up invalid pending attestations from the queue.
-// 2. Check if pending attestations can be processed when the block has arrived.
-// 3. Request block from a random peer if unable to proceed step 2.
-func (s *Service) processPendingAtts(ctx context.Context) error {
-	ctx, span := trace.StartSpan(ctx, "processPendingAtts")
+// This method processes pending attestations as a "known" block as arrived. With validations,
+// the valid attestations get saved into the operation mem pool, and the invalid attestations gets deleted
+// from the sync pending pool.
+func (s *Service) processPendingAttsForBlock(ctx context.Context, bRoot [32]byte) error {
+	ctx, span := trace.StartSpan(ctx, "processPendingAttsForBlock")
 	defer span.End()
+
+	// Confirm that the pending attestation's missing block arrived and the node processed the block.
+	if !s.cfg.beaconDB.HasBlock(ctx, bRoot) || !(s.cfg.beaconDB.HasState(ctx, bRoot) || s.cfg.beaconDB.HasStateSummary(ctx, bRoot)) || !s.cfg.chain.InForkchoice(bRoot) {
+		return fmt.Errorf("could not process unknown block root %#x", bRoot)
+	}
 
 	// Before a node processes pending attestations queue, it verifies
 	// the attestations in the queue are still valid. Attestations will
@@ -55,39 +43,30 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 	s.validatePendingAtts(ctx, s.cfg.clock.CurrentSlot())
 
 	s.pendingAttsLock.RLock()
-	roots := make([][32]byte, 0, len(s.blkRootToPendingAtts))
-	for br := range s.blkRootToPendingAtts {
-		roots = append(roots, br)
-	}
+	attestations := s.blkRootToPendingAtts[bRoot]
 	s.pendingAttsLock.RUnlock()
 
-	var pendingRoots [][32]byte
-	randGen := rand.NewGenerator()
-	for _, bRoot := range roots {
-		s.pendingAttsLock.RLock()
-		attestations := s.blkRootToPendingAtts[bRoot]
-		s.pendingAttsLock.RUnlock()
-		// has the pending attestation's missing block arrived and the node processed block yet?
-		if s.cfg.beaconDB.HasBlock(ctx, bRoot) && (s.cfg.beaconDB.HasState(ctx, bRoot) || s.cfg.beaconDB.HasStateSummary(ctx, bRoot)) && s.cfg.chain.InForkchoice(bRoot) {
-			s.processAttestations(ctx, attestations)
-			log.WithFields(logrus.Fields{
-				"blockRoot":        hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
-				"pendingAttsCount": len(attestations),
-			}).Debug("Verified and saved pending attestations to pool")
+	s.processAttestations(ctx, attestations)
+	log.WithFields(logrus.Fields{
+		"blockRoot":        hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
+		"pendingAttsCount": len(attestations),
+	}).Debug("Verified and saved pending attestations to pool")
 
-			// Delete the missing block root key from pending attestation queue so a node will not request for the block again.
-			s.pendingAttsLock.Lock()
-			delete(s.blkRootToPendingAtts, bRoot)
-			s.pendingAttsLock.Unlock()
-		} else {
-			s.pendingQueueLock.RLock()
-			seen := s.seenPendingBlocks[bRoot]
-			s.pendingQueueLock.RUnlock()
-			if !seen {
-				pendingRoots = append(pendingRoots, bRoot)
-			}
+	randGen := rand.NewGenerator()
+	// Delete the missing block root key from pending attestation queue so a node will not request for the block again.
+	s.pendingAttsLock.Lock()
+	delete(s.blkRootToPendingAtts, bRoot)
+	pendingRoots := make([][32]byte, 0, len(s.blkRootToPendingAtts))
+	s.pendingQueueLock.RLock()
+	for r := range s.blkRootToPendingAtts {
+		if !s.seenPendingBlocks[r] {
+			pendingRoots = append(pendingRoots, r)
 		}
 	}
+	s.pendingQueueLock.RUnlock()
+	s.pendingAttsLock.Unlock()
+
+	//  Request the blocks for the pending attestations that could not be processed.
 	return s.sendBatchRootRequest(ctx, pendingRoots, randGen)
 }
 

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -46,12 +46,13 @@ func (s *Service) processPendingAttsForBlock(ctx context.Context, bRoot [32]byte
 	attestations := s.blkRootToPendingAtts[bRoot]
 	s.pendingAttsLock.RUnlock()
 
-	s.processAttestations(ctx, attestations)
-	log.WithFields(logrus.Fields{
-		"blockRoot":        hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
-		"pendingAttsCount": len(attestations),
-	}).Debug("Verified and saved pending attestations to pool")
-
+	if len(attestations) > 0 {
+		s.processAttestations(ctx, attestations)
+		log.WithFields(logrus.Fields{
+			"blockRoot":        hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
+			"pendingAttsCount": len(attestations),
+		}).Debug("Verified and saved pending attestations to pool")
+	}
 	randGen := rand.NewGenerator()
 	// Delete the missing block root key from pending attestation queue so a node will not request for the block again.
 	s.pendingAttsLock.Lock()

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -62,7 +62,7 @@ func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 
 	a := &ethpb.Attestation{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{Root: make([]byte, 32)}}}
 	r.blkRootToPendingAtts[[32]byte{'A'}] = []any{a}
-	require.NoError(t, r.processPendingAtts(t.Context()))
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), [32]byte{'A'}))
 	require.LogsContain(t, hook, "Requesting block by root")
 }
 
@@ -141,7 +141,7 @@ func TestProcessPendingAtts_HasBlockSaveUnaggregatedAtt(t *testing.T) {
 	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
 	r.blkRootToPendingAtts[root] = []any{att}
-	require.NoError(t, r.processPendingAtts(t.Context()))
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -235,7 +235,7 @@ func TestProcessPendingAtts_HasBlockSaveUnaggregatedAttElectra(t *testing.T) {
 	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
 	r.blkRootToPendingAtts[root] = []any{att}
-	require.NoError(t, r.processPendingAtts(t.Context()))
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -360,7 +360,7 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAttElectra_VerifyAlreadySeen
 	r.blkRootToPendingAtts[root] = []any{
 		att,
 	}
-	require.NoError(t, r.processPendingAtts(t.Context()))
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
 	// Verify that the event feed receives the expected attestation.
 	var wg sync.WaitGroup
@@ -471,7 +471,7 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 	}
 
 	s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: a, Signature: make([]byte, fieldparams.BLSSignatureLength)}}
-	require.NoError(t, s.processPendingAtts(t.Context()))
+	require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
 
 	assert.Equal(t, false, p2p.BroadcastCalled.Load(), "Broadcasted bad aggregate")
 
@@ -510,7 +510,7 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	s.blkRootToPendingAtts[r32] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, s.processPendingAtts(t.Context()))
+	require.NoError(t, s.processPendingAttsForBlock(t.Context(), r32))
 
 	assert.Equal(t, true, p2p.BroadcastCalled.Load(), "The good aggregate was not broadcasted")
 
@@ -601,7 +601,7 @@ func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
 	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, r.processPendingAtts(t.Context()))
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
 	assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
 	assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
@@ -696,7 +696,7 @@ func TestProcessPendingAtts_HasBlockSaveAggregatedAttElectra(t *testing.T) {
 	require.NoError(t, r.cfg.beaconDB.SaveState(t.Context(), s, root))
 
 	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProofElectra{Message: aggregateAndProof, Signature: aggreSig}}
-	require.NoError(t, r.processPendingAtts(t.Context()))
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
 	assert.Equal(t, 1, len(r.cfg.attPool.AggregatedAttestations()), "Did not save aggregated att")
 	assert.DeepEqual(t, att, r.cfg.attPool.AggregatedAttestations()[0], "Incorrect saved att")
@@ -781,7 +781,7 @@ func TestProcessPendingAtts_BlockNotInForkChoice(t *testing.T) {
 	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}}
 
 	// Process pending attestations - should not process because block is not in fork choice
-	require.NoError(t, r.processPendingAtts(t.Context()))
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
 
 	// Verify attestations were not processed (should still be pending)
 	assert.Equal(t, 1, len(r.blkRootToPendingAtts[root]), "Attestations should still be pending")

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -53,16 +53,47 @@ func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 	p1.Peers().SetConnectionState(p2.PeerID(), peers.Connected)
 	p1.Peers().SetChainState(p2.PeerID(), &ethpb.StatusV2{})
 
-	chain := &mock.ChainService{Genesis: prysmTime.Now(), FinalizedCheckPoint: &ethpb.Checkpoint{}}
+	// Create and save block 'A' to DB
+	blockA := util.NewBeaconBlock()
+	util.SaveBlock(t, t.Context(), db, blockA)
+	rootA, err := blockA.Block.HashTreeRoot()
+	require.NoError(t, err)
+
+	// Save state for block 'A'
+	stateA, err := util.NewBeaconState()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveState(t.Context(), stateA, rootA))
+
+	// Setup chain service with block 'A' in forkchoice
+	chain := &mock.ChainService{
+		Genesis:             prysmTime.Now(),
+		FinalizedCheckPoint: &ethpb.Checkpoint{},
+		// NotFinalized: false means InForkchoice returns true
+	}
+
 	r := &Service{
 		cfg:                  &config{p2p: p1, beaconDB: db, chain: chain, clock: startup.NewClock(chain.Genesis, chain.ValidatorsRoot)},
 		blkRootToPendingAtts: make(map[[32]byte][]any),
+		seenPendingBlocks:    make(map[[32]byte]bool),
 		chainStarted:         abool.New(),
 	}
 
-	a := &ethpb.Attestation{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{Root: make([]byte, 32)}}}
-	r.blkRootToPendingAtts[[32]byte{'A'}] = []any{a}
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), [32]byte{'A'}))
+	// Add pending attestations for OTHER block roots (not block A)
+	// These are blocks we don't have yet, so they should be requested
+	attB := &ethpb.Attestation{Data: &ethpb.AttestationData{
+		BeaconBlockRoot: bytesutil.PadTo([]byte{'B'}, 32),
+		Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+	}}
+	attC := &ethpb.Attestation{Data: &ethpb.AttestationData{
+		BeaconBlockRoot: bytesutil.PadTo([]byte{'C'}, 32),
+		Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+	}}
+	r.blkRootToPendingAtts[[32]byte{'B'}] = []any{attB}
+	r.blkRootToPendingAtts[[32]byte{'C'}] = []any{attC}
+
+	// Process block A (which exists and has no pending attestations)
+	// This should skip processing attestations for A and request blocks B and C
+	require.NoError(t, r.processPendingAttsForBlock(t.Context(), rootA))
 	require.LogsContain(t, hook, "Requesting block by root")
 }
 
@@ -780,8 +811,8 @@ func TestProcessPendingAtts_BlockNotInForkChoice(t *testing.T) {
 	// Add pending attestation
 	r.blkRootToPendingAtts[root] = []any{&ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof}}
 
-	// Process pending attestations - should not process because block is not in fork choice
-	require.NoError(t, r.processPendingAttsForBlock(t.Context(), root))
+	// Process pending attestations - should return error because block is not in fork choice
+	require.ErrorContains(t, "could not process unknown block root", r.processPendingAttsForBlock(t.Context(), root))
 
 	// Verify attestations were not processed (should still be pending)
 	assert.Equal(t, 1, len(r.blkRootToPendingAtts[root]), "Attestations should still be pending")

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -274,7 +274,6 @@ func (s *Service) Start() {
 	s.cfg.p2p.AddPingMethod(s.sendPingRequest)
 
 	s.processPendingBlocksQueue()
-	s.runPendingAttsQueue()
 	s.maintainPeerStatuses()
 
 	if params.FuluEnabled() {

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -68,7 +68,10 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 		}
 		return err
 	}
-	return err
+	if err := s.processPendingAttsForBlock(ctx, root); err != nil {
+		return errors.Wrap(err, "process pending atts for block")
+	}
+	return nil
 }
 
 // processSidecarsFromExecutionFromBlock retrieves (if available) sidecars data from the execution client,

--- a/changelog/potuz_process_pending_atts.md
+++ b/changelog/potuz_process_pending_atts.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Process pending attestations as soon as the block arrives. 


### PR DESCRIPTION
This PR clears the pending attestation queue right after processing a beacon block. This is needed due to deterioring aggregation   caused to having defaulted to attest-timely. h/t to @terencechain to recalling this issue. 

This PR also changes the cache size to 32K since we can now get most attestations on the pending queue in fact. 

This PR is a revamp of #9679 that was never merged cause @nisdas never trusted me. 

Revier note: this PR should not be released without a prior optimization of attestation verification because with the increasing number of pending attestations, this can take several seconds. 