### PR TITLE
`--subscribe-all-subnets`: Define it as an alias and define `--subscribe-all-attestation-and-sync-subnets` as the main value.

### DIFF
--- a/changelog/manu-subscribe-all-attestations-and-sync-subnets.md
+++ b/changelog/manu-subscribe-all-attestations-and-sync-subnets.md
@@ -1,0 +1,2 @@
+### Added 
+- Rename `--subscribe-all-subnets` into `--subscribe-all-attestation-and-sync-subnets` and set `--subscribe-all-subnets` as an alias.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -229,10 +229,11 @@ var (
 		Name:  "disable-debug-rpc-endpoints",
 		Usage: "Disables the debug Beacon API namespace.",
 	}
-	// SubscribeToAllSubnets defines a flag to specify whether to subscribe to all possible attestation/sync subnets or not.
-	SubscribeToAllSubnets = &cli.BoolFlag{
-		Name:  "subscribe-all-subnets",
-		Usage: "Subscribe to all possible attestation and sync subnets.",
+	// SubscribeToAllAttAndSyncSubnets defines a flag to specify whether to subscribe to all possible attestation/sync subnets or not.
+	SubscribeToAllAttAndSyncSubnets = &cli.BoolFlag{
+		Name:    "subscribe-all-attestation-and-sync-subnets",
+		Aliases: []string{"subscribe-all-subnets"},
+		Usage:   "Subscribe to all possible attestation and sync subnets.",
 	}
 	// HistoricalSlasherNode is a set of beacon node flags required for performing historical detection with a slasher.
 	HistoricalSlasherNode = &cli.BoolFlag{

--- a/cmd/beacon-chain/flags/config.go
+++ b/cmd/beacon-chain/flags/config.go
@@ -41,7 +41,7 @@ func Init(c *GlobalFlags) {
 func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg := &GlobalFlags{}
 
-	if ctx.Bool(SubscribeToAllSubnets.Name) {
+	if ctx.Bool(SubscribeToAllAttAndSyncSubnets.Name) {
 		log.Warning("Subscribing to all attestation subnets")
 		cfg.SubscribeToAllSubnets = true
 	}

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -64,7 +64,7 @@ var appFlags = []cli.Flag{
 	flags.InteropMockEth1DataVotesFlag,
 	flags.SlotsPerArchivedPoint,
 	flags.DisableDebugRPCEndpoints,
-	flags.SubscribeToAllSubnets,
+	flags.SubscribeToAllAttAndSyncSubnets,
 	flags.SubscribeAllDataSubnets,
 	flags.HistoricalSlasherNode,
 	flags.ChainID,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -106,7 +106,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.MaxConcurrentDials,
 			flags.MinPeersPerSubnet,
 			flags.MinSyncPeers,
-			flags.SubscribeToAllSubnets,
+			flags.SubscribeToAllAttAndSyncSubnets,
 			flags.SubscribeAllDataSubnets,
 		},
 	},


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
This PR tries, ensuring the back compatibility, to solve the not so clear behavior of
`--subscribe-all-subnets` versus `--subscribe-all-attestation-and-sync-subnets`.

[A complaint](https://discord.com/channels/476244492043812875/476588476393848832/1426251556830838804).

**Which issues(s) does this PR fix?**
Partially fixes
- https://github.com/OffchainLabs/prysm/issues/15857

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
