### PR TITLE
fix: pass ctx to decode in migrateArchivedIndex

### DIFF
--- a/beacon-chain/db/kv/migration_archived_index.go
+++ b/beacon-chain/db/kv/migration_archived_index.go
@@ -38,7 +38,7 @@ func migrateArchivedIndex(ctx context.Context, db *bolt.DB) error {
 				continue
 			}
 			blk := &ethpb.SignedBeaconBlock{}
-			if err := decode(context.TODO(), b, blk); err != nil {
+			if err := decode(ctx, b, blk); err != nil {
 				return err
 			}
 			if err := tx.Bucket(stateSlotIndicesBucket).Put(bytesutil.SlotToBytesBigEndian(blk.Block.Slot), v); err != nil {


### PR DESCRIPTION
The migration was calling `decode(context.TODO(), ...)`, which bypassed cancellation and tracing even though the function already accepts a ctx and checks ctx.Err() in the loop. This change replaces context.TODO() with the function’s ctx to ensure decode operations are cancelable and properly traced. No behavior changes expected aside from respecting cancellations and improving observability.