### PR TITLE
Windows: Enable data column sidecars cache warmup on Windows

### DIFF
--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -988,8 +988,7 @@ func filePath(root [fieldparams.RootLength]byte, epoch primitives.Epoch) string 
 // extractFileMetadata extracts the metadata from a file path.
 // If the path is not a leaf, it returns nil.
 func extractFileMetadata(path string) (*fileMetadata, error) {
-	// Is this Windows friendly?
-	parts := strings.Split(path, "/")
+	parts := strings.Split(path, string(filepath.Separator))
 	if len(parts) != 3 {
 		return nil, errors.Errorf("unexpected file %s", path)
 	}

--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -200,6 +200,7 @@ func (dcs *DataColumnStorage) WarmCache() {
 		fileMetadata, err := extractFileMetadata(path)
 		if err != nil {
 			log.WithError(err).Error("Error encountered while extracting file metadata")
+			return nil
 		}
 
 		// Open the data column filesystem file.

--- a/changelog/manu-handle-windows.md
+++ b/changelog/manu-handle-windows.md
@@ -1,0 +1,3 @@
+### Fixed 
+- `WarmCache`: Return if `extractFileMetadata` fails.
+- `extractFileMetadata`: Use filepath.Separator instead of `/` for Windows support.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Without this PR, a Prysm beacon node starting on Windows fails if some data column sidecars are already in the DB.
(No issue if no data column sidecars are already in the storage.)

**Which issues(s) does this PR fix?**

Fixes:
- https://github.com/OffchainLabs/prysm/issues/15898

**Other notes for review**
Please read commit by commit, with commit messages...

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
