### PR TITLE
Start processing all attestation gossip validation batches within 5ms

### DIFF
--- a/beacon-chain/sync/batch_verifier.go
+++ b/beacon-chain/sync/batch_verifier.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const signatureVerificationInterval = 50 * time.Millisecond
+const signatureVerificationInterval = 5 * time.Millisecond
 
 type signatureVerifier struct {
 	set     *bls.SignatureBatch

--- a/changelog/kasey_att-batch-5ms-deadline.md
+++ b/changelog/kasey_att-batch-5ms-deadline.md
@@ -1,0 +1,2 @@
+### Fixed
+- Decreased attestation gossip validation batch deadline to 5ms.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR decreases the amount of time that a gossipsub validation callback waits for a batch signature verification from 50ms to 5ms. This change is the result of some great work by the EF p2p team which showed that our validation batching mechanism was adding unwanted latency to attestation processing at the network level. Thank you @bharath-123 and @raulk !

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
