### PR TITLE
Avoid recomputing argument list between Prysm restarts on Windows

### DIFF
--- a/prysm.ps1
+++ b/prysm.ps1
@@ -111,10 +111,9 @@ If you must wish to continue running an unverified binary, use:
 }
 
 # Finally, start the process.
+$argumentList = @($args | Select-Object -Skip 1);
 do {
     Write-Host "Starting: prysm $($args -join ' ')";
-
-    $argumentList = $args | Select-Object -Skip 1;
 
     if ($argumentList.Length -gt 0) {
         $process = Start-Process -FilePath $folderBin -ArgumentList $argumentList -NoNewWindow -PassThru -Wait;


### PR DESCRIPTION
compute $argumentList once before the restart loop so we don’t keep re-running the pipeline, reuse the cached arguments when restarting, keeping behavior unchanged while dropping redundant work, keep the autorestart flow identical apart from the removed recomputation