### PR TITLE
When looking for peers, skip peers with error instead of aborting the whole function

### DIFF
--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -25,6 +25,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -223,8 +224,14 @@ func (s *Service) findPeersWithSubnets(
 		// Skip nodes that are not subscribed to any of the defective subnets.
 		nodeSubnets, err := filter(node)
 		if err != nil {
-			return nil, errors.Wrap(err, "filter node")
+			log.WithError(err).WithFields(logrus.Fields{
+				"nodeID":      node.ID(),
+				"topicFormat": topicFormat,
+			}).Debug("Could not get needed subnets from peer")
+
+			continue
 		}
+
 		if len(nodeSubnets) == 0 {
 			continue
 		}

--- a/changelog/manu-skip-bad-peers.md
+++ b/changelog/manu-skip-bad-peers.md
@@ -1,0 +1,3 @@
+### Fixed 
+- `findPeersWithSubnets`: If the filter function returns an error for a given peer, log an error and skip the peer instead of aborting the whole function.
+- `computeIndicesByRootByPeer`: If the loop returns an error for a given peer, log an error and skip the peer instead of aborting the whole function.


### PR DESCRIPTION

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
- `findPeersWithSubnets`: If the filter function returns an error for a given peer, log an error and skip the peer instead of aborting the whole function.
- `computeIndicesByRootByPeer`: If the loop returns an error for a given peer, log an error and skip the peer instead of aborting the whole function.

**Other notes for review**
Please read commit by commit.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
