### PR TITLE
refactor(container): remove redundant variable in thread-safe Map.Keys()

### DIFF
--- a/container/thread-safe/map.go
+++ b/container/thread-safe/map.go
@@ -32,8 +32,7 @@ func (m *Map[K, V]) Keys() (r []K) {
 	m.View(func(mp map[K]V) {
 		r = make([]K, 0, len(m.items))
 		for k := range mp {
-			key := k
-			r = append(r, key)
+			r = append(r, k)
 		}
 	})
 	return r


### PR DESCRIPTION
Simplified the `Keys()` method in the thread-safe map by removing an unnecessary intermediate variable assignment.