### PR TITLE
Update consensus spec tests to `v1.6.0-beta.1`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -253,16 +253,16 @@ filegroup(
     url = "https://github.com/ethereum/EIPs/archive/5480440fe51742ed23342b68cf106cefd427e39d.tar.gz",
 )
 
-consensus_spec_version = "v1.6.0-beta.0"
+consensus_spec_version = "v1.6.0-beta.1"
 
 load("@prysm//tools:download_spectests.bzl", "consensus_spec_tests")
 
 consensus_spec_tests(
     name = "consensus_spec_tests",
     flavors = {
-        "general": "sha256-rT3jQp2+ZaDiO66gIQggetzqr+kGeexaLqEhbx4HDMY=",
-        "minimal": "sha256-wowwwyvd0KJLsE+oDOtPkrhZyJndJpJ0lbXYsLH6XBw=",
-        "mainnet": "sha256-4ZLrLNeO7NihZ4TuWH5V5fUhvW9Y3mAPBQDCqrfShps=",
+        "general": "sha256-oEj0MTViJHjZo32nABK36gfvSXpbwkBk/jt6Mj7pWFI=",
+        "minimal": "sha256-cS4NPv6IRBoCSmWomQ8OEo8IsVNW9YawUFqoRZQBUj4=",
+        "mainnet": "sha256-BYuLndMPAh4p13IRJgNfVakrCVL69KRrNw2tdc3ETbE=",
     },
     version = consensus_spec_version,
 )
@@ -278,7 +278,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    integrity = "sha256-sBe3Rx8zGq9IrvfgIhZQpYidGjy3mE1SiCb6/+pjLdY=",
+    integrity = "sha256-yrq3tdwPS8Ri+ueeLAHssIT3ssMrX7zvHiJ8Xf9GVYs=",
     strip_prefix = "consensus-specs-" + consensus_spec_version[1:],
     url = "https://github.com/ethereum/consensus-specs/archive/refs/tags/%s.tar.gz" % consensus_spec_version,
 )

--- a/changelog/ttsao_update-spec-tests.md
+++ b/changelog/ttsao_update-spec-tests.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Updated consensus spec tests to v1.6.0-beta.1 with new hashes and URL template

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.6.0-beta.0
+version: v1.6.0-beta.1
 style: full
 
 specrefs:
@@ -18,6 +18,7 @@ exceptions:
     - UPDATE_TIMEOUT#altair
 
     # Not implemented: gloas (future fork)
+    - BUILDER_PENDING_WITHDRAWALS_LIMIT#gloas
     - MAX_PAYLOAD_ATTESTATIONS#gloas
     - PTC_SIZE#gloas
 
@@ -50,7 +51,6 @@ exceptions:
     # Not implemented: gloas (future fork)
     - BUILDER_PAYMENT_THRESHOLD_DENOMINATOR#gloas
     - BUILDER_PAYMENT_THRESHOLD_NUMERATOR#gloas
-    - BUILDER_PENDING_WITHDRAWALS_LIMIT#gloas
     - BUILDER_WITHDRAWAL_PREFIX#gloas
     - DOMAIN_BEACON_BUILDER#gloas
     - DOMAIN_PTC_ATTESTER#gloas
@@ -82,6 +82,12 @@ exceptions:
     - Eth1Block#phase0
     - MatrixEntry#fulu
 
+    # Not implemented: capella
+    - LightClientBootstrap#capella
+    - LightClientFinalityUpdate#capella
+    - LightClientOptimisticUpdate#capella
+    - LightClientUpdate#capella
+
     # Not implemented: gloas (future fork)
     - BeaconBlockBody#gloas
     - BeaconState#gloas
@@ -105,6 +111,9 @@ exceptions:
     - LightClientStore#altair
     - OptimisticStore#bellatrix
     - Store#phase0
+
+    # Not implemented: capella
+    - LightClientStore#capella
 
     # Not implemented: gloas (future fork)
     - LatestMessage#gloas
@@ -213,6 +222,7 @@ exceptions:
     - xor#phase0
 
     # Not implemented: altair
+    - compute_merkle_proof#altair
     - compute_sync_committee_period_at_slot#altair
     - get_contribution_and_proof#altair
     - get_contribution_due_ms#altair
@@ -354,6 +364,7 @@ exceptions:
     - upgrade_to_gloas#gloas
     - validate_merge_block#gloas
     - validate_on_attestation#gloas
+    - verify_data_column_sidecar#gloas
     - verify_data_column_sidecar_inclusion_proof#gloas
     - verify_execution_payload_envelope_signature#gloas
     - verify_execution_payload_bid_signature#gloas

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -971,12 +971,12 @@
     - file: proto/prysm/v1alpha1/light_client.proto
       search: message LightClientHeaderCapella {
   spec: |
-    <spec ssz_object="LightClientHeader" fork="capella" hash="366cbdcd">
+    <spec ssz_object="LightClientHeader" fork="capella" hash="b625e61e">
     class LightClientHeader(Container):
-        # Beacon block header
         beacon: BeaconBlockHeader
-        # Execution payload header corresponding to `beacon.body_root` (from Capella onward)
+        # [New in Capella]
         execution: ExecutionPayloadHeader
+        # [New in Capella]
         execution_branch: ExecutionBranch
     </spec>
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1303,9 +1303,24 @@
     - file: crypto/bls/bls.go
       search: func AggregatePublicKeys(
   spec: |
-    <spec fn="eth_aggregate_pubkeys" fork="altair" hash="977edbdb">
+    <spec fn="eth_aggregate_pubkeys" fork="altair" hash="bfb5ddd0">
     def eth_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
-        return bls.AggregatePKs(pubkeys)
+        """
+        Return the aggregate public key for the public keys in ``pubkeys``.
+
+        Note: the ``+`` operation should be interpreted as elliptic curve point addition, which takes as input
+        elliptic curve points that must be decoded from the input ``BLSPubkey``s.
+        This implementation is for demonstrative purposes only and ignores encoding/decoding concerns.
+        Refer to the BLS signature draft standard for more information.
+        """
+        assert len(pubkeys) > 0
+        # Ensure that the given inputs are valid pubkeys
+        assert all(bls.KeyValidate(pubkey) for pubkey in pubkeys)
+
+        result = copy(pubkeys[0])
+        for pubkey in pubkeys[1:]:
+            result += pubkey
+        return result
     </spec>
 
 - name: eth_fast_aggregate_verify
@@ -4494,12 +4509,12 @@
     - file: beacon-chain/core/helpers/weak_subjectivity.go
       search: func IsWithinWeakSubjectivityPeriod(
   spec: |
-    <spec fn="is_within_weak_subjectivity_period" fork="phase0" hash="f8a94089">
+    <spec fn="is_within_weak_subjectivity_period" fork="phase0" hash="aef08e82">
     def is_within_weak_subjectivity_period(
         store: Store, ws_state: BeaconState, ws_checkpoint: Checkpoint
     ) -> bool:
         # Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
-        assert ws_state.latest_block_header.state_root == ws_checkpoint.root
+        assert get_block_root(ws_state, ws_checkpoint.epoch) == ws_checkpoint.root
         assert compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch
 
         ws_period = compute_weak_subjectivity_period(ws_state)
@@ -4511,12 +4526,12 @@
 - name: is_within_weak_subjectivity_period#electra
   sources: []
   spec: |
-    <spec fn="is_within_weak_subjectivity_period" fork="electra" hash="c89ae316">
+    <spec fn="is_within_weak_subjectivity_period" fork="electra" hash="d05d230d">
     def is_within_weak_subjectivity_period(
         store: Store, ws_state: BeaconState, ws_checkpoint: Checkpoint
     ) -> bool:
         # Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
-        assert ws_state.latest_block_header.state_root == ws_checkpoint.root
+        assert get_block_root(ws_state, ws_checkpoint.epoch) == ws_checkpoint.root
         assert compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch
 
         # [Modified in Electra]
@@ -7649,8 +7664,8 @@
 - name: upgrade_lc_bootstrap_to_capella
   sources: []
   spec: |
-    <spec fn="upgrade_lc_bootstrap_to_capella" fork="capella" hash="2c8939e7">
-    def upgrade_lc_bootstrap_to_capella(pre: bellatrix.LightClientBootstrap) -> LightClientBootstrap:
+    <spec fn="upgrade_lc_bootstrap_to_capella" fork="capella" hash="d5f1203a">
+    def upgrade_lc_bootstrap_to_capella(pre: altair.LightClientBootstrap) -> LightClientBootstrap:
         return LightClientBootstrap(
             header=upgrade_lc_header_to_capella(pre.header),
             current_sync_committee=pre.current_sync_committee,
@@ -7687,9 +7702,9 @@
 - name: upgrade_lc_finality_update_to_capella
   sources: []
   spec: |
-    <spec fn="upgrade_lc_finality_update_to_capella" fork="capella" hash="5315d1df">
+    <spec fn="upgrade_lc_finality_update_to_capella" fork="capella" hash="c314b172">
     def upgrade_lc_finality_update_to_capella(
-        pre: bellatrix.LightClientFinalityUpdate,
+        pre: altair.LightClientFinalityUpdate,
     ) -> LightClientFinalityUpdate:
         return LightClientFinalityUpdate(
             attested_header=upgrade_lc_header_to_capella(pre.attested_header),
@@ -7735,10 +7750,12 @@
 - name: upgrade_lc_header_to_capella
   sources: []
   spec: |
-    <spec fn="upgrade_lc_header_to_capella" fork="capella" hash="9eaa5026">
-    def upgrade_lc_header_to_capella(pre: bellatrix.LightClientHeader) -> LightClientHeader:
+    <spec fn="upgrade_lc_header_to_capella" fork="capella" hash="9f7a832d">
+    def upgrade_lc_header_to_capella(pre: altair.LightClientHeader) -> LightClientHeader:
         return LightClientHeader(
             beacon=pre.beacon,
+            execution=ExecutionPayloadHeader(),
+            execution_branch=ExecutionBranch(),
         )
     </spec>
 
@@ -7789,9 +7806,9 @@
 - name: upgrade_lc_optimistic_update_to_capella
   sources: []
   spec: |
-    <spec fn="upgrade_lc_optimistic_update_to_capella" fork="capella" hash="488c41c5">
+    <spec fn="upgrade_lc_optimistic_update_to_capella" fork="capella" hash="c4c29295">
     def upgrade_lc_optimistic_update_to_capella(
-        pre: bellatrix.LightClientOptimisticUpdate,
+        pre: altair.LightClientOptimisticUpdate,
     ) -> LightClientOptimisticUpdate:
         return LightClientOptimisticUpdate(
             attested_header=upgrade_lc_header_to_capella(pre.attested_header),
@@ -7831,8 +7848,8 @@
 - name: upgrade_lc_store_to_capella
   sources: []
   spec: |
-    <spec fn="upgrade_lc_store_to_capella" fork="capella" hash="a25064df">
-    def upgrade_lc_store_to_capella(pre: bellatrix.LightClientStore) -> LightClientStore:
+    <spec fn="upgrade_lc_store_to_capella" fork="capella" hash="d02773ec">
+    def upgrade_lc_store_to_capella(pre: altair.LightClientStore) -> LightClientStore:
         if pre.best_valid_update is None:
             best_valid_update = None
         else:
@@ -7891,8 +7908,8 @@
 - name: upgrade_lc_update_to_capella
   sources: []
   spec: |
-    <spec fn="upgrade_lc_update_to_capella" fork="capella" hash="e7dbaf33">
-    def upgrade_lc_update_to_capella(pre: bellatrix.LightClientUpdate) -> LightClientUpdate:
+    <spec fn="upgrade_lc_update_to_capella" fork="capella" hash="ba863d2f">
+    def upgrade_lc_update_to_capella(pre: altair.LightClientUpdate) -> LightClientUpdate:
         return LightClientUpdate(
             attested_header=upgrade_lc_header_to_capella(pre.attested_header),
             next_sync_committee=pre.next_sync_committee,
@@ -8539,7 +8556,7 @@
     - file: beacon-chain/core/peerdas/p2p_interface.go
       search: func VerifyDataColumnSidecar(
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="fulu" hash="509c0986">
+    <spec fn="verify_data_column_sidecar" fork="fulu" hash="1517491f">
     def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
         """
         Verify if the data column sidecar is valid.
@@ -8550,6 +8567,11 @@
 
         # A sidecar for zero blobs is invalid
         if len(sidecar.kzg_commitments) == 0:
+            return False
+
+        # Check that the sidecar respects the blob limit
+        epoch = compute_epoch_at_slot(sidecar.signed_block_header.message.slot)
+        if len(sidecar.kzg_commitments) > get_blob_parameters(epoch).max_blobs_per_block:
             return False
 
         # The column length must be equal to the number of commitments/proofs

--- a/tools/download_spectests.bzl
+++ b/tools/download_spectests.bzl
@@ -110,6 +110,6 @@ consensus_spec_tests = repository_rule(
         "repo": attr.string(default = "ethereum/consensus-specs"),
         "workflow": attr.string(default = "generate_vectors.yml"),
         "branch": attr.string(default = "dev"),
-        "release_url_template": attr.string(default = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s"),
+        "release_url_template": attr.string(default = "https://github.com/ethereum/consensus-specs/releases/download/%s"),
     },
 )


### PR DESCRIPTION
This PR updates consensus spec and tests to `beta.1`
Per @jtraglia:
```
This release contains a notable change to how reference tests are published. Due to a persistent issue, the reference test tarballs (eg mainnet.tar.gz) are now available in the consensus-specs release assets
```
I had to update `tools/download_spectests.bzl`'s `release_url_template`