### PR TITLE
Fix rejected data column sidecars at node boot

### DIFF
--- a/changelog/manu-flight.md
+++ b/changelog/manu-flight.md
@@ -1,0 +1,2 @@
+### Fixed 
+- `SidecarProposerExpected`: Use the correct value of proposer index in the singleflight group.

--- a/testing/util/deneb.go
+++ b/testing/util/deneb.go
@@ -58,9 +58,10 @@ func WithDenebSlot(slot primitives.Slot) DenebBlockGeneratorOption {
 
 func GenerateTestDenebBlockWithSidecar(t *testing.T, parent [32]byte, slot primitives.Slot, nblobs int, opts ...DenebBlockGeneratorOption) (blocks.ROBlock, []blocks.ROBlob) {
 	g := &denebBlockGenerator{
-		parent: parent,
-		slot:   slot,
-		nblobs: nblobs,
+		parent:   parent,
+		slot:     slot,
+		nblobs:   nblobs,
+		proposer: 3, // Anything else than zero not to fallback to the default uin64 value.
 	}
 	for _, o := range opts {
 		o(g)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**Before this PR**, right after the node boot, some
```
[2025-11-06 14:24:01.52] DEBUG sync: Gossip message was rejected agent=Lighthouse/v8.0.0-e3ee7fe/x86_64-linux error=data columns failed verification: verification failureinvalid blobsidecar was not proposed by the expected proposer_index gossipScore=0 multiaddress=/ip4/37.187.71.181/udp/9001/quic-v1 peerID=16Uiu2HAkwA5dqknFtbQzrTuPZr9specoF8hnFtBqYegtQjE9NFgS topic=/eth2/ae9f70a0/data_column_sidecar_21/ssz_snappy
```

logs were displayed.

As a consequence, the peer count dropped before raising again.

<img width="268" height="234" alt="image" src="https://github.com/user-attachments/assets/872e3a0f-de66-43f5-8b5f-6d596fb78232" />


**After this PR**, no more rejection of data column sidecars gossip messages at boot, and the peer count strictly increases.

<img width="190" height="187" alt="image" src="https://github.com/user-attachments/assets/79d52eff-2ff1-4fb9-8ad1-470eac45ed4b" />


What was the cause of this issue?
- https://github.com/OffchainLabs/prysm/pull/15954, and
- https://github.com/OffchainLabs/prysm/pull/15976

introduces a single flight group, to avoid the same expensive operation to be done again and again when receiving a lot of data column sidecars via gossip. (One by one, but globally at the same time.)

For the first sidecar, no issue.
For the following sidecars (if received while the first one is processing, which may happen):

```
		idx, cached := dv.pc.Proposer(checkpoint, dataColumnSlot)
```

`cached` is false, and `idx` is the default value (`0`).

We **don't** enter in the function executed by
```
dv.sg.Do(concatRootSlot(parentRoot, dataColumnSlot)
```

(precisely because the first sidecar is processed by this single flight group).
When the single flight group returns, we **don't** use the correct `idx` value.
We use the `idx` value set earlier by `dv.pc.Proposer` (which always is 0).

This PR fixes this, and modifies the unit test to run concurrently twice the `SidecarProposerExpected` with the same arguments.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
