### PR TITLE
feat: narrow lock scope in processAggregatedAttestation

### DIFF
--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -209,11 +209,12 @@ func (s *Service) processUnaggregatedAttestation(ctx context.Context, att ethpb.
 
 // processUnaggregatedAttestation logs when the beacon node observes an aggregated attestation from tracked validator.
 func (s *Service) processAggregatedAttestation(ctx context.Context, att ethpb.AggregateAttAndProof) {
+	aggregatorIndex := att.GetAggregatorIndex()
+
 	s.Lock()
-	defer s.Unlock()
-	if s.trackedIndex(att.GetAggregatorIndex()) {
+	if s.trackedIndex(aggregatorIndex) {
 		log.WithFields(logrus.Fields{
-			"aggregatorIndex": att.GetAggregatorIndex(),
+			"aggregatorIndex": aggregatorIndex,
 			"slot":            att.AggregateVal().GetData().Slot,
 			"beaconBlockRoot": fmt.Sprintf("%#x", bytesutil.Trunc(
 				att.AggregateVal().GetData().BeaconBlockRoot)),
@@ -222,11 +223,12 @@ func (s *Service) processAggregatedAttestation(ctx context.Context, att ethpb.Ag
 			"targetRoot": fmt.Sprintf("%#x", bytesutil.Trunc(
 				att.AggregateVal().GetData().Target.Root)),
 		}).Info("Processed attestation aggregation")
-		aggregatedPerf := s.aggregatedPerformance[att.GetAggregatorIndex()]
+		aggregatedPerf := s.aggregatedPerformance[aggregatorIndex]
 		aggregatedPerf.totalAggregations++
-		s.aggregatedPerformance[att.GetAggregatorIndex()] = aggregatedPerf
-		aggregationCounter.WithLabelValues(fmt.Sprintf("%d", att.GetAggregatorIndex())).Inc()
+		s.aggregatedPerformance[aggregatorIndex] = aggregatedPerf
+		aggregationCounter.WithLabelValues(fmt.Sprintf("%d", aggregatorIndex)).Inc()
 	}
+	s.Unlock()
 
 	var root [32]byte
 	copy(root[:], att.AggregateVal().GetData().BeaconBlockRoot)
@@ -241,9 +243,13 @@ func (s *Service) processAggregatedAttestation(ctx context.Context, att ethpb.Ag
 		log.WithError(err).Error("Could not get attesting indices")
 		return
 	}
+
+	s.RLock()
+	defer s.RUnlock()
 	for _, idx := range attestingIndices {
-		if s.canUpdateAttestedValidator(primitives.ValidatorIndex(idx), att.AggregateVal().GetData().Slot) {
-			logFields := logMessageTimelyFlagsForIndex(primitives.ValidatorIndex(idx), att.AggregateVal().GetData())
+		validatorIdx := primitives.ValidatorIndex(idx)
+		if s.canUpdateAttestedValidator(validatorIdx, att.AggregateVal().GetData().Slot) {
+			logFields := logMessageTimelyFlagsForIndex(validatorIdx, att.AggregateVal().GetData())
 			log.WithFields(logFields).Info("Processed aggregated attestation")
 		}
 	}

--- a/changelog/kurahin_shorten_lock.md
+++ b/changelog/kurahin_shorten_lock.md
@@ -1,0 +1,3 @@
+### fix
+
+- narrow lock scope in processAggregatedAttestation 


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Shorten the section in processAggregatedAttestation to reduce contention on the Service mutex. The write lock is now only held while updating the aggregator's performance counters and metrics. State lookup and committee computation are performed without holding the Service lock, and the final loop that checks canUpdateAttestedValidator runs under a read lock. This keeps access to the Service maps thread-safe while aligning the locking pattern with processIncludedAttestation and avoiding unnecessary blocking under load.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ x I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
