### PR TITLE
Move `BlockGossipReceived` event to the end of gossip validation.

### DIFF
--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -75,17 +75,8 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationReject, errors.New("block.Block is nil")
 	}
 
-	// Broadcast the block on both block and operation feeds to notify other services in the beacon node
+	// Broadcast the block on a feed to notify other services in the beacon node
 	// of a received block (even if it does not process correctly through a state transition).
-	if s.cfg.operationNotifier != nil {
-		s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
-			Type: operation.BlockGossipReceived,
-			Data: &operation.BlockGossipReceivedData{
-				SignedBlock: blk,
-			},
-		})
-	}
-
 	s.cfg.blockNotifier.BlockFeed().Send(&feed.Event{
 		Type: blockfeed.ReceivedBlock,
 		Data: &blockfeed.ReceivedBlockData{
@@ -247,6 +238,16 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 
 	blockArrivalGossipSummary.Observe(float64(sinceSlotStartTime.Milliseconds()))
 	blockVerificationGossipSummary.Observe(float64(validationTime.Milliseconds()))
+
+	if s.cfg.operationNotifier != nil {
+		s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
+			Type: operation.BlockGossipReceived,
+			Data: &operation.BlockGossipReceivedData{
+				SignedBlock: blk,
+			},
+		})
+	}
+
 	return pubsub.ValidationAccept, nil
 }
 

--- a/changelog/radek_move-block-gossip-event.md
+++ b/changelog/radek_move-block-gossip-event.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Move `BlockGossipReceived` event to the end of gossip validation.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

https://github.com/OffchainLabs/prysm/pull/15038 added support for the `block_gossip` event stream topic. In the Beacon API specification it's described as
> The node has received a block (from P2P or API) that passes validation rules of the beacon_block topic

but we send it almost immediately, after only checking that the block is not nil. This PR moves the event to the end of the validation pipeline.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
