### PR TITLE
Async: stop re-copying input on every hash loop

### DIFF
--- a/async/benchmark_test.go
+++ b/async/benchmark_test.go
@@ -33,8 +33,8 @@ func init() {
 // hash repeatedly hashes the data passed to it
 func hash(input [][]byte) [][]byte {
 	output := make([][]byte, len(input))
+	copy(output, input)
 	for i := range input {
-		copy(output, input)
 		for j := 0; j < benchmarkHashRuns; j++ {
 			hash := sha256.Sum256(output[i])
 			output[i] = hash[:]


### PR DESCRIPTION
Summary: Move the copy(output, input) out of the per-element loop in hash, so the benchmark keeps identical behavior while avoiding O(n²) copies. Why: Each iteration previously copied the entire slice even though the data was unchanged. One upfront copy preserves semantics and eliminates redundant work. Testing: go test ./async/... (cannot run here: Go toolchain missing in environment)
