### PR TITLE
fixing Origin block root is not set error log

### DIFF
--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -954,16 +954,11 @@ func (s *Store) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint pr
 	deletedRoots := make([][32]byte, 0)
 
 	oRoot, err := s.OriginCheckpointBlockRoot(ctx)
-	hasOriginRoot := true
-	if err != nil {
-		if !errors.Is(err, ErrNotFoundOriginBlockRoot) {
-			return err
-		}
-		// Origin block root is not set (e.g., starting from genesis or certain forks)
-		hasOriginRoot = false
+	if err != nil && !errors.Is(err, ErrNotFoundOriginBlockRoot) {
+		// If origin block root is not found (e.g., starting from genesis or certain forks),
+		// use zero hash which will never match any actual state root
+		return err
 	}
-	// If origin block root is not found (e.g., starting from genesis or certain forks),
-	// use zero hash which will never match any actual state root
 
 	err = s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(stateSlotIndicesBucket)
@@ -992,7 +987,7 @@ func (s *Store) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint pr
 				return nil
 			}
 
-			if hasOriginRoot && oRoot == root {
+			if oRoot == root {
 				return nil
 			}
 

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -954,9 +954,16 @@ func (s *Store) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint pr
 	deletedRoots := make([][32]byte, 0)
 
 	oRoot, err := s.OriginCheckpointBlockRoot(ctx)
+	hasOriginRoot := true
 	if err != nil {
-		return err
+		if !errors.Is(err, ErrNotFoundOriginBlockRoot) {
+			return err
+		}
+		// Origin block root is not set (e.g., starting from genesis or certain forks)
+		hasOriginRoot = false
 	}
+	// If origin block root is not found (e.g., starting from genesis or certain forks),
+	// use zero hash which will never match any actual state root
 
 	err = s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(stateSlotIndicesBucket)
@@ -985,7 +992,7 @@ func (s *Store) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint pr
 				return nil
 			}
 
-			if oRoot == root {
+			if hasOriginRoot && oRoot == root {
 				return nil
 			}
 

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -955,8 +955,8 @@ func (s *Store) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint pr
 
 	oRoot, err := s.OriginCheckpointBlockRoot(ctx)
 	if err != nil && !errors.Is(err, ErrNotFoundOriginBlockRoot) {
-		// If origin block root is not found (e.g., starting from genesis or certain forks),
-		// use zero hash which will never match any actual state root
+		// If the node did not use checkpoint sync, there will be no origin block root.
+		// Use zero hash which will never match any actual state root
 		return err
 	}
 

--- a/changelog/james-prysm_fix-origin-block-log.md
+++ b/changelog/james-prysm_fix-origin-block-log.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fixes level=error msg="Could not clean up dirty states" error="OriginBlockRoot: not found in db" prefix=state-gen error when starting in kurtosis


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

this pr fixes a log we see each time we start from a fork but seems mostly cosmetic
`helpers.go:242: time="2025-10-03 16:32:17.59" level=error msg="Could not clean up dirty states" error="OriginBlockRoot: not found in db" prefix=state-gen` 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
