### PR TITLE
fix: Remove duplicate verifier factory wrappers

### DIFF
--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -25,7 +25,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stategen"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
-	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/container/trie"
 	contracts "github.com/OffchainLabs/prysm/v7/contracts/deposit"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -242,7 +241,7 @@ func (s *Service) Start() {
 		log.WithError(err).Error("Could not get verification initializer")
 		return
 	}
-	s.blobVerifier = newBlobVerifierFromInitializer(v)
+	s.blobVerifier = verification.BlobVerifierFactory(v)
 
 	s.isRunning = true
 
@@ -913,12 +912,6 @@ func (s *Service) initDepositRequests() {
 		return
 	}
 	s.depositRequestsStarted = helpers.DepositRequestsStarted(fState)
-}
-
-func newBlobVerifierFromInitializer(ini *verification.Initializer) verification.NewBlobVerifier {
-	return func(b blocks.ROBlob, reqs []verification.Requirement) verification.BlobVerifier {
-		return ini.NewBlobVerifier(b, reqs)
-	}
 }
 
 type capabilityCache struct {

--- a/beacon-chain/sync/backfill/service.go
+++ b/beacon-chain/sync/backfill/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
-	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/proto/dbval"
@@ -353,18 +352,6 @@ func syncEpochOffset(current primitives.Slot, subtract primitives.Epoch) primiti
 		return 1
 	}
 	return current - offset
-}
-
-func newBlobVerifierFromInitializer(ini *verification.Initializer) verification.NewBlobVerifier {
-	return func(b blocks.ROBlob, reqs []verification.Requirement) verification.BlobVerifier {
-		return ini.NewBlobVerifier(b, reqs)
-	}
-}
-
-func newDataColumnVerifierFromInitializer(ini *verification.Initializer) verification.NewDataColumnsVerifier {
-	return func(cols []blocks.RODataColumn, reqs []verification.Requirement) verification.DataColumnsVerifier {
-		return ini.NewDataColumnsVerifier(cols, reqs)
-	}
 }
 
 func (s *Service) markComplete() {

--- a/beacon-chain/sync/backfill/worker.go
+++ b/beacon-chain/sync/backfill/worker.go
@@ -56,8 +56,8 @@ func initWorkerCfg(ctx context.Context, cfg *workerCfg, vw InitializerWaiter, st
 	}
 	cfg.verifier = v
 	cfg.ctxMap = cm
-	cfg.newVB = newBlobVerifierFromInitializer(vi)
-	cfg.newVC = newDataColumnVerifierFromInitializer(vi)
+	cfg.newVB = verification.BlobVerifierFactory(vi)
+	cfg.newVC = verification.DataColumnsVerifierFactory(vi)
 	return nil
 }
 

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -158,7 +158,7 @@ func TestFetchDataColumnSidecars(t *testing.T) {
 	initializer, err := waiter.WaitForInitializer(t.Context())
 	require.NoError(t, err)
 
-	newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+	newDataColumnsVerifier := verification.DataColumnsVerifierFactory(initializer)
 
 	other.SetStreamHandler(byRangeProtocol, func(stream network.Stream) {
 		expectedRequest := &ethpb.DataColumnSidecarsByRangeRequest{
@@ -791,7 +791,7 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 		initializer, err := waiter.WaitForInitializer(t.Context())
 		require.NoError(t, err)
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+		newDataColumnsVerifier := verification.DataColumnsVerifierFactory(initializer)
 		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, roDataColumnsByPeer)
 		require.NoError(t, err)
 
@@ -836,7 +836,7 @@ func TestVerifyDataColumnSidecarsByPeer(t *testing.T) {
 		initializer, err := waiter.WaitForInitializer(t.Context())
 		require.NoError(t, err)
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+		newDataColumnsVerifier := verification.DataColumnsVerifierFactory(initializer)
 		actual, err := verifyDataColumnSidecarsByPeer(p2p, newDataColumnsVerifier, roDataColumnsByPeer)
 		require.NoError(t, err)
 

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -168,8 +168,8 @@ func (s *Service) Start() {
 		log.WithError(err).Error("Could not get verification initializer")
 		return
 	}
-	s.newBlobVerifier = newBlobVerifierFromInitializer(v)
-	s.newDataColumnsVerifier = newDataColumnsVerifierFromInitializer(v)
+	s.newBlobVerifier = verification.BlobVerifierFactory(v)
+	s.newDataColumnsVerifier = verification.DataColumnsVerifierFactory(v)
 
 	gt := clock.GenesisTime()
 	if gt.IsZero() {
@@ -518,16 +518,4 @@ func shufflePeers(pids []peer.ID) {
 	rg.Shuffle(len(pids), func(i, j int) {
 		pids[i], pids[j] = pids[j], pids[i]
 	})
-}
-
-func newBlobVerifierFromInitializer(ini *verification.Initializer) verification.NewBlobVerifier {
-	return func(b blocks.ROBlob, reqs []verification.Requirement) verification.BlobVerifier {
-		return ini.NewBlobVerifier(b, reqs)
-	}
-}
-
-func newDataColumnsVerifierFromInitializer(ini *verification.Initializer) verification.NewDataColumnsVerifier {
-	return func(roDataColumns []blocks.RODataColumn, reqs []verification.Requirement) verification.DataColumnsVerifier {
-		return ini.NewDataColumnsVerifier(roDataColumns, reqs)
-	}
 }

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -791,7 +791,7 @@ func TestFetchOriginColumns(t *testing.T) {
 		initializer, err := waiter.WaitForInitializer(t.Context())
 		require.NoError(t, err)
 
-		newDataColumnsVerifier := newDataColumnsVerifierFromInitializer(initializer)
+		newDataColumnsVerifier := verification.DataColumnsVerifierFactory(initializer)
 
 		// Create a block with blob commitments and sidecars
 		roBlock, _, verifiedRoSidecars := util.GenerateTestFuluBlockWithSidecars(t, blobCount)

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -34,7 +34,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
 	"github.com/OffchainLabs/prysm/v7/config/params"
-	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	leakybucket "github.com/OffchainLabs/prysm/v7/container/leaky-bucket"
 	"github.com/OffchainLabs/prysm/v7/crypto/rand"
@@ -239,18 +238,6 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 	return r
 }
 
-func newBlobVerifierFromInitializer(ini *verification.Initializer) verification.NewBlobVerifier {
-	return func(b blocks.ROBlob, reqs []verification.Requirement) verification.BlobVerifier {
-		return ini.NewBlobVerifier(b, reqs)
-	}
-}
-
-func newDataColumnsVerifierFromInitializer(ini *verification.Initializer) verification.NewDataColumnsVerifier {
-	return func(roDataColumns []blocks.RODataColumn, reqs []verification.Requirement) verification.DataColumnsVerifier {
-		return ini.NewDataColumnsVerifier(roDataColumns, reqs)
-	}
-}
-
 // Start the regular sync service.
 func (s *Service) Start() {
 	v, err := s.verifierWaiter.WaitForInitializer(s.ctx)
@@ -258,8 +245,8 @@ func (s *Service) Start() {
 		log.WithError(err).Error("Could not get verification initializer")
 		return
 	}
-	s.newBlobVerifier = newBlobVerifierFromInitializer(v)
-	s.newColumnsVerifier = newDataColumnsVerifierFromInitializer(v)
+	s.newBlobVerifier = verification.BlobVerifierFactory(v)
+	s.newColumnsVerifier = verification.DataColumnsVerifierFactory(v)
 
 	go s.verifierRoutine()
 	go s.kzgVerifierRoutine()

--- a/beacon-chain/verification/initializer.go
+++ b/beacon-chain/verification/initializer.go
@@ -86,6 +86,20 @@ func (ini *Initializer) NewDataColumnsVerifier(roDataColumns []blocks.RODataColu
 	}
 }
 
+// BlobVerifierFactory adapts Initializer.NewBlobVerifier to the mock-friendly interface type.
+func BlobVerifierFactory(ini *Initializer) NewBlobVerifier {
+	return func(b blocks.ROBlob, reqs []Requirement) BlobVerifier {
+		return ini.NewBlobVerifier(b, reqs)
+	}
+}
+
+// DataColumnsVerifierFactory adapts Initializer.NewDataColumnsVerifier to the interface type.
+func DataColumnsVerifierFactory(ini *Initializer) NewDataColumnsVerifier {
+	return func(roDataColumns []blocks.RODataColumn, reqs []Requirement) DataColumnsVerifier {
+		return ini.NewDataColumnsVerifier(roDataColumns, reqs)
+	}
+}
+
 // InitializerWaiter provides an Initializer once all dependent resources are ready
 // via the WaitForInitializer method.
 type InitializerWaiter struct {


### PR DESCRIPTION


Consolidates duplicate `newBlobVerifierFromInitializer` and `newDataColumnsVerifierFromInitializer` wrapper functions into centralized factory methods in the `verification` package.

