### PR TITLE
fix: propagate mnemonic confirmation prompt errors

### DIFF
--- a/changelog/MoNyAvA_fix_ack_error.md
+++ b/changelog/MoNyAvA_fix_ack_error.md
@@ -1,0 +1,3 @@
+### Fix
+
+- Propagate mnemonic confirmation prompt errors [#16193](https://github.com/OffchainLabs/prysm/pull/16193)

--- a/validator/keymanager/derived/mnemonic.go
+++ b/validator/keymanager/derived/mnemonic.go
@@ -76,7 +76,7 @@ func (m *MnemonicGenerator) ConfirmAcknowledgement(phrase string) error {
 	// Confirm the user has written down the mnemonic phrase offline.
 	_, err := prompt.ValidatePrompt(os.Stdin, confirmationText, prompt.ValidateConfirmation)
 	if err != nil {
-		log.Errorf("Could not confirm acknowledgement of userprompt, please enter y")
+		return errors.Wrap(err, "could not confirm acknowledgement of user prompt")
 	}
 	return nil
 }


### PR DESCRIPTION
ConfirmAcknowledgement was logging and discarding errors from prompt.ValidatePrompt, which meant GenerateAndConfirmMnemonic always succeeded even when the confirmation prompt could not be completed (for example when stdin was closed). This change propagates the error from ValidatePrompt so callers can correctly fail wallet creation when the user confirmation cannot be obtained.