### PR TITLE
fix: error reporting when importing slashing protection in ImportKeystores

### DIFF
--- a/changelog/Snezhkko_fix-error-reporting.md
+++ b/changelog/Snezhkko_fix-error-reporting.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- Fix error reporting when importing slashing protection in ImportKeystores

--- a/validator/rpc/handlers_keymanager.go
+++ b/validator/rpc/handlers_keymanager.go
@@ -137,12 +137,18 @@ func (s *Server) ImportKeystores(w http.ResponseWriter, r *http.Request) {
 		keystores[i] = k
 	}
 	if req.SlashingProtection != "" {
-		if s.db == nil || s.db.ImportStandardProtectionJSON(ctx, bytes.NewBufferString(req.SlashingProtection)) != nil {
+		var impErr error
+		if s.db == nil {
+			impErr = errors.New("could not find validator database")
+		} else {
+			impErr = s.db.ImportStandardProtectionJSON(ctx, bytes.NewBufferString(req.SlashingProtection))
+		}
+		if impErr != nil {
 			statuses := make([]*keymanager.KeyStatus, len(req.Keystores))
 			for i := 0; i < len(req.Keystores); i++ {
 				statuses[i] = &keymanager.KeyStatus{
 					Status:  keymanager.StatusError,
-					Message: fmt.Sprintf("could not import slashing protection: %v", err),
+					Message: fmt.Sprintf("could not import slashing protection: %v", impErr),
 				}
 			}
 			httputil.WriteJson(w, &ImportKeystoresResponse{Data: statuses})


### PR DESCRIPTION
The ImportKeystores handler used a stale err variable when reporting failures during slashing protection import, which could yield “could not import slashing protection: ” or mask the real cause. This change explicitly captures the import error into a local impErr, including the s.db == nil case as “could not find validator database,” and uses it in the per-key status message. Behavior remains aligned with existing tests that expect HTTP 200 with per-key StatusError entries on bad input, and it matches the error propagation style of the dedicated ImportSlashingProtection endpoint.