### PR TITLE
Remove `Reading static P2P private key from a file.` log if Fulu is enabled.

### DIFF
--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -68,7 +68,10 @@ func privKey(cfg *Config) (*ecdsa.PrivateKey, error) {
 	}
 
 	if defaultKeysExist {
-		log.WithField("filePath", defaultKeyPath).Info("Reading static P2P private key from a file. To generate a new random private key at every start, please remove this file.")
+		if !params.FuluEnabled() {
+			log.WithField("filePath", defaultKeyPath).Info("Reading static P2P private key from a file. To generate a new random private key at every start, please remove this file.")
+		}
+
 		return privKeyFromFile(defaultKeyPath)
 	}
 

--- a/changelog/manu-fulu-log.md
+++ b/changelog/manu-fulu-log.md
@@ -1,0 +1,2 @@
+### Fixed 
+- Remove `Reading static P2P private key from a file.` log if Fulu is enabled.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Starting at Fulu, we stop generating a new node private key at each reboot: The public key is computed from the private key, and the data columns to custody are computed from the public key. We don't want the data columns to custody to change at every reboot.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
