### PR TITLE
Track the dependent root of the latest finalized checkpoint

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -642,8 +642,12 @@ func (f *ForkChoice) DependentRootForEpoch(root [32]byte, epoch primitives.Epoch
 	if !ok || node == nil {
 		return [32]byte{}, ErrNilNode
 	}
-	if slots.ToEpoch(node.slot) >= epoch && node.parent != nil {
-		node = node.parent
+	if slots.ToEpoch(node.slot) >= epoch {
+		if node.parent != nil {
+			node = node.parent
+		} else {
+			return f.store.finalizedDependentRoot, nil
+		}
 	}
 	return node.root, nil
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -212,6 +212,9 @@ func (s *Store) prune(ctx context.Context) error {
 		return nil
 	}
 
+	// Save the new finalized dependent root because it will be pruned
+	s.finalizedDependentRoot = finalizedNode.parent.root
+
 	// Prune nodeByRoot starting from root
 	if err := s.pruneFinalizedNodeByRootMap(ctx, s.treeRootNode, finalizedNode); err != nil {
 		return err

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -31,6 +31,7 @@ type Store struct {
 	proposerBoostRoot             [fieldparams.RootLength]byte           // latest block root that was boosted after being received in a timely manner.
 	previousProposerBoostRoot     [fieldparams.RootLength]byte           // previous block root that was boosted after being received in a timely manner.
 	previousProposerBoostScore    uint64                                 // previous proposer boosted root score.
+	finalizedDependentRoot        [fieldparams.RootLength]byte           // dependent root at finalized checkpoint.
 	committeeWeight               uint64                                 // tracks the total active validator balance divided by the number of slots per Epoch.
 	treeRootNode                  *Node                                  // the root node of the store tree.
 	headNode                      *Node                                  // last head Node

--- a/changelog/potuz_finalized_deproot.md
+++ b/changelog/potuz_finalized_deproot.md
@@ -1,0 +1,3 @@
+### Added
+
+- Track the dependent root of the latest finalized checkpoint in forkchoice.


### PR DESCRIPTION
This PR adds the dependent root of the latest finalized checkpoint to forkchoice since this node will be typically pruned upon finalization.

