### PR TITLE
Return early if there's no block for data column sidecar

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -93,6 +93,10 @@ func (s *Service) sendBeaconBlocksRequest(ctx context.Context, requests *types.B
 // requestAndSaveMissingDataColumns checks if the data columns are missing for the given block.
 // If so, requests them and saves them to the storage.
 func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock) error {
+	if len(blks) == 0 {
+		return nil
+	}
+
 	samplesPerSlot := params.BeaconConfig().SamplesPerSlot
 
 	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount()

--- a/changelog/ttsao_return-early-req-column.md
+++ b/changelog/ttsao_return-early-req-column.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Return early if there's no block for `requestAndSaveMissingDataColumnSidecars`


### PR DESCRIPTION
When running Prysm on mainnet (where fulu not active), we see the following fulu custody log:
```
  [2025-10-02 13:17:38.07] DEBUG sync: Could not send recent block request error=request and save missing data columns: fetch custody group count from peer: no custody info available
```
The error occurs in the following sequence:

  1. `sendBeaconBlocksRequest` calls `SendBeaconBlocksByRootRequest` to fetch blocks from peers
  2. When blocks are received, they go through a callback function that processes each block
  3. The callback checks `if blockVersion >= version.Fulu` to identify blocks that need data column processing
  4. Even when no blocks match this condition, `postFuluBlocks` remains empty
  5. The code still calls `requestAndSaveMissingDataColumnSidecars(postFuluBlocks)` with an empty slice
  6. Inside this function, `s.cfg.p2p.CustodyGroupCount()` is called regardless of whether there are blocks to process
  7. This error bubbles up and appears as a "Could not send recent block request" message

The solution proposed in this PR is to return early for empty block list so handles gracefullly
