### PR TITLE
perf: avoid string copy when importing slashing protection JSON

### DIFF
--- a/changelog/Fibonacci747_perf.md
+++ b/changelog/Fibonacci747_perf.md
@@ -1,0 +1,3 @@
+### Changed
+
+- avoid string copy when importing slashing protection JSON [#16081](https://github.com/OffchainLabs/prysm/pull/16081)

--- a/validator/rpc/handlers_slashing.go
+++ b/validator/rpc/handlers_slashing.go
@@ -1,10 +1,10 @@
 package rpc
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
@@ -74,9 +74,8 @@ func (s *Server) ImportSlashingProtection(w http.ResponseWriter, r *http.Request
 		httputil.HandleError(w, "empty slashing_protection_json specified", http.StatusBadRequest)
 		return
 	}
-	enc := []byte(req.SlashingProtectionJson)
-	buf := bytes.NewBuffer(enc)
-	if err := s.db.ImportStandardProtectionJSON(ctx, buf); err != nil {
+	rdr := strings.NewReader(req.SlashingProtectionJson)
+	if err := s.db.ImportStandardProtectionJSON(ctx, rdr); err != nil {
 		httputil.HandleError(w, errors.Wrap(err, "could not import slashing protection history").Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Made this change to eliminate unnecessary allocations in the slashing protection import paths because this reduces memory usage and avoids an extra copy when passing request JSON into the DB importer which already reads from an io.Reader.