### PR TITLE
Fix state diff repetitive anchor slot bug

### DIFF
--- a/beacon-chain/db/kv/state_diff_helpers.go
+++ b/beacon-chain/db/kv/state_diff_helpers.go
@@ -221,13 +221,15 @@ func (s *Store) getBaseAndDiffChain(offset uint64, slot primitives.Slot) (state.
 	}
 
 	var diffChainItems []diffItem
+	lastSeenAnchorSlot := baseAnchorSlot
 	for i, exp := range exponents[1 : lvl+1] {
 		span := math.PowerOf2(uint64(exp))
 		diffSlot := rel / span * span
-		if diffSlot == baseAnchorSlot {
+		if diffSlot == lastSeenAnchorSlot {
 			continue
 		}
 		diffChainItems = append(diffChainItems, diffItem{level: i + 1, slot: diffSlot + offset})
+		lastSeenAnchorSlot = diffSlot
 	}
 
 	baseSnapshot, err := s.getFullSnapshot(baseAnchorSlot)

--- a/changelog/bastin_state-diff-anchor-slot-bug.md
+++ b/changelog/bastin_state-diff-anchor-slot-bug.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix state diff repetitive anchor slot bug.


### PR DESCRIPTION
**What type of PR is this?**
 Bug fix

**What does this PR do? Why is it needed?**
This PR fixes a bug in the state diff `getBaseAndDiffChain()` method. In the process of finding the diff chain indices, there could be a scenario where multiple levels return the same diff slot number not equal to the base (full snapshot) slot number. 
This resulted in multiple diff items being added to the diff chain for the same slot, but on different levels, which resulted in errors reading the diff.

Fix: we keep a `lastSeenAnchorSlot` equal to the `BaseAnchorSlot` and update it every time we see a new anchor slot. We ignore if the current found anchor slot is equal to the `lastSeenAnchorSlot`.

Scenario example: 
exponents: [20, 14, 10, 7, 5]
offset: 0
slots saved: slot 2^11, and slot (2^11 + 2^5)
slot to read: slot (2^11 + 2^5)
resulting list of anchor slots (diff chain indices): [0, 0, 2^11, 2^11, 2^11 + 2^5]