### PR TITLE
fix: prevent false sync status when beacon_head_slot is missing

### DIFF
--- a/changelog/fix-beacon-head-slot-validation.md
+++ b/changelog/fix-beacon-head-slot-validation.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Fix incorrect `sync_eth2_synced` status when `beacon_head_slot` metric is missing. The comparison now only occurs when both `beacon_head_slot` and `beacon_clock_time_slot` metrics are successfully retrieved.
+

--- a/monitoring/clientstats/scrapers.go
+++ b/monitoring/clientstats/scrapers.go
@@ -183,6 +183,7 @@ func populateBeaconNodeStats(pf metricMap) BeaconNodeStats {
 
 	var f *dto.MetricFamily
 	var m *dto.Metric
+	headSlotSet := false
 
 	f, err = pf.getFamily("beacon_head_slot")
 	if err != nil {
@@ -190,6 +191,7 @@ func populateBeaconNodeStats(pf metricMap) BeaconNodeStats {
 	} else {
 		m = f.Metric[0]
 		bs.SyncBeaconHeadSlot = int64(m.Gauge.GetValue())
+		headSlotSet = true
 	}
 
 	f, err = pf.getFamily("beacon_clock_time_slot")
@@ -197,7 +199,8 @@ func populateBeaconNodeStats(pf metricMap) BeaconNodeStats {
 		log.WithError(err).Debug("Failed to get beacon_clock_time_slot")
 	} else {
 		m = f.Metric[0]
-		if int64(m.Gauge.GetValue()) == bs.SyncBeaconHeadSlot {
+		// Only compare if beacon_head_slot was successfully retrieved
+		if headSlotSet && int64(m.Gauge.GetValue()) == bs.SyncBeaconHeadSlot {
 			bs.SyncEth2Synced = true
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Fixes a bug where `SyncEth2Synced` could be incorrectly set to `true` when `beacon_head_slot` metric is missing but `beacon_clock_time_slot` is zero. Adds a check to ensure `beacon_head_slot` is successfully retrieved before comparison.

**Which issues(s) does this PR fix?**

Fixes # (Small bug fix, no issue filed)

**Other notes for review**

All existing tests pass. The fix adds a flag to track successful retrieval of `beacon_head_slot` before performing the comparison.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).