### PR TITLE
Guard KZG send with context cancellation

### DIFF
--- a/changelog/avoid_kzg_send_after_context_cancel.md
+++ b/changelog/avoid_kzg_send_after_context_cancel.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prevent blocked sends to the KZG batch verifier when the caller context is already canceled, avoiding useless queueing and potential hangs.


### PR DESCRIPTION
Avoid sending KZG verification reqs when the caller context is already canceled to prevent blocking on the channel