### PR TITLE
Do not process slots and copy state for payload attributes post Fulu

### DIFF
--- a/changelog/potuz_next_epoch_attributes.md
+++ b/changelog/potuz_next_epoch_attributes.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Do not process slots and copy states for next epoch proposers after Fulu


### PR DESCRIPTION
When computing payload attributes post-Fulu, we do not need to process slots, nor copy the state if we need to find out if the node is proposing in the next slot. This prevents an immediate epoch processing after block 31 is processed unless we are actually proposing. 