### PR TITLE
Use bazel mirror due to expired cert

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,1 @@
+BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -32,6 +32,10 @@ import %workspace%/.bazelrc
 # startup --digest_function=blake3
 
 startup --host_jvm_args=-Xmx8g --host_jvm_args=-Xms4g
+
+# Disable bzlmod to avoid BCR registry access (certificate issues)
+common --noenable_bzlmod
+
 build --experimental_strict_action_env
 build --sandbox_tmpfs_path=/tmp
 build --verbose_failures

--- a/bazel.sh
+++ b/bazel.sh
@@ -8,4 +8,5 @@ env -i \
  PATH=/usr/bin:/bin \
  HOME="$HOME" \
  GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
+ BAZELISK_BASE_URL="https://github.com/bazelbuild/bazel/releases/download" \
  bazel "$@"

--- a/changelog/potuz_use_baze_mirror.md
+++ b/changelog/potuz_use_baze_mirror.md
@@ -1,0 +1,2 @@
+### Ignored
+- Use bazel mirror due to expired certificate.


### PR DESCRIPTION
See https://github.com/DataDog/datadog-agent/pull/44621 and the original issue in
https://github.com/bazelbuild/bazel/issues/28101