### PR TITLE
Allow custom headers in validator client HTTP requests

### DIFF
--- a/api/client/BUILD.bazel
+++ b/api/client/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "client.go",
         "errors.go",
         "options.go",
+        "transport.go",
     ],
     importpath = "github.com/OffchainLabs/prysm/v6/api/client",
     visibility = ["//visibility:public"],
@@ -14,7 +15,13 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["client_test.go"],
+    srcs = [
+        "client_test.go",
+        "transport_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["//testing/require:go_default_library"],
+    deps = [
+        "//testing/assert:go_default_library",
+        "//testing/require:go_default_library",
+    ],
 )

--- a/api/client/transport.go
+++ b/api/client/transport.go
@@ -1,0 +1,25 @@
+package client
+
+import "net/http"
+
+// CustomHeadersTransport adds custom headers to each request
+type CustomHeadersTransport struct {
+	base    http.RoundTripper
+	headers map[string][]string
+}
+
+func NewCustomHeadersTransport(base http.RoundTripper, headers map[string][]string) *CustomHeadersTransport {
+	return &CustomHeadersTransport{
+		base:    base,
+		headers: headers,
+	}
+}
+
+func (t *CustomHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for header, values := range t.headers {
+		for _, value := range values {
+			req.Header.Add(header, value)
+		}
+	}
+	return t.base.RoundTrip(req)
+}

--- a/api/client/transport_test.go
+++ b/api/client/transport_test.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v6/testing/assert"
+	"github.com/OffchainLabs/prysm/v6/testing/require"
+)
+
+type noopTransport struct{}
+
+func (*noopTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestRoundTrip(t *testing.T) {
+	tr := &CustomHeadersTransport{base: &noopTransport{}, headers: map[string][]string{"key1": []string{"value1", "value2"}, "key2": []string{"value3"}}}
+	req := httptest.NewRequest("GET", "http://foo", nil)
+	_, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	assert.DeepEqual(t, []string{"value1", "value2"}, req.Header.Values("key1"))
+	assert.DeepEqual(t, []string{"value3"}, req.Header.Values("key2"))
+}

--- a/changelog/radek_rest-custom-headers.md
+++ b/changelog/radek_rest-custom-headers.md
@@ -1,0 +1,3 @@
+### Added
+
+- Allow custom headers in validator client HTTP requests.

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -45,6 +45,12 @@ var (
 		Usage: "Beacon node REST API provider endpoint.",
 		Value: "http://127.0.0.1:3500",
 	}
+	// BeaconRESTApiHeaders defines a list of headers to send with all HTTP requests to the beacon node.
+	BeaconRESTApiHeaders = &cli.StringFlag{
+		Name: "beacon-rest-api-headers",
+		Usage: `Comma-separated list of key value pairs to pass as headers for all HTTP calls to the beacon node.
+		Example: --grpc-headers=key1=value1, key2=value2`,
+	}
 	// CertFlag defines a flag for the node's TLS certificate.
 	CertFlag = &cli.StringFlag{
 		Name:  "tls-cert",

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -48,8 +48,9 @@ var (
 	// BeaconRESTApiHeaders defines a list of headers to send with all HTTP requests to the beacon node.
 	BeaconRESTApiHeaders = &cli.StringFlag{
 		Name: "beacon-rest-api-headers",
-		Usage: `Comma-separated list of key value pairs to pass as headers for all HTTP calls to the beacon node.
-		Example: --grpc-headers=key1=value1, key2=value2`,
+		Usage: `Comma-separated list of key value pairs to pass as headers for all HTTP calls to the beacon node. 
+		To provide multiple values for the same key, specify the same key for each value. 
+		Example: --grpc-headers=key1=value1,key1=value2,key2=value3`,
 	}
 	// CertFlag defines a flag for the node's TLS certificate.
 	CertFlag = &cli.StringFlag{

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -51,6 +51,7 @@ func startNode(ctx *cli.Context) error {
 var appFlags = []cli.Flag{
 	flags.BeaconRPCProviderFlag,
 	flags.BeaconRESTApiProviderFlag,
+	flags.BeaconRESTApiHeaders,
 	flags.CertFlag,
 	flags.GraffitiFlag,
 	flags.DisablePenaltyRewardLogFlag,

--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -93,6 +93,7 @@ var appHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			flags.CertFlag,
 			flags.BeaconRPCProviderFlag,
+			flags.BeaconRESTApiHeaders,
 			flags.EnableRPCFlag,
 			flags.RPCHost,
 			flags.RPCPort,

--- a/validator/accounts/cli_manager.go
+++ b/validator/accounts/cli_manager.go
@@ -84,6 +84,7 @@ func (acm *CLIManager) prepareBeaconClients(ctx context.Context) (*iface.Validat
 	conn := validatorHelpers.NewNodeConnection(
 		grpcConn,
 		acm.beaconApiEndpoint,
+		nil,
 		acm.beaconApiTimeout,
 	)
 

--- a/validator/accounts/cli_manager.go
+++ b/validator/accounts/cli_manager.go
@@ -84,8 +84,7 @@ func (acm *CLIManager) prepareBeaconClients(ctx context.Context) (*iface.Validat
 	conn := validatorHelpers.NewNodeConnection(
 		grpcConn,
 		acm.beaconApiEndpoint,
-		nil,
-		acm.beaconApiTimeout,
+		validatorHelpers.WithBeaconApiTimeout(acm.beaconApiTimeout),
 	)
 
 	restHandler := beaconApi.NewBeaconApiRestHandler(

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -144,8 +144,8 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 	s.conn = validatorHelpers.NewNodeConnection(
 		grpcConn,
 		cfg.BeaconApiEndpoint,
-		cfg.BeaconApiHeaders,
-		cfg.BeaconApiTimeout,
+		validatorHelpers.WithBeaconApiHeaders(cfg.BeaconApiHeaders),
+		validatorHelpers.WithBeaconApiTimeout(cfg.BeaconApiTimeout),
 	)
 
 	return s, nil

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	api "github.com/OffchainLabs/prysm/v6/api/client"
 	eventClient "github.com/OffchainLabs/prysm/v6/api/client/event"
 	grpcutil "github.com/OffchainLabs/prysm/v6/api/grpc"
 	"github.com/OffchainLabs/prysm/v6/async/event"
@@ -79,6 +80,7 @@ type Config struct {
 	BeaconNodeGRPCEndpoint  string
 	BeaconNodeCert          string
 	BeaconApiEndpoint       string
+	BeaconApiHeaders        map[string][]string
 	BeaconApiTimeout        time.Duration
 	Graffiti                string
 	GraffitiStruct          *graffiti.Graffiti
@@ -142,6 +144,7 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 	s.conn = validatorHelpers.NewNodeConnection(
 		grpcConn,
 		cfg.BeaconApiEndpoint,
+		cfg.BeaconApiHeaders,
 		cfg.BeaconApiTimeout,
 	)
 
@@ -185,8 +188,9 @@ func (v *ValidatorService) Start() {
 		return
 	}
 
+	headersTransport := api.NewCustomHeadersTransport(http.DefaultTransport, v.conn.GetBeaconApiHeaders())
 	restHandler := beaconApi.NewBeaconApiRestHandler(
-		http.Client{Timeout: v.conn.GetBeaconApiTimeout(), Transport: otelhttp.NewTransport(http.DefaultTransport)},
+		http.Client{Timeout: v.conn.GetBeaconApiTimeout(), Transport: otelhttp.NewTransport(headersTransport)},
 		hosts[0],
 	)
 

--- a/validator/helpers/node_connection.go
+++ b/validator/helpers/node_connection.go
@@ -24,6 +24,7 @@ type nodeConnection struct {
 	beaconApiTimeout time.Duration
 }
 
+// NodeConnectionOption is a functional option for configuring the node connection.
 type NodeConnectionOption func(nc NodeConnection)
 
 // WithBeaconApiHeaders sets the HTTP headers that should be sent to the server along with each request.

--- a/validator/helpers/node_connection.go
+++ b/validator/helpers/node_connection.go
@@ -11,7 +11,9 @@ type NodeConnection interface {
 	GetGrpcClientConn() *grpc.ClientConn
 	GetBeaconApiUrl() string
 	GetBeaconApiHeaders() map[string][]string
+	setBeaconApiHeaders(map[string][]string)
 	GetBeaconApiTimeout() time.Duration
+	setBeaconApiTimeout(time.Duration)
 	dummy()
 }
 
@@ -20,6 +22,22 @@ type nodeConnection struct {
 	beaconApiUrl     string
 	beaconApiHeaders map[string][]string
 	beaconApiTimeout time.Duration
+}
+
+type NodeConnectionOption func(nc NodeConnection)
+
+// WithBeaconApiHeaders sets the HTTP headers that should be sent to the server along with each request.
+func WithBeaconApiHeaders(headers map[string][]string) NodeConnectionOption {
+	return func(nc NodeConnection) {
+		nc.setBeaconApiHeaders(headers)
+	}
+}
+
+// WithBeaconApiTimeout sets the HTTP request timeout.
+func WithBeaconApiTimeout(timeout time.Duration) NodeConnectionOption {
+	return func(nc NodeConnection) {
+		nc.setBeaconApiTimeout(timeout)
+	}
 }
 
 func (c *nodeConnection) GetGrpcClientConn() *grpc.ClientConn {
@@ -34,17 +52,26 @@ func (c *nodeConnection) GetBeaconApiHeaders() map[string][]string {
 	return c.beaconApiHeaders
 }
 
+func (c *nodeConnection) setBeaconApiHeaders(headers map[string][]string) {
+	c.beaconApiHeaders = headers
+}
+
 func (c *nodeConnection) GetBeaconApiTimeout() time.Duration {
 	return c.beaconApiTimeout
 }
 
+func (c *nodeConnection) setBeaconApiTimeout(timeout time.Duration) {
+	c.beaconApiTimeout = timeout
+}
+
 func (*nodeConnection) dummy() {}
 
-func NewNodeConnection(grpcConn *grpc.ClientConn, beaconApiUrl string, beaconApiHeaders map[string][]string, beaconApiTimeout time.Duration) NodeConnection {
+func NewNodeConnection(grpcConn *grpc.ClientConn, beaconApiUrl string, opts ...NodeConnectionOption) NodeConnection {
 	conn := &nodeConnection{}
 	conn.grpcClientConn = grpcConn
 	conn.beaconApiUrl = beaconApiUrl
-	conn.beaconApiHeaders = beaconApiHeaders
-	conn.beaconApiTimeout = beaconApiTimeout
+	for _, opt := range opts {
+		opt(conn)
+	}
 	return conn
 }

--- a/validator/helpers/node_connection.go
+++ b/validator/helpers/node_connection.go
@@ -10,6 +10,7 @@ import (
 type NodeConnection interface {
 	GetGrpcClientConn() *grpc.ClientConn
 	GetBeaconApiUrl() string
+	GetBeaconApiHeaders() map[string][]string
 	GetBeaconApiTimeout() time.Duration
 	dummy()
 }
@@ -17,6 +18,7 @@ type NodeConnection interface {
 type nodeConnection struct {
 	grpcClientConn   *grpc.ClientConn
 	beaconApiUrl     string
+	beaconApiHeaders map[string][]string
 	beaconApiTimeout time.Duration
 }
 
@@ -28,16 +30,21 @@ func (c *nodeConnection) GetBeaconApiUrl() string {
 	return c.beaconApiUrl
 }
 
+func (c *nodeConnection) GetBeaconApiHeaders() map[string][]string {
+	return c.beaconApiHeaders
+}
+
 func (c *nodeConnection) GetBeaconApiTimeout() time.Duration {
 	return c.beaconApiTimeout
 }
 
 func (*nodeConnection) dummy() {}
 
-func NewNodeConnection(grpcConn *grpc.ClientConn, beaconApiUrl string, beaconApiTimeout time.Duration) NodeConnection {
+func NewNodeConnection(grpcConn *grpc.ClientConn, beaconApiUrl string, beaconApiHeaders map[string][]string, beaconApiTimeout time.Duration) NodeConnection {
 	conn := &nodeConnection{}
 	conn.grpcClientConn = grpcConn
 	conn.beaconApiUrl = beaconApiUrl
+	conn.beaconApiHeaders = beaconApiHeaders
 	conn.beaconApiTimeout = beaconApiTimeout
 	return conn
 }

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -433,6 +433,7 @@ func (c *ValidatorClient) registerValidatorService(cliCtx *cli.Context) error {
 		BeaconNodeGRPCEndpoint:  cliCtx.String(flags.BeaconRPCProviderFlag.Name),
 		BeaconNodeCert:          cliCtx.String(flags.CertFlag.Name),
 		BeaconApiEndpoint:       cliCtx.String(flags.BeaconRESTApiProviderFlag.Name),
+		BeaconApiHeaders:        parseBeaconApiHeaders(cliCtx.String(flags.BeaconRESTApiHeaders.Name)),
 		BeaconApiTimeout:        time.Second * 30,
 		Graffiti:                g.ParseHexGraffiti(cliCtx.String(flags.GraffitiFlag.Name)),
 		GraffitiStruct:          graffitiStruct,
@@ -552,6 +553,7 @@ func (c *ValidatorClient) registerRPCService(cliCtx *cli.Context) error {
 		GRPCHeaders:            strings.Split(cliCtx.String(flags.GRPCHeadersFlag.Name), ","),
 		BeaconNodeGRPCEndpoint: cliCtx.String(flags.BeaconRPCProviderFlag.Name),
 		BeaconApiEndpoint:      cliCtx.String(flags.BeaconRESTApiProviderFlag.Name),
+		BeaconAPIHeaders:       parseBeaconApiHeaders(cliCtx.String(flags.BeaconRESTApiHeaders.Name)),
 		BeaconApiTimeout:       time.Second * 30,
 		BeaconNodeCert:         cliCtx.String(flags.CertFlag.Name),
 		DB:                     c.db,
@@ -635,4 +637,20 @@ func clearDB(ctx context.Context, dataDir string, force bool, isDatabaseMinimal 
 	}
 
 	return nil
+}
+
+func parseBeaconApiHeaders(rawHeaders string) map[string][]string {
+	result := make(map[string][]string)
+	pairs := strings.Split(rawHeaders, ",")
+	for _, pair := range pairs {
+		key, value, found := strings.Cut(pair, "=")
+		if !found {
+			// Skip malformed pairs
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		result[key] = append(result[key], value)
+	}
+	return result
 }

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -650,6 +650,10 @@ func parseBeaconApiHeaders(rawHeaders string) map[string][]string {
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			// Skip malformed pairs
+			continue
+		}
 		result[key] = append(result[key], value)
 	}
 	return result

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -308,3 +308,17 @@ func TestWeb3SignerConfig(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseBeaconApiHeaders(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		h := parseBeaconApiHeaders("key1=value1,key1=value2,key2=value3")
+		assert.Equal(t, 2, len(h))
+		assert.DeepEqual(t, []string{"value1", "value2"}, h["key1"])
+		assert.DeepEqual(t, []string{"value3"}, h["key2"])
+	})
+	t.Run("ignores malformed", func(t *testing.T) {
+		h := parseBeaconApiHeaders("key1=value1,key2value2,key3=,=key4")
+		assert.Equal(t, 1, len(h))
+		assert.DeepEqual(t, []string{"value1"}, h["key1"])
+	})
+}

--- a/validator/rpc/BUILD.bazel
+++ b/validator/rpc/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     ],
     deps = [
         "//api:go_default_library",
+        "//api/client:go_default_library",
         "//api/grpc:go_default_library",
         "//api/pagination:go_default_library",
         "//api/server:go_default_library",

--- a/validator/rpc/beacon.go
+++ b/validator/rpc/beacon.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"net/http"
 
+	api "github.com/OffchainLabs/prysm/v6/api/client"
 	grpcutil "github.com/OffchainLabs/prysm/v6/api/grpc"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v6/validator/client"
@@ -52,11 +53,13 @@ func (s *Server) registerBeaconClient() error {
 	conn := validatorHelpers.NewNodeConnection(
 		grpcConn,
 		s.beaconApiEndpoint,
+		s.beaconApiHeaders,
 		s.beaconApiTimeout,
 	)
 
+	headersTransport := api.NewCustomHeadersTransport(http.DefaultTransport, conn.GetBeaconApiHeaders())
 	restHandler := beaconApi.NewBeaconApiRestHandler(
-		http.Client{Timeout: s.beaconApiTimeout, Transport: otelhttp.NewTransport(http.DefaultTransport)},
+		http.Client{Timeout: s.beaconApiTimeout, Transport: otelhttp.NewTransport(headersTransport)},
 		s.beaconApiEndpoint,
 	)
 

--- a/validator/rpc/beacon.go
+++ b/validator/rpc/beacon.go
@@ -53,8 +53,8 @@ func (s *Server) registerBeaconClient() error {
 	conn := validatorHelpers.NewNodeConnection(
 		grpcConn,
 		s.beaconApiEndpoint,
-		s.beaconApiHeaders,
-		s.beaconApiTimeout,
+		validatorHelpers.WithBeaconApiHeaders(s.beaconApiHeaders),
+		validatorHelpers.WithBeaconApiTimeout(s.beaconApiTimeout),
 	)
 
 	headersTransport := api.NewCustomHeadersTransport(http.DefaultTransport, conn.GetBeaconApiHeaders())

--- a/validator/rpc/server.go
+++ b/validator/rpc/server.go
@@ -34,6 +34,7 @@ type Config struct {
 	GRPCHeaders            []string
 	BeaconNodeGRPCEndpoint string
 	BeaconApiEndpoint      string
+	BeaconAPIHeaders       map[string][]string
 	BeaconApiTimeout       time.Duration
 	BeaconNodeCert         string
 	DB                     db.Database
@@ -64,6 +65,7 @@ type Server struct {
 	authTokenPath             string
 	beaconNodeCert            string
 	beaconApiEndpoint         string
+	beaconApiHeaders          map[string][]string
 	beaconNodeEndpoint        string
 	healthClient              ethpb.HealthClient
 	nodeClient                iface.NodeClient
@@ -103,6 +105,7 @@ func NewServer(ctx context.Context, cfg *Config) *Server {
 		wallet:                 cfg.Wallet,
 		beaconApiTimeout:       cfg.BeaconApiTimeout,
 		beaconApiEndpoint:      cfg.BeaconApiEndpoint,
+		beaconApiHeaders:       cfg.BeaconAPIHeaders,
 		beaconNodeEndpoint:     cfg.BeaconNodeGRPCEndpoint,
 		router:                 cfg.Router,
 	}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds a new `--beacon-rest-api-headers` flag that allows to specify custom HTTP headers that will be sent to the beacon node with each validator client request. This feature is supported in grpc through the `--grpc-headers` flag.

**Which issues(s) does this PR fix?**

Fixes #14528

**Other notes for review**

Tested in Kurtosis

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
