### PR TITLE
Fix timer leak in data column peer selection

### DIFF
--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -1133,9 +1133,14 @@ func randomPeer(
 			"delay":     waitPeriod,
 		}).Debug("Waiting for a peer with enough bandwidth for data column sidecars")
 
+		timer := time.NewTimer(waitPeriod)
 		select {
-		case <-time.After(waitPeriod):
+		case <-timer.C:
+			// Timer expired, retry the loop
 		case <-ctx.Done():
+			// Context cancelled - stop timer to prevent leak
+			timer.Stop()
+			return "", ctx.Err()
 		}
 	}
 

--- a/changelog/ttsao_fix-timer.md
+++ b/changelog/ttsao_fix-timer.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Replace `time.After()` with `time.NewTimer()` and explicitly stop the timer when the context is cancelled


### PR DESCRIPTION
The randomPeer function in has a timer leak that occurs when waiting for peers with sufficient bandwidth and context is done
```
  for ctx.Err() == nil {
      // ... check for peers with bandwidth ...

      select {
      case <-time.After(waitPeriod):  // Creates new timer every iteration
      case <-ctx.Done():               // If context cancelled, timer never cleaned up
      }
  }
```
One way to fix this is to replace time.After() with time.NewTimer() and explicitly stop the timer when the context is cancelled

