### PR TITLE
fix: slasher_double_proposals_total to count DB-detected proposer slashings

### DIFF
--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -56,6 +56,9 @@ func (s *Service) detectProposerSlashings(
 		return nil, errors.Wrap(err, "could not check for double proposals on disk")
 	}
 
+	// Increment metric for DB-detected double proposals.
+	doubleProposalsTotal.Add(float64(len(databaseSlashings)))
+
 	// We save the safe proposals (with respect to the database) to our database.
 	// If some proposals in incomingProposals are slashable with respect to each other,
 	// we (arbitrarily) save the last one to the database.

--- a/changelog/GarmashAlex_fix-slasher-proposals.md
+++ b/changelog/GarmashAlex_fix-slasher-proposals.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix slasher_double_proposals_total to count DB-detected proposer slashings [#16000](https://github.com/OffchainLabs/prysm/pull/16000).


### PR DESCRIPTION

**What type of PR is this?**


> Bug fix

**What does this PR do? Why is it needed?**

Adjusted the proposer slashing detection path to increment slasher_double_proposals_total for slashings identified against the database as well as intra-batch, because the metric’s help states it should reflect total successfully detected slashable proposals, and the attestation path already increments for both in-batch and DB checks, so this change aligns block metrics with intended semantics and existing attestation behavior.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
