### PR TITLE
Fix TOCTOU race validating attestations

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -265,7 +265,7 @@ func (s *Service) processVerifiedAttestation(
 	if key, err := generateUnaggregatedAttCacheKey(broadcastAtt); err != nil {
 		log.WithError(err).Error("Failed to generate cache key for attestation tracking")
 	} else {
-		s.setSeenUnaggregatedAtt(key)
+		_ = s.setSeenUnaggregatedAtt(key)
 	}
 
 	valCount, err := helpers.ActiveValidatorCount(ctx, preState, slots.ToEpoch(data.Slot))
@@ -320,7 +320,7 @@ func (s *Service) processAggregate(ctx context.Context, aggregate ethpb.SignedAg
 		return
 	}
 
-	s.setAggregatorIndexEpochSeen(att.GetData().Target.Epoch, aggregate.AggregateAttestationAndProof().GetAggregatorIndex())
+	_ = s.setAggregatorIndexEpochSeen(att.GetData().Target.Epoch, aggregate.AggregateAttestationAndProof().GetAggregatorIndex())
 
 	if err := s.cfg.p2p.Broadcast(ctx, aggregate); err != nil {
 		log.WithError(err).Debug("Could not broadcast aggregated attestation")

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -801,3 +801,27 @@ func TestValidateAggregateAndProof_RejectWhenAttEpochDoesntEqualTargetEpoch(t *t
 	assert.NotNil(t, err)
 	assert.Equal(t, pubsub.ValidationReject, res)
 }
+
+func Test_SetAggregatorIndexEpochSeen(t *testing.T) {
+	db := dbtest.SetupDB(t)
+	p := p2ptest.NewTestP2P(t)
+
+	r := &Service{
+		cfg: &config{
+			p2p:      p,
+			beaconDB: db,
+		},
+		seenAggregatedAttestationCache: lruwrpr.New(10),
+	}
+
+	aggIndex := primitives.ValidatorIndex(42)
+	epoch := primitives.Epoch(7)
+
+	require.Equal(t, false, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
+	first := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
+	require.Equal(t, true, first)
+	require.Equal(t, true, r.hasSeenAggregatorIndexEpoch(epoch, aggIndex))
+
+	second := r.setAggregatorIndexEpochSeen(epoch, aggIndex)
+	require.Equal(t, false, second)
+}

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -229,12 +229,9 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		Data: eventData,
 	})
 
-	if s.hasSeenUnaggregatedAtt(attKey) {
-		// We do a second check here in case another goroutine added it while we were validating
-		// the attestation.  In that case, we just ignore this attestation.
+	if first := s.setSeenUnaggregatedAtt(attKey); !first {
+		// Another concurrent validation processed the same attestation meanwhile
 		return pubsub.ValidationIgnore, nil
-	} else {
-		s.setSeenUnaggregatedAtt(attKey)
 	}
 
 	// Attach final validated attestation to the message for further pipeline use
@@ -392,11 +389,16 @@ func (s *Service) hasSeenUnaggregatedAtt(key string) bool {
 }
 
 // Set an incoming attestation as seen for the participating validator for the slot.
-func (s *Service) setSeenUnaggregatedAtt(key string) {
+// Returns false if the attestation was already seen.
+func (s *Service) setSeenUnaggregatedAtt(key string) bool {
 	s.seenUnAggregatedAttestationLock.Lock()
 	defer s.seenUnAggregatedAttestationLock.Unlock()
-
+	_, seen := s.seenUnAggregatedAttestationCache.Get(key)
+	if seen {
+		return false
+	}
 	s.seenUnAggregatedAttestationCache.Add(key, true)
+	return true
 }
 
 // hasBlockAndState returns true if the beacon node knows about a block and associated state in the

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -104,7 +104,8 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	}
 
 	if !s.slasherEnabled {
-		// Verify this the first attestation received for the participating validator for the slot.
+		// Verify this the first attestation received for the participating validator for the slot. This verification is here to return early if we've already seen this attestation.
+		// This verification is carried again later after all other validations to avoid TOCTOU issues.
 		if s.hasSeenUnaggregatedAtt(attKey) {
 			return pubsub.ValidationIgnore, nil
 		}
@@ -228,7 +229,13 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		Data: eventData,
 	})
 
-	s.setSeenUnaggregatedAtt(attKey)
+	if s.hasSeenUnaggregatedAtt(attKey) {
+		// We do a second check here in case another goroutine added it while we were validating
+		// the attestation.  In that case, we just ignore this attestation.
+		return pubsub.ValidationIgnore, nil
+	} else {
+		s.setSeenUnaggregatedAtt(attKey)
+	}
 
 	// Attach final validated attestation to the message for further pipeline use
 	msg.ValidatorData = attForValidation

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -499,6 +499,10 @@ func TestService_setSeenUnaggregatedAtt(t *testing.T) {
 			Data:            &ethpb.AttestationData{Slot: 2, CommitteeIndex: 0},
 			AggregationBits: bitfield.Bitlist{0b1001},
 		}
+		s3c0a0 := &ethpb.Attestation{
+			Data:            &ethpb.AttestationData{Slot: 3, CommitteeIndex: 0},
+			AggregationBits: bitfield.Bitlist{0b1001},
+		}
 
 		t.Run("empty cache", func(t *testing.T) {
 			key := generateKey(t, s0c0a0)
@@ -506,26 +510,39 @@ func TestService_setSeenUnaggregatedAtt(t *testing.T) {
 		})
 		t.Run("ok", func(t *testing.T) {
 			key := generateKey(t, s0c0a0)
-			s.setSeenUnaggregatedAtt(key)
+			first := s.setSeenUnaggregatedAtt(key)
 			assert.Equal(t, true, s.hasSeenUnaggregatedAtt(key))
+			assert.Equal(t, true, first)
+		})
+		t.Run("already seen", func(t *testing.T) {
+			key := generateKey(t, s3c0a0)
+			first := s.setSeenUnaggregatedAtt(key)
+			assert.Equal(t, true, s.hasSeenUnaggregatedAtt(key))
+			assert.Equal(t, true, first)
+			first = s.setSeenUnaggregatedAtt(key)
+			assert.Equal(t, true, s.hasSeenUnaggregatedAtt(key))
+			assert.Equal(t, false, first)
 		})
 		t.Run("different slot", func(t *testing.T) {
 			key1 := generateKey(t, s1c0a0)
 			key2 := generateKey(t, s2c0a0)
-			s.setSeenUnaggregatedAtt(key1)
+			first := s.setSeenUnaggregatedAtt(key1)
 			assert.Equal(t, false, s.hasSeenUnaggregatedAtt(key2))
+			assert.Equal(t, true, first)
 		})
 		t.Run("different committee index", func(t *testing.T) {
 			key1 := generateKey(t, s0c1a0)
 			key2 := generateKey(t, s0c2a0)
-			s.setSeenUnaggregatedAtt(key1)
+			first := s.setSeenUnaggregatedAtt(key1)
 			assert.Equal(t, false, s.hasSeenUnaggregatedAtt(key2))
+			assert.Equal(t, true, first)
 		})
 		t.Run("different bit", func(t *testing.T) {
 			key1 := generateKey(t, s0c0a1)
 			key2 := generateKey(t, s0c0a2)
-			s.setSeenUnaggregatedAtt(key1)
+			first := s.setSeenUnaggregatedAtt(key1)
 			assert.Equal(t, false, s.hasSeenUnaggregatedAtt(key2))
+			assert.Equal(t, true, first)
 		})
 		t.Run("0 bits set is considered not seen", func(t *testing.T) {
 			a := &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b1000}}
@@ -576,6 +593,11 @@ func TestService_setSeenUnaggregatedAtt(t *testing.T) {
 			CommitteeId:   0,
 			AttesterIndex: 0,
 		}
+		s3c0a0 := &ethpb.SingleAttestation{
+			Data:          &ethpb.AttestationData{Slot: 2},
+			CommitteeId:   0,
+			AttesterIndex: 0,
+		}
 
 		t.Run("empty cache", func(t *testing.T) {
 			key := generateKey(t, s0c0a0)
@@ -583,26 +605,39 @@ func TestService_setSeenUnaggregatedAtt(t *testing.T) {
 		})
 		t.Run("ok", func(t *testing.T) {
 			key := generateKey(t, s0c0a0)
-			s.setSeenUnaggregatedAtt(key)
+			first := s.setSeenUnaggregatedAtt(key)
 			assert.Equal(t, true, s.hasSeenUnaggregatedAtt(key))
+			assert.Equal(t, true, first)
 		})
 		t.Run("different slot", func(t *testing.T) {
 			key1 := generateKey(t, s1c0a0)
 			key2 := generateKey(t, s2c0a0)
-			s.setSeenUnaggregatedAtt(key1)
+			first := s.setSeenUnaggregatedAtt(key1)
 			assert.Equal(t, false, s.hasSeenUnaggregatedAtt(key2))
+			assert.Equal(t, true, first)
+		})
+		t.Run("already seen", func(t *testing.T) {
+			key := generateKey(t, s3c0a0)
+			first := s.setSeenUnaggregatedAtt(key)
+			assert.Equal(t, true, s.hasSeenUnaggregatedAtt(key))
+			assert.Equal(t, true, first)
+			first = s.setSeenUnaggregatedAtt(key)
+			assert.Equal(t, true, s.hasSeenUnaggregatedAtt(key))
+			assert.Equal(t, false, first)
 		})
 		t.Run("different committee index", func(t *testing.T) {
 			key1 := generateKey(t, s0c1a0)
 			key2 := generateKey(t, s0c2a0)
-			s.setSeenUnaggregatedAtt(key1)
+			first := s.setSeenUnaggregatedAtt(key1)
 			assert.Equal(t, false, s.hasSeenUnaggregatedAtt(key2))
+			assert.Equal(t, true, first)
 		})
 		t.Run("different attester", func(t *testing.T) {
 			key1 := generateKey(t, s0c0a1)
 			key2 := generateKey(t, s0c0a2)
-			s.setSeenUnaggregatedAtt(key1)
+			first := s.setSeenUnaggregatedAtt(key1)
 			assert.Equal(t, false, s.hasSeenUnaggregatedAtt(key2))
+			assert.Equal(t, true, first)
 		})
 		t.Run("single attestation is considered not seen", func(t *testing.T) {
 			a := &ethpb.AttestationElectra{}

--- a/changelog/potuz_check_twice_attseen.md
+++ b/changelog/potuz_check_twice_attseen.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed possible race when validating two attestations at the same time. 


### PR DESCRIPTION
A TOCTOU issue was reported by EF security in which two attestations being validated at the same time may result in both of them being forwarded. The spec says that we need to forward only the first one.
