### PR TITLE
fix setting genesis block to 0 when the block is pruned

### DIFF
--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	ethpb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	prysmTime "github.com/OffchainLabs/prysm/v6/time"
 	"github.com/OffchainLabs/prysm/v6/time/slots"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -566,12 +568,18 @@ func (s *Service) initPOWService() {
 				if genHash != [32]byte{} {
 					genHeader, err := s.HeaderByHash(ctx, genHash)
 					if err != nil {
-						err = errors.Wrapf(err, "HeaderByHash, hash=%#x", genHash)
-						s.retryExecutionClientConnection(ctx, err)
-						errorLogger(err, "Unable to retrieve proof-of-stake genesis block data")
-						continue
+						wrapErr := errors.Wrapf(err, "HeaderByHash, hash=%#x", genHash)
+						if !errors.Is(err, ethereum.NotFound) ||
+							!strings.Contains(err.Error(), "pruned history unavailable") {
+							s.retryExecutionClientConnection(ctx, wrapErr)
+							errorLogger(wrapErr, "Unable to retrieve proof-of-stake genesis block data")
+							continue
+						}
+						log.WithError(wrapErr).Warn("Could not retrieve PoS genesis block data; the block may be pruned. Setting genesis block to 0.")
+						genBlock = 0
+					} else {
+						genBlock = genHeader.Number.Uint64()
 					}
-					genBlock = genHeader.Number.Uint64()
 				}
 				s.chainStartData.GenesisBlock = genBlock
 				if err := s.savePowchainData(ctx); err != nil {

--- a/changelog/muzry_fix_gensis_block_init.md
+++ b/changelog/muzry_fix_gensis_block_init.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix setting genesis block to 0 when the block is pruned


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**

Try to fix #15889.
If the beacon node encounters an error indicating that the genesis block number is not found or has been pruned, we can set the genesis block number to 0.
Since the genesis block is only used for comparison with the canonical block number, this change should have no functional impact.
Please let me know if I’ve misunderstood anything.

**Which issues(s) does this PR fix?**

Fixes #15889

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
