### PR TITLE
`requestAndSaveMissingDataColumnSidecars`: Fix error message

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -97,7 +97,7 @@ func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock)
 
 	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount()
 	if err != nil {
-		return errors.Wrap(err, "fetch custody group count from peer")
+		return errors.Wrap(err, "custody group count")
 	}
 
 	samplingSize := max(custodyGroupCount, samplesPerSlot)

--- a/changelog/manu-fix-log.md
+++ b/changelog/manu-fix-log.md
@@ -1,0 +1,3 @@
+### Ignored
+- `requestAndSaveMissingDataColumnSidecars`: Fix log
+


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this PR, the error message made the reader believe that we were not able to retrieve the custody group count of the peer, whereas we actually are not be able to retrieve the custody group count of our own node.

This PR fixes this.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
