### PR TITLE
chore(container/thread-safe): remove redundant key copy in map keys

### DIFF
--- a/container/thread-safe/map.go
+++ b/container/thread-safe/map.go
@@ -32,8 +32,7 @@ func (m *Map[K, V]) Keys() (r []K) {
 	m.View(func(mp map[K]V) {
 		r = make([]K, 0, len(m.items))
 		for k := range mp {
-			key := k
-			r = append(r, key)
+			r = append(r, k)
 		}
 	})
 	return r


### PR DESCRIPTION
drop the temporary `key` variable in `Map.Keys`,  rely on the range variable `k`, which is already an independent copy, keep the method behavior intact while trimming an unnecessary allocation