### PR TITLE
fix: propagate request context in backup webhook handler

### DIFF
--- a/monitoring/backup/http_backup_handler.go
+++ b/monitoring/backup/http_backup_handler.go
@@ -22,7 +22,7 @@ func Handler(bk Exporter, outputDir string) func(http.ResponseWriter, *http.Requ
 
 		_, permissionOverride := r.URL.Query()["permissionOverride"]
 
-		if err := bk.Backup(context.Background(), outputDir, permissionOverride); err != nil {
+		if err := bk.Backup(r.Context(), outputDir, permissionOverride); err != nil {
 			log.WithError(err).Error("Failed to create backup")
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Use r.Context() instead of context.Background() when triggering backups from the HTTP webhook. This preserves request-scoped cancellation and deadlines and correctly attaches OpenTelemetry spans to the originating HTTP request, aligning with the project’s handler conventions.