### PR TITLE
`VerifyDataColumnsSidecarKZGProofs`: Check if sizes match.

### DIFF
--- a/beacon-chain/core/peerdas/p2p_interface.go
+++ b/beacon-chain/core/peerdas/p2p_interface.go
@@ -79,10 +79,30 @@ func VerifyDataColumnsSidecarKZGProofs(sidecars []blocks.RODataColumn) error {
 
 	for _, sidecar := range sidecars {
 		for i := range sidecar.Column {
-			commitments = append(commitments, kzg.Bytes48(sidecar.KzgCommitments[i]))
+			var (
+				commitment kzg.Bytes48
+				cell       kzg.Cell
+				proof      kzg.Bytes48
+			)
+
+			commitmentBytes := sidecar.KzgCommitments[i]
+			cellBytes := sidecar.Column[i]
+			proofBytes := sidecar.KzgProofs[i]
+
+			if len(commitmentBytes) != len(commitment) ||
+				len(cellBytes) != len(cell) ||
+				len(proofBytes) != len(proof) {
+				return ErrMismatchLength
+			}
+
+			copy(commitment[:], commitmentBytes)
+			copy(cell[:], cellBytes)
+			copy(proof[:], proofBytes)
+
+			commitments = append(commitments, commitment)
 			indices = append(indices, sidecar.Index)
-			cells = append(cells, kzg.Cell(sidecar.Column[i]))
-			proofs = append(proofs, kzg.Bytes48(sidecar.KzgProofs[i]))
+			cells = append(cells, cell)
+			proofs = append(proofs, proof)
 		}
 	}
 

--- a/beacon-chain/core/peerdas/p2p_interface_test.go
+++ b/beacon-chain/core/peerdas/p2p_interface_test.go
@@ -68,6 +68,14 @@ func TestVerifyDataColumnSidecarKZGProofs(t *testing.T) {
 	err := kzg.Start()
 	require.NoError(t, err)
 
+	t.Run("size mismatch", func(t *testing.T) {
+		sidecars := generateRandomSidecars(t, seed, blobCount)
+		sidecars[0].Column[0] = sidecars[0].Column[0][:len(sidecars[0].Column[0])-1] // Remove one byte to create size mismatch
+
+		err := peerdas.VerifyDataColumnsSidecarKZGProofs(sidecars)
+		require.ErrorIs(t, err, peerdas.ErrMismatchLength)
+	})
+
 	t.Run("invalid proof", func(t *testing.T) {
 		sidecars := generateRandomSidecars(t, seed, blobCount)
 		sidecars[0].Column[0][0]++ // It is OK to overflow

--- a/changelog/manu-verify-data-column-sidecar-kzg-proofs.md
+++ b/changelog/manu-verify-data-column-sidecar-kzg-proofs.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `VerifyDataColumnsSidecarKZGProofs`: Check if sizes match.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
`VerifyDataColumnsSidecarKZGProofs`: Check if sizes match.

Before this PR: Calling `VerifyDataColumnsSidecarKZGProofs` may panic if a commitment, cell or proof in one of an input sidecar has not the expected shape.

This PR fixes this.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
