### PR TITLE
ci: update golangci-lint-action to v9

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
           go-version: '1.25.1'
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.4
 


### PR DESCRIPTION
Updated [golangci-lint-action](https://github.com/golangci/golangci-lint-action/releases/tag/v9.0.0) from v8 to v9 in the lint workflow.
