### PR TITLE
chore: refactor to use builtin max/min

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -16,7 +16,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
-	"github.com/OffchainLabs/prysm/v6/math"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
 	ethpbv1 "github.com/OffchainLabs/prysm/v6/proto/eth/v1"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
@@ -108,7 +107,7 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 			commonRoot = params.BeaconConfig().ZeroHash
 		}
 		dis := headSlot + newHeadSlot - 2*forkSlot
-		dep := math.Max(uint64(headSlot-forkSlot), uint64(newHeadSlot-forkSlot))
+		dep := max(uint64(headSlot-forkSlot), uint64(newHeadSlot-forkSlot))
 		oldWeight, err := s.cfg.ForkChoiceStore.Weight(oldHeadRoot)
 		if err != nil {
 			log.WithField("root", fmt.Sprintf("%#x", oldHeadRoot)).Warn("Could not determine node weight")
@@ -135,7 +134,7 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 			Type: statefeed.Reorg,
 			Data: &ethpbv1.EventChainReorg{
 				Slot:                newHeadSlot,
-				Depth:               math.Max(uint64(headSlot-forkSlot), uint64(newHeadSlot-forkSlot)),
+				Depth:               max(uint64(headSlot-forkSlot), uint64(newHeadSlot-forkSlot)),
 				OldHeadBlock:        oldHeadRoot[:],
 				NewHeadBlock:        newHeadRoot[:],
 				OldHeadState:        oldStateRoot[:],

--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -5,7 +5,6 @@ package cache
 import (
 	"context"
 	"errors"
-	"math"
 	"sync"
 	"time"
 
@@ -272,7 +271,7 @@ func (c *CommitteeCache) checkInProgress(ctx context.Context, seed [32]byte) err
 		// for the in progress boolean to flip to false.
 		time.Sleep(time.Duration(delay) * time.Nanosecond)
 		delay *= delayFactor
-		delay = math.Min(delay, maxDelay)
+		delay = min(delay, maxDelay)
 	}
 	return nil
 }

--- a/beacon-chain/cache/depositsnapshot/merkle_tree.go
+++ b/beacon-chain/cache/depositsnapshot/merkle_tree.go
@@ -52,7 +52,7 @@ func create(leaves [][32]byte, depth uint64) MerkleTreeNode {
 	if depth == 0 {
 		return &LeafNode{hash: leaves[0]}
 	}
-	split := math.Min(math.PowerOf2(depth-1), length)
+	split := min(math.PowerOf2(depth-1), length)
 	left := create(leaves[0:split], depth-1)
 	right := create(leaves[split:], depth-1)
 	return &InnerNode{left: left, right: right}

--- a/beacon-chain/cache/skip_slot_cache.go
+++ b/beacon-chain/cache/skip_slot_cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"math"
 	"sync"
 	"time"
 
@@ -90,7 +89,7 @@ func (c *SkipSlotCache) Get(ctx context.Context, r [32]byte) (state.BeaconState,
 		// for the in progress boolean to flip to false.
 		time.Sleep(time.Duration(delay) * time.Nanosecond)
 		delay *= delayFactor
-		delay = math.Min(delay, maxDelay)
+		delay = min(delay, maxDelay)
 	}
 	span.SetAttributes(trace.BoolAttribute("inProgress", inProgress))
 

--- a/beacon-chain/core/altair/sync_committee.go
+++ b/beacon-chain/core/altair/sync_committee.go
@@ -16,7 +16,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/crypto/bls"
 	"github.com/OffchainLabs/prysm/v6/crypto/hash"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
-	"github.com/OffchainLabs/prysm/v6/math"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
@@ -209,7 +208,7 @@ func IsSyncCommitteeAggregator(sig []byte) (bool, error) {
 	}
 
 	cfg := params.BeaconConfig()
-	modulo := math.Max(1, cfg.SyncCommitteeSize/cfg.SyncCommitteeSubnetCount/cfg.TargetAggregatorsPerSyncSubcommittee)
+	modulo := max(1, cfg.SyncCommitteeSize/cfg.SyncCommitteeSubnetCount/cfg.TargetAggregatorsPerSyncSubcommittee)
 	hashedSig := hash.Hash(sig)
 	return bytesutil.FromBytes8(hashedSig[:8])%modulo == 0, nil
 }

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//encoding/ssz:go_default_library",
-        "//math:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/beacon-chain/core/blocks/deposit.go
+++ b/beacon-chain/core/blocks/deposit.go
@@ -11,7 +11,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/contracts/deposit"
 	"github.com/OffchainLabs/prysm/v6/crypto/bls"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
-	"github.com/OffchainLabs/prysm/v6/math"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/pkg/errors"
 )
@@ -34,7 +33,7 @@ func ActivateValidatorWithEffectiveBalance(beaconState state.BeaconState, deposi
 		if err != nil {
 			return nil, err
 		}
-		validator.EffectiveBalance = math.Min(balance-balance%params.BeaconConfig().EffectiveBalanceIncrement, params.BeaconConfig().MaxEffectiveBalance)
+		validator.EffectiveBalance = min(balance-balance%params.BeaconConfig().EffectiveBalanceIncrement, params.BeaconConfig().MaxEffectiveBalance)
 		if validator.EffectiveBalance ==
 			params.BeaconConfig().MaxEffectiveBalance {
 			validator.ActivationEligibilityEpoch = 0

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -233,7 +233,7 @@ func ProcessSlashings(st state.BeaconState) error {
 	// a callback is used here to apply the following actions to all validators
 	// below equally.
 	increment := params.BeaconConfig().EffectiveBalanceIncrement
-	minSlashing := math.Min(totalSlashing*slashingMultiplier, totalBalance)
+	minSlashing := min(totalSlashing*slashingMultiplier, totalBalance)
 
 	// Modified in Electra:EIP7251
 	var penaltyPerEffectiveBalanceIncrement uint64

--- a/beacon-chain/core/epoch/precompute/slashing.go
+++ b/beacon-chain/core/epoch/precompute/slashing.go
@@ -5,7 +5,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/time"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v6/config/params"
-	"github.com/OffchainLabs/prysm/v6/math"
 )
 
 // ProcessSlashingsPrecompute processes the slashed validators during epoch processing.
@@ -21,7 +20,7 @@ func ProcessSlashingsPrecompute(s state.BeaconState, pBal *Balance) error {
 		totalSlashing += slashing
 	}
 
-	minSlashing := math.Min(totalSlashing*params.BeaconConfig().ProportionalSlashingMultiplier, pBal.ActiveCurrentEpoch)
+	minSlashing := min(totalSlashing*params.BeaconConfig().ProportionalSlashingMultiplier, pBal.ActiveCurrentEpoch)
 	epochToWithdraw := currentEpoch + exitLength/2
 
 	var hasSlashing bool

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -79,7 +79,7 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 	}
 
 	// Spec defines `EffectiveBalanceIncrement` as min to avoid divisions by zero.
-	total = mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, total)
+	total = max(params.BeaconConfig().EffectiveBalanceIncrement, total)
 	if err := balanceCache.AddTotalEffectiveBalance(s, total); err != nil {
 		return 0, err
 	}

--- a/beacon-chain/core/helpers/weak_subjectivity.go
+++ b/beacon-chain/core/helpers/weak_subjectivity.go
@@ -14,7 +14,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
-	"github.com/OffchainLabs/prysm/v6/math"
 	v1alpha1 "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
 )
@@ -95,7 +94,7 @@ func ComputeWeakSubjectivityPeriod(ctx context.Context, st state.ReadOnlyBeaconS
 	if T*(200+3*D) < t*(200+12*D) {
 		epochsForValidatorSetChurn := N * (t*(200+12*D) - T*(200+3*D)) / (600 * delta * (2*t + T))
 		epochsForBalanceTopUps := N * (200 + 3*D) / (600 * Delta)
-		wsp += math.Max(epochsForValidatorSetChurn, epochsForBalanceTopUps)
+		wsp += max(epochsForValidatorSetChurn, epochsForBalanceTopUps)
 	} else {
 		wsp += 3 * N * D * t / (200 * Delta * (T - t))
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -13,7 +13,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/math"
-	mathutil "github.com/OffchainLabs/prysm/v6/math"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
@@ -60,7 +59,7 @@ func ExitInformation(s state.BeaconState) *ExitInfo {
 	_ = err
 
 	// Apply minimum balance as per spec
-	exitInfo.TotalActiveBalance = mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, totalActiveBalance)
+	exitInfo.TotalActiveBalance = max(params.BeaconConfig().EffectiveBalanceIncrement, totalActiveBalance)
 	return exitInfo
 }
 

--- a/beacon-chain/operations/blstoexec/pool.go
+++ b/beacon-chain/operations/blstoexec/pool.go
@@ -1,7 +1,6 @@
 package blstoexec
 
 import (
-	"math"
 	"sync"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
@@ -87,7 +86,7 @@ func (p *Pool) PendingBLSToExecChanges() ([]*ethpb.SignedBLSToExecutionChange, e
 func (p *Pool) BLSToExecChangesForInclusion(st state.ReadOnlyBeaconState) ([]*ethpb.SignedBLSToExecutionChange, error) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
-	length := int(math.Min(float64(params.BeaconConfig().MaxBlsToExecutionChanges), float64(p.pending.Len())))
+	length := int(min(float64(params.BeaconConfig().MaxBlsToExecutionChanges), float64(p.pending.Len())))
 	result := make([]*ethpb.SignedBLSToExecutionChange, 0, length)
 	node := p.pending.Last()
 	for node != nil && len(result) < length {

--- a/beacon-chain/operations/voluntaryexits/pool.go
+++ b/beacon-chain/operations/voluntaryexits/pool.go
@@ -1,7 +1,6 @@
 package voluntaryexits
 
 import (
-	"math"
 	"sync"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
@@ -63,7 +62,7 @@ func (p *Pool) PendingExits() ([]*ethpb.SignedVoluntaryExit, error) {
 // return more than the block enforced MaxVoluntaryExits.
 func (p *Pool) ExitsForInclusion(state state.ReadOnlyBeaconState, slot types.Slot) ([]*ethpb.SignedVoluntaryExit, error) {
 	p.lock.RLock()
-	length := int(math.Min(float64(params.BeaconConfig().MaxVoluntaryExits), float64(p.pending.Len())))
+	length := int(min(float64(params.BeaconConfig().MaxVoluntaryExits), float64(p.pending.Len())))
 	result := make([]*ethpb.SignedVoluntaryExit, 0, length)
 	node := p.pending.First()
 	for node != nil && len(result) < length {

--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -24,7 +24,6 @@ package peers
 
 import (
 	"context"
-	"math"
 	"net"
 	"sort"
 	"strings"
@@ -411,7 +410,7 @@ func (p *Status) RandomizeBackOff(pid peer.ID) {
 		return
 	}
 
-	duration := time.Duration(math.Max(MinBackOffDuration, float64(p.rand.Intn(MaxBackOffDuration)))) * time.Millisecond
+	duration := time.Duration(max(MinBackOffDuration, float64(p.rand.Intn(MaxBackOffDuration)))) * time.Millisecond
 	peerData.NextValidTime = time.Now().Add(duration)
 }
 

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -11,7 +11,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
-	mathutil "github.com/OffchainLabs/prysm/v6/math"
 	pbrpc "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -246,5 +245,5 @@ func ExtractGossipDigest(topic string) ([4]byte, error) {
 //	# Allow 1024 bytes for framing and encoding overhead but at least 1MiB in case MAX_PAYLOAD_SIZE is small.
 //	return max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1024 * 1024)
 func MaxMessageSize() uint64 {
-	return mathutil.Max(encoder.MaxCompressedLen(params.BeaconConfig().MaxPayloadSize)+1024, 1024*1024)
+	return max(encoder.MaxCompressedLen(params.BeaconConfig().MaxPayloadSize)+1024, 1024*1024)
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deposits.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deposits.go
@@ -11,7 +11,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/container/trie"
-	"github.com/OffchainLabs/prysm/v6/math"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
@@ -143,7 +142,7 @@ func (vs *Server) deposits(
 			if err != nil {
 				return nil, errors.Wrap(err, "could not retrieve requests start index")
 			}
-			eth1DepositIndexLimit := math.Min(canonicalEth1Data.DepositCount, requestsStartIndex)
+			eth1DepositIndexLimit := min(canonicalEth1Data.DepositCount, requestsStartIndex)
 			if beaconState.Eth1DepositIndex() < eth1DepositIndexLimit {
 				if uint64(dep.Index) >= beaconState.Eth1DepositIndex() && uint64(dep.Index) < eth1DepositIndexLimit {
 					pendingDeps = append(pendingDeps, dep)

--- a/beacon-chain/state/state-native/getters_withdrawal.go
+++ b/beacon-chain/state/state-native/getters_withdrawal.go
@@ -160,7 +160,7 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, uint64, err
 	}
 
 	validatorsLen := b.validatorsLen()
-	bound := mathutil.Min(uint64(validatorsLen), params.BeaconConfig().MaxValidatorsPerWithdrawalsSweep)
+	bound := min(uint64(validatorsLen), params.BeaconConfig().MaxValidatorsPerWithdrawalsSweep)
 	for i := uint64(0); i < bound; i++ {
 		val, err := b.validatorAtIndexReadOnly(validatorIndex)
 		if err != nil {

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -3,7 +3,6 @@ package stategen
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state"
@@ -54,7 +53,7 @@ func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, st stat
 	defer span.End()
 
 	// Duration can't be 0 to prevent panic for division.
-	duration := uint64(math.Max(float64(s.saveHotStateDB.duration), 1))
+	duration := uint64(max(float64(s.saveHotStateDB.duration), 1))
 
 	s.saveHotStateDB.lock.Lock()
 	if s.saveHotStateDB.enabled && st.Slot().Mod(duration) == 0 {

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_peers.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_peers.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/peers/scorers"
 	"github.com/OffchainLabs/prysm/v6/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v6/config/params"
-	mathutil "github.com/OffchainLabs/prysm/v6/math"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
 	prysmTime "github.com/OffchainLabs/prysm/v6/time"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
@@ -133,6 +132,6 @@ func trimPeers(peers []peer.ID, peersPercentage float64) []peer.ID {
 	// Limit cannot be less that minimum peers required by sync mechanism.
 	limit = max(limit, uint64(required))
 	// Limit cannot be higher than number of peers available (safe-guard).
-	limit = mathutil.Min(limit, uint64(len(peers)))
+	limit = min(limit, uint64(len(peers)))
 	return peers[:limit]
 }

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_peers.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_peers.go
@@ -131,7 +131,7 @@ func trimPeers(peers []peer.ID, peersPercentage float64) []peer.ID {
 	// Weak/slow peers will be pushed down the list and trimmed since only percentage of peers is selected.
 	limit := uint64(math.Round(float64(len(peers)) * peersPercentage))
 	// Limit cannot be less that minimum peers required by sync mechanism.
-	limit = mathutil.Max(limit, uint64(required))
+	limit = max(limit, uint64(required))
 	// Limit cannot be higher than number of peers available (safe-guard).
 	limit = mathutil.Min(limit, uint64(len(peers)))
 	return peers[:limit]

--- a/changelog/sahil-4555-use-inbuilt-max-min.md
+++ b/changelog/sahil-4555-use-inbuilt-max-min.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- switch to built-in min/max

--- a/math/math_helper.go
+++ b/math/math_helper.go
@@ -117,18 +117,6 @@ func PowerOf2(n uint64) uint64 {
 	return 1 << n
 }
 
-// Min returns the smaller integer of the two
-// given ones. This is used over the Min function
-// in the standard math library because that min function
-// has to check for some special floating point cases
-// making it slower by a magnitude of 10.
-func Min(a, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // Mul64 multiples 2 64-bit unsigned integers and checks if they
 // lead to an overflow. If they do not, it returns the result
 // without an error.

--- a/math/math_helper.go
+++ b/math/math_helper.go
@@ -117,18 +117,6 @@ func PowerOf2(n uint64) uint64 {
 	return 1 << n
 }
 
-// Max returns the larger integer of the two
-// given ones.This is used over the Max function
-// in the standard math library because that max function
-// has to check for some special floating point cases
-// making it slower by a magnitude of 10.
-func Max(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Min returns the smaller integer of the two
 // given ones. This is used over the Min function
 // in the standard math library because that min function

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -294,43 +294,6 @@ func TestPowerOf2(t *testing.T) {
 	}
 }
 
-func TestMinValue(t *testing.T) {
-	tests := []struct {
-		a      uint64
-		b      uint64
-		result uint64
-	}{
-		{
-			a:      10,
-			b:      8,
-			result: 8,
-		},
-		{
-			a:      300,
-			b:      256,
-			result: 256,
-		},
-		{
-			a:      1200,
-			b:      1024,
-			result: 1024,
-		},
-		{
-			a:      4500,
-			b:      4096,
-			result: 4096,
-		},
-		{
-			a:      9999,
-			b:      9999,
-			result: 9999,
-		},
-	}
-	for _, tt := range tests {
-		require.Equal(t, tt.result, math.Min(tt.a, tt.b))
-	}
-}
-
 func TestMul64(t *testing.T) {
 	type args struct {
 		a uint64

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -294,43 +294,6 @@ func TestPowerOf2(t *testing.T) {
 	}
 }
 
-func TestMaxValue(t *testing.T) {
-	tests := []struct {
-		a      uint64
-		b      uint64
-		result uint64
-	}{
-		{
-			a:      10,
-			b:      8,
-			result: 10,
-		},
-		{
-			a:      300,
-			b:      256,
-			result: 300,
-		},
-		{
-			a:      1200,
-			b:      1024,
-			result: 1200,
-		},
-		{
-			a:      4500,
-			b:      4096,
-			result: 4500,
-		},
-		{
-			a:      9999,
-			b:      9999,
-			result: 9999,
-		},
-	}
-	for _, tt := range tests {
-		require.Equal(t, tt.result, math.Max(tt.a, tt.b))
-	}
-}
-
 func TestMinValue(t *testing.T) {
 	tests := []struct {
 		a      uint64

--- a/testing/util/attestation.go
+++ b/testing/util/attestation.go
@@ -207,7 +207,7 @@ func GenerateAttestations(bState state.BeaconState, privs []bls.SecretKey, numTo
 		)
 	}
 
-	attsPerCommittee := math.Max(float64(numToGen/committeesPerSlot), 1)
+	attsPerCommittee := max(float64(numToGen/committeesPerSlot), 1)
 	if math.Trunc(attsPerCommittee) != attsPerCommittee {
 		return nil, fmt.Errorf(
 			"requested attestations %d must be easily divisible by committees in slot %d, calculated %f",

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -46,7 +46,6 @@ go_library(
         "//crypto/hash:go_default_library",
         "//crypto/rand:go_default_library",
         "//encoding/bytesutil:go_default_library",
-        "//math:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
         "//network/httputil:go_default_library",

--- a/validator/client/wait_for_activation.go
+++ b/validator/client/wait_for_activation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/OffchainLabs/prysm/v6/math"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v6/monitoring/tracing/trace"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
@@ -65,7 +64,7 @@ func (v *validator) retryWaitForActivation(ctx context.Context, span octrace.Spa
 	attempts := activationAttempts(ctx)
 	log.WithError(err).WithField("attempts", attempts).Error(message)
 	// Reconnection attempt backoff, up to 60s.
-	time.Sleep(time.Second * time.Duration(math.Min(uint64(attempts), 60)))
+	time.Sleep(time.Second * time.Duration(min(uint64(attempts), 60)))
 	// TODO: refactor this to use the health tracker instead for reattempt
 	return v.WaitForActivation(incrementRetries(ctx))
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
> Other

**What does this PR do? Why is it needed?**
This PR refactors the codebase to use Go’s built-in min and max functions instead of maintaining custom helper functions. This simplifies the code, reduces duplication, and improves readability by relying on standard library functions.

**Which issues(s) does this PR fix?**
Refactor to use Go’s built-in min/max instead of custom functions making the code cleaner and easier to maintain.

This is the same as [PR #15755](https://github.com/OffchainLabs/prysm/pull/15755), but that one was closed due to some end-to-end tests not passing. I’m reopening this PR after resolving it.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
