### PR TITLE
fix: TestSubmitAggregateAndProof_AggregateOk to assert RPC result and not mutate pool

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/aggregator_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/aggregator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/crypto/bls"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
+	"github.com/OffchainLabs/prysm/v6/encoding/ssz/equality"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1/attestation"
 	attaggregation "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1/attestation/aggregation/attestations"
@@ -169,15 +170,15 @@ func TestSubmitAggregateAndProof_AggregateOk(t *testing.T) {
 
 	require.NoError(t, aggregatorServer.AttPool.SaveAggregatedAttestation(att0))
 	require.NoError(t, aggregatorServer.AttPool.SaveAggregatedAttestation(att1))
-	_, err = aggregatorServer.SubmitAggregateSelectionProof(ctx, req)
+	res, err := aggregatorServer.SubmitAggregateSelectionProof(ctx, req)
 	require.NoError(t, err)
 
-	aggregatedAtts := aggregatorServer.AttPool.AggregatedAttestations()
-	wanted, err := attaggregation.AggregatePair(att0, att1)
-	require.NoError(t, err)
-	if reflect.DeepEqual(aggregatedAtts, wanted) {
+	// Validate the server returned one of the pre-existing aggregated attestations (no pool mutation expected).
+	if !equality.DeepEqual(res.AggregateAndProof.Aggregate, att0) && !equality.DeepEqual(res.AggregateAndProof.Aggregate, att1) {
 		t.Error("Did not receive wanted attestation")
 	}
+	// Optionally confirm the pool was not mutated by the call.
+	assert.Equal(t, 2, len(aggregatorServer.AttPool.AggregatedAttestations()))
 }
 
 func TestSubmitAggregateAndProof_AggregateNotOk(t *testing.T) {

--- a/changelog/GarmashAlex_fix-validator-aggregator.md
+++ b/changelog/GarmashAlex_fix-validator-aggregator.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix TestSubmitAggregateAndProof_AggregateOk to assert RPC result and not mutate pool (#15861).


### PR DESCRIPTION
**What type of PR is this?**


> Bug fix


**What does this PR do? Why is it needed?**

The test incorrectly compared a slice of aggregated attestations from the pool with a single attestation produced by AggregatePair, which can never be equal (slice vs single struct) and did not validate the intended behavior. The server’s SubmitAggregateSelectionProof does not aggregate or mutate the pool; it selects and returns an existing “best” attestation.

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.
