### PR TITLE
fix(validator): Ensure RPC/Web UI handles multi Beacon REST endpoints

### DIFF
--- a/changelog/lukema95_fix-beacon-rest-api-provider.md
+++ b/changelog/lukema95_fix-beacon-rest-api-provider.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fix RPC/Web UI handling of comma-separated `--beacon-rest-api-provider` endpoints. The validator RPC server now properly parses and uses the first valid host from the comma-separated list, matching the behavior of the validator client service.
+

--- a/validator/rpc/beacon.go
+++ b/validator/rpc/beacon.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"net/http"
+	"strings"
 
 	api "github.com/OffchainLabs/prysm/v7/api/client"
 	grpcutil "github.com/OffchainLabs/prysm/v7/api/grpc"
@@ -57,10 +58,22 @@ func (s *Server) registerBeaconClient() error {
 		validatorHelpers.WithBeaconApiTimeout(s.beaconApiTimeout),
 	)
 
+	trimmed := strings.ReplaceAll(s.beaconApiEndpoint, " ", "")
+	rawHosts := strings.Split(trimmed, ",")
+	var hosts []string
+	for _, h := range rawHosts {
+		if h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	if len(hosts) == 0 {
+		return errors.New("no beacon API hosts provided")
+	}
+
 	headersTransport := api.NewCustomHeadersTransport(http.DefaultTransport, conn.GetBeaconApiHeaders())
 	restHandler := beaconApi.NewBeaconApiRestHandler(
 		http.Client{Timeout: s.beaconApiTimeout, Transport: otelhttp.NewTransport(headersTransport)},
-		s.beaconApiEndpoint,
+		hosts[0],
 	)
 
 	s.chainClient = beaconChainClientFactory.NewChainClient(conn, restHandler)

--- a/validator/rpc/beacon_test.go
+++ b/validator/rpc/beacon_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -19,4 +20,72 @@ func TestGrpcHeaders(t *testing.T) {
 	require.Equal(t, 2, md.Len(), "MetadataV0 contains wrong number of values")
 	assert.Equal(t, "value1", md.Get("first")[0])
 	assert.Equal(t, "value2", md.Get("second")[0])
+}
+
+func TestRegisterBeaconClient_CommaSeparatedEndpoints(t *testing.T) {
+	tests := []struct {
+		name              string
+		beaconApiEndpoint string
+		wantError         bool
+		errorContains     string
+		expectedFirstHost string
+	}{
+		{
+			name:              "single endpoint",
+			beaconApiEndpoint: "http://localhost:5052",
+			wantError:         false,
+			expectedFirstHost: "http://localhost:5052",
+		},
+		{
+			name:              "comma-separated endpoints",
+			beaconApiEndpoint: "http://node1:5052,http://node2:5052",
+			wantError:         false,
+			expectedFirstHost: "http://node1:5052",
+		},
+		{
+			name:              "comma-separated endpoints with spaces",
+			beaconApiEndpoint: "http://node1:5052 , http://node2:5052",
+			wantError:         false,
+			expectedFirstHost: "http://node1:5052",
+		},
+		{
+			name:              "empty endpoint",
+			beaconApiEndpoint: "",
+			wantError:         true,
+			errorContains:     "no beacon API hosts provided",
+		},
+		{
+			name:              "only spaces",
+			beaconApiEndpoint: "   ",
+			wantError:         true,
+			errorContains:     "no beacon API hosts provided",
+		},
+		{
+			name:              "multiple endpoints with empty ones",
+			beaconApiEndpoint: "http://node1:5052,,http://node2:5052",
+			wantError:         false,
+			expectedFirstHost: "http://node1:5052",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trimmed := strings.ReplaceAll(tt.beaconApiEndpoint, " ", "")
+			rawHosts := strings.Split(trimmed, ",")
+			var hosts []string
+			for _, h := range rawHosts {
+				if h != "" {
+					hosts = append(hosts, h)
+				}
+			}
+
+			if tt.wantError {
+				require.Equal(t, 0, len(hosts), "Should have no valid hosts for error cases")
+			} else {
+				require.NotEmpty(t, hosts, "Should have at least one valid host")
+				// Verify the first host is correctly parsed
+				assert.Equal(t, tt.expectedFirstHost, hosts[0])
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**

The validator CLI allows `--beacon-rest-api-provider` to be a comma-separated list of REST nodes (e.g. `http://node1:5052,http://node2:5052`) for high availability. The validator service already splits and trims that string before handing a single host to its REST handler, so it can rotate through the nodes. The RPC/Web server, by contrast, feeds the raw (possibly comma-filled) string directly into `NewBeaconApiRestHandler`. Every request then does `url := c.host + endpoint`, so as soon as the host string contains a comma, `http.NewRequest` rejects it with `invalid character ',' in host name`, and the RPC/Web API becomes unusable even though the validator client works.

Update `validator/rpc/beacon.go::registerBeaconClient()` to reuse the same logic as `validator/client/service.go`: trim whitespace, split on commas, drop empty entries, and only pass a single, valid host into `NewBeaconApiRestHandler`. If no valid host remains, return an error instead of constructing an invalid HTTP client.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
