### PR TITLE
skipping slot 1 sync committee check e2e

### DIFF
--- a/changelog/james-prysm_skip-e2e-slot1-check.md
+++ b/changelog/james-prysm_skip-e2e-slot1-check.md
@@ -1,0 +1,3 @@
+### Changed
+
+- e2e sync committee evaluator now skips the first slot after startup, we already skip the fork epoch for checks here, this skip only applies on startup, due to altair always from 0 and validators need to warm up.

--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -258,10 +258,13 @@ func validatorsSyncParticipation(_ *types.EvaluationContext, conns ...*grpc.Clie
 		if err != nil {
 			return err
 		}
-		if forkStartSlot == b.Block().Slot() || forkStartSlot+1 == b.Block().Slot() {
-			// Skip fork slot and the slot immediately after (validators still ramping up).
-			// In e2e tests, AltairForkEpoch is always 0 since tests start from Bellatrix or later,
-			// so this skips slots 0 and 1 where sync participation is unreliable due to startup timing.
+		if forkStartSlot == b.Block().Slot() {
+			// Skip fork slot.
+			continue
+		}
+		// Skip slot 1 at genesis - validators need time to ramp up after chain start.
+		// This is a startup timing issue, not a fork transition issue.
+		if b.Block().Slot() == 1 {
 			continue
 		}
 		expectedParticipation := expectedSyncParticipation

--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -258,8 +258,10 @@ func validatorsSyncParticipation(_ *types.EvaluationContext, conns ...*grpc.Clie
 		if err != nil {
 			return err
 		}
-		if forkStartSlot == b.Block().Slot() {
-			// Skip fork slot.
+		if forkStartSlot == b.Block().Slot() || forkStartSlot+1 == b.Block().Slot() {
+			// Skip fork slot and the slot immediately after (validators still ramping up).
+			// In e2e tests, AltairForkEpoch is always 0 since tests start from Bellatrix or later,
+			// so this skips slots 0 and 1 where sync participation is unreliable due to startup timing.
 			continue
 		}
 		expectedParticipation := expectedSyncParticipation


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Tests

**What does this PR do? Why is it needed?**

```

--- PASS: TestEndToEnd_MinimalConfig/chain_started (0.50s)
--
--- PASS: TestEndToEnd_MinimalConfig/finished_syncing_0 (0.00s)
--- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_0 (0.00s)
--- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_0 (0.00s)
--- FAIL: TestEndToEnd_MinimalConfig/validator_sync_participation_0 (0.01s)
--- PASS: TestEndToEnd_MinimalConfig/peers_connect_epoch_0 (0.11s)


```
This PR attempts to reduce flakes on validator sync participation failures by skipping the first slot of the block after startup

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
