### PR TITLE
genesis: correct loadState error wrap to reflect file-based state loading

### DIFF
--- a/changelog/Bashmunta_fix-err-message.md
+++ b/changelog/Bashmunta_fix-err-message.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- correct loadState error wrap to reflect file-based state loading 

--- a/genesis/storage.go
+++ b/genesis/storage.go
@@ -147,7 +147,7 @@ func loadState() (state.BeaconState, error) {
 
 	s, err := stateFromFile(data.FilePath())
 	if err != nil {
-		return nil, errors.Wrapf(err, "InitializeFromProtoUnsafePhase0")
+		return nil, errors.Wrapf(err, "load genesis state from %s", data.FilePath())
 	}
 
 	data.State = s


### PR DESCRIPTION
This change corrects a stale error wrap message in genesis/storage.go within loadState(), replacing a misleading reference to InitializeFromProtoUnsafePhase0 with a precise description that the failure occurred while loading the genesis state from a file and includes the file path. The previous message was a refactor leftover that incorrectly implied a different initialization routine, causing confusion during diagnostics, while the new message aligns with the actual flow (stateFromFile -> detect.UnmarshalState) and improves debuggability by providing path context.