### PR TITLE
Add grandine in known agents

### DIFF
--- a/beacon-chain/p2p/monitoring.go
+++ b/beacon-chain/p2p/monitoring.go
@@ -11,14 +11,14 @@ import (
 
 var (
 	knownAgentVersions = []string{
+		"erigon/caplin",
+		"js-libp2p",
 		"lighthouse",
+		"lodestar",
 		"nimbus",
 		"prysm",
 		"teku",
-		"lodestar",
-		"js-libp2p",
 		"rust-libp2p",
-		"erigon/caplin",
 	}
 	p2pPeerCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "p2p_peer_count",

--- a/beacon-chain/p2p/monitoring.go
+++ b/beacon-chain/p2p/monitoring.go
@@ -12,6 +12,7 @@ import (
 var (
 	knownAgentVersions = []string{
 		"erigon/caplin",
+		"grandine",
 		"js-libp2p",
 		"lighthouse",
 		"lodestar",

--- a/changelog/manu-grandine-known-agents.md
+++ b/changelog/manu-grandine-known-agents.md
@@ -1,0 +1,2 @@
+### Added 
+- Add Grandine to P2P known agents. (Useful for metrics)


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Currently Grandine is in `unknown`.
This PR fixes this.

<img width="782" height="317" alt="image" src="https://github.com/user-attachments/assets/dec4e5a5-9ebd-4317-bc4a-ec0c05b001b2" />


**Other notes for review**
Please read commit by commit.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
