### PR TITLE
fix: handle target starting with colon in RelativeTestTargetPath

### DIFF
--- a/build/bazel/bazel.go
+++ b/build/bazel/bazel.go
@@ -96,7 +96,11 @@ func RelativeTestTargetPath() string {
 	}
 
 	// Drop target name.
-	if last := strings.LastIndex(target, ":"); last > 0 {
+	if last := strings.LastIndex(target, ":"); last >= 0 {
+		if last == 0 {
+			// Target starts with ':', return empty string for current package
+			return ""
+		}
 		target = target[:last]
 	}
 	return strings.TrimPrefix(target, "//")

--- a/changelog/fix-relative-test-target-path-colon.md
+++ b/changelog/fix-relative-test-target-path-colon.md
@@ -1,0 +1,4 @@
+### Ignored
+
+- Fix edge case in `RelativeTestTargetPath()` for Bazel targets starting with `:` (internal build tool fix, not user-facing)
+


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Bug fix
> ~~Feature~~
> ~~Documentation~~
> ~~Other~~

**What does this PR do? Why is it needed?**

Fixes a bug in `RelativeTestTargetPath()` where Bazel targets starting with `:` (e.g., `":bar"`) were incorrectly returned as-is instead of an empty string. The condition `last > 0` missed the edge case when the colon is at position 0, which could cause invalid paths when used in `path.Join()` operations within `TestDataPath()`.

The fix adds explicit handling for targets starting with `:`, returning an empty string to represent the current package, which is the correct behavior for such targets in Bazel.

**Which issues(s) does this PR fix?**

Fixes # (no issue filed - small bug fix)

**Other notes for review**

- The change is minimal and only affects the edge case handling
- All existing tests pass (`go test -tags=bazel ./build/bazel/...`)
- The fix has been verified with test cases including `":bar"`, `"//:bar"`, and standard formats like `"//pkg/cmd/foo:bar"`
- This is an internal build tool fix and not user-facing, so changelog uses "Ignored" section

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).