### PR TITLE
exclude unscheduled forks from the schedule

### DIFF
--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -117,6 +117,7 @@ func TestService_decodePubsubMessage(t *testing.T) {
 
 func TestExtractDataType(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
+	params.BeaconConfig().FuluForkEpoch = params.BeaconConfig().ElectraForkEpoch + 4096*2
 	params.BeaconConfig().InitializeForkSchedule()
 
 	type args struct {

--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -304,6 +304,9 @@ func TestExtractDataType(t *testing.T) {
 }
 
 func TestExtractDataTypeFromTypeMapInvalid(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	params.BeaconConfig().FuluForkEpoch = params.BeaconConfig().ElectraForkEpoch + 4096*2
+	params.BeaconConfig().InitializeForkSchedule()
 	chain := &mock.ChainService{ValidatorsRoot: [32]byte{}}
 	_, err := extractDataTypeFromTypeMap(types.BlockMap, []byte{0x00, 0x01}, chain)
 	require.ErrorIs(t, err, errInvalidDigest)

--- a/changelog/kasey_exclude-far-future-fork.md
+++ b/changelog/kasey_exclude-far-future-fork.md
@@ -1,0 +1,2 @@
+### Fixed
+- Don't include entries in the fork schedule if their epoch is set to far future epoch. Avoids reporting next_fork_version == <unscheduled fork>.

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -632,11 +632,6 @@ func configForkSchedule(b *BeaconChainConfig) map[[fieldparams.VersionLength]byt
 	fvs[bytesutil.ToBytes4(b.DenebForkVersion)] = b.DenebForkEpoch
 	fvs[bytesutil.ToBytes4(b.ElectraForkVersion)] = b.ElectraForkEpoch
 	fvs[bytesutil.ToBytes4(b.FuluForkVersion)] = b.FuluForkEpoch
-	for k, v := range fvs {
-		if v == b.FarFutureEpoch {
-			delete(fvs, k)
-		}
-	}
 	return fvs
 }
 

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -526,6 +526,13 @@ func (ns *NetworkSchedule) index(e NetworkScheduleEntry) {
 }
 
 func (ns *NetworkSchedule) prepare(b *BeaconChainConfig) error {
+	// Only keep entries up to FarFutureEpoch.
+	for i := range ns.entries {
+		if ns.entries[i].Epoch == b.FarFutureEpoch {
+			ns.entries = ns.entries[:i]
+			break
+		}
+	}
 	if len(ns.entries) == 0 {
 		return errors.New("cannot compute digests for an empty network schedule")
 	}
@@ -625,6 +632,11 @@ func configForkSchedule(b *BeaconChainConfig) map[[fieldparams.VersionLength]byt
 	fvs[bytesutil.ToBytes4(b.DenebForkVersion)] = b.DenebForkEpoch
 	fvs[bytesutil.ToBytes4(b.ElectraForkVersion)] = b.ElectraForkEpoch
 	fvs[bytesutil.ToBytes4(b.FuluForkVersion)] = b.FuluForkEpoch
+	for k, v := range fvs {
+		if v == b.FarFutureEpoch {
+			delete(fvs, k)
+		}
+	}
 	return fvs
 }
 

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -467,7 +467,7 @@ func (ns *NetworkSchedule) LastEntry() NetworkScheduleEntry {
 // LastFork is the last full fork (this is used by e2e testing)
 func (ns *NetworkSchedule) LastFork() NetworkScheduleEntry {
 	for i := len(ns.entries) - 1; i >= 0; i-- {
-		if ns.entries[i].isFork && ns.entries[i].Epoch != BeaconConfig().FarFutureEpoch {
+		if ns.entries[i].isFork {
 			return ns.entries[i]
 		}
 	}

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -274,3 +274,16 @@ func TestFilterFarFuture(t *testing.T) {
 	last := params.LastNetworkScheduleEntry()
 	require.Equal(t, [4]byte(params.BeaconConfig().ElectraForkVersion), last.ForkVersion)
 }
+
+func TestFarFuturePrepareFilter(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	oldElectra := cfg.ElectraForkEpoch
+	// This should cause electra to be filtered from the schedule, so looking up the entry for electra's epoch
+	// should return the previous entry (deneb).
+	cfg.ElectraForkEpoch = params.BeaconConfig().FarFutureEpoch
+	cfg.FuluForkEpoch = params.BeaconConfig().FarFutureEpoch
+	params.OverrideBeaconConfig(cfg)
+	entry := params.GetNetworkScheduleEntry(oldElectra)
+	require.Equal(t, [4]byte(params.BeaconConfig().DenebForkVersion), entry.ForkVersion)
+}

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -266,3 +266,11 @@ func testConfigForSchedule(gvr [32]byte) *params.BeaconChainConfig {
 	}
 	return cfg
 }
+
+func TestFilterFarFuture(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	params.BeaconConfig().FuluForkEpoch = params.BeaconConfig().FarFutureEpoch
+	params.BeaconConfig().InitializeForkSchedule()
+	last := params.LastNetworkScheduleEntry()
+	require.Equal(t, [4]byte(params.BeaconConfig().ElectraForkVersion), last.ForkVersion)
+}

--- a/config/params/fork.go
+++ b/config/params/fork.go
@@ -102,7 +102,8 @@ func LastForkEpoch() primitives.Epoch {
 }
 
 func LastNetworkScheduleEntry() NetworkScheduleEntry {
-	return BeaconConfig().networkSchedule.LastFork()
+	lastIdx := len(BeaconConfig().networkSchedule.entries) - 1
+	return BeaconConfig().networkSchedule.entries[lastIdx]
 }
 
 func GetNetworkScheduleEntry(epoch primitives.Epoch) NetworkScheduleEntry {

--- a/config/params/fork.go
+++ b/config/params/fork.go
@@ -101,6 +101,10 @@ func LastForkEpoch() primitives.Epoch {
 	return BeaconConfig().networkSchedule.LastFork().Epoch
 }
 
+func LastNetworkScheduleEntry() NetworkScheduleEntry {
+	return BeaconConfig().networkSchedule.LastFork()
+}
+
 func GetNetworkScheduleEntry(epoch primitives.Epoch) NetworkScheduleEntry {
 	entry := BeaconConfig().networkSchedule.ForEpoch(epoch)
 	return entry

--- a/config/params/fork_test.go
+++ b/config/params/fork_test.go
@@ -142,8 +142,8 @@ func TestNextForkData(t *testing.T) {
 		{
 			name:              "after last bpo - should be far future epoch and 0x00000000",
 			currEpoch:         params.LastForkEpoch() + 1,
-			wantedForkVersion: [4]byte(cfg.FuluForkVersion),
-			wantedEpoch:       cfg.FarFutureEpoch,
+			wantedForkVersion: [4]byte(cfg.ElectraForkVersion),
+			wantedEpoch:       cfg.ElectraForkEpoch,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

This drops unscheduled forks (defined as epoch == FAR_FUTURE_EPOCH) from the network schedule. Without this change we were using the fulu entry for the next_fork_version.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
