### PR TITLE
disable backfill if the checkpoint sync origin slot is in fulu

### DIFF
--- a/beacon-chain/sync/backfill/BUILD.bazel
+++ b/beacon-chain/sync/backfill/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//runtime/interop:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
+        "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_libp2p_go_libp2p//core/peer:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/changelog/kasey_disable-backfill-if-fulu.md
+++ b/changelog/kasey_disable-backfill-if-fulu.md
@@ -1,0 +1,2 @@
+### Fixed
+- Backfill disabled if checkpoint sync origin is after fulu fork due to lack of DataColumnSidecar support in backfill. To track the availability of fulu-compatible backfill please watch https://github.com/OffchainLabs/prysm/issues/15982


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Until DataColumnSidecar backfill is fully supported in develop we want to prevent backfill from being enabled when back syncing from a fulu block, because currently running backfill in a post-fulu network will cause bugs and not be helpful.

For context see https://github.com/OffchainLabs/prysm/issues/15982

**Which issues(s) does this PR fix?**

Fixes #15978

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
