### PR TITLE
Dependent root instead of target

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -79,6 +79,7 @@ type HeadFetcher interface {
 	HeadPublicKeyToValidatorIndex(pubKey [fieldparams.BLSPubkeyLength]byte) (primitives.ValidatorIndex, bool)
 	HeadValidatorIndexToPublicKey(ctx context.Context, index primitives.ValidatorIndex) ([fieldparams.BLSPubkeyLength]byte, error)
 	ChainHeads() ([][32]byte, []primitives.Slot)
+	DependentRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	HeadSyncCommitteeFetcher
 	HeadDomainFetcher
@@ -468,6 +469,13 @@ func (s *Service) IsOptimisticForRoot(ctx context.Context, root [32]byte) (bool,
 		return true, nil
 	}
 	return !isCanonical, nil
+}
+
+// DependentRootForEpoch wraps the corresponding method in forkchoice
+func (s *Service) DependentRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
+	return s.cfg.ForkChoiceStore.DependentRootForEpoch(root, epoch)
 }
 
 // TargetRootForEpoch wraps the corresponding method in forkchoice

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -1,7 +1,6 @@
 package blockchain
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -34,11 +33,15 @@ func (s *Service) getRecentPreState(ctx context.Context, c *ethpb.Checkpoint) st
 	if err != nil {
 		return nil
 	}
-	headTarget, err := s.cfg.ForkChoiceStore.TargetRootForEpoch([32]byte(headRoot), c.Epoch)
+	headDependent, err := s.cfg.ForkChoiceStore.DependentRootForEpoch([32]byte(headRoot), c.Epoch)
 	if err != nil {
 		return nil
 	}
-	if !bytes.Equal(c.Root, headTarget[:]) {
+	targetDependent, err := s.cfg.ForkChoiceStore.DependentRootForEpoch([32]byte(c.Root), c.Epoch)
+	if err != nil {
+		return nil
+	}
+	if targetDependent != headDependent {
 		return nil
 	}
 

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -758,6 +758,11 @@ func (c *ChainService) ReceiveDataColumns(dcs []blocks.VerifiedRODataColumn) err
 	return nil
 }
 
+// DependentRootForEpoch mocks the same method in the chain service
+func (c *ChainService) DependentRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
+	return c.TargetRoot, nil
+}
+
 // TargetRootForEpoch mocks the same method in the chain service
 func (c *ChainService) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
 	return c.TargetRoot, nil

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -626,21 +626,26 @@ func (f *ForkChoice) Slot(root [32]byte) (primitives.Slot, error) {
 
 // DependentRoot returns the last root of the epoch prior to the requested ecoch in the canonical chain.
 func (f *ForkChoice) DependentRoot(epoch primitives.Epoch) ([32]byte, error) {
-	tr, err := f.TargetRootForEpoch(f.CachedHeadRoot(), epoch)
+	return f.DependentRootForEpoch(f.CachedHeadRoot(), epoch)
+}
+
+// DependentRootForEpoch return the last root of the epoch prior to the requested ecoch for the given root.
+func (f *ForkChoice) DependentRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+	tr, err := f.TargetRootForEpoch(root, epoch)
 	if err != nil {
 		return [32]byte{}, err
 	}
 	if tr == [32]byte{} {
 		return [32]byte{}, nil
 	}
-	n, ok := f.store.nodeByRoot[tr]
-	if !ok || n == nil {
+	node, ok := f.store.nodeByRoot[tr]
+	if !ok || node == nil {
 		return [32]byte{}, ErrNilNode
 	}
-	if slots.ToEpoch(n.slot) == epoch && n.parent != nil {
-		n = n.parent
+	if slots.ToEpoch(node.slot) >= epoch && node.parent != nil {
+		node = node.parent
 	}
-	return n.root, nil
+	return node.root, nil
 }
 
 // TargetRootForEpoch returns the root of the target block for a given epoch.

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -81,6 +81,7 @@ type FastGetter interface {
 	ShouldOverrideFCU() bool
 	Slot([32]byte) (primitives.Slot, error)
 	DependentRoot(primitives.Epoch) ([32]byte, error)
+	DependentRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	UnrealizedJustifiedPayloadBlockHash() [32]byte
 	Weight(root [32]byte) (uint64, error)

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -177,6 +177,13 @@ func (ro *ROForkChoice) DependentRoot(epoch primitives.Epoch) ([32]byte, error) 
 	return ro.getter.DependentRoot(epoch)
 }
 
+// DependentRootForEpoch delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) DependentRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.DependentRootForEpoch(root, epoch)
+}
+
 // TargetRootForEpoch delegates to the underlying forkchoice call, under a lock.
 func (ro *ROForkChoice) TargetRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
 	ro.l.RLock()

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -40,6 +40,7 @@ const (
 	targetRootForEpochCalled
 	parentRootCalled
 	dependentRootCalled
+	dependentRootForEpochCalled
 )
 
 func _discard(t *testing.T, e error) {
@@ -302,6 +303,12 @@ func (ro *mockROForkchoice) LastRoot(_ primitives.Epoch) [32]byte {
 // DependentRoot impoements FastGetter.
 func (ro *mockROForkchoice) DependentRoot(_ primitives.Epoch) ([32]byte, error) {
 	ro.calls = append(ro.calls, dependentRootCalled)
+	return [32]byte{}, nil
+}
+
+// DependentRootForEpoch implements FastGetter.
+func (ro *mockROForkchoice) DependentRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
+	ro.calls = append(ro.calls, dependentRootForEpochCalled)
 	return [32]byte{}, nil
 }
 

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -337,17 +337,17 @@ func (s *Service) blockVerifyingState(ctx context.Context, blk interfaces.ReadOn
 		}
 		return transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, blockSlot)
 	}
-	// If head and block are in the same epoch and head is compatible with the parent's target, then use head
+	// If head and block are in the same epoch and head is compatible with the parent's dependent root, then use head
 	if blockEpoch == headEpoch {
-		headTarget, err := s.cfg.chain.TargetRootForEpoch([32]byte(headRoot), blockEpoch)
+		headDependent, err := s.cfg.chain.DependentRootForEpoch([32]byte(headRoot), blockEpoch)
 		if err != nil {
 			return nil, err
 		}
-		parentTarget, err := s.cfg.chain.TargetRootForEpoch([32]byte(parentRoot), blockEpoch)
+		parentDependent, err := s.cfg.chain.DependentRootForEpoch([32]byte(parentRoot), blockEpoch)
 		if err != nil {
 			return nil, err
 		}
-		if bytes.Equal(headTarget[:], parentTarget[:]) {
+		if bytes.Equal(headDependent[:], parentDependent[:]) {
 			return s.cfg.chain.HeadStateReadOnly(ctx)
 		}
 	}

--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -548,11 +548,12 @@ func TestRequirementSatisfaction(t *testing.T) {
 }
 
 type mockForkchoicer struct {
-	FinalizedCheckpointCB func() *forkchoicetypes.Checkpoint
-	HasNodeCB             func([32]byte) bool
-	IsCanonicalCB         func(root [32]byte) bool
-	SlotCB                func([32]byte) (primitives.Slot, error)
-	TargetRootForEpochCB  func([32]byte, primitives.Epoch) ([32]byte, error)
+	FinalizedCheckpointCB   func() *forkchoicetypes.Checkpoint
+	HasNodeCB               func([32]byte) bool
+	IsCanonicalCB           func(root [32]byte) bool
+	SlotCB                  func([32]byte) (primitives.Slot, error)
+	DependentRootForEpochCB func([32]byte, primitives.Epoch) ([32]byte, error)
+	TargetRootForEpochCB    func([32]byte, primitives.Epoch) ([32]byte, error)
 }
 
 var _ Forkchoicer = &mockForkchoicer{}
@@ -571,6 +572,10 @@ func (m *mockForkchoicer) IsCanonical(root [32]byte) bool {
 
 func (m *mockForkchoicer) Slot(root [32]byte) (primitives.Slot, error) {
 	return m.SlotCB(root)
+}
+
+func (m *mockForkchoicer) DependentRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+	return m.DependentRootForEpochCB(root, epoch)
 }
 
 func (m *mockForkchoicer) TargetRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -319,17 +319,17 @@ func (dv *RODataColumnsVerifier) getVerifyingState(ctx context.Context, dataColu
 		return transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, dataColumnSlot)
 	}
 
-	// If head and data column are in the same epoch and head is compatible with the parent's target, then use head
+	// If head and data column are in the same epoch and head is compatible with the parent's depdendent root, then use head
 	if dataColumnEpoch == headEpoch {
-		headTarget, err := dv.fc.TargetRootForEpoch(bytesutil.ToBytes32(headRoot), dataColumnEpoch)
+		headDependent, err := dv.fc.DependentRootForEpoch(bytesutil.ToBytes32(headRoot), dataColumnEpoch)
 		if err != nil {
 			return nil, err
 		}
-		parentTarget, err := dv.fc.TargetRootForEpoch(parentRoot, dataColumnEpoch)
+		parentDependent, err := dv.fc.DependentRootForEpoch(parentRoot, dataColumnEpoch)
 		if err != nil {
 			return nil, err
 		}
-		if bytes.Equal(headTarget[:], parentTarget[:]) {
+		if bytes.Equal(headDependent[:], parentDependent[:]) {
 			return dv.hsp.HeadStateReadOnly(ctx)
 		}
 	}

--- a/beacon-chain/verification/initializer.go
+++ b/beacon-chain/verification/initializer.go
@@ -25,6 +25,7 @@ type Forkchoicer interface {
 	HasNode([32]byte) bool
 	IsCanonical(root [32]byte) bool
 	Slot([32]byte) (primitives.Slot, error)
+	DependentRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 }
 

--- a/changelog/potuz_use_dependent_root_instead_of_target.md
+++ b/changelog/potuz_use_dependent_root_instead_of_target.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use dependent root instead of target when possible.


### PR DESCRIPTION
Use dependent root to pick head instead of target. This allows the head state to be used for verification in the situation in which we have a fork like
```
... <---- 31 < ---- 32 <-----------------34
                \___________33        (<----------------- This is the head state) 
```

And we are trying to validate attestations/sidecars/blocks etc for 34 but our head is 33. The current algorithm will pick up the state at 32 and advance because the target of 34 is different than that of 33 (the target for 31 has root 31). This PR allows in this situation to use head since anyway has the exact same active validator set (and shuffling). 