### PR TITLE
refactor: remove redundant fmt.Sprintf in tlogger.Write

### DIFF
--- a/validator/client/runner_test.go
+++ b/validator/client/runner_test.go
@@ -345,7 +345,7 @@ type tlogger struct {
 }
 
 func (t tlogger) Write(p []byte) (n int, err error) {
-	t.t.Log(fmt.Sprintf("%s", p))
+	t.t.Log(string(p))
 	return len(p), nil
 }
 


### PR DESCRIPTION
Optimized byte-to-string conversion in test logger by replacing fmt.Sprintf("%s", p) with direct string(p) conversion.