### PR TITLE
fix: missing return after version header check

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -711,6 +711,7 @@ func (s *Server) SubmitAttesterSlashingsV2(w http.ResponseWriter, r *http.Reques
 	versionHeader := r.Header.Get(api.VersionHeader)
 	if versionHeader == "" {
 		httputil.HandleError(w, api.VersionHeader+" header is required", http.StatusBadRequest)
+		return
 	}
 	v, err := version.FromString(versionHeader)
 	if err != nil {

--- a/changelog/SashaMalysehko_fix-return-after-check.md
+++ b/changelog/SashaMalysehko_fix-return-after-check.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- Fix missing return after version header check in SubmitAttesterSlashingsV2.


### PR DESCRIPTION
Ensure SubmitAttesterSlashingsV2 returns immediately when the Eth-Consensus-Version header is missing. Without this early return the handler calls version.FromString with an empty value and writes a second JSON error to the response, producing invalid JSON and duplicating error output. This change aligns the handler with the error-handling pattern used in other endpoints that validate the version header.