### PR TITLE
`inclusionProofKey`: Include the commitments in the key.

### DIFF
--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -2,6 +2,7 @@ package verification
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"time"
@@ -524,18 +525,23 @@ func columnErrBuilder(baseErr error) error {
 	return errors.Wrap(baseErr, errColumnsInvalid.Error())
 }
 
-func inclusionProofKey(c blocks.RODataColumn) ([160]byte, error) {
-	var key [160]byte
+// incluseionProofKey computes a unique key based on the KZG commitments,
+// the KZG commitments inclusion proof, and the signed block header root.
+func inclusionProofKey(c blocks.RODataColumn) ([192]byte, error) {
+	var key [192]byte
+
 	if len(c.KzgCommitmentsInclusionProof) != 4 {
 		// This should be already enforced by ssz unmarshaling; still check so we don't panic on array bounds.
 		return key, columnErrBuilder(ErrSidecarInclusionProofInvalid)
 	}
 
+	// Include the block root in the key.
 	root, err := c.SignedBlockHeader.HashTreeRoot()
 	if err != nil {
-		return [160]byte{}, columnErrBuilder(errors.Wrap(err, "hash tree root"))
+		return key, columnErrBuilder(errors.Wrap(err, "hash tree root"))
 	}
 
+	// Include the commitments inclusion proof in the key.
 	for i := range c.KzgCommitmentsInclusionProof {
 		if copy(key[32*i:32*i+32], c.KzgCommitmentsInclusionProof[i]) != 32 {
 			return key, columnErrBuilder(ErrSidecarInclusionProofInvalid)
@@ -543,5 +549,15 @@ func inclusionProofKey(c blocks.RODataColumn) ([160]byte, error) {
 	}
 
 	copy(key[128:], root[:])
+
+	// Include the commitments in the key.
+	commitmentsFlat := make([]byte, 0, len(c.KzgCommitments)*fieldparams.KzgCommitmentSize)
+	for _, commitment := range c.KzgCommitments {
+		commitmentsFlat = append(commitmentsFlat, commitment...)
+	}
+
+	commitmentsHash := sha256.Sum256(commitmentsFlat)
+	copy(key[160:], commitmentsHash[:])
+
 	return key, nil
 }

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -527,37 +527,41 @@ func columnErrBuilder(baseErr error) error {
 
 // incluseionProofKey computes a unique key based on the KZG commitments,
 // the KZG commitments inclusion proof, and the signed block header root.
-func inclusionProofKey(c blocks.RODataColumn) ([192]byte, error) {
-	var key [192]byte
+func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
+	const (
+		commsIncProofLen       = 4
+		commsIncProofByteCount = commsIncProofLen * 32
+	)
 
-	if len(c.KzgCommitmentsInclusionProof) != 4 {
+	if len(c.KzgCommitmentsInclusionProof) != commsIncProofLen {
 		// This should be already enforced by ssz unmarshaling; still check so we don't panic on array bounds.
-		return key, columnErrBuilder(ErrSidecarInclusionProofInvalid)
+		return [32]byte{}, columnErrBuilder(ErrSidecarInclusionProofInvalid)
+	}
+
+	commsByteCount := len(c.KzgCommitments) * fieldparams.KzgCommitmentSize
+	unhashedKey := make([]byte, commsIncProofByteCount+fieldparams.RootLength+commsByteCount)
+
+	// Include the commitments inclusion proof in the key.
+	for i := range c.KzgCommitmentsInclusionProof {
+		if copy(unhashedKey[32*i:32*(i+1)], c.KzgCommitmentsInclusionProof[i]) != 32 {
+			return [32]byte{}, columnErrBuilder(ErrSidecarInclusionProofInvalid)
+		}
 	}
 
 	// Include the block root in the key.
 	root, err := c.SignedBlockHeader.HashTreeRoot()
 	if err != nil {
-		return key, columnErrBuilder(errors.Wrap(err, "hash tree root"))
+		return [32]byte{}, columnErrBuilder(errors.Wrap(err, "hash tree root"))
 	}
 
-	// Include the commitments inclusion proof in the key.
-	for i := range c.KzgCommitmentsInclusionProof {
-		if copy(key[32*i:32*i+32], c.KzgCommitmentsInclusionProof[i]) != 32 {
-			return key, columnErrBuilder(ErrSidecarInclusionProofInvalid)
+	copy(unhashedKey[128:], root[:])
+
+	// Include the commitments in the key.
+	for i := range c.KzgCommitments {
+		if copy(unhashedKey[160+i*fieldparams.KzgCommitmentSize:160+(i+1)*fieldparams.KzgCommitmentSize], c.KzgCommitments[i]) != fieldparams.KzgCommitmentSize {
+			return [32]byte{}, columnErrBuilder(ErrSidecarInclusionProofInvalid)
 		}
 	}
 
-	copy(key[128:], root[:])
-
-	// Include the commitments in the key.
-	commitmentsFlat := make([]byte, 0, len(c.KzgCommitments)*fieldparams.KzgCommitmentSize)
-	for _, commitment := range c.KzgCommitments {
-		commitmentsFlat = append(commitmentsFlat, commitment...)
-	}
-
-	commitmentsHash := sha256.Sum256(commitmentsFlat)
-	copy(key[160:], commitmentsHash[:])
-
-	return key, nil
+	return sha256.Sum256(unhashedKey), nil
 }

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -539,13 +539,11 @@ func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
 	}
 
 	commsByteCount := len(c.KzgCommitments) * fieldparams.KzgCommitmentSize
-	unhashedKey := make([]byte, commsIncProofByteCount+fieldparams.RootLength+commsByteCount)
+	unhashedKey := make([]byte, 0, commsIncProofByteCount+fieldparams.RootLength+commsByteCount)
 
 	// Include the commitments inclusion proof in the key.
-	for i := range c.KzgCommitmentsInclusionProof {
-		if copy(unhashedKey[32*i:32*(i+1)], c.KzgCommitmentsInclusionProof[i]) != 32 {
-			return [32]byte{}, columnErrBuilder(ErrSidecarInclusionProofInvalid)
-		}
+	for _, proof := range c.KzgCommitmentsInclusionProof {
+		unhashedKey = append(unhashedKey, proof...)
 	}
 
 	// Include the block root in the key.
@@ -554,13 +552,11 @@ func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
 		return [32]byte{}, columnErrBuilder(errors.Wrap(err, "hash tree root"))
 	}
 
-	copy(unhashedKey[commsIncProofByteCount:], root[:])
+	unhashedKey = append(unhashedKey, root[:]...)
 
 	// Include the commitments in the key.
-	for i := range c.KzgCommitments {
-		if copy(unhashedKey[160+i*fieldparams.KzgCommitmentSize:160+(i+1)*fieldparams.KzgCommitmentSize], c.KzgCommitments[i]) != fieldparams.KzgCommitmentSize {
-			return [32]byte{}, columnErrBuilder(ErrSidecarInclusionProofInvalid)
-		}
+	for _, commitment := range c.KzgCommitments {
+		unhashedKey = append(unhashedKey, commitment...)
 	}
 
 	return sha256.Sum256(unhashedKey), nil

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -554,7 +554,7 @@ func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
 		return [32]byte{}, columnErrBuilder(errors.Wrap(err, "hash tree root"))
 	}
 
-	copy(unhashedKey[128:], root[:])
+	copy(unhashedKey[commsIncProofByteCount:], root[:])
 
 	// Include the commitments in the key.
 	for i := range c.KzgCommitments {

--- a/changelog/manu-inclusion-cache-key.md
+++ b/changelog/manu-inclusion-cache-key.md
@@ -1,0 +1,3 @@
+### Fixed
+- `inclusionProofKey`: Include the commitments in the key.
+


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
All in the title.

[Spec reference](https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#blob-subnets)
> _Note_: In the `verify_data_column_sidecar_inclusion_proof(sidecar)` check, for all the sidecars of the same block, it verifies against the same set of `kzg_commitments` of the given beacon block. Client can choose to cache the result of the arguments tuple `(sidecar.kzg_commitments, sidecar.kzg_commitments_inclusion_proof, sidecar.signed_block_header)`.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
