### PR TITLE
Add proper handling for submit blind block 502 error

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -726,6 +726,12 @@ func unexpectedStatusErr(response *http.Response, expected int) error {
 			return errors.Wrap(jsonErr, "unable to read response body")
 		}
 		return errors.Wrap(ErrNotOK, errMessage.Message)
+	case http.StatusBadGateway:
+		log.WithError(ErrBadGateway).Debug(msg)
+		if jsonErr := json.Unmarshal(bodyBytes, &errMessage); jsonErr != nil {
+			return errors.Wrap(jsonErr, "unable to read response body")
+		}
+		return errors.Wrap(ErrBadGateway, errMessage.Message)
 	default:
 		log.WithError(ErrNotOK).Debug(msg)
 		return errors.Wrap(ErrNotOK, fmt.Sprintf("unsupported error code: %d", response.StatusCode))

--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/OffchainLabs/prysm/v6/api"
 	"github.com/OffchainLabs/prysm/v6/api/server/structs"
-	"github.com/OffchainLabs/prysm/v6/testing/util"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
@@ -22,6 +21,7 @@ import (
 	eth "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/testing/assert"
 	"github.com/OffchainLabs/prysm/v6/testing/require"
+	"github.com/OffchainLabs/prysm/v6/testing/util"
 	"github.com/prysmaticlabs/go-bitfield"
 	log "github.com/sirupsen/logrus"
 )

--- a/api/client/builder/errors.go
+++ b/api/client/builder/errors.go
@@ -21,3 +21,4 @@ var ErrUnsupportedMediaType = errors.Wrap(ErrNotOK, "The media type in \"Content
 
 // ErrNotAcceptable specifically means that a '406 - Not Acceptable' was received from the API.
 var ErrNotAcceptable = errors.Wrap(ErrNotOK, "The accept header value is not acceptable")
+var ErrBadGateway = errors.Wrap(ErrNotOK, "recv 502 BadGateway response from API")

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -3302,7 +3302,6 @@ func Test_postBlockProcess_EventSending(t *testing.T) {
 	}
 }
 
-
 func setupLightClientTestRequirements(ctx context.Context, t *testing.T, s *Service, v int, options ...util.LightClientOption) (*util.TestLightClient, *postBlockProcessConfig) {
 	var l *util.TestLightClient
 	switch v {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -316,8 +316,8 @@ func (vs *Server) ProposeBeaconBlock(ctx context.Context, req *ethpb.GenericSign
 		blobSidecars, dataColumnSidecars, err = vs.handleUnblindedBlock(rob, req)
 	}
 	if err != nil {
-		if errors.Is(err, builderapi.ErrBadGateway) {
-			log.Error("Builder relay returned 502 error - relay temporarily unavailable, block may arrive over P2P")
+		if errors.Is(err, builderapi.ErrBadGateway) && block.IsBlinded() {
+			log.WithError(err).Info("Builder relay returned 502 error - relay temporarily unavailable, block may arrive over P2P")
 			return &ethpb.ProposeResponse{BlockRoot: root[:]}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "%s: %v", "handle block failed", err)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -316,6 +316,10 @@ func (vs *Server) ProposeBeaconBlock(ctx context.Context, req *ethpb.GenericSign
 		blobSidecars, dataColumnSidecars, err = vs.handleUnblindedBlock(rob, req)
 	}
 	if err != nil {
+		if errors.Is(err, builderapi.ErrBadGateway) {
+			log.Error("Builder relay returned 502 error - relay temporarily unavailable, block may arrive over P2P")
+			return &ethpb.ProposeResponse{BlockRoot: root[:]}, nil
+		}
 		return nil, status.Errorf(codes.Internal, "%s: %v", "handle block failed", err)
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -317,7 +317,7 @@ func (vs *Server) ProposeBeaconBlock(ctx context.Context, req *ethpb.GenericSign
 	}
 	if err != nil {
 		if errors.Is(err, builderapi.ErrBadGateway) && block.IsBlinded() {
-			log.WithError(err).Info("Builder relay returned 502 error - relay temporarily unavailable, block may arrive over P2P")
+			log.WithError(err).Info("Optimistically proposed block - builder relay temporarily unavailable, block may arrive over P2P")
 			return &ethpb.ProposeResponse{BlockRoot: root[:]}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "%s: %v", "handle block failed", err)

--- a/changelog/ttsao_handle-relay-502-errors.md
+++ b/changelog/ttsao_handle-relay-502-errors.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Gracefully handle submit blind block returning 502 errors.

--- a/validator/client/beacon-api/beacon_api_validator_client_test.go
+++ b/validator/client/beacon-api/beacon_api_validator_client_test.go
@@ -202,10 +202,10 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockError_ThenPass(t *testing.T)
 
 func TestBeaconApiValidatorClient_ProposeBeaconBlockAllTypes(t *testing.T) {
 	tests := []struct {
-		name          string
-		block         *ethpb.GenericSignedBeaconBlock
-		expectedPath  string
-		wantErr       bool
+		name         string
+		block        *ethpb.GenericSignedBeaconBlock
+		expectedPath string
+		wantErr      bool
 		errorMessage string
 	}{
 		{
@@ -374,7 +374,7 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockHTTPErrors(t *testing.T) {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil, nil, tt.sszError).Times(1)
-			
+
 			if tt.expectJSON {
 				// When SSZ fails, it falls back to JSON
 				jsonRestHandler.EXPECT().Post(

--- a/validator/client/beacon-api/mock/json_rest_handler_mock.go
+++ b/validator/client/beacon-api/mock/json_rest_handler_mock.go
@@ -121,7 +121,7 @@ func (m *MockJsonRestHandler) PostSSZ(ctx context.Context, endpoint string, head
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(http.Header)
 	ret2, _ := ret[2].(error)
-	return ret0,ret1,ret2
+	return ret0, ret1, ret2
 }
 
 // Post indicates an expected call of Post.


### PR DESCRIPTION
In the event relay times out or return 502, we simply log the error instead of returning the error from grpc end point
I also ran go fmt and picked up some unrelated changes