### PR TITLE
Move the "Not enough connected peers" (for a given subnet) from WARN to DEBUG

### DIFF
--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -638,7 +638,7 @@ func (s *Service) logMinimumPeersPerSubnet(ctx context.Context, p subscribeParam
 					log.WithFields(logrus.Fields{
 						"topic":  topic,
 						"actual": count,
-					}).Warning("Not enough connected peers")
+					}).Debug("Not enough connected peers")
 				}
 			}
 			if !isSubnetWithMissingPeers {

--- a/changelog/manu-not-enough-conneted-peers.md
+++ b/changelog/manu-not-enough-conneted-peers.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Move the "Not enough connected peers" (for a given subnet) from WARN to DEBUG


### PR DESCRIPTION


**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Move the "Not enough connected peers" (for a given subnet) from WARN to DEBUG

**Rationale:**
The
<img width="1839" height="31" alt="image" src="https://github.com/user-attachments/assets/44dbdc8d-3e37-42ee-967b-75a7a1fbcafb" />
log is (potentially) printed every 5 minutes.
Every 5 minutes, the BN checks if, for a given subnet, the actual count of peers is at least equal to a minimum one.
If not, this kind of log is printed.

When validators are connected and selected to be an aggregator in the next epoch, the BN needs to subscribe and find new peers in the corresponding attestation subnet.
If, right after the beacon is subscribed (but before it had time to find peers), the "5 min ticker" ticks, then this warning log is displayed, even if the slot for which the validator is selected as an aggregator is still minutes away.

For this reason, this log is moved from WARN to DEBUG

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
