### PR TITLE
Extend `httperror` analyzer to more functions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -193,7 +193,7 @@ nogo(
         "//tools/analyzers/featureconfig:go_default_library",
         "//tools/analyzers/gocognit:go_default_library",
         "//tools/analyzers/ineffassign:go_default_library",
-        "//tools/analyzers/httperror:go_default_library",
+        "//tools/analyzers/httpwriter:go_default_library",
         "//tools/analyzers/interfacechecker:go_default_library",
         "//tools/analyzers/logcapitalization:go_default_library",
         "//tools/analyzers/logruswitherror:go_default_library",

--- a/changelog/radek_extend-http-analyzer.md
+++ b/changelog/radek_extend-http-analyzer.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Extend `httperror` analyzer to more functions.

--- a/network/httputil/writer.go
+++ b/network/httputil/writer.go
@@ -43,6 +43,7 @@ func WriteJson(w http.ResponseWriter, v any) {
 func WriteSsz(w http.ResponseWriter, respSsz []byte) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(respSsz)))
 	w.Header().Set("Content-Type", api.OctetStreamMediaType)
+	w.WriteHeader(http.StatusOK)
 	if _, err := io.Copy(w, io.NopCloser(bytes.NewReader(respSsz))); err != nil {
 		log.WithError(err).Error("Could not write response message")
 	}

--- a/tools/analyzers/httpwriter/BUILD.bazel
+++ b/tools/analyzers/httpwriter/BUILD.bazel
@@ -3,7 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["analyzer.go"],
-    importpath = "github.com/OffchainLabs/prysm/v7/tools/analyzers/httperror",
+    importpath = "github.com/OffchainLabs/prysm/v7/tools/analyzers/httpwriter",
     visibility = ["//visibility:public"],
     deps = [
         "@org_golang_x_tools//go/analysis:go_default_library",

--- a/tools/analyzers/httpwriter/analyzer.go
+++ b/tools/analyzers/httpwriter/analyzer.go
@@ -1,4 +1,4 @@
-package httperror
+package httpwriter
 
 import (
 	"go/ast"
@@ -9,8 +9,8 @@ import (
 )
 
 var Analyzer = &analysis.Analyzer{
-	Name: "httperror",
-	Doc:  "Ensures calls to httputil.HandleError are immediately followed by a return statement.",
+	Name: "httpwriter",
+	Doc:  "Ensures that httputil functions which make use of the writer are immediately followed by a return statement.",
 	Requires: []*analysis.Analyzer{
 		inspect.Analyzer,
 	},
@@ -156,7 +156,9 @@ func findHandleErrorCall(stmt ast.Stmt) *ast.CallExpr {
 	if !ok {
 		return nil
 	}
-	if pkgIdent.Name == "httputil" && sel.Sel.Name == "HandleError" {
+	selectorName := sel.Sel.Name
+	if pkgIdent.Name == "httputil" &&
+		(selectorName == "HandleError" || selectorName == "WriteError" || selectorName == "WriteJson" || selectorName == "WriteSSZ") {
 		return call
 	}
 	return nil

--- a/tools/analyzers/httpwriter/analyzer.go
+++ b/tools/analyzers/httpwriter/analyzer.go
@@ -1,6 +1,7 @@
 package httpwriter
 
 import (
+	"fmt"
 	"go/ast"
 
 	"golang.org/x/tools/go/analysis"
@@ -99,7 +100,7 @@ func checkBlock(pass *analysis.Pass, fn *ast.FuncDecl, block *ast.BlockStmt, nex
 
 		// Now check the current statement itself: is it (or does it contain) a direct call to httputil.HandleError?
 		// We only consider ExprStmt that are direct CallExpr to httputil.HandleError.
-		call := findHandleErrorCall(stmt)
+		call, name := findHandleErrorCall(stmt)
 		if call == nil {
 			continue
 		}
@@ -121,7 +122,7 @@ func checkBlock(pass *analysis.Pass, fn *ast.FuncDecl, block *ast.BlockStmt, nex
 				continue
 			}
 			// otherwise it's not a return (even if it's an if/for etc) -> violation
-			pass.Reportf(stmt.Pos(), "call to httputil.HandleError must be immediately followed by a return statement")
+			pass.Reportf(stmt.Pos(), fmt.Sprintf("call to httputil.%s must be immediately followed by a return statement", name))
 			continue
 		}
 
@@ -133,33 +134,33 @@ func checkBlock(pass *analysis.Pass, fn *ast.FuncDecl, block *ast.BlockStmt, nex
 		}
 
 		// Non-void function and it's the last statement → violation
-		pass.Reportf(stmt.Pos(), "call to httputil.HandleError must be followed by return because function has return values")
+		pass.Reportf(stmt.Pos(), fmt.Sprintf("call to httputil.%s must be immediately followed by a return statement", name))
 	}
 }
 
 // findHandleErrorCall returns the call expression if stmt is a direct call to httputil.HandleError(...),
 // otherwise nil. We only match direct ExprStmt -> CallExpr -> SelectorExpr where selector is httputil.HandleError.
-func findHandleErrorCall(stmt ast.Stmt) *ast.CallExpr {
+func findHandleErrorCall(stmt ast.Stmt) (*ast.CallExpr, string) {
 	es, ok := stmt.(*ast.ExprStmt)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 	call, ok := es.X.(*ast.CallExpr)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 	pkgIdent, ok := sel.X.(*ast.Ident)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 	selectorName := sel.Sel.Name
 	if pkgIdent.Name == "httputil" &&
 		(selectorName == "HandleError" || selectorName == "WriteError" || selectorName == "WriteJson" || selectorName == "WriteSSZ") {
-		return call
+		return call, selectorName
 	}
-	return nil
+	return nil, ""
 }

--- a/tools/analyzers/httpwriter/analyzer.go
+++ b/tools/analyzers/httpwriter/analyzer.go
@@ -1,7 +1,6 @@
 package httpwriter
 
 import (
-	"fmt"
 	"go/ast"
 
 	"golang.org/x/tools/go/analysis"
@@ -122,7 +121,7 @@ func checkBlock(pass *analysis.Pass, fn *ast.FuncDecl, block *ast.BlockStmt, nex
 				continue
 			}
 			// otherwise it's not a return (even if it's an if/for etc) -> violation
-			pass.Reportf(stmt.Pos(), fmt.Sprintf("call to httputil.%s must be immediately followed by a return statement", name))
+			pass.Reportf(stmt.Pos(), "call to httputil.%s must be immediately followed by a return statement", name)
 			continue
 		}
 
@@ -134,7 +133,7 @@ func checkBlock(pass *analysis.Pass, fn *ast.FuncDecl, block *ast.BlockStmt, nex
 		}
 
 		// Non-void function and it's the last statement → violation
-		pass.Reportf(stmt.Pos(), fmt.Sprintf("call to httputil.%s must be immediately followed by a return statement", name))
+		pass.Reportf(stmt.Pos(), "call to httputil.%s must be immediately followed by a return statement", name)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Tooling

**What does this PR do? Why is it needed?**

Renames `httperror` analyzer to `httpwriter` and extends it to the following functions:
- `WriteError`
- `WriteJson`
- `WriteSsz`

_**NOTE: The PR is currently red because the fix in https://github.com/OffchainLabs/prysm/pull/16175 must be merged first**_

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
