### PR TITLE
correct defaultRetentionEpochs & epoch aligned pruning

### DIFF
--- a/beacon-chain/db/pruner/BUILD.bazel
+++ b/beacon-chain/db/pruner/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
+        "//time/slots:go_default_library",
         "//time/slots/testing:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",

--- a/beacon-chain/db/pruner/pruner.go
+++ b/beacon-chain/db/pruner/pruner.go
@@ -36,7 +36,7 @@ type ServiceOption func(*Service)
 // The retention period is specified in epochs, and must be >= MIN_EPOCHS_FOR_BLOCK_REQUESTS.
 func WithRetentionPeriod(retentionEpochs primitives.Epoch) ServiceOption {
 	return func(s *Service) {
-		defaultRetentionEpochs := primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests) + 1
+		defaultRetentionEpochs := primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests)
 		if retentionEpochs < defaultRetentionEpochs {
 			log.WithField("userEpochs", retentionEpochs).
 				WithField("minRequired", defaultRetentionEpochs).
@@ -75,7 +75,7 @@ func New(ctx context.Context, db iface.Database, genesisTime time.Time, initSync
 	p := &Service{
 		ctx:            ctx,
 		db:             db,
-		ps:             pruneStartSlotFunc(primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests) + 1), // Default retention epochs is MIN_EPOCHS_FOR_BLOCK_REQUESTS + 1 from the current slot.
+		ps:             pruneStartSlotFunc(primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests)),
 		done:           make(chan struct{}),
 		slotTicker:     slots.NewSlotTicker(slots.UnsafeStartTime(genesisTime, 0), params.BeaconConfig().SecondsPerSlot),
 		initSyncWaiter: initSyncWaiter,

--- a/beacon-chain/db/pruner/pruner.go
+++ b/beacon-chain/db/pruner/pruner.go
@@ -242,11 +242,12 @@ func (p *Service) pruneBatches(pruneUpto primitives.Slot) (int, error) {
 // The pruning calculation is epoch-aligned,
 // ensuring that earliestAvailableSlot is always at an epoch boundary.
 // So that we prune epoch-wise.
-// e.g. if retentionEpochs is 3 i.e. we should keep at least 3 epochs from current slot, 
-//  current slot is 325 (=> current epoch is 10), 
-//  then we should keep epoch 7 onwards (inclusive of epoch 7). 
-//  So we can prune up to the last slot of 6th epoch i.e. 32 x 7 - 1 = 223
-//  Earliest available slot would be 224 in that case. 
+// e.g. if retentionEpochs is 3 i.e. we should keep at least 3 epochs from current slot,
+//
+//	current slot is 325 (=> current epoch is 10),
+//	then we should keep epoch 7 onwards (inclusive of epoch 7).
+//	So we can prune up to the last slot of 6th epoch i.e. 32 x 7 - 1 = 223
+//	Earliest available slot would be 224 in that case.
 func pruneStartSlotFunc(retentionEpochs primitives.Epoch) func(primitives.Slot) primitives.Slot {
 	return func(current primitives.Slot) primitives.Slot {
 		if retentionEpochs > slots.MaxSafeEpoch() {

--- a/beacon-chain/db/pruner/pruner.go
+++ b/beacon-chain/db/pruner/pruner.go
@@ -239,15 +239,37 @@ func (p *Service) pruneBatches(pruneUpto primitives.Slot) (int, error) {
 }
 
 // pruneStartSlotFunc returns the function to determine the start slot to start pruning.
+// The pruning calculation is epoch-aligned,
+// ensuring that earliestAvailableSlot is always at an epoch boundary.
+// So that we prune epoch-wise.
+// e.g. if retentionEpochs is 3 i.e. we should keep at least 3 epochs from current slot, 
+//  current slot is 325 (=> current epoch is 10), 
+//  then we should keep epoch 7 onwards (inclusive of epoch 7). 
+//  So we can prune up to the last slot of 6th epoch i.e. 32 x 7 - 1 = 223
+//  Earliest available slot would be 224 in that case. 
 func pruneStartSlotFunc(retentionEpochs primitives.Epoch) func(primitives.Slot) primitives.Slot {
 	return func(current primitives.Slot) primitives.Slot {
 		if retentionEpochs > slots.MaxSafeEpoch() {
 			retentionEpochs = slots.MaxSafeEpoch()
 		}
-		offset := slots.UnsafeEpochStart(retentionEpochs)
-		if offset >= current {
+
+		// Calculate epoch-aligned minimum required slot
+		currentEpoch := slots.ToEpoch(current)
+		var minRequiredEpoch primitives.Epoch
+		if currentEpoch > retentionEpochs {
+			minRequiredEpoch = currentEpoch - retentionEpochs
+		} else {
+			minRequiredEpoch = 0
+		}
+
+		// Get the start slot of the minimum required epoch
+		minRequiredSlot, err := slots.EpochStart(minRequiredEpoch)
+		if err != nil || minRequiredSlot == 0 {
 			return 0
 		}
-		return current - offset
+
+		// Prune up to (but not including) the minimum required slot
+		// This ensures earliestAvailableSlot (pruneUpto + 1) is at the epoch boundary
+		return minRequiredSlot - 1
 	}
 }

--- a/beacon-chain/db/pruner/pruner_test.go
+++ b/beacon-chain/db/pruner/pruner_test.go
@@ -363,11 +363,9 @@ func TestWithRetentionPeriod_AcceptsSpecMinimum(t *testing.T) {
 	require.NoError(t, err)
 	expectedPruneSlot := minRequiredSlot - 1
 
-	// This should pass: spec minimum should be accepted and used
 	assert.Equal(t, expectedPruneSlot, pruneUptoSlot,
 		"Pruner should accept and use MIN_EPOCHS_FOR_BLOCK_REQUESTS without adding 1")
 
-	// This should pass: no warning should be logged for the spec minimum
 	for _, entry := range hook.AllEntries() {
 		if entry.Level == logrus.WarnLevel {
 			t.Errorf("Unexpected warning when using spec minimum: %s", entry.Message)

--- a/beacon-chain/db/pruner/pruner_test.go
+++ b/beacon-chain/db/pruner/pruner_test.go
@@ -11,6 +11,7 @@ import (
 	eth "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 
 	"github.com/OffchainLabs/prysm/v6/testing/util"
+	"github.com/OffchainLabs/prysm/v6/time/slots"
 	slottest "github.com/OffchainLabs/prysm/v6/time/slots/testing"
 	"github.com/sirupsen/logrus"
 
@@ -247,11 +248,22 @@ func TestWithRetentionPeriod_EnforcesMinimum(t *testing.T) {
 	ctx := t.Context()
 	beaconDB := dbtest.SetupDB(t)
 
-	// Get the minimum required epochs (272 + 1 = 273 for minimal)
-	minRequiredEpochs := primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests + 1)
+	// Get the minimum required epochs (272 for minimal)
+	minRequiredEpochs := primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests)
 
 	// Use a slot that's guaranteed to be after the minimum retention period
 	currentSlot := primitives.Slot(minRequiredEpochs+100) * (params.BeaconConfig().SlotsPerEpoch)
+
+	// Calculate epoch-aligned expected prune slot
+	// For epoch-aligned pruning: pruneUpto = epochStart(currentEpoch - retention) - 1
+	currentEpoch := slots.ToEpoch(currentSlot)
+
+	// Helper function to calculate expected prune slot for a given retention
+	calcExpectedPruneSlot := func(retention primitives.Epoch) primitives.Slot {
+		minEpoch := currentEpoch - retention
+		minSlot, _ := slots.EpochStart(minEpoch)
+		return minSlot - 1
+	}
 
 	tests := []struct {
 		name                string
@@ -262,19 +274,19 @@ func TestWithRetentionPeriod_EnforcesMinimum(t *testing.T) {
 		{
 			name:                "User value below minimum - should use minimum",
 			userRetentionEpochs: 2, // Way below minimum
-			expectedPruneSlot:   currentSlot - primitives.Slot(minRequiredEpochs)*params.BeaconConfig().SlotsPerEpoch,
+			expectedPruneSlot:   calcExpectedPruneSlot(minRequiredEpochs),
 			description:         "Should use minimum when user value is too low",
 		},
 		{
 			name:                "User value at minimum",
 			userRetentionEpochs: minRequiredEpochs,
-			expectedPruneSlot:   currentSlot - primitives.Slot(minRequiredEpochs)*params.BeaconConfig().SlotsPerEpoch,
+			expectedPruneSlot:   calcExpectedPruneSlot(minRequiredEpochs),
 			description:         "Should use user value when at minimum",
 		},
 		{
 			name:                "User value above minimum",
 			userRetentionEpochs: minRequiredEpochs + 10,
-			expectedPruneSlot:   currentSlot - primitives.Slot(minRequiredEpochs+10)*params.BeaconConfig().SlotsPerEpoch,
+			expectedPruneSlot:   calcExpectedPruneSlot(minRequiredEpochs + 10),
 			description:         "Should use user value when above minimum",
 		},
 	}
@@ -307,6 +319,135 @@ func TestWithRetentionPeriod_EnforcesMinimum(t *testing.T) {
 			if tt.userRetentionEpochs < minRequiredEpochs {
 				assert.LogsContain(t, hook, "Retention period too low, ignoring and using minimum required value")
 			}
+		})
+	}
+}
+
+func TestWithRetentionPeriod_AcceptsSpecMinimum(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	config := params.MinimalSpecConfig()
+	params.OverrideBeaconConfig(config)
+
+	ctx := t.Context()
+	beaconDB := dbtest.SetupDB(t)
+
+	hook := logTest.NewGlobal()
+	logrus.SetLevel(logrus.WarnLevel)
+
+	// The spec minimum - this SHOULD be accepted without warning
+	specMinimum := primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests)
+
+	// Use a slot that's guaranteed to be after the minimum retention period
+	currentSlot := primitives.Slot(specMinimum+100) * (params.BeaconConfig().SlotsPerEpoch)
+
+	mockCustody := &mockCustodyUpdater{}
+	p, err := New(
+		ctx,
+		beaconDB,
+		time.Now(),
+		nil,
+		nil,
+		mockCustody,
+		WithRetentionPeriod(specMinimum),
+	)
+	require.NoError(t, err)
+
+	// Test the pruning calculation
+	pruneUptoSlot := p.ps(currentSlot)
+
+	// The expected prune slot should use epoch-aligned calculation
+	// pruneUpto = epochStart(currentEpoch - retention) - 1
+	currentEpoch := slots.ToEpoch(currentSlot)
+	minRequiredEpoch := currentEpoch - specMinimum
+	minRequiredSlot, err := slots.EpochStart(minRequiredEpoch)
+	require.NoError(t, err)
+	expectedPruneSlot := minRequiredSlot - 1
+
+	// This should pass: spec minimum should be accepted and used
+	assert.Equal(t, expectedPruneSlot, pruneUptoSlot,
+		"Pruner should accept and use MIN_EPOCHS_FOR_BLOCK_REQUESTS without adding 1")
+
+	// This should pass: no warning should be logged for the spec minimum
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.WarnLevel {
+			t.Errorf("Unexpected warning when using spec minimum: %s", entry.Message)
+		}
+	}
+}
+
+func TestPruneStartSlotFunc_EpochAlignment(t *testing.T) {
+	// This test verifies that the pruning calculation is epoch-aligned.
+	params.SetupTestConfigCleanup(t)
+	config := params.MinimalSpecConfig()
+	params.OverrideBeaconConfig(config)
+
+	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch // 8 for minimal config
+	retentionEpochs := primitives.Epoch(3)
+
+	tests := []struct {
+		name                    string
+		currentSlot             primitives.Slot
+		expectedEpochAlignment  bool
+		expectedMinRequiredSlot primitives.Slot
+		description             string
+	}{
+		{
+			name:                    "Pruning at epoch boundary",
+			currentSlot:             primitives.Slot(4 * slotsPerEpoch), // Slot 32 (epoch 4, slot 0 of epoch)
+			expectedEpochAlignment:  true,
+			expectedMinRequiredSlot: primitives.Slot(1 * slotsPerEpoch), // Epoch 1 start = slot 8
+			description:             "When pruning at epoch boundary, earliestAvailableSlot should be at epoch boundary",
+		},
+		{
+			name:                    "Pruning at middle of epoch",
+			currentSlot:             primitives.Slot(4*slotsPerEpoch + 4), // Slot 36 (epoch 4, slot 4 of epoch)
+			expectedEpochAlignment:  true,
+			expectedMinRequiredSlot: primitives.Slot(1 * slotsPerEpoch), // Epoch 1 start = slot 8
+			description:             "When pruning mid-epoch, earliestAvailableSlot must still be at epoch boundary",
+		},
+		{
+			name:                    "Pruning at end of epoch",
+			currentSlot:             primitives.Slot(5*slotsPerEpoch - 1), // Slot 39 (epoch 4, last slot)
+			expectedEpochAlignment:  true,
+			expectedMinRequiredSlot: primitives.Slot(1 * slotsPerEpoch), // Epoch 1 start = slot 8
+			description:             "When pruning at epoch end, earliestAvailableSlot must be at epoch boundary",
+		},
+		{
+			name:                    "Pruning at various epoch positions",
+			currentSlot:             primitives.Slot(8*slotsPerEpoch + 5), // Slot 69 (epoch 8, slot 5 of epoch)
+			expectedEpochAlignment:  true,
+			expectedMinRequiredSlot: primitives.Slot(5 * slotsPerEpoch), // Epoch 5 start = slot 40
+			description:             "EarliestAvailableSlot should always align to epoch boundary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create the prune start slot function
+			ps := pruneStartSlotFunc(retentionEpochs)
+
+			// Calculate pruneUpto slot
+			pruneUpto := ps(tt.currentSlot)
+
+			// EarliestAvailableSlot is pruneUpto + 1
+			earliestAvailableSlot := pruneUpto + 1
+
+			// Verify epoch alignment: earliestAvailableSlot should be at an epoch boundary
+			if tt.expectedEpochAlignment {
+				// Check if earliestAvailableSlot is at the start of an epoch
+				epoch := slots.ToEpoch(earliestAvailableSlot)
+				epochStartSlot, err := slots.EpochStart(epoch)
+				require.NoError(t, err)
+
+				assert.Equal(t, epochStartSlot, earliestAvailableSlot,
+					"%s: earliestAvailableSlot (%d) should be at epoch boundary (slot %d of epoch %d)",
+					tt.description, earliestAvailableSlot, epochStartSlot, epoch)
+			}
+
+			// Verify it matches the expected minimum required slot for custody validation
+			assert.Equal(t, tt.expectedMinRequiredSlot, earliestAvailableSlot,
+				"%s: earliestAvailableSlot should match custody minimum required slot",
+				tt.description)
 		})
 	}
 }

--- a/changelog/satushh-plus-one-bug.md
+++ b/changelog/satushh-plus-one-bug.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - corrected defaultRetentionEpochs in pruner
+- epoch aligned pruning: pruning should be epoch-wise. No fractional epoch pruning.

--- a/changelog/satushh-plus-one-bug.md
+++ b/changelog/satushh-plus-one-bug.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- corrected defaultRetentionEpochs in pruner


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

 Bug fix


**What does this PR do? Why is it needed?**

- If you set `retentionEpochs` to be exactly equal to `MinEpochsForBlockRequests` then it should be allowed. The previous code rejected it. This is more of a non-critical correctness bug. 

- This PR also ensures epoch-aligned pruning. So we keep complete epochs rather than fractional epochs. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

Example Scenario for `func pruneStartSlotFunc(retentionEpochs primitives.Epoch) func(primitives.Slot) primitives.Slot` in `pruner.go`

Current Slot: 325 (Epoch 10, slot 5 within epoch)
  Retention: 3 epochs

  Epoch Timeline:
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Epoch 0:  [  0 -  31]
  Epoch 1:  [ 32 -  63]
  Epoch 2:  [ 64 -  95]
  Epoch 3:  [ 96 - 127]
  Epoch 4:  [128 - 159]
  Epoch 5:  [160 - 191]
  Epoch 6:  [192 - 223]  ← Prune up to here (inclusive)
            ═══════════ ═══════════
  Epoch 7:  [224 - 255]  ← Earliest available (keep from here)
  Epoch 8:  [256 - 287]
  Epoch 9:  [288 - 319]
  Epoch 10: [320 - 351]  ← Current slot 325 is here
            ↑
            Current head

  Calculation:
    currentEpoch = 10
    retentionEpochs = 3
    minRequiredEpoch = 10 - 3 = 7

    DELETE: Epochs 0-6 (slots 0-223)
    KEEP:   Epochs 7-10 onwards (slots 224+)

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
