### PR TITLE
Remove unused wrappers from testing/util: deduplicate random helpers

### DIFF
--- a/testing/util/deneb.go
+++ b/testing/util/deneb.go
@@ -203,15 +203,6 @@ func ExtendBlocksPlusBlobs(t *testing.T, blks []blocks.ROBlock, size int) ([]blo
 	return blks, blobs
 }
 
-func DeterministicRandomness(seed int64) [32]byte {
-	return random.DeterministicRandomness(seed)
-}
-
-// Returns a serialized random field element in big-endian
-func GetRandFieldElement(seed int64) [32]byte {
-	return random.GetRandFieldElement(seed)
-}
-
 // Returns a random blob using the passed seed as entropy
 func GetRandBlob(seed int64) GoKZG.Blob {
 	return random.GetRandBlob(seed)


### PR DESCRIPTION


### Description
- Removed two unused wrapper functions in `testing/util/deneb.go`:
  - `DeterministicRandomness(seed int64) [32]byte`
  - `GetRandFieldElement(seed int64) [32]byte`
- These wrappers duplicated `crypto/random` without adding logic and were not referenced anywhere.

Why
- Reduce duplicated API surface and cognitive overhead by keeping a single source of truth (`crypto/random`).

