### PR TITLE
Custody Info: Waits for initialization

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -712,7 +712,7 @@ func (s *Service) areDataColumnsAvailable(
 	nodeID := s.cfg.P2P.NodeID()
 
 	// Get the custody group sampling size for the node.
-	custodyGroupCount, err := s.cfg.P2P.CustodyGroupCount()
+	custodyGroupCount, err := s.cfg.P2P.CustodyGroupCount(ctx)
 	if err != nil {
 		return errors.Wrap(err, "custody group count")
 	}

--- a/beacon-chain/blockchain/setup_test.go
+++ b/beacon-chain/blockchain/setup_test.go
@@ -106,14 +106,14 @@ type mockCustodyManager struct {
 	custodyGroupCount     uint64
 }
 
-func (dch *mockCustodyManager) EarliestAvailableSlot() (primitives.Slot, error) {
+func (dch *mockCustodyManager) EarliestAvailableSlot(context.Context) (primitives.Slot, error) {
 	dch.mut.RLock()
 	defer dch.mut.RUnlock()
 
 	return dch.earliestAvailableSlot, nil
 }
 
-func (dch *mockCustodyManager) CustodyGroupCount() (uint64, error) {
+func (dch *mockCustodyManager) CustodyGroupCount(context.Context) (uint64, error) {
 	dch.mut.RLock()
 	defer dch.mut.RUnlock()
 

--- a/beacon-chain/p2p/custody.go
+++ b/beacon-chain/p2p/custody.go
@@ -15,27 +15,25 @@ import (
 var _ CustodyManager = (*Service)(nil)
 
 // EarliestAvailableSlot returns the earliest available slot.
+// It blocks until the custody info is set or the context is done.
 func (s *Service) EarliestAvailableSlot(ctx context.Context) (primitives.Slot, error) {
-	s.custodyInfoLock.RLock()
-	defer s.custodyInfoLock.RUnlock()
-
-	if s.custodyInfo == nil {
-		return 0, errors.New("no custody info available")
+	custodyInfo, err := s.waitForCustodyInfo(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "wait for custody info")
 	}
 
-	return s.custodyInfo.earliestAvailableSlot, nil
+	return custodyInfo.earliestAvailableSlot, nil
 }
 
 // CustodyGroupCount returns the custody group count.
-func (s *Service) CustodyGroupCount(context.Context) (uint64, error) {
-	s.custodyInfoLock.Lock()
-	defer s.custodyInfoLock.Unlock()
-
-	if s.custodyInfo == nil {
-		return 0, errors.New("no custody info available")
+// It blocks until the custody info is set or the context is done.
+func (s *Service) CustodyGroupCount(ctx context.Context) (uint64, error) {
+	custodyInfo, err := s.waitForCustodyInfo(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "wait for custody info")
 	}
 
-	return s.custodyInfo.groupCount, nil
+	return custodyInfo.groupCount, nil
 }
 
 // UpdateCustodyInfo updates the stored custody group count to the incoming one
@@ -79,6 +77,9 @@ func (s *Service) UpdateCustodyInfo(earliestAvailableSlot primitives.Slot, custo
 			earliestAvailableSlot: earliestAvailableSlot,
 			groupCount:            custodyGroupCount,
 		}
+
+		close(s.custodyInfoSet)
+
 		return earliestAvailableSlot, custodyGroupCount, nil
 	}
 
@@ -145,6 +146,33 @@ func (s *Service) CustodyGroupCountFromPeer(pid peer.ID) uint64 {
 	}
 
 	return custodyCount
+}
+
+func (s *Service) waitForCustodyInfo(ctx context.Context) (custodyInfo, error) {
+	select {
+	case <-s.custodyInfoSet:
+		info, ok := s.copyCustodyInfo()
+		if !ok {
+			return custodyInfo{}, errors.New("custody info was set but is nil")
+		}
+
+		return info, nil
+	case <-ctx.Done():
+		return custodyInfo{}, ctx.Err()
+	}
+}
+
+// copyCustodyInfo returns a copy of the current custody info in a thread-safe manner.
+// If no custody info is set, it returns false as the second return value.
+func (s *Service) copyCustodyInfo() (custodyInfo, bool) {
+	s.custodyInfoLock.RLock()
+	defer s.custodyInfoLock.RUnlock()
+
+	if s.custodyInfo == nil {
+		return custodyInfo{}, false
+	}
+
+	return *s.custodyInfo, true
 }
 
 // custodyGroupCountFromPeerENR retrieves the custody count from the peer's ENR.

--- a/beacon-chain/p2p/custody.go
+++ b/beacon-chain/p2p/custody.go
@@ -10,8 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var errNoCustodyInfo = errors.New("no custody info available")
-
 var _ CustodyManager = (*Service)(nil)
 
 // EarliestAvailableSlot returns the earliest available slot.
@@ -32,7 +30,7 @@ func (s *Service) CustodyGroupCount() (uint64, error) {
 	defer s.custodyInfoLock.Unlock()
 
 	if s.custodyInfo == nil {
-		return 0, errNoCustodyInfo
+		return 0, errors.New("no custody info available")
 	}
 
 	return s.custodyInfo.groupCount, nil

--- a/beacon-chain/p2p/custody.go
+++ b/beacon-chain/p2p/custody.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"context"
+
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
@@ -13,7 +15,7 @@ import (
 var _ CustodyManager = (*Service)(nil)
 
 // EarliestAvailableSlot returns the earliest available slot.
-func (s *Service) EarliestAvailableSlot() (primitives.Slot, error) {
+func (s *Service) EarliestAvailableSlot(ctx context.Context) (primitives.Slot, error) {
 	s.custodyInfoLock.RLock()
 	defer s.custodyInfoLock.RUnlock()
 
@@ -25,7 +27,7 @@ func (s *Service) EarliestAvailableSlot() (primitives.Slot, error) {
 }
 
 // CustodyGroupCount returns the custody group count.
-func (s *Service) CustodyGroupCount() (uint64, error) {
+func (s *Service) CustodyGroupCount(context.Context) (uint64, error) {
 	s.custodyInfoLock.Lock()
 	defer s.custodyInfoLock.Unlock()
 

--- a/beacon-chain/p2p/custody_test.go
+++ b/beacon-chain/p2p/custody_test.go
@@ -20,62 +20,37 @@ import (
 )
 
 func TestEarliestAvailableSlot(t *testing.T) {
-	ctx := t.Context()
+	const expected primitives.Slot = 100
 
-	t.Run("No custody info available", func(t *testing.T) {
-		service := &Service{
-			custodyInfo: nil,
-		}
+	service := &Service{
+		custodyInfoSet: make(chan struct{}),
+		custodyInfo: &custodyInfo{
+			earliestAvailableSlot: expected,
+		},
+	}
 
-		_, err := service.EarliestAvailableSlot(ctx)
+	close(service.custodyInfoSet)
+	slot, err := service.EarliestAvailableSlot(t.Context())
 
-		require.NotNil(t, err)
-	})
-
-	t.Run("Valid custody info", func(t *testing.T) {
-		const expected primitives.Slot = 100
-
-		service := &Service{
-			custodyInfo: &custodyInfo{
-				earliestAvailableSlot: expected,
-			},
-		}
-
-		slot, err := service.EarliestAvailableSlot(ctx)
-
-		require.NoError(t, err)
-		require.Equal(t, expected, slot)
-	})
+	require.NoError(t, err)
+	require.Equal(t, expected, slot)
 }
 
 func TestCustodyGroupCount(t *testing.T) {
-	ctx := t.Context()
+	const expected uint64 = 5
 
-	t.Run("No custody info available", func(t *testing.T) {
-		service := &Service{
-			custodyInfo: nil,
-		}
+	service := &Service{
+		custodyInfoSet: make(chan struct{}),
+		custodyInfo: &custodyInfo{
+			groupCount: expected,
+		},
+	}
 
-		_, err := service.CustodyGroupCount(ctx)
+	close(service.custodyInfoSet)
+	count, err := service.CustodyGroupCount(t.Context())
 
-		require.NotNil(t, err)
-		require.Equal(t, true, strings.Contains(err.Error(), "no custody info available"))
-	})
-
-	t.Run("Valid custody info", func(t *testing.T) {
-		const expected uint64 = 5
-
-		service := &Service{
-			custodyInfo: &custodyInfo{
-				groupCount: expected,
-			},
-		}
-
-		count, err := service.CustodyGroupCount(ctx)
-
-		require.NoError(t, err)
-		require.Equal(t, expected, count)
-	})
+	require.NoError(t, err)
+	require.Equal(t, expected, count)
 }
 
 func TestUpdateCustodyInfo(t *testing.T) {
@@ -167,7 +142,8 @@ func TestUpdateCustodyInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			service := &Service{
-				custodyInfo: tc.initialCustodyInfo,
+				custodyInfoSet: make(chan struct{}),
+				custodyInfo:    tc.initialCustodyInfo,
 			}
 
 			slot, groupCount, err := service.UpdateCustodyInfo(tc.inputSlot, tc.inputGroupCount)

--- a/beacon-chain/p2p/custody_test.go
+++ b/beacon-chain/p2p/custody_test.go
@@ -20,12 +20,14 @@ import (
 )
 
 func TestEarliestAvailableSlot(t *testing.T) {
+	ctx := t.Context()
+
 	t.Run("No custody info available", func(t *testing.T) {
 		service := &Service{
 			custodyInfo: nil,
 		}
 
-		_, err := service.EarliestAvailableSlot()
+		_, err := service.EarliestAvailableSlot(ctx)
 
 		require.NotNil(t, err)
 	})
@@ -39,7 +41,7 @@ func TestEarliestAvailableSlot(t *testing.T) {
 			},
 		}
 
-		slot, err := service.EarliestAvailableSlot()
+		slot, err := service.EarliestAvailableSlot(ctx)
 
 		require.NoError(t, err)
 		require.Equal(t, expected, slot)
@@ -47,12 +49,14 @@ func TestEarliestAvailableSlot(t *testing.T) {
 }
 
 func TestCustodyGroupCount(t *testing.T) {
+	ctx := t.Context()
+
 	t.Run("No custody info available", func(t *testing.T) {
 		service := &Service{
 			custodyInfo: nil,
 		}
 
-		_, err := service.CustodyGroupCount()
+		_, err := service.CustodyGroupCount(ctx)
 
 		require.NotNil(t, err)
 		require.Equal(t, true, strings.Contains(err.Error(), "no custody info available"))
@@ -67,7 +71,7 @@ func TestCustodyGroupCount(t *testing.T) {
 			},
 		}
 
-		count, err := service.CustodyGroupCount()
+		count, err := service.CustodyGroupCount(ctx)
 
 		require.NoError(t, err)
 		require.Equal(t, expected, count)

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -253,7 +253,7 @@ func (s *Service) RefreshPersistentSubnets() {
 			return
 		}
 
-		custodyGroupCount, err = s.CustodyGroupCount()
+		custodyGroupCount, err = s.CustodyGroupCount(s.ctx)
 		if err != nil {
 			log.WithError(err).Error("Could not retrieve custody group count")
 			return
@@ -604,7 +604,7 @@ func (s *Service) createLocalNode(
 	localNode = initializeSyncCommSubnets(localNode)
 
 	if params.FuluEnabled() {
-		custodyGroupCount, err := s.CustodyGroupCount()
+		custodyGroupCount, err := s.CustodyGroupCount(s.ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not retrieve custody group count")
 		}

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -614,7 +614,6 @@ func (s *Service) createLocalNode(
 			custodyGroupCount, err = s.CustodyGroupCount()
 			if errors.Is(err, errNoCustodyInfo) {
 				log.WithField("delay", delay).Debug("No custody info available yet, retrying later")
-				time.Sleep(delay)
 				continue
 			}
 

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -604,26 +604,13 @@ func (s *Service) createLocalNode(
 	localNode = initializeSyncCommSubnets(localNode)
 
 	if params.FuluEnabled() {
-		// TODO: Replace this quick fix with a proper synchronization scheme (chan?)
-		const delay = 1 * time.Second
-
-		var custodyGroupCount uint64
-
-		err := errNoCustodyInfo
-		for errors.Is(err, errNoCustodyInfo) {
-			custodyGroupCount, err = s.CustodyGroupCount()
-			if errors.Is(err, errNoCustodyInfo) {
-				log.WithField("delay", delay).Debug("No custody info available yet, retrying later")
-				continue
-			}
-
-			if err != nil {
-				return nil, errors.Wrap(err, "retrieve custody group count")
-			}
-
-			custodyGroupCountEntry := peerdas.Cgc(custodyGroupCount)
-			localNode.Set(custodyGroupCountEntry)
+		custodyGroupCount, err := s.CustodyGroupCount()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not retrieve custody group count")
 		}
+
+		custodyGroupCountEntry := peerdas.Cgc(custodyGroupCount)
+		localNode.Set(custodyGroupCountEntry)
 	}
 
 	if s.cfg != nil && s.cfg.HostAddress != "" {

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -281,8 +281,12 @@ func TestCreateLocalNode(t *testing.T) {
 				genesisTime:           time.Now(),
 				genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
 				cfg:                   tt.cfg,
+				ctx:                   t.Context(),
 				custodyInfo:           &custodyInfo{groupCount: custodyRequirement},
+				custodyInfoSet:        make(chan struct{}),
 			}
+
+			close(service.custodyInfoSet)
 
 			localNode, err := service.createLocalNode(privKey, address, udpPort, tcpPort, quicPort)
 			if tt.expectedError {
@@ -912,8 +916,12 @@ func TestRefreshPersistentSubnets(t *testing.T) {
 				peers:                 p2p.Peers(),
 				genesisTime:           time.Now().Add(-time.Duration(tc.epochSinceGenesis*secondsPerEpoch) * time.Second),
 				genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+				ctx:                   t.Context(),
+				custodyInfoSet:        make(chan struct{}),
 				custodyInfo:           &custodyInfo{groupCount: custodyGroupCount},
 			}
+
+			close(service.custodyInfoSet)
 
 			// Set the listener and the metadata.
 			createListener := func() (*discover.UDPv5, error) {

--- a/beacon-chain/p2p/interfaces.go
+++ b/beacon-chain/p2p/interfaces.go
@@ -123,8 +123,8 @@ type (
 
 	// CustodyManager abstracts some data columns related methods.
 	CustodyManager interface {
-		EarliestAvailableSlot() (primitives.Slot, error)
-		CustodyGroupCount() (uint64, error)
+		EarliestAvailableSlot(ctx context.Context) (primitives.Slot, error)
+		CustodyGroupCount(ctx context.Context) (uint64, error)
 		UpdateCustodyInfo(earliestAvailableSlot primitives.Slot, custodyGroupCount uint64) (primitives.Slot, uint64, error)
 		CustodyGroupCountFromPeer(peer.ID) uint64
 	}

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -91,6 +91,7 @@ type Service struct {
 	peerDisconnectionTime *cache.Cache
 	custodyInfo           *custodyInfo
 	custodyInfoLock       sync.RWMutex // Lock access to custodyInfo
+	custodyInfoSet        chan struct{}
 	allForkDigests        map[[4]byte]struct{}
 }
 
@@ -137,6 +138,7 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 		joinedTopics:          make(map[string]*pubsub.Topic, len(gossipTopicMappings)),
 		subnetsLock:           make(map[uint64]*sync.RWMutex),
 		peerDisconnectionTime: cache.New(1*time.Second, 1*time.Minute),
+		custodyInfoSet:        make(chan struct{}),
 	}
 
 	ipAddr := prysmnetwork.IPAddr()

--- a/beacon-chain/p2p/testing/fuzz_p2p.go
+++ b/beacon-chain/p2p/testing/fuzz_p2p.go
@@ -199,12 +199,12 @@ func (*FakeP2P) InterceptUpgraded(network.Conn) (allow bool, reason control.Disc
 }
 
 // EarliestAvailableSlot -- fake.
-func (*FakeP2P) EarliestAvailableSlot() (primitives.Slot, error) {
+func (*FakeP2P) EarliestAvailableSlot(context.Context) (primitives.Slot, error) {
 	return 0, nil
 }
 
 // CustodyGroupCount -- fake.
-func (*FakeP2P) CustodyGroupCount() (uint64, error) {
+func (*FakeP2P) CustodyGroupCount(context.Context) (uint64, error) {
 	return 0, nil
 }
 

--- a/beacon-chain/p2p/testing/p2p.go
+++ b/beacon-chain/p2p/testing/p2p.go
@@ -473,7 +473,7 @@ func (*TestP2P) InterceptUpgraded(network.Conn) (allow bool, reason control.Disc
 }
 
 // EarliestAvailableSlot .
-func (s *TestP2P) EarliestAvailableSlot() (primitives.Slot, error) {
+func (s *TestP2P) EarliestAvailableSlot(context.Context) (primitives.Slot, error) {
 	s.custodyInfoMut.RLock()
 	defer s.custodyInfoMut.RUnlock()
 
@@ -481,7 +481,7 @@ func (s *TestP2P) EarliestAvailableSlot() (primitives.Slot, error) {
 }
 
 // CustodyGroupCount .
-func (s *TestP2P) CustodyGroupCount() (uint64, error) {
+func (s *TestP2P) CustodyGroupCount(context.Context) (uint64, error) {
 	s.custodyInfoMut.RLock()
 	defer s.custodyInfoMut.RUnlock()
 

--- a/beacon-chain/sync/custody.go
+++ b/beacon-chain/sync/custody.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -29,13 +30,13 @@ func (s *Service) updateCustodyInfoIfNeeded() error {
 	const minimumPeerCount = 1
 
 	// Get our actual custody group count.
-	actualCustodyGrounpCount, err := s.cfg.p2p.CustodyGroupCount()
+	actualCustodyGrounpCount, err := s.cfg.p2p.CustodyGroupCount(s.ctx)
 	if err != nil {
 		return errors.Wrap(err, "p2p custody group count")
 	}
 
 	// Get our target custody group count.
-	targetCustodyGroupCount, err := s.custodyGroupCount()
+	targetCustodyGroupCount, err := s.custodyGroupCount(s.ctx)
 	if err != nil {
 		return errors.Wrap(err, "custody group count")
 	}
@@ -88,7 +89,7 @@ func (s *Service) updateCustodyInfoIfNeeded() error {
 
 // custodyGroupCount computes the custody group count based on the custody requirement,
 // the validators custody requirement, and whether the node is subscribed to all data subnets.
-func (s *Service) custodyGroupCount() (uint64, error) {
+func (s *Service) custodyGroupCount(context.Context) (uint64, error) {
 	beaconConfig := params.BeaconConfig()
 
 	if flags.Get().SubscribeAllDataSubnets {

--- a/beacon-chain/sync/custody_test.go
+++ b/beacon-chain/sync/custody_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
-	eth "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 )
@@ -55,9 +54,9 @@ func setupCustodyTest(t *testing.T, withChain bool) *testSetup {
 
 	if withChain {
 		const headSlot = primitives.Slot(100)
-		block, err := blocks.NewSignedBeaconBlock(&eth.SignedBeaconBlock{
-			Block: &eth.BeaconBlock{
-				Body: &eth.BeaconBlockBody{},
+		block, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlock{
+			Block: &ethpb.BeaconBlock{
+				Body: &ethpb.BeaconBlockBody{},
 				Slot: headSlot,
 			},
 		})

--- a/beacon-chain/sync/custody_test.go
+++ b/beacon-chain/sync/custody_test.go
@@ -90,11 +90,13 @@ func setupCustodyTest(t *testing.T, withChain bool) *testSetup {
 }
 
 func (ts *testSetup) assertCustodyInfo(t *testing.T, expectedSlot primitives.Slot, expectedCount uint64) {
-	p2pEarliestSlot, err := ts.p2pService.EarliestAvailableSlot()
+	ctx := t.Context()
+
+	p2pEarliestSlot, err := ts.p2pService.EarliestAvailableSlot(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expectedSlot, p2pEarliestSlot)
 
-	p2pCustodyCount, err := ts.p2pService.CustodyGroupCount()
+	p2pCustodyCount, err := ts.p2pService.CustodyGroupCount(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expectedCount, p2pCustodyCount)
 
@@ -170,13 +172,15 @@ func TestCustodyGroupCount(t *testing.T) {
 	config.CustodyRequirement = 3
 	params.OverrideBeaconConfig(config)
 
+	ctx := t.Context()
+
 	t.Run("SubscribeAllDataSubnets enabled returns NumberOfCustodyGroups", func(t *testing.T) {
 		withSubscribeAllDataSubnets(t, func() {
 			service := &Service{
 				ctx: context.Background(),
 			}
 
-			result, err := service.custodyGroupCount()
+			result, err := service.custodyGroupCount(ctx)
 			require.NoError(t, err)
 			require.Equal(t, config.NumberOfCustodyGroups, result)
 		})
@@ -188,7 +192,7 @@ func TestCustodyGroupCount(t *testing.T) {
 			trackedValidatorsCache: cache.NewTrackedValidatorsCache(),
 		}
 
-		result, err := service.custodyGroupCount()
+		result, err := service.custodyGroupCount(ctx)
 		require.NoError(t, err)
 		require.Equal(t, config.CustodyRequirement, result)
 	})

--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -20,7 +20,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	leakybucket "github.com/OffchainLabs/prysm/v6/container/leaky-bucket"
 	"github.com/OffchainLabs/prysm/v6/crypto/rand"
-	eth "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	goPeer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
@@ -921,7 +920,7 @@ func buildByRangeRequests(
 func buildByRootRequest(indicesByRoot map[[fieldparams.RootLength]byte]map[uint64]bool) p2ptypes.DataColumnsByRootIdentifiers {
 	identifiers := make(p2ptypes.DataColumnsByRootIdentifiers, 0, len(indicesByRoot))
 	for root, indices := range indicesByRoot {
-		identifier := &eth.DataColumnsByRootIdentifier{
+		identifier := &ethpb.DataColumnsByRootIdentifier{
 			BlockRoot: root[:],
 			Columns:   helpers.SortedSliceFromMap(indices),
 		}
@@ -929,7 +928,7 @@ func buildByRootRequest(indicesByRoot map[[fieldparams.RootLength]byte]map[uint6
 	}
 
 	// Sort identifiers to have a deterministic output.
-	slices.SortFunc(identifiers, func(left, right *eth.DataColumnsByRootIdentifier) int {
+	slices.SortFunc(identifiers, func(left, right *ethpb.DataColumnsByRootIdentifier) int {
 		if cmp := bytes.Compare(left.BlockRoot, right.BlockRoot); cmp != 0 {
 			return cmp
 		}

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/wrapper"
 	leakybucket "github.com/OffchainLabs/prysm/v6/container/leaky-bucket"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
-	pb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/testing/assert"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
 	"github.com/OffchainLabs/prysm/v6/testing/util"
@@ -144,7 +143,7 @@ func TestFetchDataColumnSidecars(t *testing.T) {
 		HeadSlot: 8,
 	})
 
-	p2p.Peers().SetMetadata(other.PeerID(), wrapper.WrappedMetadataV2(&pb.MetaDataV2{
+	p2p.Peers().SetMetadata(other.PeerID(), wrapper.WrappedMetadataV2(&ethpb.MetaDataV2{
 		CustodyGroupCount: 128,
 	}))
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -384,7 +384,7 @@ func (f *blocksFetcher) fetchSidecars(ctx context.Context, pid peer.ID, peers []
 	}
 
 	// Compute the columns to request.
-	custodyGroupCount, err := f.p2p.CustodyGroupCount()
+	custodyGroupCount, err := f.p2p.CustodyGroupCount(ctx)
 	if err != nil {
 		return blobsPid, errors.Wrap(err, "custody group count")
 	}

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -413,7 +413,7 @@ func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock, delay ti
 	}
 
 	// Compute the indices we need to custody.
-	custodyGroupCount, err := s.cfg.P2P.CustodyGroupCount()
+	custodyGroupCount, err := s.cfg.P2P.CustodyGroupCount(s.ctx)
 	if err != nil {
 		return errors.Wrap(err, "custody group count")
 	}

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -629,7 +629,7 @@ func TestFetchOriginSidecars(t *testing.T) {
 
 		// Compute the columns to request.
 		p2p := p2ptest.NewTestP2P(t)
-		custodyGroupCount, err := p2p.CustodyGroupCount()
+		custodyGroupCount, err := p2p.CustodyGroupCount(t.Context())
 		require.NoError(t, err)
 
 		samplingSize := max(custodyGroupCount, samplesPerSlot)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -95,7 +95,7 @@ func (s *Service) sendBeaconBlocksRequest(ctx context.Context, requests *types.B
 func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock) error {
 	samplesPerSlot := params.BeaconConfig().SamplesPerSlot
 
-	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount()
+	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount(s.ctx)
 	if err != nil {
 		return errors.Wrap(err, "fetch custody group count from peer")
 	}

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -354,7 +354,7 @@ func (s *Service) buildStatusFromStream(
 	}
 
 	if streamVersion == p2p.SchemaVersionV2 {
-		earliestAvailableSlot, err := s.cfg.p2p.EarliestAvailableSlot()
+		earliestAvailableSlot, err := s.cfg.p2p.EarliestAvailableSlot(s.ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "earliest available slot")
 		}

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -675,7 +675,7 @@ func (s *Service) samplingSize() (uint64, error) {
 		return 0, errors.Wrap(err, "validators custody requirement")
 	}
 
-	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount()
+	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount(s.ctx)
 	if err != nil {
 		return 0, errors.Wrap(err, "custody group count")
 	}

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -299,7 +299,7 @@ func (s *Service) columnIndicesToSample() (map[uint64]bool, error) {
 	nodeID := s.cfg.p2p.NodeID()
 
 	// Get the custody group sampling size for the node.
-	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount()
+	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount(s.ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "custody group count")
 	}

--- a/changelog/manu-fix-cgc-not-initialized.md
+++ b/changelog/manu-fix-cgc-not-initialized.md
@@ -1,2 +1,0 @@
-### Fixed 
-- In P2P service start, wait for the custody info to be correctly initialized.

--- a/changelog/manu-wait-init-custody-info.md
+++ b/changelog/manu-wait-init-custody-info.md
@@ -1,0 +1,2 @@
+### Fixed 
+- Wait for custody info to be initialized before querying them.

--- a/changelog/manu-wait.md
+++ b/changelog/manu-wait.md
@@ -1,2 +1,0 @@
-### Fixed 
-- `createLocalNode`: Wait before retrying to retrieve the custody group count if not present.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR:
- Reverts hack previously done to achieve the same purpose (commits 1 and 2)
- Only add context to required functions, without changing any functionality (commit 3)
- Remove double imports, not related to this feature, but done here (commit 4)
- Implements a chan to know when custody info is set (commit 5) **<-- Important one**

**Which issues(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/15787

**Other notes for review**
Please read commit by commit

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
