### PR TITLE
also ignore errors from readdirnames

### DIFF
--- a/changelog/kasey_ignore-readdir-errors.md
+++ b/changelog/kasey_ignore-readdir-errors.md
@@ -1,0 +1,2 @@
+### Ignored
+- Fix bug with layout detection when readdirnames returns io.EOF.

--- a/cmd/beacon-chain/storage/options.go
+++ b/cmd/beacon-chain/storage/options.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"slices"
@@ -139,6 +140,10 @@ func detectLayout(dir string, c stringFlagGetter) (string, error) {
 	// amount of wiggle room to be confident that we'll likely see a by-root director if one exists.
 	entries, err := base.Readdirnames(16)
 	if err != nil {
+		// We can get this error if the directory exists and is empty
+		if errors.Is(err, io.EOF) {
+			return filesystem.LayoutNameByEpoch, nil
+		}
 		return "", errors.Wrap(err, "reading blob storage directory")
 	}
 	for _, entry := range entries {

--- a/cmd/beacon-chain/storage/options_test.go
+++ b/cmd/beacon-chain/storage/options_test.go
@@ -192,6 +192,13 @@ func TestDetectLayout(t *testing.T) {
 			},
 			expectedErr: syscall.ENOTDIR,
 		},
+		{
+			name: "empty blobs dir",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+			},
+			expected: filesystem.LayoutNameByEpoch,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Readdirnames returns io.EOF if there are no directory entries. In some OS's when the directory is non-existent, `os.Open` will succeed without an error but then calling `Readdirnames` can fail with `io.EOF`. In these cases the blobs dir either hasn't been made yet or is empty, so we want to ignore the error and use by-epoch layout.

**Fixes**
- https://github.com/OffchainLabs/prysm/issues/15943

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
