### PR TITLE
fix: use KZG inclusion proof in BlobAlignsWithBlock

### DIFF
--- a/beacon-chain/sync/verify/blob.go
+++ b/beacon-chain/sync/verify/blob.go
@@ -3,7 +3,6 @@ package verify
 import (
 	"github.com/OffchainLabs/prysm/v6/config/params"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/blocks"
-	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v6/runtime/version"
 	"github.com/pkg/errors"
 )
@@ -32,16 +31,9 @@ func BlobAlignsWithBlock(blob blocks.ROBlob, block blocks.ROBlock) error {
 		return ErrBlobBlockMisaligned
 	}
 
-	// Verify commitment byte values match
-	// TODO: verify commitment inclusion proof - actually replace this with a better rpc blob verification stack altogether.
-	commits, err := block.Block().Body().BlobKzgCommitments()
-	if err != nil {
-		return err
-	}
-	blockCommitment := bytesutil.ToBytes48(commits[blob.Index])
-	blobCommitment := bytesutil.ToBytes48(blob.KzgCommitment)
-	if blobCommitment != blockCommitment {
-		return errors.Wrapf(ErrMismatchedBlobCommitments, "commitment %#x != block commitment %#x, at index %d for block root %#x at slot %d ", blobCommitment, blockCommitment, blob.Index, block.Root(), blob.Slot())
+	// Verify commitment inclusion proof in the block body
+	if err := blocks.VerifyKZGInclusionProof(blob); err != nil {
+		return errors.Wrap(ErrMismatchedBlobCommitments, err.Error())
 	}
 	return nil
 }

--- a/changelog/VolodymyrBg_fix-verify-kzg-inclusion-proof.md
+++ b/changelog/VolodymyrBg_fix-verify-kzg-inclusion-proof.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- use KZG inclusion proof in BlobAlignsWithBlock [#15936](https://github.com/OffchainLabs/prysm/pull/15936)


### PR DESCRIPTION
This change updates BlobAlignsWithBlock in beacon-chain/sync/verify/blob.go to validate blob commitments by verifying the KZG inclusion proof via blocks.VerifyKZGInclusionProof instead of reading BlobKzgCommitments and comparing bytes at the provided index. This eliminates a possible index-out-of-range panic when a sidecar reports an index within MAX_BLOBS_PER_BLOCK but the block has fewer commitments, and ensures spec-accurate validation against the block body root. The bytesutil import is removed as it is no longer needed. Existing version and block-root alignment checks are preserved, and downstream batch verification flows remain compatible.