### PR TITLE
Fix uint64 overflow in `/eth/v1/beacon/rewards/attestations/{epoch}` validation

### DIFF
--- a/beacon-chain/rpc/eth/rewards/handlers.go
+++ b/beacon-chain/rpc/eth/rewards/handlers.go
@@ -210,7 +210,9 @@ func (s *Server) attRewardsState(w http.ResponseWriter, r *http.Request) (state.
 		return nil, false
 	}
 	currentEpoch := uint64(slots.ToEpoch(s.TimeFetcher.CurrentSlot()))
-	if requestedEpoch+1 >= currentEpoch {
+	// Check if requested epoch is too recent (need at least 2 epochs of separation).
+	// Avoid adding values to requestedEpoch to avoid uint64 overflow when requestedEpoch is near max value.
+	if currentEpoch < 2 || requestedEpoch > currentEpoch-2 {
 		httputil.HandleError(w,
 			"Attestation rewards are available after two epoch transitions to ensure all attestations have a chance of inclusion",
 			http.StatusNotFound)

--- a/beacon-chain/rpc/eth/rewards/handlers_test.go
+++ b/beacon-chain/rpc/eth/rewards/handlers_test.go
@@ -747,6 +747,47 @@ func TestAttestationRewards(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.Equal(t, "Attestation rewards are available after two epoch transitions to ensure all attestations have a chance of inclusion", e.Message)
 	})
+	t.Run("current epoch", func(t *testing.T) {
+		url := "http://only.the.epoch.number.at.the.end.is.important/3"
+		request := httptest.NewRequest("POST", url, nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.AttestationRewards(writer, request)
+		assert.Equal(t, http.StatusNotFound, writer.Code)
+		e := &httputil.DefaultJsonError{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusNotFound, e.Code)
+		assert.Equal(t, "Attestation rewards are available after two epoch transitions to ensure all attestations have a chance of inclusion", e.Message)
+	})
+	t.Run("future epoch", func(t *testing.T) {
+		url := "http://only.the.epoch.number.at.the.end.is.important/100"
+		request := httptest.NewRequest("POST", url, nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.AttestationRewards(writer, request)
+		assert.Equal(t, http.StatusNotFound, writer.Code)
+		e := &httputil.DefaultJsonError{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusNotFound, e.Code)
+		assert.Equal(t, "Attestation rewards are available after two epoch transitions to ensure all attestations have a chance of inclusion", e.Message)
+	})
+	t.Run("extreme future epoch with overflow", func(t *testing.T) {
+		// This test specifically checks the fix for issue #15969
+		// When requestedEpoch is max uint64, requestedEpoch+1 would overflow to 0
+		url := "http://only.the.epoch.number.at.the.end.is.important/18446744073709551615"
+		request := httptest.NewRequest("POST", url, nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.AttestationRewards(writer, request)
+		assert.Equal(t, http.StatusNotFound, writer.Code)
+		e := &httputil.DefaultJsonError{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusNotFound, e.Code)
+		assert.Equal(t, "Attestation rewards are available after two epoch transitions to ensure all attestations have a chance of inclusion", e.Message)
+	})
 }
 
 func TestSyncCommiteeRewards(t *testing.T) {

--- a/changelog/AntiD2ta_fix-attestation-rewards-overflow.md
+++ b/changelog/AntiD2ta_fix-attestation-rewards-overflow.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix uint64 overflow in attestation rewards endpoint epoch validation that allowed invalid future epoch requests to return data instead of 404 error (#15969).


### PR DESCRIPTION
Fixes #15969 - The attestation rewards endpoint had a uint64 overflow bug in epoch validation.

## Changes
  - Fixed overflow in epoch validation by rewriting condition to avoid `requestedEpoch+1` overflow
  - Added test cases for current epoch, future epoch, and extreme overflow scenario (max uint64)
  - Added inline comments explaining the overflow fix

  ## Testing
  All existing tests pass, plus 3 new test cases specifically for this bug.

  ## Root Cause
  When `requestedEpoch = 18446744073709551615` (max uint64), the condition `requestedEpoch+1 >= currentEpoch` causes overflow where `requestedEpoch+1` wraps to `0`, bypassing validation.

  ## Fix
  Rewrote validation to: `currentEpoch < 2 || requestedEpoch > currentEpoch-2` which is mathematically equivalent but avoids overflow.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #15969

**Other notes for review**

**Acknowledgements**

- [X] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [X] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [X] I have added a description to this PR with sufficient context for reviewers to understand this PR.
