### PR TITLE
`randomPeer`: Return if the context is cancelled when waiting for peers.

### DIFF
--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -1129,7 +1129,12 @@ func randomPeer(
 				"peerCount": peerCount,
 				"delay":     waitPeriod,
 			}).Debug("Waiting for a peer with enough bandwidth for data column sidecars")
-			time.Sleep(waitPeriod)
+
+			select {
+			case <-time.After(waitPeriod):
+			case <-ctx.Done():
+			}
+
 			continue
 		}
 

--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -1122,24 +1122,21 @@ func randomPeer(
 			}
 		}
 
-		slices.Sort(nonRateLimitedPeers)
-
-		if len(nonRateLimitedPeers) == 0 {
-			log.WithFields(logrus.Fields{
-				"peerCount": peerCount,
-				"delay":     waitPeriod,
-			}).Debug("Waiting for a peer with enough bandwidth for data column sidecars")
-
-			select {
-			case <-time.After(waitPeriod):
-			case <-ctx.Done():
-			}
-
-			continue
+		if len(nonRateLimitedPeers) > 0 {
+			slices.Sort(nonRateLimitedPeers)
+			randomIndex := randomSource.Intn(len(nonRateLimitedPeers))
+			return nonRateLimitedPeers[randomIndex], nil
 		}
 
-		randomIndex := randomSource.Intn(len(nonRateLimitedPeers))
-		return nonRateLimitedPeers[randomIndex], nil
+		log.WithFields(logrus.Fields{
+			"peerCount": peerCount,
+			"delay":     waitPeriod,
+		}).Debug("Waiting for a peer with enough bandwidth for data column sidecars")
+
+		select {
+		case <-time.After(waitPeriod):
+		case <-ctx.Done():
+		}
 	}
 
 	return "", ctx.Err()

--- a/changelog/manu-random-peer.md
+++ b/changelog/manu-random-peer.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `randomPeer`: Return if the context is cancelled when waiting for peers.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
`randomPeer`: Return if the context is cancelled when waiting for peers.

**Other notes for review**
Please read commit by commit

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
