### PR TITLE
Clear disconnected peers from connected_libp2p_peers

### DIFF
--- a/beacon-chain/p2p/monitoring.go
+++ b/beacon-chain/p2p/monitoring.go
@@ -198,9 +198,11 @@ func (s *Service) updateMetrics() {
 		overallScore := s.peers.Scorers().Score(pid)
 		peerScoresByClient[foundName] = append(peerScoresByClient[foundName], overallScore)
 	}
+	connectedPeersCount.Reset() // Clear out previous results.
 	for agent, total := range numConnectedPeersByClient {
 		connectedPeersCount.WithLabelValues(agent).Set(total)
 	}
+	avgScoreConnectedClients.Reset() // Clear out previous results.
 	for agent, scoringData := range peerScoresByClient {
 		avgScore := average(scoringData)
 		avgScoreConnectedClients.WithLabelValues(agent).Set(avgScore)

--- a/changelog/pvl-peer-metrics-fix.md
+++ b/changelog/pvl-peer-metrics-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Correctly clear disconnected peers from `connected_libp2p_peers` and `connected_libp2p_peers_average_scores`.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR resets the metrics before assigning new values again. When the last peer disconnects with a specific agent type, the number is not set to zero so it appears as if there is still 1 peer connected with that agent type.

This PR will remove the label from the gauge entirely, rather than setting the value to 0. 

**Which issues(s) does this PR fix?**

Fixes #15806

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
