### PR TITLE
stop emitting payload attribute events during late block handling

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -946,6 +946,10 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	}
 
 	attribute := s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:])
+	// return early if we are not proposing next slot
+	if attribute.IsEmpty() {
+		return
+	}
 
 	s.headLock.RLock()
 	headBlock, err := s.headBlock()

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -946,17 +946,6 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	}
 
 	attribute := s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:])
-	// return early if we are not proposing next slot
-	if attribute.IsEmpty() {
-		headBlock, err := s.headBlock()
-		if err != nil {
-			log.WithError(err).WithField("head_root", headRoot).Error("Unable to retrieve head block to fire payload attributes event")
-		}
-		// notifyForkchoiceUpdate fires the payload attribute event. But in this case, we won't
-		// call notifyForkchoiceUpdate, so the event is fired here.
-		go s.firePayloadAttributesEvent(s.cfg.StateNotifier.StateFeed(), headBlock, headRoot, s.CurrentSlot()+1)
-		return
-	}
 
 	s.headLock.RLock()
 	headBlock, err := s.headBlock()

--- a/changelog/late-block-dont-fire-attribute.md
+++ b/changelog/late-block-dont-fire-attribute.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Stop emitting payload attribute events during late block handling when we are not proposing the next slot


### PR DESCRIPTION
This aligns behavior with beacon api definitions and how teku and lighthouse do payload attribute SSE