### PR TITLE
fix: use RunContext with signal-aware root context for graceful shutdown

### DIFF
--- a/changelog/radik878_fix-clieant-stats-shutdown.md
+++ b/changelog/radik878_fix-clieant-stats-shutdown.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- apply RunContext with signal-aware root context for graceful shutdown [#16056](https://github.com/OffchainLabs/prysm/pull/16056)

--- a/cmd/client-stats/main.go
+++ b/cmd/client-stats/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	runtimeDebug "runtime/debug"
+	"syscall"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/cmd"
@@ -100,7 +103,10 @@ func main() {
 		}
 	}()
 
-	if err := app.Run(os.Args); err != nil {
+	rctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := app.RunContext(rctx, os.Args); err != nil {
 		log.Error(err.Error())
 	}
 }


### PR DESCRIPTION
The client-stats command was relying on ctx.Done() inside run() to stop the ticker, but main() invoked app.Run(os.Args), which wraps RunContext(context.Background(), ...). Because the root context was not cancelable, ctx.Done() would never fire on process termination, preventing graceful shutdown. This change introduces a signal-aware cancelable root context using signal.NotifyContext and switches to app.RunContext(rctx, os.Args). As a result, when SIGINT or SIGTERM is received, rctx is canceled, the cli.Context’s embedded context is canceled, and the select case on ctx.Done() triggers, ensuring the ticker is stopped and the loop exits cleanly. This behavior aligns with how beacon-chain wires its context and fixes the shutdown semantics without altering run() logic.