### PR TITLE
refactor: remove redundant IsInSlots wrapper in favor of slices.Contains

### DIFF
--- a/container/slice/slice.go
+++ b/container/slice/slice.go
@@ -347,10 +347,6 @@ func NotSlot(a, b []primitives.Slot) []primitives.Slot {
 	return set
 }
 
-// IsInSlots returns true if a is in b and False otherwise.
-func IsInSlots(a primitives.Slot, b []primitives.Slot) bool {
-	return slices.Contains(b, a)
-}
 
 // Unique returns an array with duplicates filtered based on the type given
 func Unique[T comparable](a []T) []T {

--- a/container/slice/slice_test.go
+++ b/container/slice/slice_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"slices"
 
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/container/slice"
@@ -281,13 +282,14 @@ func TestIsInUint64(t *testing.T) {
 		{4, []uint64{2, 3, 5, 4, 6}, true},
 		{100, []uint64{2, 3, 5, 4, 6}, false},
 	}
-	for _, tt := range testCases {
-		result := slice.IsInUint64(tt.a, tt.b)
-		if result != tt.result {
-			t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
-				tt.a, tt.b, result, tt.result)
-		}
-	}
+    for _, tt := range testCases {
+        // Use standard library slices.Contains instead of a thin wrapper.
+        result := slices.Contains(tt.b, tt.a)
+        if result != tt.result {
+            t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
+                tt.a, tt.b, result, tt.result)
+        }
+    }
 }
 
 func TestIsInInt64(t *testing.T) {
@@ -301,13 +303,14 @@ func TestIsInInt64(t *testing.T) {
 		{4, []int64{2, 3, 5, 4, 6}, true},
 		{100, []int64{2, 3, 5, 4, 6}, false},
 	}
-	for _, tt := range testCases {
-		result := slice.IsInInt64(tt.a, tt.b)
-		if result != tt.result {
-			t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
-				tt.a, tt.b, result, tt.result)
-		}
-	}
+    for _, tt := range testCases {
+        // Use standard library slices.Contains instead of a thin wrapper.
+        result := slices.Contains(tt.b, tt.a)
+        if result != tt.result {
+            t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
+                tt.a, tt.b, result, tt.result)
+        }
+    }
 }
 
 func TestUnionByteSlices(t *testing.T) {
@@ -580,13 +583,14 @@ func TestIsInSlots(t *testing.T) {
 		{4, []primitives.Slot{2, 3, 5, 4, 6}, true},
 		{100, []primitives.Slot{2, 3, 5, 4, 6}, false},
 	}
-	for _, tt := range testCases {
-		result := slice.IsInSlots(tt.a, tt.b)
-		if result != tt.result {
-			t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
-				tt.a, tt.b, result, tt.result)
-		}
-	}
+    for _, tt := range testCases {
+        // Use standard library slices.Contains instead of a thin wrapper.
+        result := slices.Contains(tt.b, tt.a)
+        if result != tt.result {
+            t.Errorf("IsIn(%d, %v)=%v, wanted: %v",
+                tt.a, tt.b, result, tt.result)
+        }
+    }
 }
 
 func TestUnique(t *testing.T) {

--- a/testing/endtoend/evaluators/slashing.go
+++ b/testing/endtoend/evaluators/slashing.go
@@ -3,6 +3,7 @@ package evaluators
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/core/signing"
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
@@ -196,12 +197,13 @@ func proposeDoubleBlock(_ *e2eTypes.EvaluationContext, conns ...*grpc.ClientConn
 	}
 
 	var proposerIndex primitives.ValidatorIndex
-	for i, duty := range duties.CurrentEpochDuties {
-		if slice.IsInSlots(chainHead.HeadSlot-1, duty.ProposerSlots) {
-			proposerIndex = primitives.ValidatorIndex(i)
-			break
-		}
-	}
+    for i, duty := range duties.CurrentEpochDuties {
+        // Use standard library slices.Contains instead of a thin wrapper.
+        if slices.Contains(duty.ProposerSlots, chainHead.HeadSlot-1) {
+            proposerIndex = primitives.ValidatorIndex(i)
+            break
+        }
+    }
 
 	validatorNum := int(params.BeaconConfig().MinGenesisActiveValidatorCount)
 	beaconNodeNum := e2e.TestParams.BeaconNodeCount


### PR DESCRIPTION

## Summary
Removes the unnecessary `IsInSlots` wrapper function that was just calling `slices.Contains` with swapped arguments.

## Changes
- **Removed** `IsInSlots` function from `container/slice/slice.go`
- **Updated** usage in `testing/endtoend/evaluators/slashing.go` to use `slices.Contains` directly
- **Updated** tests in `container/slice/slice_test.go` to test `slices.Contains` instead of the wrapper

