### PR TITLE
fix: use BLSPubkeyLength for Pubkey field in ValidatorRegistration mock

### DIFF
--- a/changelog/Bilogweb3_fix-bls-pubkey-length.md
+++ b/changelog/Bilogweb3_fix-bls-pubkey-length.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use correct BLSPubkeyLength (48 bytes) instead of BLSSignatureLength (96 bytes) for Pubkey field in ValidatorRegistration mock

--- a/validator/keymanager/remote-web3signer/types/mock/mocks.go
+++ b/validator/keymanager/remote-web3signer/types/mock/mocks.go
@@ -527,7 +527,7 @@ func GetMockSignRequest(t string) *validatorpb.SignRequest {
 					FeeRecipient: make([]byte, fieldparams.FeeRecipientLength),
 					GasLimit:     uint64(0),
 					Timestamp:    uint64(0),
-					Pubkey:       make([]byte, fieldparams.BLSSignatureLength),
+					Pubkey:       make([]byte, fieldparams.BLSPubkeyLength),
 				},
 			},
 			SigningSlot: 0,
@@ -709,7 +709,7 @@ func ValidatorRegistrationSignRequest() *types.ValidatorRegistrationSignRequest 
 			FeeRecipient: make([]byte, fieldparams.FeeRecipientLength),
 			GasLimit:     fmt.Sprint(0),
 			Timestamp:    fmt.Sprint(0),
-			Pubkey:       make([]byte, fieldparams.BLSSignatureLength),
+			Pubkey:       make([]byte, fieldparams.BLSPubkeyLength),
 		},
 	}
 }


### PR DESCRIPTION
The Pubkey field in ValidatorRegistration was incorrectly using BLSSignatureLength (96 bytes) instead of BLSPubkeyLength (48 bytes).

BLS public keys are 48 bytes, not 96. This is confirmed by the proto definition in beacon_block.proto where pubkey has ssz_size="48".

Fixed in two places in mocks.go:
- GetMockSignRequest() for VALIDATOR_REGISTRATION case
- ValidatorRegistrationSignRequest()