### PR TITLE
Record gossip KZG batch verification durations

### DIFF
--- a/beacon-chain/sync/batch_verifier.go
+++ b/beacon-chain/sync/batch_verifier.go
@@ -190,7 +190,7 @@ func (s *Service) validateUnbatchedColumnsKzg(ctx context.Context, columns []blo
 		tracing.AnnotateError(span, err)
 		return pubsub.ValidationReject, err
 	}
-	verification.DataColumnBatchKZGVerificationHistogram.Observe(float64(time.Since(start).Milliseconds()))
+	verification.DataColumnBatchKZGVerificationHistogram.WithLabelValues("fallback").Observe(float64(time.Since(start).Milliseconds()))
 	return pubsub.ValidationAccept, nil
 }
 
@@ -210,7 +210,7 @@ func verifyKzgBatch(kzgBatch []*kzgVerifier) {
 	if err != nil {
 		verificationErr = errors.Wrap(err, "batch KZG verification failed")
 	} else {
-		verification.DataColumnBatchKZGVerificationHistogram.Observe(float64(time.Since(start).Milliseconds()))
+		verification.DataColumnBatchKZGVerificationHistogram.WithLabelValues("batch").Observe(float64(time.Since(start).Milliseconds()))
 	}
 
 	// Send the same result to all verifiers in the batch

--- a/beacon-chain/sync/batch_verifier.go
+++ b/beacon-chain/sync/batch_verifier.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
@@ -183,11 +184,13 @@ func (s *Service) validateWithKzgBatchVerifier(ctx context.Context, dataColumns 
 func (s *Service) validateUnbatchedColumnsKzg(ctx context.Context, columns []blocks.RODataColumn) (pubsub.ValidationResult, error) {
 	_, span := trace.StartSpan(ctx, "sync.validateUnbatchedColumnsKzg")
 	defer span.End()
+	start := time.Now()
 	if err := peerdas.VerifyDataColumnsSidecarKZGProofs(columns); err != nil {
 		err = errors.Wrap(err, "could not verify")
 		tracing.AnnotateError(span, err)
 		return pubsub.ValidationReject, err
 	}
+	verification.DataColumnBatchKZGVerificationHistogram.Observe(float64(time.Since(start).Milliseconds()))
 	return pubsub.ValidationAccept, nil
 }
 
@@ -202,9 +205,12 @@ func verifyKzgBatch(kzgBatch []*kzgVerifier) {
 	}
 
 	var verificationErr error
+	start := time.Now()
 	err := peerdas.VerifyDataColumnsSidecarKZGProofs(allDataColumns)
 	if err != nil {
 		verificationErr = errors.Wrap(err, "batch KZG verification failed")
+	} else {
+		verification.DataColumnBatchKZGVerificationHistogram.Observe(float64(time.Since(start).Milliseconds()))
 	}
 
 	// Send the same result to all verifiers in the batch

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -473,7 +473,7 @@ func (dv *RODataColumnsVerifier) SidecarKzgProofVerified() (err error) {
 		return columnErrBuilder(errors.Wrap(err, "verify data column commitment"))
 	}
 
-	DataColumnBatchKZGVerificationHistogram.Observe(float64(time.Since(startTime).Milliseconds()))
+	DataColumnBatchKZGVerificationHistogram.WithLabelValues("direct").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -473,7 +473,7 @@ func (dv *RODataColumnsVerifier) SidecarKzgProofVerified() (err error) {
 		return columnErrBuilder(errors.Wrap(err, "verify data column commitment"))
 	}
 
-	dataColumnBatchKZGVerificationHistogram.Observe(float64(time.Since(startTime).Milliseconds()))
+	DataColumnBatchKZGVerificationHistogram.Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 

--- a/beacon-chain/verification/metrics.go
+++ b/beacon-chain/verification/metrics.go
@@ -27,11 +27,12 @@ var (
 			Buckets: []float64{5, 10, 50, 100, 150, 250, 500, 1000, 2000},
 		},
 	)
-	DataColumnBatchKZGVerificationHistogram = promauto.NewHistogram(
+	DataColumnBatchKZGVerificationHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "beacon_kzg_verification_data_column_batch_milliseconds",
 			Help:    "Captures the time taken for batched data column kzg verification.",
 			Buckets: []float64{5, 10, 50, 100, 150, 250, 500, 1000, 2000},
 		},
+		[]string{"path"},
 	)
 )

--- a/beacon-chain/verification/metrics.go
+++ b/beacon-chain/verification/metrics.go
@@ -27,7 +27,7 @@ var (
 			Buckets: []float64{5, 10, 50, 100, 150, 250, 500, 1000, 2000},
 		},
 	)
-	dataColumnBatchKZGVerificationHistogram = promauto.NewHistogram(
+	DataColumnBatchKZGVerificationHistogram = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "beacon_kzg_verification_data_column_batch_milliseconds",
 			Help:    "Captures the time taken for batched data column kzg verification.",

--- a/changelog/terence_gossip-kzg-latency.md
+++ b/changelog/terence_gossip-kzg-latency.md
@@ -1,3 +1,3 @@
 ### Added
 
-- Record data column gossip KZG batch verification latency in both the pooled worker and fallback paths so the `beacon_kzg_verification_data_column_batch_milliseconds` histogram reflects gossip traffic.
+- Record data column gossip KZG batch verification latency in both the pooled worker and fallback paths so the `beacon_kzg_verification_data_column_batch_milliseconds` histogram reflects gossip traffic, annotated with `path` labels to distinguish the sources.

--- a/changelog/terence_gossip-kzg-latency.md
+++ b/changelog/terence_gossip-kzg-latency.md
@@ -1,0 +1,3 @@
+### Added
+
+- Record data column gossip KZG batch verification latency in both the pooled worker and fallback paths so the `beacon_kzg_verification_data_column_batch_milliseconds` histogram reflects gossip traffic.


### PR DESCRIPTION
This PR:
- export the existing `beacon_kzg_verification_data_column_batch_milliseconds` histogram
- record gossip batch-verifier runtimes in both the pooled worker path and the unbatched fallback so the metric reflects every gossip verification