### PR TITLE
Fix route authorization bypass vulnerability in HTTP handler

### DIFF
--- a/validator/rpc/intercepter.go
+++ b/validator/rpc/intercepter.go
@@ -38,7 +38,7 @@ func (s *Server) AuthTokenInterceptor() grpc.UnaryServerInterceptor {
 func (s *Server) AuthTokenHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// if it's not initialize or has a web prefix
-		if (strings.Contains(r.URL.Path, api.WebApiUrlPrefix) || strings.Contains(r.URL.Path, api.KeymanagerApiPrefix)) && !strings.Contains(r.URL.Path, api.SystemLogsPrefix) {
+		if (strings.HasPrefix(r.URL.Path, api.WebApiUrlPrefix) || strings.HasPrefix(r.URL.Path, api.KeymanagerApiPrefix)) && !strings.HasPrefix(r.URL.Path, "/"+api.SystemLogsPrefix) {
 			// ignore some routes
 			reqToken := r.Header.Get("Authorization")
 			if reqToken == "" {


### PR DESCRIPTION


###  **Summary**

Replaced substring-based path matching with prefix-based matching in `AuthTokenHandler` to prevent authorization bypass attacks.

### 🔍 **Problem**

The original code used `strings.Contains()` for route authorization:

```go
if (strings.Contains(r.URL.Path, api.WebApiUrlPrefix) || 
    strings.Contains(r.URL.Path, api.KeymanagerApiPrefix)) && 
   !strings.Contains(r.URL.Path, api.SystemLogsPrefix)
```

This approach is vulnerable to path traversal attacks where malicious URLs containing the protected prefixes as substrings could bypass authentication.

### **Solution**

Changed to `strings.HasPrefix()` for precise prefix matching:

```go
if (strings.HasPrefix(r.URL.Path, api.WebApiUrlPrefix) || 
    strings.HasPrefix(r.URL.Path, api.KeymanagerApiPrefix)) && 
   !strings.HasPrefix(r.URL.Path, "/"+api.SystemLogsPrefix)
```

