### PR TITLE
Fix/slashing empty block signingroot

### DIFF
--- a/changelog/lisenokdonbassenok_slashing-empty-block.md
+++ b/changelog/lisenokdonbassenok_slashing-empty-block.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- treat empty block signing roots as missing in EIP-3076 import

--- a/validator/db/kv/import.go
+++ b/validator/db/kv/import.go
@@ -287,7 +287,7 @@ func filterSlashablePubKeysFromBlocks(_ context.Context, historyByPubKey map[[fi
 		seenSigningRootsBySlot := make(map[primitives.Slot][]byte)
 		for _, blk := range proposals.Proposals {
 			if signingRoot, ok := seenSigningRootsBySlot[blk.Slot]; ok {
-				if signingRoot == nil || !bytes.Equal(signingRoot, blk.SigningRoot) {
+				if len(signingRoot) == 0 || !bytes.Equal(signingRoot, blk.SigningRoot) {
 					slashablePubKeys = append(slashablePubKeys, pubKey)
 					break
 				}


### PR DESCRIPTION
**What type of PR is this?**


> Bug fix


**What does this PR do? Why is it needed?**

Align slashable proposer detection with EIP-3076 semantics and existing tests by treating an empty signing root (len==0) as “missing” rather than only checking for nil. During EIP-3076 slashing protection import, blocks without signing_root are currently encoded as zero-length byte slices, so the previous signingRoot == nil condition in filterSlashablePubKeysFromBlocks failed to classify repeated blocks at the same slot without a signing root as slashable.

This change switches the condition to len(signingRoot) == 0 || !bytes.Equal(...), matching how we already handle attestations and how proposal history is interpreted at the DB layer. As a result, keys with repeated blocks on the same slot, with either missing or differing signing roots, are now correctly flagged and blacklisted during import.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
