### PR TITLE
Fix proposer to use advanced state for sync committee position calculation

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -229,7 +229,7 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 		sBlk.SetVoluntaryExits(vs.getExits(head, sBlk.Block().Slot()))
 
 		// Set sync aggregate. New in Altair.
-		vs.setSyncAggregate(ctx, sBlk)
+		vs.setSyncAggregate(ctx, sBlk, head)
 
 		// Set bls to execution change. New in Capella.
 		vs.setBlsToExecData(sBlk, head)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair_test.go
@@ -9,6 +9,7 @@ import (
 	mockSync "github.com/OffchainLabs/prysm/v6/beacon-chain/sync/initial-sync/testing"
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v6/crypto/bls"
 	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
@@ -198,4 +199,95 @@ func Test_aggregatedSyncCommitteeMessages_NoIntersectionWithPoolContributions(t 
 	require.NoError(t, err)
 	require.Equal(t, 1, len(aggregated))
 	assert.Equal(t, false, aggregated[0].AggregationBits.BitAt(3))
+}
+
+func TestGetSyncAggregate_CorrectStateAtSyncCommitteePeriodBoundary(t *testing.T) {
+	helpers.ClearCache()
+	syncPeriodBoundaryEpoch := primitives.Epoch(274176) // Real epoch from the bug report
+	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
+
+	preEpochState, keys := util.DeterministicGenesisStateAltair(t, 100)
+	require.NoError(t, preEpochState.SetSlot(primitives.Slot(syncPeriodBoundaryEpoch)*slotsPerEpoch-1)) // Last slot of previous epoch
+
+	postEpochState := preEpochState.Copy()
+	require.NoError(t, postEpochState.SetSlot(primitives.Slot(syncPeriodBoundaryEpoch)*slotsPerEpoch+2)) // After 2 missed slots
+
+	oldCommittee := &ethpb.SyncCommittee{
+		Pubkeys: make([][]byte, params.BeaconConfig().SyncCommitteeSize),
+	}
+	newCommittee := &ethpb.SyncCommittee{
+		Pubkeys: make([][]byte, params.BeaconConfig().SyncCommitteeSize),
+	}
+
+	for i := 0; i < int(params.BeaconConfig().SyncCommitteeSize); i++ {
+		if i < len(keys) {
+			oldCommittee.Pubkeys[i] = keys[i%len(keys)].PublicKey().Marshal()
+			// Use different keys for new committee to simulate rotation
+			newCommittee.Pubkeys[i] = keys[(i+10)%len(keys)].PublicKey().Marshal()
+		}
+	}
+
+	require.NoError(t, preEpochState.SetCurrentSyncCommittee(oldCommittee))
+	require.NoError(t, postEpochState.SetCurrentSyncCommittee(newCommittee))
+
+	mockChainService := &chainmock.ChainService{
+		State: postEpochState,
+	}
+
+	proposerServer := &Server{
+		HeadFetcher:       mockChainService,
+		SyncChecker:       &mockSync.Sync{IsSyncing: false},
+		SyncCommitteePool: synccommittee.NewStore(),
+	}
+
+	slot := primitives.Slot(syncPeriodBoundaryEpoch)*slotsPerEpoch + 1 // First slot of new epoch
+	blockRoot := [32]byte{0x01, 0x02, 0x03}
+
+	msg1 := &ethpb.SyncCommitteeMessage{
+		Slot:           slot,
+		BlockRoot:      blockRoot[:],
+		ValidatorIndex: 0, // This validator is in position 0 of OLD committee
+		Signature:      bls.NewAggregateSignature().Marshal(),
+	}
+	msg2 := &ethpb.SyncCommitteeMessage{
+		Slot:           slot,
+		BlockRoot:      blockRoot[:],
+		ValidatorIndex: 1, // This validator is in position 1 of OLD committee
+		Signature:      bls.NewAggregateSignature().Marshal(),
+	}
+
+	require.NoError(t, proposerServer.SyncCommitteePool.SaveSyncCommitteeMessage(msg1))
+	require.NoError(t, proposerServer.SyncCommitteePool.SaveSyncCommitteeMessage(msg2))
+
+	aggregateWrongState, err := proposerServer.getSyncAggregate(t.Context(), slot, blockRoot, postEpochState)
+	require.NoError(t, err)
+
+	aggregateCorrectState, err := proposerServer.getSyncAggregate(t.Context(), slot, blockRoot, preEpochState)
+	require.NoError(t, err)
+
+	wrongStateBits := bitfield.Bitlist(aggregateWrongState.SyncCommitteeBits)
+	correctStateBits := bitfield.Bitlist(aggregateCorrectState.SyncCommitteeBits)
+
+	wrongStateHasValidators := false
+	correctStateHasValidators := false
+
+	for i := 0; i < len(wrongStateBits); i++ {
+		if wrongStateBits[i] != 0 {
+			wrongStateHasValidators = true
+			break
+		}
+	}
+
+	for i := 0; i < len(correctStateBits); i++ {
+		if correctStateBits[i] != 0 {
+			correctStateHasValidators = true
+			break
+		}
+	}
+
+	assert.Equal(t, true, correctStateHasValidators, "Correct state should include validators that sent messages")
+	assert.Equal(t, false, wrongStateHasValidators, "Wrong state should not find validators in incorrect sync committee")
+
+	t.Logf("Wrong state aggregate bits: %x (has validators: %v)", wrongStateBits, wrongStateHasValidators)
+	t.Logf("Correct state aggregate bits: %x (has validators: %v)", correctStateBits, correctStateHasValidators)
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair_test.go
@@ -51,15 +51,15 @@ func TestProposer_GetSyncAggregate_OK(t *testing.T) {
 		require.NoError(t, proposerServer.SyncCommitteePool.SaveSyncCommitteeContribution(cont))
 	}
 
-	aggregate, err := proposerServer.getSyncAggregate(t.Context(), 1, bytesutil.ToBytes32(conts[0].BlockRoot))
+	aggregate, err := proposerServer.getSyncAggregate(t.Context(), 1, bytesutil.ToBytes32(conts[0].BlockRoot), st)
 	require.NoError(t, err)
 	require.DeepEqual(t, bitfield.Bitvector32{0xf, 0xf, 0xf, 0xf}, aggregate.SyncCommitteeBits)
 
-	aggregate, err = proposerServer.getSyncAggregate(t.Context(), 2, bytesutil.ToBytes32(conts[0].BlockRoot))
+	aggregate, err = proposerServer.getSyncAggregate(t.Context(), 2, bytesutil.ToBytes32(conts[0].BlockRoot), st)
 	require.NoError(t, err)
 	require.DeepEqual(t, bitfield.Bitvector32{0xaa, 0xaa, 0xaa, 0xaa}, aggregate.SyncCommitteeBits)
 
-	aggregate, err = proposerServer.getSyncAggregate(t.Context(), 3, bytesutil.ToBytes32(conts[0].BlockRoot))
+	aggregate, err = proposerServer.getSyncAggregate(t.Context(), 3, bytesutil.ToBytes32(conts[0].BlockRoot), st)
 	require.NoError(t, err)
 	require.DeepEqual(t, bitfield.NewBitvector32(), aggregate.SyncCommitteeBits)
 }
@@ -68,7 +68,7 @@ func TestServer_SetSyncAggregate_EmptyCase(t *testing.T) {
 	b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockAltair())
 	require.NoError(t, err)
 	s := &Server{} // Sever is not initialized with sync committee pool.
-	s.setSyncAggregate(t.Context(), b)
+	s.setSyncAggregate(t.Context(), b, nil)
 	agg, err := b.Block().Body().SyncAggregate()
 	require.NoError(t, err)
 
@@ -138,7 +138,7 @@ func TestProposer_GetSyncAggregate_IncludesSyncCommitteeMessages(t *testing.T) {
 	}
 
 	// The final sync aggregates must have indexes [0,1,2,3] set for both subcommittees
-	sa, err := proposerServer.getSyncAggregate(t.Context(), 1, r)
+	sa, err := proposerServer.getSyncAggregate(t.Context(), 1, r, st)
 	require.NoError(t, err)
 	assert.Equal(t, true, sa.SyncCommitteeBits.BitAt(0))
 	assert.Equal(t, true, sa.SyncCommitteeBits.BitAt(1))
@@ -194,7 +194,7 @@ func Test_aggregatedSyncCommitteeMessages_NoIntersectionWithPoolContributions(t 
 		BlockRoot:         r[:],
 	}
 
-	aggregated, err := proposerServer.aggregatedSyncCommitteeMessages(t.Context(), 1, r, []*ethpb.SyncCommitteeContribution{cont})
+	aggregated, err := proposerServer.aggregatedSyncCommitteeMessages(t.Context(), 1, r, []*ethpb.SyncCommitteeContribution{cont}, st)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(aggregated))
 	assert.Equal(t, false, aggregated[0].AggregationBits.BitAt(3))

--- a/changelog/ttsao_fix-sync-aggregate-state.md
+++ b/changelog/ttsao_fix-sync-aggregate-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Sync committee uses correct state to calculate position


### PR DESCRIPTION
Fixes a bug in #15608

At sync committee boundary we see:
```
could not process block: process_sync_aggregate failed: could not verify sync committee signature: invalid sync committee signature
```
Instead of using head state, I think it should use head state advanced to the proposal slot