### PR TITLE
fix: treat fork schedule init failures as fatal config errors

### DIFF
--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestService_decodePubsubMessage(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
+	require.NoError(t, params.BeaconConfig().InitializeForkSchedule())
 	entry := params.GetNetworkScheduleEntry(params.BeaconConfig().GenesisEpoch)
 	tests := []struct {
 		name    string
@@ -118,7 +118,7 @@ func TestService_decodePubsubMessage(t *testing.T) {
 func TestExtractDataType(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	params.BeaconConfig().FuluForkEpoch = params.BeaconConfig().ElectraForkEpoch + 4096*2
-	params.BeaconConfig().InitializeForkSchedule()
+	require.NoError(t, params.BeaconConfig().InitializeForkSchedule())
 
 	type args struct {
 		digest [4]byte
@@ -307,7 +307,7 @@ func TestExtractDataType(t *testing.T) {
 func TestExtractDataTypeFromTypeMapInvalid(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	params.BeaconConfig().FuluForkEpoch = params.BeaconConfig().ElectraForkEpoch + 4096*2
-	params.BeaconConfig().InitializeForkSchedule()
+	require.NoError(t, params.BeaconConfig().InitializeForkSchedule())
 	chain := &mock.ChainService{ValidatorsRoot: [32]byte{}}
 	_, err := extractDataTypeFromTypeMap(types.BlockMap, []byte{0x00, 0x01}, chain)
 	require.ErrorIs(t, err, errInvalidDigest)

--- a/changelog/bashmunta_fix-init-error.md
+++ b/changelog/bashmunta_fix-init-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- treat fork schedule init failures as fatal config errors

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -387,20 +387,17 @@ func (b *BeaconChainConfig) ApplyOptions(opts ...Option) {
 }
 
 // InitializeForkSchedule initializes the scheduled forks and BPOs baked into the config.
-func (b *BeaconChainConfig) InitializeForkSchedule() {
-	// TODO: this needs to be able to return an error. The network schedule code has
-	// to implement weird fallbacks when it is not initialized properly, it would be better
-	// if the beacon node could crash if there isn't a valid fork schedule
-	// at the return of this function.
+func (b *BeaconChainConfig) InitializeForkSchedule() error {
 	b.ForkVersionSchedule = configForkSchedule(b)
 	b.ForkVersionNames = configForkNames(b)
 	b.forkSchedule = initForkSchedule(b)
 	b.bpoSchedule = initBPOSchedule(b)
 	combined := b.forkSchedule.merge(b.bpoSchedule)
 	if err := combined.prepare(b); err != nil {
-		log.WithError(err).Error("Failed to prepare network schedule")
+		return err
 	}
 	b.networkSchedule = combined
+	return nil
 }
 
 func LogDigests(b *BeaconChainConfig) {

--- a/config/params/config_test.go
+++ b/config/params/config_test.go
@@ -132,7 +132,7 @@ func TestMaxBlobsJumbled(t *testing.T) {
 		schedule = append(schedule, params.BlobScheduleEntry{Epoch: epoch, MaxBlobsPerBlock: maxBlobs[epoch]})
 	}
 	cfg.BlobSchedule = schedule
-	cfg.InitializeForkSchedule()
+	require.NoError(t, cfg.InitializeForkSchedule())
 	for i := 1; i < len(cfg.BlobSchedule); i++ {
 		beforeEpoch, epoch := cfg.BlobSchedule[i-1].Epoch, cfg.BlobSchedule[i].Epoch
 		before, after := maxBlobs[beforeEpoch], maxBlobs[epoch]
@@ -165,7 +165,7 @@ func TestFirstBPOAtFork(t *testing.T) {
 		{Epoch: cfg.FuluForkEpoch, MaxBlobsPerBlock: electraMaxBlobs + 1},
 		{Epoch: cfg.FuluForkEpoch + 1, MaxBlobsPerBlock: electraMaxBlobs + 2},
 	}
-	cfg.InitializeForkSchedule()
+	require.NoError(t, cfg.InitializeForkSchedule())
 	require.Equal(t, electraMaxBlobs, uint64(cfg.MaxBlobsPerBlockAtEpoch(cfg.FuluForkEpoch-1)))
 	require.Equal(t, electraMaxBlobs+1, uint64(cfg.MaxBlobsPerBlockAtEpoch(cfg.FuluForkEpoch)))
 	require.Equal(t, electraMaxBlobs+2, uint64(cfg.MaxBlobsPerBlockAtEpoch(cfg.FuluForkEpoch+2)))
@@ -176,7 +176,7 @@ func TestMaxBlobsNoSchedule(t *testing.T) {
 	cfg := params.MainnetConfig()
 	electraMaxBlobs := uint64(cfg.DeprecatedMaxBlobsPerBlockElectra)
 	cfg.BlobSchedule = nil
-	cfg.InitializeForkSchedule()
+	require.NoError(t, cfg.InitializeForkSchedule())
 	require.Equal(t, electraMaxBlobs, uint64(cfg.MaxBlobsPerBlockAtEpoch(cfg.FuluForkEpoch-1)))
 	require.Equal(t, electraMaxBlobs, uint64(cfg.MaxBlobsPerBlockAtEpoch(cfg.ElectraForkEpoch)))
 	require.Equal(t, cfg.DeprecatedMaxBlobsPerBlock, cfg.MaxBlobsPerBlockAtEpoch(cfg.ElectraForkEpoch-1))
@@ -333,7 +333,7 @@ func TestEntryWithForkDigest(t *testing.T) {
 		three: testConfigForSchedule(three),
 	}
 	for _, cfg := range configs {
-		cfg.InitializeForkSchedule()
+		require.NoError(t, cfg.InitializeForkSchedule())
 	}
 	cases := []struct {
 		epoch    primitives.Epoch
@@ -395,7 +395,7 @@ func testConfigForSchedule(gvr [32]byte) *params.BeaconChainConfig {
 func TestFilterFarFuture(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	params.BeaconConfig().FuluForkEpoch = params.BeaconConfig().FarFutureEpoch
-	params.BeaconConfig().InitializeForkSchedule()
+	require.NoError(t, params.BeaconConfig().InitializeForkSchedule())
 	last := params.LastNetworkScheduleEntry()
 	require.Equal(t, [4]byte(params.BeaconConfig().ElectraForkVersion), last.ForkVersion)
 }

--- a/config/params/config_utils_develop.go
+++ b/config/params/config_utils_develop.go
@@ -22,7 +22,9 @@ func BeaconConfig() *BeaconChainConfig {
 // OverrideBeaconConfig(c). Any subsequent calls to params.BeaconConfig() will
 // return this new configuration.
 func OverrideBeaconConfig(c *BeaconChainConfig) {
-	c.InitializeForkSchedule()
+	if err := c.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	cfgrw.Lock()
 	defer cfgrw.Unlock()
 	configs.active = c

--- a/config/params/config_utils_prod.go
+++ b/config/params/config_utils_prod.go
@@ -16,7 +16,9 @@ func BeaconConfig() *BeaconChainConfig {
 // OverrideBeaconConfig(c). Any subsequent calls to params.BeaconConfig() will
 // return this new configuration.
 func OverrideBeaconConfig(c *BeaconChainConfig) {
-	c.InitializeForkSchedule()
+	if err := c.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	configs.active = c
 }
 

--- a/config/params/configset.go
+++ b/config/params/configset.go
@@ -69,7 +69,9 @@ func (r *configset) add(c *BeaconChainConfig) error {
 	if _, exists := r.nameToConfig[name]; exists {
 		return errors.Wrapf(errCollisionName, "ConfigName=%s", name)
 	}
-	c.InitializeForkSchedule()
+	if err := c.InitializeForkSchedule(); err != nil {
+		return errors.Wrap(err, "failed to initialize fork schedule")
+	}
 	for v := range c.ForkVersionSchedule {
 		if n, exists := r.versionToName[v]; exists {
 			// determine the fork name for the colliding version

--- a/config/params/fork_test.go
+++ b/config/params/fork_test.go
@@ -94,7 +94,7 @@ func TestRetrieveForkDataFromDigest(t *testing.T) {
 
 func TestNextForkData(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	params.BeaconConfig().InitializeForkSchedule()
+	require.NoError(t, params.BeaconConfig().InitializeForkSchedule())
 	cfg := params.BeaconConfig()
 	require.Equal(t, true, params.LastForkEpoch() < cfg.FarFutureEpoch)
 	tests := []struct {
@@ -163,7 +163,7 @@ func TestForkFromConfig_UsesPassedConfig(t *testing.T) {
 	testCfg.AltairForkVersion = []byte{0x02, 0x00, 0x00, 0x00}
 	testCfg.GenesisForkVersion = []byte{0x03, 0x00, 0x00, 0x00}
 	testCfg.AltairForkEpoch = 100
-	testCfg.InitializeForkSchedule()
+	require.NoError(t, testCfg.InitializeForkSchedule())
 
 	// Test at Altair fork epoch - should use the passed config's versions
 	fork := params.ForkFromConfig(testCfg, testCfg.AltairForkEpoch)

--- a/config/params/interop.go
+++ b/config/params/interop.go
@@ -14,6 +14,8 @@ func InteropConfig() *BeaconChainConfig {
 	c.ElectraForkVersion = []byte{5, 0, 0, 235}
 	c.FuluForkVersion = []byte{6, 0, 0, 235}
 
-	c.InitializeForkSchedule()
+	if err := c.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	return c
 }

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -66,7 +66,9 @@ func UnmarshalConfig(yamlFile []byte, conf *BeaconChainConfig) (*BeaconChainConf
 	// recompute SqrRootSlotsPerEpoch constant to handle non-standard values of SlotsPerEpoch
 	conf.SqrRootSlotsPerEpoch = primitives.Slot(math.IntegerSquareRoot(uint64(conf.SlotsPerEpoch)))
 	// Recompute the fork schedule
-	conf.InitializeForkSchedule()
+	if err := conf.InitializeForkSchedule(); err != nil {
+		return nil, errors.Wrap(err, "Failed to initialize fork schedule from yaml config")
+	}
 	log.Debugf("Config file values: %+v", conf)
 	return conf, nil
 }

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -12,7 +12,9 @@ import (
 // MainnetConfig returns the configuration to be used in the main network.
 func MainnetConfig() *BeaconChainConfig {
 	if mainnetBeaconConfig.ForkVersionSchedule == nil {
-		mainnetBeaconConfig.InitializeForkSchedule()
+		if err := mainnetBeaconConfig.InitializeForkSchedule(); err != nil {
+			panic(err)
+		}
 	}
 	return mainnetBeaconConfig.Copy()
 }

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -129,6 +129,8 @@ func MinimalSpecConfig() *BeaconChainConfig {
 
 	minimalConfig.BlobSchedule = make([]BlobScheduleEntry, 0)
 
-	minimalConfig.InitializeForkSchedule()
+	if err := minimalConfig.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	return minimalConfig
 }

--- a/config/params/testnet_e2e_config.go
+++ b/config/params/testnet_e2e_config.go
@@ -66,7 +66,9 @@ func E2ETestConfig() *BeaconChainConfig {
 		{Epoch: e2eConfig.ElectraForkEpoch, MaxBlobsPerBlock: uint64(e2eConfig.DeprecatedMaxBlobsPerBlockElectra)},
 	}
 
-	e2eConfig.InitializeForkSchedule()
+	if err := e2eConfig.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	return e2eConfig
 }
 

--- a/config/params/testnet_holesky_config.go
+++ b/config/params/testnet_holesky_config.go
@@ -54,6 +54,8 @@ func HoleskyConfig() *BeaconChainConfig {
 			Epoch:            167936, // 2025-10-13 21:10:24 UTC
 		},
 	}
-	cfg.InitializeForkSchedule()
+	if err := cfg.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	return cfg
 }

--- a/config/params/testnet_hoodi_config.go
+++ b/config/params/testnet_hoodi_config.go
@@ -60,6 +60,8 @@ func HoodiConfig() *BeaconChainConfig {
 		},
 	}
 	cfg.DefaultBuilderGasLimit = uint64(60000000)
-	cfg.InitializeForkSchedule()
+	if err := cfg.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	return cfg
 }

--- a/config/params/testnet_sepolia_config.go
+++ b/config/params/testnet_sepolia_config.go
@@ -59,6 +59,8 @@ func SepoliaConfig() *BeaconChainConfig {
 			Epoch:            275712, // 2025-10-27 23:16:48 UTC
 		},
 	}
-	cfg.InitializeForkSchedule()
+	if err := cfg.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	return cfg
 }

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -186,7 +186,9 @@ func (r *testRunner) postStartConfigure() {
 
 	// initialize genesis and fork schedule params in the test runner config to the same values they will have in the components
 	params.BeaconConfig().ApplyOptions(params.WithGenesisValidatorsRoot(bytesutil.ToBytes32(gs.GenesisValidatorsRoot())))
-	params.BeaconConfig().InitializeForkSchedule()
+	if err := params.BeaconConfig().InitializeForkSchedule(); err != nil {
+		r.t.Fatal(errors.Wrap(err, "initialize fork schedule")) // lint:nopanic -- test runner startup path expects fatal on config errors
+	}
 }
 
 // runEvaluators executes assigned evaluators.

--- a/testing/endtoend/slasher_simulator_e2e_test.go
+++ b/testing/endtoend/slasher_simulator_e2e_test.go
@@ -50,7 +50,7 @@ func (mockSyncChecker) IsSynced(_ context.Context) (bool, error) {
 func TestEndToEnd_SlasherSimulator(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.E2ETestConfig().Copy())
-	params.BeaconConfig().InitializeForkSchedule()
+	require.NoError(t, params.BeaconConfig().InitializeForkSchedule())
 
 	hook := logTest.NewGlobal()
 	ctx := t.Context()

--- a/testing/endtoend/types/fork.go
+++ b/testing/endtoend/types/fork.go
@@ -73,6 +73,8 @@ func InitForkCfg(start, end int, c *params.BeaconChainConfig) *params.BeaconChai
 			Epoch: c.ElectraForkEpoch, MaxBlobsPerBlock: uint64(c.DeprecatedMaxBlobsPerBlockElectra),
 		})
 	}
-	c.InitializeForkSchedule()
+	if err := c.InitializeForkSchedule(); err != nil {
+		panic(err)
+	}
 	return c
 }


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

InitializeForkSchedule now returns an error instead of logging and continuing when NetworkSchedule.prepare fails. All config constructors and helpers that build BeaconChainConfig (mainnet, minimal, interop, testnets, E2E configs) now panic on initialization failure to surface invalid fork schedules as hard configuration errors. configset.add, OverrideBeaconConfig, and YAML config loading handle the new error-returning API and either propagate or fail fast. Tests that relied on InitializeForkSchedule were updated to assert require.NoError, and E2E helpers now abort the test when fork schedule initialization fails.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
