### PR TITLE
Fix ignored gossip attestation validation for early arriving attestations

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	// "github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed/operation"
@@ -116,23 +116,8 @@ func (s *Service) processAttestationBucket(ctx context.Context, bucket *attestat
 	data := bucket.data
 
 	// Shared validations for the entire bucket.
-	blockRoot := bytesutil.ToBytes32(data.BeaconBlockRoot)
-	if !s.cfg.chain.InForkchoice(blockRoot) {
-		// Enhanced logging to diagnose forkchoice pruning issues
-		currentSlot := s.cfg.clock.CurrentSlot()
-		finalizedCheckpoint := s.cfg.chain.FinalizedCheckpt()
-		log.WithFields(logrus.Fields{
-			"blockRoot":      fmt.Sprintf("%#x", data.BeaconBlockRoot),
-			"attSlot":        data.Slot,
-			"attTargetEpoch": data.Target.Epoch,
-			"attTargetRoot":  fmt.Sprintf("%#x", data.Target.Root),
-			"currentSlot":    currentSlot,
-			"finalizedEpoch": finalizedCheckpoint.Epoch,
-			"finalizedRoot":  fmt.Sprintf("%#x", finalizedCheckpoint.Root),
-			"attCount":       len(bucket.attestations),
-			"hasBlock":       s.cfg.beaconDB.HasBlock(ctx, blockRoot),
-			"isFinalized":    s.cfg.chain.IsFinalized(ctx, blockRoot),
-		}).Debug("Failed forkchoice check for bucket - block not descendant of finalized checkpoint")
+	if !s.cfg.chain.InForkchoice(bytesutil.ToBytes32(data.BeaconBlockRoot)) {
+		log.WithError(blockchain.ErrNotDescendantOfFinalized).WithField("root", fmt.Sprintf("%#x", data.BeaconBlockRoot)).Debug("Failed forkchoice check for bucket")
 		return
 	}
 

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
+	// "github.com/OffchainLabs/prysm/v6/beacon-chain/blockchain"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/blocks"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/feed/operation"
@@ -116,8 +116,23 @@ func (s *Service) processAttestationBucket(ctx context.Context, bucket *attestat
 	data := bucket.data
 
 	// Shared validations for the entire bucket.
-	if !s.cfg.chain.InForkchoice(bytesutil.ToBytes32(data.BeaconBlockRoot)) {
-		log.WithError(blockchain.ErrNotDescendantOfFinalized).WithField("root", fmt.Sprintf("%#x", data.BeaconBlockRoot)).Debug("Failed forkchoice check for bucket")
+	blockRoot := bytesutil.ToBytes32(data.BeaconBlockRoot)
+	if !s.cfg.chain.InForkchoice(blockRoot) {
+		// Enhanced logging to diagnose forkchoice pruning issues
+		currentSlot := s.cfg.clock.CurrentSlot()
+		finalizedCheckpoint := s.cfg.chain.FinalizedCheckpt()
+		log.WithFields(logrus.Fields{
+			"blockRoot":      fmt.Sprintf("%#x", data.BeaconBlockRoot),
+			"attSlot":        data.Slot,
+			"attTargetEpoch": data.Target.Epoch,
+			"attTargetRoot":  fmt.Sprintf("%#x", data.Target.Root),
+			"currentSlot":    currentSlot,
+			"finalizedEpoch": finalizedCheckpoint.Epoch,
+			"finalizedRoot":  fmt.Sprintf("%#x", finalizedCheckpoint.Root),
+			"attCount":       len(bucket.attestations),
+			"hasBlock":       s.cfg.beaconDB.HasBlock(ctx, blockRoot),
+			"isFinalized":    s.cfg.chain.IsFinalized(ctx, blockRoot),
+		}).Debug("Failed forkchoice check for bucket - block not descendant of finalized checkpoint")
 		return
 	}
 

--- a/changelog/satushh-gossip.md
+++ b/changelog/satushh-gossip.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed [#15812](https://github.com/OffchainLabs/prysm/issues/15812): Gossip attestation validation incorrectly rejecting attestations that arrive before their referenced blocks. Previously, attestations were saved to the pending queue but immediately rejected by forkchoice validation, causing "not descendant of finalized checkpoint" errors. Now attestations for missing blocks return `ValidationIgnore` without error, allowing them to be properly processed when their blocks arrive. This eliminates false positive rejections and prevents potential incorrect peer downscoring during network congestion.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

Addresses [#15812](https://github.com/OffchainLabs/prysm/issues/15812): 

Gossip attestation validation incorrectly rejecting attestations that arrive before their referenced blocks. 
Previously, attestations were saved to the pending queue but immediately rejected by forkchoice validation, causing "not descendant of finalized checkpoint" errors. 

Now attestations for missing blocks return `ValidationIgnore` without error, allowing them to be properly processed when their blocks arrive. This eliminates false positive rejections and prevents potential incorrect peer downscoring during network congestion.

**Which issues(s) does this PR fix?**

Fixes https://github.com/OffchainLabs/prysm/issues/15812

**Other notes for review**

The reproducing steps mentioned in the issue can be followed to check if the fix of this PR addresses the issue. 

PS: 
The above issue only used to happen when there were blob transactions. Here is the likely reason: 
The `handleDA()` when a block is received (in `ReceiveBlock()`) takes a relatively longer time when there are blobs. 
So during this time attestations may arrive and at this point the `if !s.hasBlockAndState(ctx, blockRoot)` code will become true in `beacon-chain/sync/validate_beacon_attestation.go`. 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
