### PR TITLE
`SidecarProposerExpected`: Add the slot in the single flight key.

### DIFF
--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -481,7 +481,7 @@ func (dv *RODataColumnsVerifier) SidecarProposerExpected(ctx context.Context) (e
 			parentRoot := dataColumn.ParentRoot()
 			// Ensure the expensive index computation is only performed once for
 			// concurrent requests for the same signature data.
-			if _, err, _ := dv.sg.Do(fmt.Sprintf("%#x", parentRoot), func() (any, error) {
+			if _, err, _ := dv.sg.Do(concatRootSlot(parentRoot, dataColumnSlot), func() (any, error) {
 				// Retrieve the parent state.
 				parentState, err := dv.state(ctx, parentRoot)
 				if err != nil {
@@ -576,4 +576,8 @@ func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
 	}
 
 	return sha256.Sum256(unhashedKey), nil
+}
+
+func concatRootSlot(root [fieldparams.RootLength]byte, slot primitives.Slot) string {
+	return string(root[:]) + fmt.Sprintf("%d", slot)
 }

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -579,5 +580,5 @@ func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
 }
 
 func concatRootSlot(root [fieldparams.RootLength]byte, slot primitives.Slot) string {
-	return string(root[:]) + fmt.Sprintf("%d", slot)
+	return string(root[:]) + strconv.Itoa(int(slot))
 }

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -580,5 +579,5 @@ func inclusionProofKey(c blocks.RODataColumn) ([32]byte, error) {
 }
 
 func concatRootSlot(root [fieldparams.RootLength]byte, slot primitives.Slot) string {
-	return string(root[:]) + strconv.Itoa(int(slot))
+	return string(root[:]) + fmt.Sprintf("%d", slot)
 }

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -976,3 +976,13 @@ func TestColumnRequirementSatisfaction(t *testing.T) {
 	_, err = verifier.VerifiedRODataColumns()
 	require.NoError(t, err)
 }
+
+func TestConcatRootSlot(t *testing.T) {
+	root := [fieldparams.RootLength]byte{1, 2, 3}
+	const slot = primitives.Slot(3210)
+
+	const expected = "\x01\x02\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x003210"
+
+	actual := concatRootSlot(root, slot)
+	require.Equal(t, expected, actual)
+}

--- a/changelog/manu-column-slot.md
+++ b/changelog/manu-column-slot.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `SidecarProposerExpected`: Add the slot in the single flight key.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Before this PR, only the parent root of the incoming data column sidecar was included in the key of the single flight group.

The problem is, if a slot is missed (like in the description of the fixed issue), then, at the next non-missed slot, the parent root is still the same, but the slot is different.

This PR fixes that, forcing the single flight group to recompute the expected proposer index if the slot is different, even if the parent root is the same.

**Which issues(s) does this PR fix?**
-  https://github.com/OffchainLabs/prysm/issues/15973

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
