### PR TITLE
drop unused validator RPC jwt secret state

### DIFF
--- a/validator/rpc/auth_token.go
+++ b/validator/rpc/auth_token.go
@@ -60,11 +60,10 @@ func (s *Server) initializeAuthToken() error {
 				log.Error(err)
 			}
 		}()
-		secret, token, err := readAuthTokenFile(f)
+		_, token, err := readAuthTokenFile(f)
 		if err != nil {
 			return err
 		}
-		s.jwtSecret = secret
 		s.authToken = token
 		return nil
 	}

--- a/validator/rpc/auth_token_test.go
+++ b/validator/rpc/auth_token_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/golang-jwt/jwt/v4"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 	"google.golang.org/grpc"
@@ -125,7 +124,6 @@ func TestServer_LegacyTokensStillWork(t *testing.T) {
 	err = srv.initializeAuthToken()
 	require.NoError(t, err)
 
-	require.Equal(t, hexutil.Encode(srv.jwtSecret), "0xb5bbbaf533b625a93741978857f13d7adeca58445a1fb00ecf3373420b92776c")
 	require.Equal(t, srv.authToken, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.MxwOozSH-TLbW_XKepjyYDHm2IT8Ki0tD3AHuajfNMg")
 
 	f, err := os.Open(filepath.Clean(srv.authTokenPath))

--- a/validator/rpc/server.go
+++ b/validator/rpc/server.go
@@ -78,7 +78,6 @@ type Server struct {
 	startFailure              error
 	ctx                       context.Context
 	walletDir                 string
-	jwtSecret                 []byte
 	grpcHeaders               []string
 }
 
@@ -219,7 +218,6 @@ func (s *Server) InitializeRoutes() error {
 	s.router.HandleFunc("GET "+api.WebUrlPrefix+"wallet", s.WalletConfig)
 	s.router.HandleFunc("POST "+api.WebUrlPrefix+"wallet/create", s.CreateWallet)
 	s.router.HandleFunc("POST "+api.WebUrlPrefix+"wallet/keystores/validate", s.ValidateKeystores)
-	s.router.HandleFunc("POST "+api.WebUrlPrefix+"wallet/recover", s.RecoverWallet)
 	// slashing protection endpoints
 	s.router.HandleFunc("GET "+api.WebUrlPrefix+"slashing-protection/export", s.ExportSlashingProtection)
 	s.router.HandleFunc("POST "+api.WebUrlPrefix+"slashing-protection/import", s.ImportSlashingProtection)


### PR DESCRIPTION
remove the dead `jwtSecret` field from the validator RPC server struct, stop storing the legacy secret value while still validating legacy token files, adjust the legacy token test so it only asserts the persisted auth token