### PR TITLE
Use HasPendingBalanceToWithdraw instead of PendingBalanceToWithdraw in ProcessConsolidationRequests

### DIFF
--- a/beacon-chain/core/electra/consolidations.go
+++ b/beacon-chain/core/electra/consolidations.go
@@ -278,12 +278,12 @@ func ProcessConsolidationRequests(ctx context.Context, st state.BeaconState, req
 		if uint64(curEpoch) < e {
 			continue
 		}
-		bal, err := st.PendingBalanceToWithdraw(srcIdx)
+		hasBal, err := st.HasPendingBalanceToWithdraw(srcIdx)
 		if err != nil {
 			log.WithError(err).Error("Failed to fetch pending balance to withdraw")
 			continue
 		}
-		if bal > 0 {
+		if hasBal {
 			continue
 		}
 

--- a/changelog/satushh-consolidation.md
+++ b/changelog/satushh-consolidation.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Performance improvement in ProcessConsolidationRequests: Use more performance HasPendingBalanceToWithdraw instead of PendingBalanceToWithdraw as no need to calculate full total pending balance. 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

Performance

**What does this PR do? Why is it needed?**

`PendingBalanceToWithdraw` was used to find the `bal` only to check later if `bal` is greater than 0 or not. No need to calculate the full balance and we could just check if `bal` is greater than 0 or not by using an existing function `HasPendingBalanceToWithdraw`. So this should help in reducing some unnecessary computation. 

`HasPendingBalanceToWithdraw` returns immediately on first match of non-zero instance, while `PendingBalanceToWithdraw` always iterates through all entries to compute the sum.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
