### PR TITLE
contracts/deposit: cache parsed ABI and avoid per-call parsing

### DIFF
--- a/changelog/GarmashAlex_chore-cache-deposit-abi-logs.md
+++ b/changelog/GarmashAlex_chore-cache-deposit-abi-logs.md
@@ -1,0 +1,3 @@
+### Changed
+
+- cache parsed ABI and avoid per-call parsing in UnpackDepositLogData [#16061](https://github.com/OffchainLabs/prysm/pull/16061)

--- a/contracts/deposit/logs.go
+++ b/contracts/deposit/logs.go
@@ -1,24 +1,29 @@
 package deposit
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/pkg/errors"
 )
 
+// parsed ABI cached at package level to avoid reparsing on every log unpack
+var depositABI abi.ABI
+
+func init() {
+	var err error
+	depositABI, err = abi.JSON(strings.NewReader(DepositContractABI))
+	if err != nil {
+		// DepositContractABI is a constant generated from the contract; failure here is unrecoverable
+		panic(err)
+	}
+}
+
 // UnpackDepositLogData unpacks the data from a deposit log using the ABI decoder.
 func UnpackDepositLogData(data []byte) (pubkey, withdrawalCredentials, amount, signature, index []byte, err error) {
-	reader := bytes.NewReader([]byte(DepositContractABI))
-	contractAbi, err := abi.JSON(reader)
-	if err != nil {
-		return nil, nil, nil, nil, nil, errors.Wrap(err, "unable to generate contract abi")
-	}
-
-	unpackedLogs, err := contractAbi.Unpack("DepositEvent", data)
-	if err != nil {
+	evt := new(DepositContractDepositEvent)
+	if err := depositABI.UnpackIntoInterface(evt, "DepositEvent", data); err != nil {
 		return nil, nil, nil, nil, nil, errors.Wrap(err, "unable to unpack logs")
 	}
-
-	return unpackedLogs[0].([]byte), unpackedLogs[1].([]byte), unpackedLogs[2].([]byte), unpackedLogs[3].([]byte), unpackedLogs[4].([]byte), nil
+	return evt.Pubkey, evt.WithdrawalCredentials, evt.Amount, evt.Signature, evt.Index, nil
 }


### PR DESCRIPTION
Removed unnecessary allocations and repeated ABI parsing in the hot path that processes deposit logs. Previously, UnpackDepositLogData converted the constant ABI string to a []byte, wrapped it in a bytes.Reader, and reparsed the ABI JSON on every call before unpacking into a []interface{}, incurring repeated allocations and type assertions. We now cache a parsed abi.ABI at package level using strings.NewReader and use UnpackIntoInterface to populate the generated DepositContractDepositEvent struct directly, eliminating the interface slice and assertions. The ABI is immutable and abi.ABI is safe for concurrent read-only reuse, so the cached instance is thread-safe. Behavior remains identical while reducing CPU and GC pressure during log processing.