### PR TITLE
Fix validation bug in --backfill-oldest-slot

### DIFF
--- a/beacon-chain/das/needs.go
+++ b/beacon-chain/das/needs.go
@@ -67,9 +67,9 @@ func NewSyncNeeds(current CurrentSlotter, oldestSlotFlagPtr *primitives.Slot, bl
 
 	// Override spec minimum block retention with user-provided flag only if it is lower than the spec minimum.
 	sn.blockRetention = primitives.Epoch(params.BeaconConfig().MinEpochsForBlockRequests)
+
 	if oldestSlotFlagPtr != nil {
-		oldestEpoch := slots.ToEpoch(*oldestSlotFlagPtr)
-		if oldestEpoch < sn.blockRetention {
+		if *oldestSlotFlagPtr <= syncEpochOffset(current(), sn.blockRetention) {
 			sn.validOldestSlotPtr = oldestSlotFlagPtr
 		} else {
 			log.WithField("backfill-oldest-slot", *oldestSlotFlagPtr).

--- a/changelog/kasey_fix-backfill-flag.md
+++ b/changelog/kasey_fix-backfill-flag.md
@@ -1,0 +1,2 @@
+#### Fixed
+- Fix validation logic for `--backfill-oldest-slot`, which was rejecting slots newer than 1056767.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

Validation of `--backfill-oldest-slot` fails for values > 1056767, because the validation code is comparing the slot/32 to `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (33024), instead of comparing it to `current_epoch - MIN_EPOCHS_FOR_BLOCK_REQUESTS`.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
