### PR TITLE
Do not error when indices have been computed

### DIFF
--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -152,7 +152,7 @@ func ActiveValidatorIndices(ctx context.Context, s state.ReadOnlyBeaconState, ep
 	}
 
 	if err := UpdateCommitteeCache(ctx, s, epoch); err != nil {
-		return nil, errors.Wrap(err, "could not update committee cache")
+		log.WithError(err).Error("Could not update committee cache")
 	}
 
 	return indices, nil

--- a/changelog/potuz_return_indices_updateerr.md
+++ b/changelog/potuz_return_indices_updateerr.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Do not error when committee has been computed correctly but updating the cache failed.


### PR DESCRIPTION
If there is a context deadline updating the committee cache, but the indices have been computed correctly, do not error out but rather return the indices and log the error.
