### PR TITLE
Add `--ignore-unviable-attestations` and deprecate `--disable-last-epoch-targets`

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -240,7 +240,7 @@ func (f *ForkChoice) IsViableForCheckpoint(cp *forkchoicetypes.Checkpoint) (bool
 	if node.slot == epochStart {
 		return true, nil
 	}
-	if !features.Get().DisableLastEpochTargets {
+	if !features.Get().IgnoreUnviableAttestations {
 		// Allow any node from the checkpoint epoch - 1 to be viable.
 		nodeEpoch := slots.ToEpoch(node.slot)
 		if nodeEpoch+1 == cp.Epoch {

--- a/changelog/terence_ignore-unviable-attestations-flag.md
+++ b/changelog/terence_ignore-unviable-attestations-flag.md
@@ -1,0 +1,2 @@
+### Changed
+- Introduced flag `--ignore-unviable-attestations` (replaces and deprecates `--disable-last-epoch-targets`) to drop attestations whose target state is not viable; default remains to process them unless explicitly enabled.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -71,7 +71,7 @@ type Flags struct {
 
 	DisableResourceManager     bool // Disables running the node with libp2p's resource manager.
 	DisableStakinContractCheck bool // Disables check for deposit contract when proposing blocks
-	DisableLastEpochTargets    bool // Disables processing of states for attestations to old blocks.
+	IgnoreUnviableAttestations bool // Ignore attestations whose target state is not viable (avoids lagging-node DoS).
 
 	EnableVerboseSigVerification bool // EnableVerboseSigVerification specifies whether to verify individual signature if batch verification fails
 
@@ -281,9 +281,11 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(blacklistRoots)
 		cfg.BlacklistedRoots = parseBlacklistedRoots(ctx.StringSlice(blacklistRoots.Name))
 	}
-	if ctx.IsSet(disableLastEpochTargets.Name) {
-		logEnabled(disableLastEpochTargets)
-		cfg.DisableLastEpochTargets = true
+
+	cfg.IgnoreUnviableAttestations = false
+	if ctx.IsSet(ignoreUnviableAttestations.Name) && ctx.Bool(ignoreUnviableAttestations.Name) {
+		logEnabled(ignoreUnviableAttestations)
+		cfg.IgnoreUnviableAttestations = true
 	}
 
 	if ctx.IsSet(EnableStateDiff.Name) {

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -25,4 +25,6 @@ var upcomingDeprecation = []cli.Flag{
 
 // deprecatedBeaconFlags contains flags that are still used by other components
 // and therefore cannot be added to deprecatedFlags
-var deprecatedBeaconFlags = []cli.Flag{}
+var deprecatedBeaconFlags = []cli.Flag{
+	deprecatedDisableLastEpochTargets,
+}

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -201,10 +201,15 @@ var (
 		Usage: "(Work in progress): Enables the web portal for the validator client.",
 		Value: false,
 	}
-	// disableLastEpochTargets is a flag to disable processing of attestations for old blocks.
-	disableLastEpochTargets = &cli.BoolFlag{
+	// deprecatedDisableLastEpochTargets is a flag to disable processing of attestations for old blocks.
+	deprecatedDisableLastEpochTargets = &cli.BoolFlag{
 		Name:  "disable-last-epoch-targets",
-		Usage: "Disables processing of last epoch targets.",
+		Usage: "Deprecated: disables processing of last epoch targets.",
+	}
+	// ignoreUnviableAttestations flag to skip attestations whose target state is not viable with respect to head (from lagging nodes).
+	ignoreUnviableAttestations = &cli.BoolFlag{
+		Name:  "ignore-unviable-attestations",
+		Usage: "Ignores attestations whose target state is not viable with respect to the current head (avoid expensive state replay from lagging attesters).",
 	}
 )
 
@@ -251,6 +256,7 @@ var BeaconChainFlags = combinedFlags([]cli.Flag{
 	disableStakinContractCheck,
 	SaveFullExecutionPayloads,
 	enableStartupOptimistic,
+	ignoreUnviableAttestations,
 	enableFullSSZDataLogging,
 	disableVerboseSigVerification,
 	prepareAllPayloads,
@@ -266,7 +272,6 @@ var BeaconChainFlags = combinedFlags([]cli.Flag{
 	enableExperimentalAttestationPool,
 	forceHeadFlag,
 	blacklistRoots,
-	disableLastEpochTargets,
 }, deprecatedBeaconFlags, deprecatedFlags, upcomingDeprecation)
 
 func combinedFlags(flags ...[]cli.Flag) []cli.Flag {


### PR DESCRIPTION
This PR introduces flag `--ignore-unviable-attestations` (replaces and deprecates `--disable-last-epoch-targets`) to drop attestations whose target state is not viable; default remains to process them unless explicitly enabled.