### PR TITLE
`updateCustodyInfoInDB`: Use `NumberOfCustodyGroups` instead of `NumberOfColumns`.

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -173,6 +173,7 @@ go_test(
         "//beacon-chain/state/state-native:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//beacon-chain/verification:go_default_library",
+        "//cmd/beacon-chain/flags:go_default_library",
         "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -493,7 +493,7 @@ func (s *Service) updateCustodyInfoInDB(slot primitives.Slot) (primitives.Slot, 
 	// Compute the custody group count.
 	custodyGroupCount := custodyRequirement
 	if isSubscribedToAllDataSubnets {
-		custodyGroupCount = beaconConfig.NumberOfColumns
+		custodyGroupCount = beaconConfig.NumberOfCustodyGroups
 	}
 
 	// Safely compute the fulu fork slot.

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -23,9 +23,11 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/startup"
 	state_native "github.com/OffchainLabs/prysm/v6/beacon-chain/state/state-native"
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/state/stategen"
+	"github.com/OffchainLabs/prysm/v6/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v6/config/features"
 	fieldparams "github.com/OffchainLabs/prysm/v6/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v6/config/params"
+	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	consensusblocks "github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
@@ -595,4 +597,104 @@ func TestNotifyIndex(t *testing.T) {
 	default:
 		t.Errorf("Notifier channel did not receive the index")
 	}
+}
+
+func TestUpdateCustodyInfoInDB(t *testing.T) {
+	const (
+		fuluForkEpoch         = 10
+		slotsPerEpoch         = 32
+		custodyRequirement    = uint64(4)
+		earliestStoredSlot    = primitives.Slot(12)
+		numberOfCustodyGroups = uint64(128)
+	)
+
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.FuluForkEpoch = fuluForkEpoch
+	cfg.SlotsPerEpoch = slotsPerEpoch
+	cfg.CustodyRequirement = custodyRequirement
+	cfg.NumberOfCustodyGroups = numberOfCustodyGroups
+	params.OverrideBeaconConfig(cfg)
+
+	ctx := t.Context()
+	pbBlock := util.NewBeaconBlock()
+	pbBlock.Block.Slot = 12
+	signedBeaconBlock, err := blocks.NewSignedBeaconBlock(pbBlock)
+	require.NoError(t, err)
+
+	roBlock, err := blocks.NewROBlock(signedBeaconBlock)
+	require.NoError(t, err)
+
+	t.Run("CGC increases before fulu", func(t *testing.T) {
+		service, requirements := minimalTestService(t)
+		err = requirements.db.SaveBlock(ctx, roBlock)
+		require.NoError(t, err)
+
+		// Before Fulu
+		// -----------
+		actualEas, actualCgc, err := service.updateCustodyInfoInDB(15)
+		require.NoError(t, err)
+		require.Equal(t, earliestStoredSlot, actualEas)
+		require.Equal(t, custodyRequirement, actualCgc)
+
+		actualEas, actualCgc, err = service.updateCustodyInfoInDB(17)
+		require.NoError(t, err)
+		require.Equal(t, earliestStoredSlot, actualEas)
+		require.Equal(t, custodyRequirement, actualCgc)
+
+		resetFlags := flags.Get()
+		gFlags := new(flags.GlobalFlags)
+		gFlags.SubscribeAllDataSubnets = true
+		flags.Init(gFlags)
+		defer flags.Init(resetFlags)
+
+		actualEas, actualCgc, err = service.updateCustodyInfoInDB(19)
+		require.NoError(t, err)
+		require.Equal(t, earliestStoredSlot, actualEas)
+		require.Equal(t, numberOfCustodyGroups, actualCgc)
+
+		// After Fulu
+		// ----------
+		actualEas, actualCgc, err = service.updateCustodyInfoInDB(fuluForkEpoch*primitives.Slot(slotsPerEpoch) + 1)
+		require.NoError(t, err)
+		require.Equal(t, earliestStoredSlot, actualEas)
+		require.Equal(t, numberOfCustodyGroups, actualCgc)
+	})
+
+	t.Run("CGC increases after fulu", func(t *testing.T) {
+		service, requirements := minimalTestService(t)
+		err = requirements.db.SaveBlock(ctx, roBlock)
+		require.NoError(t, err)
+
+		// Before Fulu
+		// -----------
+		actualEas, actualCgc, err := service.updateCustodyInfoInDB(15)
+		require.NoError(t, err)
+		require.Equal(t, earliestStoredSlot, actualEas)
+		require.Equal(t, custodyRequirement, actualCgc)
+
+		actualEas, actualCgc, err = service.updateCustodyInfoInDB(17)
+		require.NoError(t, err)
+		require.Equal(t, earliestStoredSlot, actualEas)
+		require.Equal(t, custodyRequirement, actualCgc)
+
+		// After Fulu
+		// ----------
+		resetFlags := flags.Get()
+		gFlags := new(flags.GlobalFlags)
+		gFlags.SubscribeAllDataSubnets = true
+		flags.Init(gFlags)
+		defer flags.Init(resetFlags)
+
+		slot := fuluForkEpoch*primitives.Slot(slotsPerEpoch) + 1
+		actualEas, actualCgc, err = service.updateCustodyInfoInDB(slot)
+		require.NoError(t, err)
+		require.Equal(t, slot, actualEas)
+		require.Equal(t, numberOfCustodyGroups, actualCgc)
+
+		actualEas, actualCgc, err = service.updateCustodyInfoInDB(slot + 2)
+		require.NoError(t, err)
+		require.Equal(t, slot, actualEas)
+		require.Equal(t, numberOfCustodyGroups, actualCgc)
+	})
 }

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -605,7 +605,8 @@ func TestUpdateCustodyInfoInDB(t *testing.T) {
 		slotsPerEpoch         = 32
 		custodyRequirement    = uint64(4)
 		earliestStoredSlot    = primitives.Slot(12)
-		numberOfCustodyGroups = uint64(128)
+		numberOfCustodyGroups = uint64(64)
+		numberOfColumns       = uint64(128)
 	)
 
 	params.SetupTestConfigCleanup(t)
@@ -614,6 +615,7 @@ func TestUpdateCustodyInfoInDB(t *testing.T) {
 	cfg.SlotsPerEpoch = slotsPerEpoch
 	cfg.CustodyRequirement = custodyRequirement
 	cfg.NumberOfCustodyGroups = numberOfCustodyGroups
+	cfg.NumberOfColumns = numberOfColumns
 	params.OverrideBeaconConfig(cfg)
 
 	ctx := t.Context()

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -602,7 +602,6 @@ func TestNotifyIndex(t *testing.T) {
 func TestUpdateCustodyInfoInDB(t *testing.T) {
 	const (
 		fuluForkEpoch         = 10
-		slotsPerEpoch         = 32
 		custodyRequirement    = uint64(4)
 		earliestStoredSlot    = primitives.Slot(12)
 		numberOfCustodyGroups = uint64(64)
@@ -612,7 +611,6 @@ func TestUpdateCustodyInfoInDB(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig()
 	cfg.FuluForkEpoch = fuluForkEpoch
-	cfg.SlotsPerEpoch = slotsPerEpoch
 	cfg.CustodyRequirement = custodyRequirement
 	cfg.NumberOfCustodyGroups = numberOfCustodyGroups
 	cfg.NumberOfColumns = numberOfColumns
@@ -657,7 +655,7 @@ func TestUpdateCustodyInfoInDB(t *testing.T) {
 
 		// After Fulu
 		// ----------
-		actualEas, actualCgc, err = service.updateCustodyInfoInDB(fuluForkEpoch*primitives.Slot(slotsPerEpoch) + 1)
+		actualEas, actualCgc, err = service.updateCustodyInfoInDB(fuluForkEpoch*primitives.Slot(cfg.SlotsPerEpoch) + 1)
 		require.NoError(t, err)
 		require.Equal(t, earliestStoredSlot, actualEas)
 		require.Equal(t, numberOfCustodyGroups, actualCgc)
@@ -688,7 +686,7 @@ func TestUpdateCustodyInfoInDB(t *testing.T) {
 		flags.Init(gFlags)
 		defer flags.Init(resetFlags)
 
-		slot := fuluForkEpoch*primitives.Slot(slotsPerEpoch) + 1
+		slot := fuluForkEpoch*primitives.Slot(cfg.SlotsPerEpoch) + 1
 		actualEas, actualCgc, err = service.updateCustodyInfoInDB(slot)
 		require.NoError(t, err)
 		require.Equal(t, slot, actualEas)

--- a/changelog/manu-number-custody-groups.md
+++ b/changelog/manu-number-custody-groups.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `updateCustodyInfoInDB`: Use `NumberOfCustodyGroups` instead of `NumberOfColumns`.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this PR, `updateCustodyInfoInDB` uses `NumberOfColumns` instead of `NumberOfCustodyGroups`.
This PR fixes that.

**Note:** On mainnet and minimal presets, `NUMBER_OF_CUSTODY_GROUPS == NUMBER_OF_COLUMNS == 128`.
==> This bug has currently no impact at all.

**Other notes for review**
Please read commit by commit.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
