### PR TITLE
Correctly advertise (in ENR and Metadata) attestation subnets when using `--subscribe-all-subnets`.

### DIFF
--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -716,10 +716,6 @@ func (s *Service) samplingSize() (uint64, error) {
 }
 
 func (s *Service) persistentAndAggregatorSubnetIndices(currentSlot primitives.Slot) map[uint64]bool {
-	if flags.Get().SubscribeToAllSubnets {
-		return mapFromCount(params.BeaconConfig().AttestationSubnetCount)
-	}
-
 	persistentSubnetIndices := persistentSubnetIndices()
 	aggregatorSubnetIndices := aggregatorSubnetIndices(currentSlot)
 

--- a/changelog/manu-advertise-atts.md
+++ b/changelog/manu-advertise-atts.md
@@ -1,0 +1,2 @@
+### Fixed 
+- Correctly advertise (in ENR and beacon API) attestation subnets when using `--subscribe-all-subnets`.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this PR, using the `--subscribe-all-subnets` flags does effectively subscribe to all (attestations and sync committee) subnets, but does **not** advertise these subscriptions on ENR and Metadata.

This PR fixes this.

**Note:** The same issue exists for sync committees subnets. But the present PR does not fix it.
(Right before merging this PR, I'll create a specific Github issue for sync committee subnets.)

**Which issues(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/15826

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
