### PR TITLE
clear genesis state file when --(force-)clear-db is specified

### DIFF
--- a/beacon-chain/node/clear_db.go
+++ b/beacon-chain/node/clear_db.go
@@ -2,11 +2,13 @@ package node
 
 import (
 	"context"
+	"os"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db/filesystem"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db/kv"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/db/slasherkv"
 	"github.com/OffchainLabs/prysm/v6/cmd"
+	"github.com/OffchainLabs/prysm/v6/genesis"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
@@ -34,6 +36,22 @@ func (c *dbClearer) clearKV(ctx context.Context, db *kv.Store) (*kv.Store, error
 		return nil, errors.Wrap(err, "could not clear database")
 	}
 	return kv.NewKVStore(ctx, db.DatabasePath())
+}
+
+func (c *dbClearer) clearGenesis(dir string) error {
+	if !c.shouldProceed() {
+		return nil
+	}
+
+	gfile, err := genesis.FindStateFile(dir)
+	if err != nil {
+		return nil
+	}
+
+	if err := os.Remove(gfile.FilePath()); err != nil {
+		return errors.Wrapf(err, "genesis state file not removed: %s", gfile.FilePath())
+	}
+	return nil
 }
 
 func (c *dbClearer) clearBlobs(bs *filesystem.BlobStorage) error {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -177,6 +177,9 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, opts ...Option) (*Beaco
 	}
 	beacon.db = kvdb
 
+	if err := dbClearer.clearGenesis(dataDir); err != nil {
+		return nil, errors.Wrap(err, "could not clear genesis state")
+	}
 	providers := append(beacon.GenesisProviders, kv.NewLegacyGenesisProvider(kvdb))
 	if err := genesis.Initialize(ctx, dataDir, providers...); err != nil {
 		return nil, errors.Wrap(err, "could not initialize genesis state")

--- a/changelog/kasey_clear-db-rm-genesis.md
+++ b/changelog/kasey_clear-db-rm-genesis.md
@@ -1,0 +1,2 @@
+### Fixed
+- Delete the genesis state file when --clear-db / --force-clear-db is specified.

--- a/genesis/initialize.go
+++ b/genesis/initialize.go
@@ -23,7 +23,7 @@ func Initialize(ctx context.Context, dir string, providers ...Provider) error {
 		setPkgVar(emb, true)
 		return nil
 	}
-	gd, err := findGenesisFile(dir)
+	gd, err := FindStateFile(dir)
 	if err == nil {
 		setPkgVar(gd, true)
 		return nil
@@ -65,7 +65,8 @@ func newGenesisData(st state.BeaconState, dir string) (GenesisData, error) {
 	}, nil
 }
 
-func findGenesisFile(dir string) (GenesisData, error) {
+// FindStateFile searches for a valid genesis state file in the specified directory.
+func FindStateFile(dir string) (GenesisData, error) {
 	if dir == "" {
 		return GenesisData{}, ErrFilePathUnset
 	}

--- a/genesis/storage.go
+++ b/genesis/storage.go
@@ -100,7 +100,8 @@ type GenesisData struct {
 	initialized    bool
 }
 
-func (d GenesisData) filePath() string {
+// FilePath returns the full path to the genesis state file.
+func (d GenesisData) FilePath() string {
 	parts := [3]string{}
 	parts[genesisPart] = "genesis"
 	parts[timePart] = strconv.FormatInt(d.Time.Unix(), 10)
@@ -115,7 +116,7 @@ func persist(d GenesisData) error {
 	if d.FileDir == "" {
 		return ErrFilePathUnset
 	}
-	fpath := d.filePath()
+	fpath := d.FilePath()
 	sb, err := d.State.MarshalSSZ()
 	if err != nil {
 		return errors.Wrap(err, "marshal ssz")
@@ -144,7 +145,7 @@ func loadState() (state.BeaconState, error) {
 	stateMu.Lock()
 	defer stateMu.Unlock()
 
-	s, err := stateFromFile(data.filePath())
+	s, err := stateFromFile(data.FilePath())
 	if err != nil {
 		return nil, errors.Wrapf(err, "InitializeFromProtoUnsafePhase0")
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Ethpandaops reuses data dirs with the `--force-clear-db` flag as they switch beacon nodes across different networks. This flag does not clean up the genesis state file, so when switching networks they wind up with a mismatched genesis state. This PR deletes the genesis file when `--clear-db` or `--force-clear-db` is specified.

**Which issues(s) does this PR fix?**

Fixes:
- #15874
- https://github.com/OffchainLabs/prysm/issues/15878

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
