### PR TITLE
Cancel roles context after slot tasks complete to prevent timer leaks

### DIFF
--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -146,8 +146,14 @@ func (r *runner) run(ctx context.Context) {
 				continue
 			}
 			// performRoles calls span.End()
-			rolesCtx, _ := context.WithDeadline(ctx, deadline) //nolint:govet
+			rolesCtx, rolesCancel := context.WithDeadline(ctx, deadline) //nolint:govet
 			performRoles(rolesCtx, allRoles, v, slot, &wg, span)
+			go func() {
+				// Cancel the roles context right after all tasks for this slot complete,
+				// to release timers and other resources before the deadline fires.
+				wg.Wait()
+				rolesCancel()
+			}()
 		case e := <-v.EventsChan():
 			v.ProcessEvent(ctx, e)
 		case currentKeys := <-v.AccountsChangedChan(): // should be less of a priority than next slot


### PR DESCRIPTION


### Description
- **Summary**: Ensure `rolesCtx` is properly canceled once all slot tasks finish, preventing timers and resources from lingering until the deadline.
- **Motivation**: Ignored cancel functions from `context.WithDeadline` may cause resource leaks in long-running validators.
- **Change**: Capture `rolesCancel` and call it after `wg.Wait()` in a goroutine.

