### PR TITLE
sync: fix KZG batch verifier deadlock on timeout

### DIFF
--- a/beacon-chain/sync/batch_verifier.go
+++ b/beacon-chain/sync/batch_verifier.go
@@ -161,7 +161,7 @@ func (s *Service) validateWithKzgBatchVerifier(ctx context.Context, dataColumns 
 
 	timeout := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
 
-	resChan := make(chan error)
+	resChan := make(chan error, 1)
 	verificationSet := &kzgVerifier{dataColumns: dataColumns, resChan: resChan}
 	s.kzgChan <- verificationSet
 

--- a/changelog/fix_kzg_batch_verifier_timeout_deadlock.md
+++ b/changelog/fix_kzg_batch_verifier_timeout_deadlock.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix deadlock in data column gossip KZG batch verification when a caller times out preventing result delivery.


### PR DESCRIPTION
`validateWithKzgBatchVerifier` could timeout (12s) and once it times out because `resChan` is unbuffered, the verifier will stuck at following line at `verifyKzgBatch` as its waiting for someone to grab the result from `resChan`:
```
	for _, verifier := range kzgBatch {
		verifier.resChan <- verificationErr
	}
```
Fix is to make kzg batch verification non blocking on timeouts by buffering each request’s buffered size 1