### PR TITLE
Data column sidecars fetch: Adjust log levels.

### DIFF
--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -169,7 +169,7 @@ func FetchDataColumnSidecars(
 		result[root] = sidecars
 	}
 
-	log.WithField("finalMissingRootCount", len(incompleteRoots)).Debug("Failed to fetch data column sidecars from storage and peers using rescue mode")
+	log.WithField("finalMissingRootCount", len(incompleteRoots)).Warning("Failed to fetch data column sidecars")
 	return result, missingByRoot, nil
 }
 
@@ -738,7 +738,7 @@ func fetchDataColumnSidecarsFromPeers(
 
 			roDataColumns, err := sendDataColumnSidecarsRequest(params, slotByRoot, slotsWithCommitments, peerID, indicesByRoot)
 			if err != nil {
-				log.WithError(err).Warning("Failed to send data column sidecars request")
+				log.WithError(err).Debug("Failed to send data column sidecars request")
 				return
 			}
 

--- a/changelog/manu-adjust-log-levels.md
+++ b/changelog/manu-adjust-log-levels.md
@@ -1,0 +1,2 @@
+### Ignored 
+- Data column sidecars fetch: Adjust log levels.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
When a single peer errors when delivering data column sidecars via Req/Resp, we have a WARN log, even if, at the end, we achieve to get what we want thanks to other peers and/or reconstruction. WARN is a little scary in that case since it is not our fault and we eventually get what we want anyhow.

On the contrary, when, at the very end, we are not able to get what we want by all possible means, then the log level is only DEBUG.

==> This PR fixes these two issues.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
