### PR TITLE
fix: avoid panic when fork schedule is empty

### DIFF
--- a/beacon-chain/rpc/eth/config/handlers.go
+++ b/beacon-chain/rpc/eth/config/handlers.go
@@ -40,6 +40,7 @@ func GetForkSchedule(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteJson(w, &structs.GetForkScheduleResponse{
 			Data: data,
 		})
+		return
 	}
 	previous := schedule[0]
 	for _, entry := range schedule {

--- a/changelog/sashass1315_fix-panic.md
+++ b/changelog/sashass1315_fix-panic.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- avoid panic when fork schedule is empty [#16175](https://github.com/OffchainLabs/prysm/pull/16175)


### PR DESCRIPTION
SortedForkSchedule should never be empty for a properly initialized network schedule, but the handler already had a branch to support an empty result. Without an early return, we wrote a JSON response and then still accessed schedule[0], which could panic and double-write the HTTP response in misconfigured setups.