### PR TITLE
kv: write recovered state summaries to stateSummaryBucket

### DIFF
--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -132,6 +132,6 @@ func recoverStateSummary(ctx context.Context, tx *bolt.Tx, root []byte) error {
 	if err != nil {
 		return err
 	}
-	summaryBucket := tx.Bucket(stateBucket)
+	summaryBucket := tx.Bucket(stateSummaryBucket)
 	return summaryBucket.Put(root, summaryEnc)
 }

--- a/changelog/MozirDmitriy_fix_kv-recover-state-summurt-bucket.md
+++ b/changelog/MozirDmitriy_fix_kv-recover-state-summurt-bucket.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix recoverStateSummary to persist state summaries in stateSummaryBucket instead of stateBucket (#15896).


### PR DESCRIPTION
Fix recoverStateSummary to persist state summaries in stateSummaryBucket instead of stateBucket. All read paths (StateSummary, HasStateSummary, flush/delete) operate on stateSummaryBucket; writing to stateBucket made recovered summaries invisible to those APIs and callers. This change aligns recovery with the established schema and ensures HasStateSummary/StateSummary see recovered entries.