### PR TITLE
ignore version|digest mismatch if far future

### DIFF
--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -79,6 +79,9 @@ func compareForkENR(self, peer *enr.Record) error {
 		// we allow the connection to continue until the fork boundary.
 		return nil
 	}
+	if selfEntry.NextForkEpoch == params.BeaconConfig().FarFutureEpoch {
+		return nil
+	}
 
 	// Since we agree on the next fork epoch, we require next fork version to also be in agreement.
 	if !bytes.Equal(peerEntry.NextForkVersion, selfEntry.NextForkVersion) {

--- a/beacon-chain/p2p/pubsub_filter.go
+++ b/beacon-chain/p2p/pubsub_filter.go
@@ -130,7 +130,7 @@ func (s *Service) logCheckSubscribableError(pid peer.ID) func(string) bool {
 				log.WithError(err).WithFields(logrus.Fields{
 					"peerID": pid,
 					"topic":  topic,
-				}).Debug("Peer subscription rejected")
+				}).Trace("Peer subscription rejected")
 			}
 			return false
 		}

--- a/changelog/kasey_ignore-far-future-mismatch.md
+++ b/changelog/kasey_ignore-far-future-mismatch.md
@@ -1,0 +1,2 @@
+### Fixed
+- Do not reject peers if they have a mismatched version|digest when the next for epoch is FAR_FUTURE_EPOCH.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

[15604](https://github.com/OffchainLabs/prysm/pull/15604) introduced a more strict filtering rule that impacts pre-fulu by rejecting connections where the peer has a different fork version (so long as our next for epochs are in agreement). When the next fork epoch is far future epoch, clients can give different versions depending on whether they are considering that epoch to be a real next fork with an unscheduled fork epoch (like fulu in prysm's case with v6.1.0) or the current epoch. This PR relaxes the filtering to ignore mismatches when the next for epoch is FAR_FUTURE_EPOCH.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
