### PR TITLE
`WithDataColumnRetentionEpochs`: Use `dataColumnRetentionEpoch` instead of `blobColumnRetentionEpoch`.

### DIFF
--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -1032,5 +1032,5 @@ func extractFileMetadata(path string) (*fileMetadata, error) {
 
 // period computes the period of a given epoch.
 func period(epoch primitives.Epoch) uint64 {
-	return uint64(epoch / params.BeaconConfig().MinEpochsForBlobsSidecarsRequest)
+	return uint64(epoch / params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest)
 }

--- a/beacon-chain/db/filesystem/mock.go
+++ b/beacon-chain/db/filesystem/mock.go
@@ -126,7 +126,7 @@ func NewWarmedEphemeralDataColumnStorageUsingFs(t testing.TB, fs afero.Fs, opts 
 
 func NewEphemeralDataColumnStorageUsingFs(t testing.TB, fs afero.Fs, opts ...DataColumnStorageOption) *DataColumnStorage {
 	opts = append(opts,
-		WithDataColumnRetentionEpochs(params.BeaconConfig().MinEpochsForBlobsSidecarsRequest),
+		WithDataColumnRetentionEpochs(params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest),
 		WithDataColumnFs(fs),
 	)
 

--- a/changelog/manu-data-column-retention-period.md
+++ b/changelog/manu-data-column-retention-period.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `WithDataColumnRetentionEpochs`: Use `dataColumnRetentionEpoch` instead of `blobColumnRetentionEpoch`.

--- a/cmd/beacon-chain/storage/options_test.go
+++ b/cmd/beacon-chain/storage/options_test.go
@@ -61,6 +61,45 @@ func TestConfigureBlobRetentionEpoch(t *testing.T) {
 	_, err = blobRetentionEpoch(cliCtx)
 	require.ErrorIs(t, err, errInvalidBlobRetentionEpochs)
 }
+
+func TestConfigureDataColumnRetentionEpoch(t *testing.T) {
+	specValue := params.BeaconConfig().MinEpochsForDataColumnSidecarsRequest
+
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	cliCtx := cli.NewContext(&app, set, nil)
+
+	// Test case: Specification value
+	expected := specValue
+
+	actual, err := dataColumnRetentionEpoch(cliCtx)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+
+	// Manually define the flag in the set, so the following code can use set.Set
+	set.Uint64(BlobRetentionEpochFlag.Name, 0, "")
+
+	// Test case: Input epoch is greater than or equal to specification value.
+	expected = specValue + 1
+
+	err = set.Set(BlobRetentionEpochFlag.Name, fmt.Sprintf("%d", expected))
+	require.NoError(t, err)
+
+	actual, err = dataColumnRetentionEpoch(cliCtx)
+	require.NoError(t, err)
+	require.Equal(t, primitives.Epoch(expected), actual)
+
+	// Test case: Input epoch is less than specification value.
+	expected = specValue - 1
+
+	err = set.Set(BlobRetentionEpochFlag.Name, fmt.Sprintf("%d", expected))
+	require.NoError(t, err)
+
+	actual, err = dataColumnRetentionEpoch(cliCtx)
+	require.ErrorIs(t, err, errInvalidBlobRetentionEpochs)
+	require.Equal(t, specValue, actual)
+}
+
 func TestDataColumnStoragePath_FlagSpecified(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this PR, the retention period of data column sidecars was based on the `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` instead of `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`.

This PR fixes that.

**Note:**
On purpose, we **don't** define a new `--data-column-retention-epochs` and still use the already existing `--blob-retention-epochs` .

Why? Adding a new `--data-column-retention-epochs` would require users already using `--blob-retention-epochs` with a value higher than the default to also add `--data-column-retention-epochs` with their own value. If they fail to do so, their nodes will prune blobs data (or more precisely, data columns data) 4096 epoch (~18 days) after the Fusaka fork epoch.

**Was Prysm broken before this PR?**
No, because `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS == MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS == 4096 epoch`.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
