### PR TITLE
Fix epoch transition on head event

### DIFF
--- a/changelog/potuz_fix_head_event.md
+++ b/changelog/potuz_fix_head_event.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Mark epoch transition correctly on new head events


### PR DESCRIPTION
h/t to the NuConstruct team for reporting this. The event feed incorrectly sends epoch transition flag on head events when the first slot of the epoch is missing (or reorgs across epoch transition).

