### PR TITLE
fix test race conditions

### DIFF
--- a/beacon-chain/sync/validate_bls_to_execution_change_test.go
+++ b/beacon-chain/sync/validate_bls_to_execution_change_test.go
@@ -429,12 +429,12 @@ func TestService_ValidateBlsToExecutionChange(t *testing.T) {
 			svc := NewService(ctx, append(opts, tt.svcopts...)...)
 			markInitSyncComplete(t, svc)
 			svc, tt.args.topic = tt.setupSvc(svc, tt.args.msg, tt.args.topic)
-			go svc.Start()
 			if tt.clock == nil {
 				tt.clock = startup.NewClock(time.Now(), [32]byte{})
 			}
 			require.NoError(t, cw.SetClock(tt.clock))
 			svc.verifierWaiter = verification.NewInitializerWaiter(cw, chainService.ForkChoiceStore, svc.cfg.stateGen)
+			go svc.Start()
 
 			marshalledObj, err := tt.args.msg.MarshalSSZ()
 			assert.NoError(t, err)

--- a/beacon-chain/sync/validate_sync_committee_message_test.go
+++ b/beacon-chain/sync/validate_sync_committee_message_test.go
@@ -410,9 +410,9 @@ func TestService_ValidateSyncCommitteeMessage(t *testing.T) {
 			var clock *startup.Clock
 			svc, tt.args.topic, clock = tt.setupSvc(svc, tt.args.msg, tt.args.topic)
 			markInitSyncComplete(t, svc)
-			go svc.Start()
 			require.NoError(t, cw.SetClock(clock))
 			svc.verifierWaiter = verification.NewInitializerWaiter(cw, chainService.ForkChoiceStore, svc.cfg.stateGen)
+			go svc.Start()
 
 			marshalledObj, err := tt.args.msg.MarshalSSZ()
 			assert.NoError(t, err)

--- a/changelog/potuz_fix_races_in_tests.md
+++ b/changelog/potuz_fix_races_in_tests.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Fix races in tests that cause nil panics. 


### PR DESCRIPTION
Fix race condition where svc.verifierWaiter was being set after svc.Start() was already running, causing nil pointer dereference.

