### PR TITLE
Use `SlotTicker` instead of `time.Ticker` for attestation pool pruning

### DIFF
--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -10,7 +10,9 @@ import (
 
 // pruneExpired prunes attestations pool on every slot interval.
 func (s *Service) pruneExpired() {
-	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
+	offset := time.Duration(secondsPerSlot-1) * time.Second
+	slotTicker := slots.NewSlotTickerWithOffset(s.genesisTime, offset, secondsPerSlot)
 	defer slotTicker.Done()
 	for {
 		select {

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -10,11 +10,11 @@ import (
 
 // pruneExpired prunes attestations pool on every slot interval.
 func (s *Service) pruneExpired() {
-	ticker := time.NewTicker(s.cfg.pruneInterval)
-	defer ticker.Stop()
+	slotTicker := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
+	defer slotTicker.Done()
 	for {
 		select {
-		case <-ticker.C:
+		case <-slotTicker.C():
 			s.pruneExpiredAtts()
 			s.updateMetrics()
 		case <-s.ctx.Done():

--- a/beacon-chain/operations/attestations/prune_expired_test.go
+++ b/beacon-chain/operations/attestations/prune_expired_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestPruneExpired_Ticker(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	// Need timeout longer than the offset (secondsPerSlot - 1) + some buffer
+	timeout := time.Duration(params.BeaconConfig().SecondsPerSlot+5) * time.Second
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	s, err := NewService(ctx, &Config{

--- a/changelog/ttsao_use-slot-ticker-pruning.md
+++ b/changelog/ttsao_use-slot-ticker-pruning.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Use SlotTicker instead of time.Ticker for attestation pool pruning

--- a/changelog/ttsao_use-slot-ticker-pruning.md
+++ b/changelog/ttsao_use-slot-ticker-pruning.md
@@ -1,3 +1,3 @@
 ### Ignored
 
-- Use SlotTicker instead of time.Ticker for attestation pool pruning
+- Use SlotTicker with offset instead of time.Ticker for attestation pool pruning to avoid conflicts with slot boundary operations


### PR DESCRIPTION
prune Interval is 12s and we use `slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)` so it runs deterministically at the start of the slot instead of a random time in the middle which would interfere with metric updates

i cant remove `pruneInterval` from config as its' still used in `pruneExpiredExperimental()`