### PR TITLE
Remove test overrides for electra and fulu epochs in beacon-chain/rpc/eth/beacon/handlers_pool_test.go

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -222,10 +222,13 @@ func TestListAttestationsV2(t *testing.T) {
 		cb2 := primitives.NewAttestationCommitteeBits()
 		cb2.SetBitAt(2, true)
 
+		config := params.BeaconConfig()
+		electraSlot := slots.UnsafeEpochStart(config.ElectraForkEpoch + 1)
+
 		attElectra1 := &ethpbv1alpha1.AttestationElectra{
 			AggregationBits: []byte{1, 10},
 			Data: &ethpbv1alpha1.AttestationData{
-				Slot:            1,
+				Slot:            electraSlot,
 				CommitteeIndex:  0,
 				BeaconBlockRoot: bytesutil.PadTo([]byte("blockroot1"), 32),
 				Source: &ethpbv1alpha1.Checkpoint{
@@ -243,7 +246,7 @@ func TestListAttestationsV2(t *testing.T) {
 		attElectra2 := &ethpbv1alpha1.AttestationElectra{
 			AggregationBits: []byte{1, 10},
 			Data: &ethpbv1alpha1.AttestationData{
-				Slot:            1,
+				Slot:            electraSlot,
 				CommitteeIndex:  0,
 				BeaconBlockRoot: bytesutil.PadTo([]byte("blockroot2"), 32),
 				Source: &ethpbv1alpha1.Checkpoint{
@@ -261,7 +264,7 @@ func TestListAttestationsV2(t *testing.T) {
 		attElectra3 := &ethpbv1alpha1.AttestationElectra{
 			AggregationBits: bitfield.NewBitlist(8),
 			Data: &ethpbv1alpha1.AttestationData{
-				Slot:            2,
+				Slot:            electraSlot + 1,
 				CommitteeIndex:  0,
 				BeaconBlockRoot: bytesutil.PadTo([]byte("blockroot3"), 32),
 				Source: &ethpbv1alpha1.Checkpoint{
@@ -279,7 +282,7 @@ func TestListAttestationsV2(t *testing.T) {
 		attElectra4 := &ethpbv1alpha1.AttestationElectra{
 			AggregationBits: bitfield.NewBitlist(8),
 			Data: &ethpbv1alpha1.AttestationData{
-				Slot:            2,
+				Slot:            electraSlot + 1,
 				CommitteeIndex:  0,
 				BeaconBlockRoot: bytesutil.PadTo([]byte("blockroot4"), 32),
 				Source: &ethpbv1alpha1.Checkpoint{
@@ -298,11 +301,8 @@ func TestListAttestationsV2(t *testing.T) {
 		require.NoError(t, err)
 
 		params.SetupTestConfigCleanup(t)
-		config := params.BeaconConfig()
-		config.ElectraForkEpoch = 0
-		params.OverrideBeaconConfig(config)
 
-		chainService := &blockchainmock.ChainService{State: bs}
+		chainService := &blockchainmock.ChainService{State: bs, Slot: &electraSlot}
 		s := &Server{
 			AttestationsPool: attestations.NewPool(),
 			ChainInfoFetcher: chainService,
@@ -331,7 +331,7 @@ func TestListAttestationsV2(t *testing.T) {
 			assert.Equal(t, "electra", resp.Version)
 		})
 		t.Run("slot request", func(t *testing.T) {
-			url := "http://example.com?slot=2"
+			url := fmt.Sprintf("http://example.com?slot=%d", electraSlot)
 			request := httptest.NewRequest(http.MethodGet, url, nil)
 			writer := httptest.NewRecorder()
 			writer.Body = &bytes.Buffer{}
@@ -348,7 +348,7 @@ func TestListAttestationsV2(t *testing.T) {
 			assert.Equal(t, 2, len(atts))
 			assert.Equal(t, "electra", resp.Version)
 			for _, a := range atts {
-				assert.Equal(t, "2", a.Data.Slot)
+				assert.Equal(t, fmt.Sprintf("%d", electraSlot), a.Data.Slot)
 			}
 		})
 		t.Run("index request", func(t *testing.T) {
@@ -378,7 +378,7 @@ func TestListAttestationsV2(t *testing.T) {
 			}
 		})
 		t.Run("both slot + index request", func(t *testing.T) {
-			url := "http://example.com?slot=2&committee_index=2"
+			url := fmt.Sprintf("http://example.com?slot=%d&committee_index=2", electraSlot)
 			request := httptest.NewRequest(http.MethodGet, url, nil)
 			writer := httptest.NewRecorder()
 			writer.Body = &bytes.Buffer{}
@@ -395,7 +395,7 @@ func TestListAttestationsV2(t *testing.T) {
 			assert.Equal(t, 1, len(atts))
 			assert.Equal(t, "electra", resp.Version)
 			for _, a := range atts {
-				assert.Equal(t, "2", a.Data.Slot)
+				assert.Equal(t, fmt.Sprintf("%d", electraSlot), a.Data.Slot)
 				assert.Equal(t, "0x0400000000000000", a.CommitteeBits)
 			}
 		})
@@ -1647,11 +1647,9 @@ func TestGetAttesterSlashingsV2(t *testing.T) {
 
 		params.SetupTestConfigCleanup(t)
 		config := params.BeaconConfig()
-		config.ElectraForkEpoch = 100
-		params.OverrideBeaconConfig(config)
 
-		chainService := &blockchainmock.ChainService{State: bs}
-
+		slot := slots.UnsafeEpochStart(config.ElectraForkEpoch + 1)
+		chainService := &blockchainmock.ChainService{State: bs, Slot: &slot}
 		s := &Server{
 			ChainInfoFetcher: chainService,
 			TimeFetcher:      chainService,
@@ -1686,10 +1684,9 @@ func TestGetAttesterSlashingsV2(t *testing.T) {
 
 		params.SetupTestConfigCleanup(t)
 		config := params.BeaconConfig()
-		config.ElectraForkEpoch = 100
-		params.OverrideBeaconConfig(config)
 
-		chainService := &blockchainmock.ChainService{State: bs}
+		slot := slots.UnsafeEpochStart(config.ElectraForkEpoch + 1)
+		chainService := &blockchainmock.ChainService{State: bs, Slot: &slot}
 
 		s := &Server{
 			ChainInfoFetcher: chainService,
@@ -1756,10 +1753,9 @@ func TestGetAttesterSlashingsV2(t *testing.T) {
 
 		params.SetupTestConfigCleanup(t)
 		config := params.BeaconConfig()
-		config.ElectraForkEpoch = 100
-		params.OverrideBeaconConfig(config)
 
-		chainService := &blockchainmock.ChainService{State: bs}
+		slot := slots.UnsafeEpochStart(config.ElectraForkEpoch + 1)
+		chainService := &blockchainmock.ChainService{State: bs, Slot: &slot}
 		s := &Server{
 			ChainInfoFetcher: chainService,
 			TimeFetcher:      chainService,

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -300,7 +300,6 @@ func TestListAttestationsV2(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		config := params.BeaconConfig()
 		config.ElectraForkEpoch = 0
-		config.FuluForkEpoch = config.FarFutureEpoch
 		params.OverrideBeaconConfig(config)
 
 		chainService := &blockchainmock.ChainService{State: bs}
@@ -361,7 +360,6 @@ func TestListAttestationsV2(t *testing.T) {
 			params.SetupTestConfigCleanup(t)
 			config := params.BeaconConfig()
 			config.ElectraForkEpoch = 0
-			config.FuluForkEpoch = config.FarFutureEpoch
 			params.OverrideBeaconConfig(config)
 
 			s.ListAttestationsV2(writer, request)
@@ -681,7 +679,6 @@ func TestSubmitAttestationsV2(t *testing.T) {
 			params.SetupTestConfigCleanup(t)
 			config := params.BeaconConfig()
 			config.ElectraForkEpoch = 0
-			config.FuluForkEpoch = config.FarFutureEpoch
 			params.OverrideBeaconConfig(config)
 
 			var body bytes.Buffer
@@ -1651,7 +1648,6 @@ func TestGetAttesterSlashingsV2(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		config := params.BeaconConfig()
 		config.ElectraForkEpoch = 100
-		config.FuluForkEpoch = config.FarFutureEpoch
 		params.OverrideBeaconConfig(config)
 
 		chainService := &blockchainmock.ChainService{State: bs}
@@ -1691,7 +1687,6 @@ func TestGetAttesterSlashingsV2(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		config := params.BeaconConfig()
 		config.ElectraForkEpoch = 100
-		config.FuluForkEpoch = config.FarFutureEpoch
 		params.OverrideBeaconConfig(config)
 
 		chainService := &blockchainmock.ChainService{State: bs}
@@ -1762,7 +1757,6 @@ func TestGetAttesterSlashingsV2(t *testing.T) {
 		params.SetupTestConfigCleanup(t)
 		config := params.BeaconConfig()
 		config.ElectraForkEpoch = 100
-		config.FuluForkEpoch = config.FarFutureEpoch
 		params.OverrideBeaconConfig(config)
 
 		chainService := &blockchainmock.ChainService{State: bs}

--- a/changelog/pvl-fulu-test-fix.md
+++ b/changelog/pvl-fulu-test-fix.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Fix test setup to properly reference electra rather than unset the fulu epoch


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Post merge feedback on PR #15975 from @kasey (Thanks, Kasey)

**Which issues(s) does this PR fix?**

This is just some clean up after PR #15975.

**Other notes for review**

I'd like to follow up in another PR to address some left over tech debt / clean up work from writing tests of fork logic before the fork epoch was known. For example, the Electra epoch is first set to FAR_FUTURE_EPOCH and the testing logic would fail if that value were used so we override the electra epoch in test in the meantime. In PRs where we update the fork epoch (like #15975), we have new tech debt that can be addressed. These items shouldn't be addressed in the same PR as the mainnet fork epoch, but should follow shortly after so that the code does not rot.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
