### PR TITLE
Improve logging and estimation in WarmCache process

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -121,11 +121,18 @@ type BlobStorage struct {
 // will be populated at node startup, avoiding a costly cold prune (~4s in syscalls) during syncing.
 func (bs *BlobStorage) WarmCache() {
 	start := time.Now()
-	if bs.layoutName == LayoutNameFlat {
-		log.Info("Blob filesystem cache warm-up started. This may take a few minutes")
-	} else {
-		log.Info("Blob filesystem cache warm-up started")
+
+	dirs, err := listDir(bs.fs, ".")
+	if err != nil {
+		log.WithError(err).Warn("Failed to list blob storage directories")
 	}
+	est := time.Duration(len(dirs)) * time.Millisecond
+
+	log.WithFields(logrus.Fields{
+		"layout":    bs.layout.name(),
+		"dir_count": len(dirs),
+		"estimated": est.String(),
+	}).Info("Warming up blob filesystem cache")
 
 	if err := warmCache(bs.layout, bs.cache); err != nil {
 		log.WithError(err).Error("Error encountered while warming up blob filesystem cache")

--- a/changelog/conj40_better-warmcache-logging.md
+++ b/changelog/conj40_better-warmcache-logging.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Improved logging in `WarmCache` to provide better insights during blob filesystem cache warm-up, including estimated time and directory count.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**
The WarmCache process currently logs a generic message when it starts, but it does not provide any progress updates or an estimated time for completion. This lack of visibility can cause confusion for users, especially when the process takes a long time (e.g., hours). Users are left wondering whether the process is stuck or how much longer it will take.

**Which issues(s) does this PR fix?**
This PR fixes the issue related to [Issue #16054](https://github.com/OffchainLabs/prysm/issues/16054) to improve the logging during the WarmCache process in the BlobStorage implementation

Fixes [Issue #16054](https://github.com/OffchainLabs/prysm/issues/16054)

**Other notes for review**

**Acknowledgements**

- [ x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
