### PR TITLE
Improve error message when the byte count read from disk when reading a data column sidecar is lower than expected. (Mostly, because the file is truncated.)

### DIFF
--- a/beacon-chain/verification/error.go
+++ b/beacon-chain/verification/error.go
@@ -71,9 +71,15 @@ var (
 	errBatchBlockRootMismatch = errors.Join(ErrBlobInvalid, errors.New("sidecar block header root does not match signed block"))
 )
 
-// errVerificationImplementationFault indicates that a code path yielding VerifiedROBlobs has an implementation
-// error, leading it to call VerifiedROBlobError with a nil error.
-var errVerificationImplementationFault = errors.New("could not verify blob data or create a valid VerifiedROBlob")
+var (
+	// errBlobVerificationImplementationFault indicates that a code path yielding VerifiedROBlobs has an implementation
+	// error, leading it to call VerifiedROBlobError with a nil error.
+	errBlobVerificationImplementationFault = errors.New("could not verify blob data or create a valid VerifiedROBlob")
+
+	// errDataColumnVerificationImplementationFault indicates that a code path yielding VerifiedRODataColumns has an implementation
+	// error, leading it to call VerifiedRODataColumnError with a nil error.
+	errDataColumnVerificationImplementationFault = errors.New("could not verify blob data or create a valid VerifiedROBlob")
+)
 
 // VerificationMultiError is a custom error that can be used to access individual verification failures.
 type VerificationMultiError struct {
@@ -111,7 +117,7 @@ func newVerificationMultiError(r *results, err error) VerificationMultiError {
 // create a value of that type in order to generate an error return value.
 func VerifiedROBlobError(err error) (blocks.VerifiedROBlob, error) {
 	if err == nil {
-		return blocks.VerifiedROBlob{}, errVerificationImplementationFault
+		return blocks.VerifiedROBlob{}, errBlobVerificationImplementationFault
 	}
 	return blocks.VerifiedROBlob{}, err
 }
@@ -120,7 +126,7 @@ func VerifiedROBlobError(err error) (blocks.VerifiedROBlob, error) {
 // create a value of that type in order to generate an error return value.
 func VerifiedRODataColumnError(err error) (blocks.VerifiedRODataColumn, error) {
 	if err == nil {
-		return blocks.VerifiedRODataColumn{}, errVerificationImplementationFault
+		return blocks.VerifiedRODataColumn{}, errDataColumnVerificationImplementationFault
 	}
 	return blocks.VerifiedRODataColumn{}, err
 }

--- a/beacon-chain/verification/filesystem.go
+++ b/beacon-chain/verification/filesystem.go
@@ -4,6 +4,7 @@ import (
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/pkg/errors"
 
 	"github.com/spf13/afero"
 )
@@ -25,7 +26,8 @@ func VerifiedROBlobFromDisk(fs afero.Fs, root [32]byte, path string) (blocks.Ver
 	return blocks.NewVerifiedROBlob(ro), nil
 }
 
-// VerifiedRODataColumnFromDisk created a verified read-only data column sidecar from disk.
+// VerifiedRODataColumnFromDisk creates a verified read-only data column sidecar from disk.
+// The file cursor must be positioned at the start of the data column sidecar SSZ data.
 func VerifiedRODataColumnFromDisk(file afero.File, root [fieldparams.RootLength]byte, sszEncodedDataColumnSidecarSize uint32) (blocks.VerifiedRODataColumn, error) {
 	// Read the ssz encoded data column sidecar from the file
 	sszEncodedDataColumnSidecar := make([]byte, sszEncodedDataColumnSidecarSize)
@@ -34,7 +36,7 @@ func VerifiedRODataColumnFromDisk(file afero.File, root [fieldparams.RootLength]
 		return VerifiedRODataColumnError(err)
 	}
 	if uint32(count) != sszEncodedDataColumnSidecarSize {
-		return VerifiedRODataColumnError(err)
+		return VerifiedRODataColumnError(errors.Errorf("read %d bytes while expecting %d", count, sszEncodedDataColumnSidecarSize))
 	}
 
 	// Unmarshal the SSZ encoded data column sidecar.

--- a/changelog/manu-read-columns-from-disk-error.md
+++ b/changelog/manu-read-columns-from-disk-error.md
@@ -1,0 +1,2 @@
+### Fixed 
+- Improve error message when the byte count read from disk when reading a data column sidecars is lower than expected. (Mostly, because the file is truncated.)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Improve error message when the byte count read from disk when reading a data column sidecar is lower than expected. (Mostly, because the file is truncated.)

**Other notes for review**
Please read commit by commit.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
