### PR TITLE
Display non-JSON error messages

### DIFF
--- a/changelog/radek_read-non-json-error.md
+++ b/changelog/radek_read-non-json-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Display error messages from the server verbatim when they are not encoded as `application/json`.

--- a/validator/client/beacon-api/rest_handler_client.go
+++ b/validator/client/beacon-api/rest_handler_client.go
@@ -135,7 +135,7 @@ func (c *BeaconApiRestHandler) GetSSZ(ctx context.Context, endpoint string) ([]b
 		decoder := json.NewDecoder(bytes.NewBuffer(body))
 		errorJson := &httputil.DefaultJsonError{}
 		if err = decoder.Decode(errorJson); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL)
+			return nil, nil, fmt.Errorf("HTTP request for %s unsuccessful (%d: %s)", httpResp.Request.URL, httpResp.StatusCode, string(body))
 		}
 		return nil, nil, errorJson
 	}
@@ -241,7 +241,7 @@ func (c *BeaconApiRestHandler) PostSSZ(
 		decoder := json.NewDecoder(bytes.NewBuffer(body))
 		errorJson := &httputil.DefaultJsonError{}
 		if err = decoder.Decode(errorJson); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL)
+			return nil, nil, fmt.Errorf("HTTP request for %s unsuccessful (%d: %s)", httpResp.Request.URL, httpResp.StatusCode, string(body))
 		}
 		return nil, nil, errorJson
 	}

--- a/validator/client/beacon-api/rest_handler_client_test.go
+++ b/validator/client/beacon-api/rest_handler_client_test.go
@@ -344,4 +344,18 @@ func Test_decodeResp(t *testing.T) {
 		err = decodeResp(r, nil)
 		assert.ErrorContains(t, "failed to decode response body into error json", err)
 	})
+	t.Run("500 not JSON", func(t *testing.T) {
+		body := bytes.Buffer{}
+		_, err := body.WriteString("foo")
+		require.NoError(t, err)
+		r := &http.Response{
+			Status:     "500",
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(&body),
+			Header:     map[string][]string{"Content-Type": {"text/plain"}},
+			Request:    &http.Request{},
+		}
+		err = decodeResp(r, nil)
+		assert.ErrorContains(t, "HTTP request unsuccessful (500: foo)", err)
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`BeaconApiRestHandler` assumes that any server-side error will be encoded as `application/json`. If it's not, then we output `failed to decode response body into error json` and the original error message is lost.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
