### PR TITLE
Integrate state-diff into `HasState()`

### DIFF
--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -142,6 +142,7 @@ go_test(
         "@com_github_golang_snappy//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
         "@io_etcd_go_bbolt//:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",

--- a/changelog/bastin_has-state-using-diff.md
+++ b/changelog/bastin_has-state-using-diff.md
@@ -1,0 +1,3 @@
+### Added
+
+- Integrate state-diff into `HasState()`.


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR adds integrates state-diff into `HasState()`. 

One thing to note: we are assuming that, for a given block root, that has either a state summary or a block in db, and also falls in the state diff tree, then there must exist a state. This function could return true, even when there is no actual state saved due to any error.
But this is fine, because we have that assumption throughout the whole state diff feature. 
