### PR TITLE
fix: allow full-capacity snapshots in fromSnapshot

### DIFF
--- a/beacon-chain/cache/depositsnapshot/deposit_tree.go
+++ b/beacon-chain/cache/depositsnapshot/deposit_tree.go
@@ -64,7 +64,7 @@ func fromSnapshot(snapshot DepositTreeSnapshot) (*DepositTree, error) {
 	if snapshot.depositRoot != root {
 		return nil, ErrInvalidSnapshotRoot
 	}
-	if snapshot.depositCount >= math.PowerOf2(uint64(DepositContractDepth)) {
+	if snapshot.depositCount > math.PowerOf2(uint64(DepositContractDepth)) {
 		return nil, ErrTooManyDeposits
 	}
 	tree, err := fromSnapshotParts(snapshot.finalized, snapshot.depositCount, DepositContractDepth)

--- a/changelog/phrwlk_fix-deposit-shapshot.md
+++ b/changelog/phrwlk_fix-deposit-shapshot.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- allow full-capacity snapshots in fromSnapshot [#16070](https://github.com/OffchainLabs/prysm/pull/16070)


### PR DESCRIPTION
The capacity guard in fromSnapshot used >= against 2^DepositContractDepth, rejecting snapshots whose deposit_count exactly equals the tree capacity. This contradicts both our fromSnapshotParts implementation, which explicitly handles the equality case by returning a FinalizedNode, and the EIP‑4881 reference implementation where deposits == 2**level is valid. Changing the check to a strict > makes equality acceptable, preventing false rejections of full trees and keeping behavior consistent with the spec and the rest of the code.