### PR TITLE
fix(validator/db): proposals progress bar count

### DIFF
--- a/changelog/Galoretka_convert-progress.md
+++ b/changelog/Galoretka_convert-progress.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix proposals progress bar count [#16020](https://github.com/OffchainLabs/prysm/pull/16020)

--- a/validator/db/convert.go
+++ b/validator/db/convert.go
@@ -212,7 +212,7 @@ func ConvertDatabase(ctx context.Context, sourceDataDir string, targetDataDir st
 
 	// Initialize the progress bar.
 	bar = common.InitializeProgressBar(
-		len(attestedPublicKeys),
+		len(proposedPublicKeys),
 		"Processing proposals:",
 	)
 


### PR DESCRIPTION
The proposals progress bar in validator/db/convert.go was initialized with len(attestedPublicKeys) while iterating over proposedPublicKeys, causing incorrect visual progress when these sets differ across backends. This change initializes the bar with len(proposedPublicKeys) to accurately reflect the number of items processed and aligns with progress bar usage patterns elsewhere in the codebase.