### PR TITLE
beacon-chain/kv: remove pruned blocks from parent index during historical deletion

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -456,6 +456,18 @@ func (s *Store) DeleteHistoricalDataBeforeSlot(ctx context.Context, cutoffSlot p
 				return nil
 			}
 
+			// Remove the child from its parent's index before deleting the block itself.
+			// This keeps the parentRoot -> [children] index consistent during pruning.
+			if enc := tx.Bucket(blocksBucket).Get(sr.root[:]); enc != nil {
+				blk, uerr := unmarshalBlock(ctx, enc)
+				if uerr != nil {
+					return uerr
+				}
+				if derr := s.deleteMatchingParentIndex(tx, blk.Block().ParentRoot(), sr.root); derr != nil {
+					return derr
+				}
+			}
+
 			// Delete block
 			if err = s.deleteBlock(tx, sr.root[:]); err != nil {
 				return err

--- a/changelog/Galoretka_db-kv-prune-parent-index-cleanup.md
+++ b/changelog/Galoretka_db-kv-prune-parent-index-cleanup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Remove pruned blocks from parent index during historical deletion


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

When pruning with DeleteHistoricalDataBeforeSlot, we deleted blocks but did not remove each child root from its parent’s entry in blockParentRootIndicesBucket (schema: parentRoot -> packed children). The code only deleted the key equal to the child’s own root (i.e., “this block as parent”), leaving stale child references under the actual parent’s key.

This is a problem because ParentRoot-based queries can return pruned (non-existent) child roots, causing downstream lookups to fail and wasting resources. It also breaks index consistency guarantees.

This change fetches the block within the same transaction, derives its ParentRoot, calls deleteMatchingParentIndex to remove the child from the parent’s packed list, and only then deletes the block and related data. This mirrors the single-block DeleteBlock behavior and keeps the parent index consistent during historical pruning.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
