### PR TITLE
p2p: Bound goodbye context with timeout to prevent blocking disconnections

### DIFF
--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -57,7 +57,10 @@ func (s *Service) disconnectFromPeerOnError(
 
 	// Only attempt a goodbye if we are still connected to the peer.
 	if s.host.Network().Connectedness(remotePeerID) == network.Connected {
-		if err := goodByeFunc(context.TODO(), remotePeerID); err != nil {
+		// Use a bounded context to avoid blocking on goodbye in unstable networks.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := goodByeFunc(ctx, remotePeerID); err != nil {
 			log.WithError(err).Error("Unable to disconnect from peer")
 		}
 	}


### PR DESCRIPTION


Description
- Summary: Replace context.TODO() with a bounded context when sending the goodbye message during peer disconnection.
- Motivation: Unbounded calls can hang under network issues, degrading shutdown responsiveness and operational stability.
- Change: Use context.WithTimeout(context.Background(), 5s) for goodByeFunc in disconnect path; add a brief comment.
- Impact: More deterministic disconnect behavior; no protocol or API changes.

