### PR TITLE
Optimize attestation cache SaveMany to batch locking

### DIFF
--- a/beacon-chain/operations/attestations/attmap/map.go
+++ b/beacon-chain/operations/attestations/attmap/map.go
@@ -39,10 +39,20 @@ func (a *Attestations) Save(att ethpb.Att) error {
 
 // SaveMany stores multiple attestation in the map.
 func (a *Attestations) SaveMany(atts []ethpb.Att) error {
+	a.Lock()
+	defer a.Unlock()
+
 	for _, att := range atts {
-		if err := a.Save(att); err != nil {
-			return err
+		if att == nil || att.IsNil() {
+			continue
 		}
+
+		id, err := attestation.NewId(att, attestation.Full)
+		if err != nil {
+			return errors.Wrap(err, "could not create attestation ID")
+		}
+
+		a.atts[id] = att		
 	}
 
 	return nil


### PR DESCRIPTION
hold the attestation cache mutex once while saving a batch instead of locking per element, skip nil/empty attestations inline and reuse the same validation logic as Save, reuse id generation inside the single critical section, eliminating redundant lock/unlock cycles




