### PR TITLE
Remove unreachable return after log.Fatal in beacon chain main

### DIFF
--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -237,7 +237,6 @@ func main() {
 		Action: func(ctx *cli.Context) error {
 			if err := startNode(ctx, cancel); err != nil {
 				log.Fatal(err.Error())
-				return err
 			}
 			return nil
 		},


### PR DESCRIPTION
drop the redundant return err that followed log.Fatal inside the beacon-chain CLI action, log.Fatal already exits the process, so the return was unreachable noise, keeps control flow minimal and avoids confusing reviewers or linters