### PR TITLE
fix: correct copy-paste error in metrics comments

### DIFF
--- a/beacon-chain/monitor/metrics.go
+++ b/beacon-chain/monitor/metrics.go
@@ -33,7 +33,7 @@ var (
 			"validator_index",
 		},
 	)
-	// timelyTargetCounter used to track attestation timely head flags
+	// timelyTargetCounter used to track attestation timely target flags
 	timelyTargetCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "monitor",
@@ -44,7 +44,7 @@ var (
 			"validator_index",
 		},
 	)
-	// timelySourceCounter used to track attestation timely head flags
+	// timelySourceCounter used to track attestation timely source flags
 	timelySourceCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "monitor",

--- a/changelog/aso20455_fix-metrics-comments.md
+++ b/changelog/aso20455_fix-metrics-comments.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix copy-paste error in monitor metrics comments [#16195](https://github.com/OffchainLabs/prysm/pull/16195)


### PR DESCRIPTION
Fix copy-paste error where timelyTargetCounter and timelySourceCounter comments incorrectly referenced "timely head flags" instead of "timely target flags" and "timely source flags" respectively.