### PR TITLE
Fixed metadata extraction on Windows by correctly splitting file paths

### DIFF
--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -200,6 +200,7 @@ func (dcs *DataColumnStorage) WarmCache() {
 		fileMetadata, err := extractFileMetadata(path)
 		if err != nil {
 			log.WithError(err).Error("Error encountered while extracting file metadata")
+			return nil
 		}
 
 		// Open the data column filesystem file.
@@ -988,8 +989,8 @@ func filePath(root [fieldparams.RootLength]byte, epoch primitives.Epoch) string 
 // extractFileMetadata extracts the metadata from a file path.
 // If the path is not a leaf, it returns nil.
 func extractFileMetadata(path string) (*fileMetadata, error) {
-	// Is this Windows friendly?
-	parts := strings.Split(path, "/")
+	// Use filepath.Separator to handle both Windows (\) and Unix (/) path separators
+	parts := strings.Split(path, string(filepath.Separator))
 	if len(parts) != 3 {
 		return nil, errors.Errorf("unexpected file %s", path)
 	}

--- a/beacon-chain/db/filesystem/data_column_test.go
+++ b/beacon-chain/db/filesystem/data_column_test.go
@@ -728,31 +728,35 @@ func TestPrune(t *testing.T) {
 }
 
 func TestExtractFileMetadata(t *testing.T) {
-	t.Run("cross-platform path separators", func(t *testing.T) {
+	t.Run("Unix", func(t *testing.T) {
 		// Test with Unix-style path separators (/)
-		unixPath := "0/1234/0x8bb2f09de48c102635622dc27e6de03ae2b22639df7c33edbc8222b2ec423746.sszs"
-		metadata, err := extractFileMetadata(unixPath)
+		path := "12/1234/0x8bb2f09de48c102635622dc27e6de03ae2b22639df7c33edbc8222b2ec423746.sszs"
+		metadata, err := extractFileMetadata(path)
 		if filepath.Separator == '/' {
 			// On Unix systems, this should succeed
 			require.NoError(t, err)
-			require.Equal(t, uint64(0), metadata.period)
+			require.Equal(t, uint64(12), metadata.period)
 			require.Equal(t, primitives.Epoch(1234), metadata.epoch)
-		} else {
-			// On Windows systems, this should fail because it uses the wrong separator
-			require.ErrorContains(t, "unexpected file", err)
+			return
 		}
 
+		// On Windows systems, this should fail because it uses the wrong separator
+		require.NotNil(t, err)
+	})
+
+	t.Run("Windows", func(t *testing.T) {
 		// Test with Windows-style path separators (\)
-		windowsPath := "0\\1234\\0x8bb2f09de48c102635622dc27e6de03ae2b22639df7c33edbc8222b2ec423746.sszs"
-		metadata, err = extractFileMetadata(windowsPath)
+		path := "12\\1234\\0x8bb2f09de48c102635622dc27e6de03ae2b22639df7c33edbc8222b2ec423746.sszs"
+		metadata, err := extractFileMetadata(path)
 		if filepath.Separator == '\\' {
 			// On Windows systems, this should succeed
 			require.NoError(t, err)
-			require.Equal(t, uint64(0), metadata.period)
+			require.Equal(t, uint64(12), metadata.period)
 			require.Equal(t, primitives.Epoch(1234), metadata.epoch)
-		} else {
-			// On Unix systems, this should fail because it uses the wrong separator
-			require.ErrorContains(t, "unexpected file", err)
+			return
 		}
+
+		// On Unix systems, this should fail because it uses the wrong separator
+		require.NotNil(t, err)
 	})
 }

--- a/beacon-chain/db/filesystem/data_column_test.go
+++ b/beacon-chain/db/filesystem/data_column_test.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"encoding/binary"
 	"os"
+	"path/filepath"
 	"testing"
 
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
@@ -723,5 +724,35 @@ func TestPrune(t *testing.T) {
 		dirs, err = listDir(dataColumnStorage.fs, "3/14098")
 		require.NoError(t, err)
 		require.Equal(t, true, compareSlices([]string{"0x0de28a18cae63cbc6f0b20dc1afb0b1df38da40824a5f09f92d485ade04de97f.sszs"}, dirs))
+	})
+}
+
+func TestExtractFileMetadata(t *testing.T) {
+	t.Run("cross-platform path separators", func(t *testing.T) {
+		// Test with Unix-style path separators (/)
+		unixPath := "0/1234/0x8bb2f09de48c102635622dc27e6de03ae2b22639df7c33edbc8222b2ec423746.sszs"
+		metadata, err := extractFileMetadata(unixPath)
+		if filepath.Separator == '/' {
+			// On Unix systems, this should succeed
+			require.NoError(t, err)
+			require.Equal(t, uint64(0), metadata.period)
+			require.Equal(t, primitives.Epoch(1234), metadata.epoch)
+		} else {
+			// On Windows systems, this should fail because it uses the wrong separator
+			require.ErrorContains(t, "unexpected file", err)
+		}
+
+		// Test with Windows-style path separators (\)
+		windowsPath := "0\\1234\\0x8bb2f09de48c102635622dc27e6de03ae2b22639df7c33edbc8222b2ec423746.sszs"
+		metadata, err = extractFileMetadata(windowsPath)
+		if filepath.Separator == '\\' {
+			// On Windows systems, this should succeed
+			require.NoError(t, err)
+			require.Equal(t, uint64(0), metadata.period)
+			require.Equal(t, primitives.Epoch(1234), metadata.epoch)
+		} else {
+			// On Unix systems, this should fail because it uses the wrong separator
+			require.ErrorContains(t, "unexpected file", err)
+		}
 	})
 }

--- a/changelog/muzry_fix_extract_metadata_file.md
+++ b/changelog/muzry_fix_extract_metadata_file.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed metadata extraction on Windows by correctly splitting file paths


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- Fixed metadata extraction on Windows by correctly splitting file paths

**Which issues(s) does this PR fix?**

Fixes #15898

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
