### PR TITLE
reducing e2e eth1lookahead

### DIFF
--- a/changelog/james-prysm_reduce-lookahead-e2e.md
+++ b/changelog/james-prysm_reduce-lookahead-e2e.md
@@ -1,0 +1,3 @@
+### Changed
+
+- reduced eth1lookahead value from 8 to 1 since e2e only supports post merge(bellatrix), this will remove the error "Beacon node is not respecting the follow distance. EL client is syncing."

--- a/config/params/testdata/e2e_config.yaml
+++ b/config/params/testdata/e2e_config.yaml
@@ -64,8 +64,9 @@ SECONDS_PER_ETH1_BLOCK: 2 # Override for e2e tests
 MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 1
 # [customized] higher frequency of committee turnover and faster time to acceptable voluntary exit
 SHARD_COMMITTEE_PERIOD: 4 # Override for e2e tests
-# [customized] process deposits more quickly, but insecure
-ETH1_FOLLOW_DISTANCE: 8 # Override for e2e tests
+# [customized] Post-merge, the follow distance is less critical since finality is guaranteed by the beacon chain.
+# Setting to 1 avoids timing issues during e2e startup when the EL has few blocks.
+ETH1_FOLLOW_DISTANCE: 1 # Override for e2e tests
 
 
 # Validator cycle

--- a/config/params/testnet_e2e_config.go
+++ b/config/params/testnet_e2e_config.go
@@ -17,7 +17,9 @@ const (
 func E2ETestConfig() *BeaconChainConfig {
 	e2eConfig := MinimalSpecConfig()
 	e2eConfig.DepositContractAddress = "0x4242424242424242424242424242424242424242"
-	e2eConfig.Eth1FollowDistance = 8
+	// Post-merge, the follow distance is less critical since finality is guaranteed by the beacon chain.
+	// Setting to 1 avoids timing issues during e2e startup when the EL has few blocks.
+	e2eConfig.Eth1FollowDistance = 1
 
 	// Misc.
 	e2eConfig.MinGenesisActiveValidatorCount = 256
@@ -73,7 +75,9 @@ func E2ETestConfig() *BeaconChainConfig {
 func E2EMainnetTestConfig() *BeaconChainConfig {
 	e2eConfig := MainnetConfig()
 	e2eConfig.DepositContractAddress = "0x4242424242424242424242424242424242424242"
-	e2eConfig.Eth1FollowDistance = 8
+	// Post-merge, the follow distance is less critical since finality is guaranteed by the beacon chain.
+	// Setting to 1 avoids timing issues during e2e startup when the EL has few blocks.
+	e2eConfig.Eth1FollowDistance = 1
 
 	// Misc.
 	e2eConfig.MinGenesisActiveValidatorCount = 256


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

e2e starts post bellatrix (the merge) and doesn't support anything prior, we continually get this error message `Beacon node is not respecting the follow distance. EL client is syncing.` 

This pr reduces eth1follow distance to 1 so we no longer get this error message. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description to this PR with sufficient context for reviewers to understand this PR.
