### PR TITLE
Fix sync committee message validation for pruned blocks

### DIFF
--- a/beacon-chain/sync/validate_sync_committee_message.go
+++ b/beacon-chain/sync/validate_sync_committee_message.go
@@ -142,7 +142,9 @@ func (s *Service) hasSeenSyncMessageIndexSlot(ctx context.Context, m *ethpb.Sync
 	}
 	if !s.cfg.chain.InForkchoice(root) && !s.cfg.beaconDB.HasBlock(ctx, root) {
 		syncMessagesForUnknownBlocks.Inc()
-		return true
+		// Previously cached block no longer exists in forkchoice or DB.
+		// The old cached entry is now invalid, so allow the new message through.
+		return false
 	}
 	msgRoot := [32]byte(m.BlockRoot)
 	if !s.cfg.chain.InForkchoice(msgRoot) && !s.cfg.beaconDB.HasBlock(ctx, msgRoot) {

--- a/changelog/VolodymyrBg_fix-sync-committee-anvalid-cache-handling.md
+++ b/changelog/VolodymyrBg_fix-sync-committee-anvalid-cache-handling.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix: allow sync committee messages when cached block is pruned


### PR DESCRIPTION
Fix incorrect return value in hasSeenSyncMessageIndexSlot when the
previously cached block no longer exists in forkchoice or database.

The function was returning 'true' (ignore new message) when the cached
block root was not found in forkchoice and database. This is incorrect
because if the previously cached block has been pruned or never existed, 
the old cache entry is invalid and the new sync committee message should
be allowed through for validation.

Changed return value from 'true' to 'false' to properly allow new
messages when the cached block reference is no longer valid. This ensures
validators can submit new sync committee messages even after their
previous message's block has been pruned from forkchoice.

The bug could cause legitimate sync committee messages to be incorrectly
ignored when forkchoice pruning removes the previously referenced block,
potentially impacting sync committee participation during chain reorgs
or optimistic sync scenarios.