### PR TITLE
Remove validator cross client from e2e

### DIFF
--- a/changelog/radek_remove-cross-validator.md
+++ b/changelog/radek_remove-cross-validator.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Remove validator cross-client from end-to-end tests.

--- a/testing/endtoend/component_handler_test.go
+++ b/testing/endtoend/component_handler_test.go
@@ -261,11 +261,15 @@ func (c *componentHandler) printPIDs(logger func(string, ...any)) {
 
 	msg += "This test PID: " + strconv.Itoa(os.Getpid()) + " (parent=" + strconv.Itoa(os.Getppid()) + ")\n"
 
-	// Beacon chain nodes
-	msg += fmt.Sprintf("Beacon chain nodes: %v\n", PIDsFromMultiComponentRunner(c.beaconNodes))
-	// Validator nodes
+	msg += fmt.Sprintf("Prysm beacon chain nodes: %v\n", PIDsFromMultiComponentRunner(c.beaconNodes))
+	msg += fmt.Sprintf("Prysm validators: %v\n", PIDsFromMultiComponentRunner(c.validatorNodes))
+	if c.lighthouseBeaconNodes != nil {
+		msg += fmt.Sprintf("Lighthouse beacon chain nodes: %v\n", PIDsFromMultiComponentRunner(c.lighthouseBeaconNodes))
+	}
+	if c.lighthouseValidatorNodes != nil {
+		msg += fmt.Sprintf("Lighthouse validators: %v\n", PIDsFromMultiComponentRunner(c.lighthouseValidatorNodes))
+	}
 	msg += fmt.Sprintf("Validators: %v\n", PIDsFromMultiComponentRunner(c.validatorNodes))
-	// ETH1 nodes
 	msg += fmt.Sprintf("ETH1 nodes: %v\n", PIDsFromMultiComponentRunner(c.eth1Nodes))
 
 	logger(msg)

--- a/testing/endtoend/components/lighthouse_beacon.go
+++ b/testing/endtoend/components/lighthouse_beacon.go
@@ -249,6 +249,10 @@ func (node *LighthouseBeaconNode) Stop() error {
 	return node.cmd.Process.Kill()
 }
 
+func (node *LighthouseBeaconNode) UnderlyingProcess() *os.Process {
+	return node.cmd.Process
+}
+
 func (node *LighthouseBeaconNode) createTestnetDir(ctx context.Context, index int) (string, error) {
 	testNetDir := e2e.TestParams.TestPath + fmt.Sprintf("/lighthouse-testnet-%d", index)
 	configPath := filepath.Join(testNetDir, "config.yaml")

--- a/testing/endtoend/components/lighthouse_validator.go
+++ b/testing/endtoend/components/lighthouse_validator.go
@@ -240,6 +240,10 @@ func (v *LighthouseValidatorNode) Stop() error {
 	return v.cmd.Process.Kill()
 }
 
+func (v *LighthouseValidatorNode) UnderlyingProcess() *os.Process {
+	return v.cmd.Process
+}
+
 var _ types.ComponentRunner = &KeystoreGenerator{}
 
 type KeystoreGenerator struct {

--- a/testing/endtoend/endtoend_setup_test.go
+++ b/testing/endtoend/endtoend_setup_test.go
@@ -20,7 +20,6 @@ func e2eMinimal(t *testing.T, cfg *params.BeaconChainConfig, cfgo ...types.E2ECo
 	require.NoError(t, params.SetActive(cfg))
 	require.NoError(t, e2eParams.Init(t, e2eParams.StandardBeaconCount))
 
-	// Run for 12 epochs if not in long-running to confirm long-running has no issues.
 	var err error
 	epochsToRun := 16
 	epochStr, longRunning := os.LookupEnv("E2E_EPOCHS")
@@ -103,7 +102,7 @@ func e2eMainnet(t *testing.T, usePrysmSh, useMultiClient bool, cfg *params.Beaco
 	} else {
 		require.NoError(t, e2eParams.Init(t, e2eParams.StandardBeaconCount))
 	}
-	// Run for 10 epochs if not in long-running to confirm long-running has no issues.
+
 	var err error
 	epochsToRun := 16
 	epochStr, longRunning := os.LookupEnv("E2E_EPOCHS")

--- a/testing/endtoend/mainnet_e2e_test.go
+++ b/testing/endtoend/mainnet_e2e_test.go
@@ -15,5 +15,5 @@ func TestEndToEnd_MainnetConfig_ValidatorAtCurrentRelease(t *testing.T) {
 }
 
 func TestEndToEnd_MainnetConfig_MultiClient(t *testing.T) {
-	e2eMainnet(t, false, true, types.InitForkCfg(version.Bellatrix, version.Electra, params.E2EMainnetTestConfig()), types.WithValidatorCrossClient()).run()
+	e2eMainnet(t, false, true, types.InitForkCfg(version.Bellatrix, version.Electra, params.E2EMainnetTestConfig())).run()
 }


### PR DESCRIPTION
**What type of PR is this?**

Tests

**What does this PR do? Why is it needed?**

Disables validator cross-client setup from post-submit e2e tests. The reason is that our current LH version used in e2e is too old to function properly with Prysm's latest VC, and updating the LH version requires starting e2e from Electra, which is currently not supported and can be a lot of effort.

The negative consequence of this change is that the Beacon API evaluator will not be executed.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
