### PR TITLE
Do not mark blocks as invalid unnecessarily

### DIFF
--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -30,7 +30,7 @@ var (
 	// errWSBlockNotFoundInEpoch is returned when a block is not found in the WS cache or DB within epoch.
 	errWSBlockNotFoundInEpoch = errors.New("weak subjectivity root not found in db within epoch")
 	// ErrNotDescendantOfFinalized is returned when a block is not a descendant of the finalized checkpoint
-	ErrNotDescendantOfFinalized = invalidBlock{error: errors.New("not descendant of finalized checkpoint")}
+	ErrNotDescendantOfFinalized = errors.New("not descendant of finalized checkpoint")
 	// ErrNotCheckpoint is returned when a given checkpoint is not a
 	// checkpoint in any chain known to forkchoice
 	ErrNotCheckpoint = errors.New("not a checkpoint in forkchoice")

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -219,6 +219,9 @@ func (s *Service) validateExecutionAndConsensus(
 	eg.Go(func() error {
 		var err error
 		postState, err = s.validateStateTransition(ctx, preState, block)
+		if errors.Is(err, ErrNotDescendantOfFinalized) {
+			return invalidBlock{error: err, root: block.Root()}
+		}
 		if err != nil {
 			return errors.Wrap(err, "failed to validate consensus state transition function")
 		}

--- a/changelog/potuz_invalid_not_descendant.md
+++ b/changelog/potuz_invalid_not_descendant.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Do not mark blocks as invalid from ErrNotDescendantOfFinalized


### PR DESCRIPTION
The error `ErrNotDescendantOfFinalized` unnecessarily aggresively returned an `invalidBlock` structure. This can lead to unncessarily mark some blocks as invalid (a recent Pull requests would have resulted in every single late block being marked as invalid)

This PR removes this wrapping and only adds it in the unique case where we do want to aggresively stop syncing a chain: that is when we receive on gossip a block that does not descends from our current finalized checkpoint. We want to prevent syncinng those chains quickly so that we avoid a double finalization. 