### PR TITLE
beacon-chain/das: remove dead slot parameter

### DIFF
--- a/beacon-chain/das/availability_blobs.go
+++ b/beacon-chain/das/availability_blobs.go
@@ -100,7 +100,7 @@ func (s *LazilyPersistentStoreBlob) IsDataAvailable(ctx context.Context, current
 	// Verify we have all the expected sidecars, and fail fast if any are missing or inconsistent.
 	// We don't try to salvage problematic batches because this indicates a misbehaving peer and we'd rather
 	// ignore their response and decrease their peer score.
-	sidecars, err := entry.filter(root, blockCommitments, b.Block().Slot())
+	sidecars, err := entry.filter(root, blockCommitments)
 	if err != nil {
 		return errors.Wrap(err, "incomplete BlobSidecar batch")
 	}

--- a/beacon-chain/das/blob_cache.go
+++ b/beacon-chain/das/blob_cache.go
@@ -88,7 +88,7 @@ func (e *blobCacheEntry) stash(sc *blocks.ROBlob) error {
 // commitments were found in the cache and the sidecar slice return value can be used
 // to perform a DA check against the cached sidecars.
 // filter only returns blobs that need to be checked. Blobs already available on disk will be excluded.
-func (e *blobCacheEntry) filter(root [32]byte, kc [][]byte, slot primitives.Slot) ([]blocks.ROBlob, error) {
+func (e *blobCacheEntry) filter(root [32]byte, kc [][]byte) ([]blocks.ROBlob, error) {
 	count := len(kc)
 	if e.diskSummary.AllAvailable(count) {
 		return nil, nil

--- a/beacon-chain/das/blob_cache_test.go
+++ b/beacon-chain/das/blob_cache_test.go
@@ -113,7 +113,7 @@ func TestFilterDiskSummary(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			entry, commits, expected := c.setup(t)
 			// first (root) argument doesn't matter, it is just for logs
-			got, err := entry.filter([32]byte{}, commits, 100)
+			got, err := entry.filter([32]byte{}, commits)
 			require.NoError(t, err)
 			require.Equal(t, len(expected), len(got))
 		})
@@ -195,7 +195,7 @@ func TestFilter(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			entry, commits, expected := c.setup(t)
 			// first (root) argument doesn't matter, it is just for logs
-			got, err := entry.filter([32]byte{}, commits, 100)
+			got, err := entry.filter([32]byte{}, commits)
 			if c.err != nil {
 				require.ErrorIs(t, err, c.err)
 				return

--- a/changelog/Fibonacci747_chore-remove-dead-stol-param.md
+++ b/changelog/Fibonacci747_chore-remove-dead-stol-param.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Removed dead slot parameter from blobCacheEntry.filter


### PR DESCRIPTION
The slot parameter in blobCacheEntry.filter was unused and redundant. All slot/epoch-sensitive checks happen before filter (commitmentsToCheck), and disk availability is handled via BlobStorageSummary (epoch-aware).

Changes:
- Drop slot from blobCacheEntry.filter signature.
- Update call sites in availability_blobs.go and blob_cache_test.go.

Mirrors the data_column_cache.filter API (which does not take slot), reduces API noise, and removes dead code without changing behavior.