### PR TITLE
Remove deprecated validator help group

### DIFF
--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -156,10 +156,6 @@ var appHelpFlagGroups = []flagGroup{
 			flags.InteropStartIndex,
 		},
 	},
-	{
-		Name:  "deprecated",
-		Flags: []cli.Flag{},
-	},
 }
 
 func init() {


### PR DESCRIPTION
Removes empty deprecated help group from validator CLI.
No behavior change.
