### PR TITLE
Process pending atts after pending blocks clear

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -147,6 +147,11 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			}
 			cancelFunction()
 
+			// Process pending attestations for this block.
+			if err := s.processPendingAttsForBlock(ctx, blkRoot); err != nil {
+				log.WithError(err).Debug("Failed to process pending attestations for block")
+			}
+
 			// Remove the processed block from the queue.
 			if err := s.removeBlockFromQueue(b, blkRoot); err != nil {
 				return err

--- a/changelog/ttsao_optimize-pending-attestation-processing.md
+++ b/changelog/ttsao_optimize-pending-attestation-processing.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Process pending attestations after pending blocks are cleared


### PR DESCRIPTION
ProcessPendingBlocks processes blocks but doesn't handle their pending attestations. This creates a mismatch between the two pending systems:
  - Pending blocks queue clears `seenPendingBlocks` when blocks are processed
  - Pending attestations queue still has entries in `blkRootToPendingAtts`

This fix is to call `processPendingAttsForBlock` in `processPendingBlocks` after block processing