### PR TITLE
Use head state in more cases

### DIFF
--- a/changelog/potuz_use_head_more_cases.md
+++ b/changelog/potuz_use_head_more_cases.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use head state to validate attestations for old blocks if they are compatible.


### PR DESCRIPTION
The head state is guaranteed to have the same shuffling and active indices if the previous dependent root coincides with the target checkpoint's in some cases. 