### PR TITLE
tools/specs-checker: open output file in write mode (O_WRONLY)

### DIFF
--- a/tools/specs-checker/download.go
+++ b/tools/specs-checker/download.go
@@ -41,7 +41,9 @@ func download(cliCtx *cli.Context) error {
 
 func getAndSaveFile(specDocUrl, outFilePath string) error {
 	// Create output file.
-	f, err := os.OpenFile(filepath.Clean(outFilePath), os.O_CREATE|os.O_EXCL, params.BeaconIoConfig().ReadWritePermissions)
+	// Open the output file in write-only mode; we intend to write to it.
+	// Using O_EXCL ensures we don't overwrite existing files.
+	f, err := os.OpenFile(filepath.Clean(outFilePath), os.O_CREATE|os.O_EXCL|os.O_WRONLY, params.BeaconIoConfig().ReadWritePermissions)
 	if err != nil {
 		return fmt.Errorf("cannot create output file: %w", err)
 	}


### PR DESCRIPTION


Description
- Summary: Open the specs output file with write permissions and add a brief comment clarifying intent.
- Why: Prevent write failures when saving extracted snippets; improves reliability and clarity.
- Changes:
  - `tools/specs-checker/download.go`: add `os.O_WRONLY` to `os.OpenFile` flags.
