### PR TITLE
Avoid repeated epoch conversion while filtering active validator keys

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1306,8 +1306,8 @@ func (v *validator) filterAndCacheActiveKeys(ctx context.Context, pubkeys [][fie
 			return nil, errors.Wrap(err, "failed to update validator status cache")
 		}
 	}
+	currEpoch := primitives.Epoch(slot / params.BeaconConfig().SlotsPerEpoch)
 	for k, s := range v.pubkeyToStatus {
-		currEpoch := primitives.Epoch(slot / params.BeaconConfig().SlotsPerEpoch)
 		currActivating := s.status.Status == ethpb.ValidatorStatus_PENDING && currEpoch >= s.status.ActivationEpoch
 
 		active := s.status.Status == ethpb.ValidatorStatus_ACTIVE
@@ -1416,7 +1416,8 @@ func (v *validator) buildSignedRegReqs(
 	if time.Now().Before(v.genesisTime) {
 		return signedValRegRequests
 	}
-
+	cfg := params.BeaconConfig()
+	
 	if v.ProposerSettings().DefaultConfig != nil && v.ProposerSettings().DefaultConfig.FeeRecipientConfig == nil && v.ProposerSettings().DefaultConfig.BuilderConfig != nil {
 		log.Warn("Builder is `enabled` in default config but will be ignored because no fee recipient was provided!")
 	}
@@ -1428,8 +1429,8 @@ func (v *validator) buildSignedRegReqs(
 			continue
 		}
 
-		feeRecipient := common.HexToAddress(params.BeaconConfig().EthBurnAddressHex)
-		gasLimit := params.BeaconConfig().DefaultBuilderGasLimit
+		feeRecipient := common.HexToAddress(cfg.EthBurnAddressHex)
+		gasLimit := cfg.DefaultBuilderGasLimit
 		enabled := false
 
 		if v.ProposerSettings().DefaultConfig != nil && v.ProposerSettings().DefaultConfig.FeeRecipientConfig != nil {
@@ -1479,7 +1480,7 @@ func (v *validator) buildSignedRegReqs(
 			continue
 		}
 
-		if hexutil.Encode(feeRecipient.Bytes()) == params.BeaconConfig().EthBurnAddressHex {
+		if hexutil.Encode(feeRecipient.Bytes()) == cfg.EthBurnAddressHex {
 			log.WithFields(logrus.Fields{
 				"pubkey":       fmt.Sprintf("%#x", req.Pubkey),
 				"feeRecipient": feeRecipient,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:
If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
an associated issue with a design discussed and decided upon. Small bug
fixes and documentation improvements don't need issues.
New features and bug fixes must have tests. Documentation may need to
be updated. If you're unsure what to update, send the PR, and we'll discuss
in review.
Note that PRs updating dependencies and new Go versions are not accepted.
Please file an issue instead.
A changelog entry is required for user facing issues.
-->
What type of PR is this?
Other
What does this PR do? Why is it needed?
Cache params.BeaconConfig() once in the validator builder path so we stop re-fetching the beacon config for every key and every registration.
Precompute currEpoch outside the status loop when filtering keys, removing redundant epoch math per validator.
These tweaks keep builder behavior identical while trimming a bit of per-slot overhead in the validator client.
Which issues(s) does this PR fix?
None.
Fixes # N/A
Other notes for review
No functional changes expected; builder registrations and fee-recipient logging continue to use the same config values.
Acknowledgements
[ ] I have read CONTRIBUTING.md.
[ ] I have included a uniquely named changelog fragment file.
[ ] I have added a description to this PR with sufficient context for reviewers to understand this PR.