### PR TITLE
Do not send FCU on block batches

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -295,14 +295,6 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []consensusblocks.ROBlo
 			return errors.Wrap(err, "could not set optimistic block to valid")
 		}
 	}
-	arg := &fcuConfig{
-		headState: preState,
-		headRoot:  lastBR,
-		headBlock: lastB,
-	}
-	if _, err := s.notifyForkchoiceUpdate(ctx, arg); err != nil {
-		return err
-	}
 	return s.saveHeadNoDB(ctx, lastB, lastBR, preState, !isValidPayload)
 }
 

--- a/changelog/potuz_no_fcu_on_batches.md
+++ b/changelog/potuz_no_fcu_on_batches.md
@@ -1,0 +1,2 @@
+### Ignored
+- D  not send FCU on block batches. 


### PR DESCRIPTION
On block batches the engine does not need to be notified of FCU, only on regular sync at the end of sync it's useful to notify the engine.

