### PR TITLE
refactor: remove dead activeIndexRoots allocations

### DIFF
--- a/beacon-chain/core/transition/state-bellatrix.go
+++ b/beacon-chain/core/transition/state-bellatrix.go
@@ -102,12 +102,6 @@ func OptimizedGenesisBeaconStateBellatrix(genesisTime uint64, preState state.Bea
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash

--- a/beacon-chain/core/transition/state.go
+++ b/beacon-chain/core/transition/state.go
@@ -129,12 +129,6 @@ func OptimizedGenesisBeaconState(genesisTime uint64, preState state.BeaconState,
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash

--- a/changelog/Forostovec_remove-dead-code.md
+++ b/changelog/Forostovec_remove-dead-code.md
@@ -1,0 +1,3 @@
+### Refactor
+
+- remove dead activeIndexRoots allocations [#16196](https://github.com/OffchainLabs/prysm/pull/16196)

--- a/testing/util/altair.go
+++ b/testing/util/altair.go
@@ -95,12 +95,6 @@ func buildGenesisBeaconState(genesisTime uint64, preState state.BeaconState, eth
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash

--- a/testing/util/bellatrix_state.go
+++ b/testing/util/bellatrix_state.go
@@ -100,12 +100,6 @@ func buildGenesisBeaconStateBellatrix(genesisTime time.Time, preState state.Beac
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash

--- a/testing/util/capella_state.go
+++ b/testing/util/capella_state.go
@@ -98,12 +98,6 @@ func buildGenesisBeaconStateCapella(genesisTime uint64, preState state.BeaconSta
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash

--- a/testing/util/deneb_state.go
+++ b/testing/util/deneb_state.go
@@ -98,12 +98,6 @@ func buildGenesisBeaconStateDeneb(genesisTime uint64, preState state.BeaconState
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash

--- a/testing/util/electra_state.go
+++ b/testing/util/electra_state.go
@@ -127,12 +127,6 @@ func buildGenesisBeaconStateElectra(genesisTime uint64, preState state.BeaconSta
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash

--- a/testing/util/fulu_state.go
+++ b/testing/util/fulu_state.go
@@ -122,12 +122,6 @@ func buildGenesisBeaconStateFulu(genesisTime uint64, preState state.BeaconState,
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
-
-	activeIndexRoots := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := range activeIndexRoots {
-		activeIndexRoots[i] = zeroHash
-	}
-
 	blockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := range blockRoots {
 		blockRoots[i] = zeroHash


### PR DESCRIPTION
Removed unused activeIndexRoots slices from genesis helpers in transition and testing utilities. These allocations were not written into any BeaconState fields and had no effect on state, so dropping them eliminates unnecessary memory use