### PR TITLE
Simplify deprecatedHistoryData.isEmpty guard logic

### DIFF
--- a/validator/db/kv/deprecated_attester_protection.go
+++ b/validator/db/kv/deprecated_attester_protection.go
@@ -41,13 +41,7 @@ func (dh deprecatedEncodedAttestingHistory) assertSize() error {
 }
 
 func (dhd *deprecatedHistoryData) isEmpty() bool {
-	if dhd == (*deprecatedHistoryData)(nil) {
-		return true
-	}
-	if dhd.Source == params.BeaconConfig().FarFutureEpoch {
-		return true
-	}
-	return false
+	return dhd == (*deprecatedHistoryData)(nil) || dhd.Source == params.BeaconConfig().FarFutureEpoch
 }
 
 func emptyHistoryData() *deprecatedHistoryData {


### PR DESCRIPTION
collapse the nested nil/FarFutureEpoch checks into a single boolean expression, preserve the original semantics while removing redundant branching