### PR TITLE
 Make `StateDiffExponents` configurable with CLI option (`--state-diff-exponents`)

### DIFF
--- a/changelog/syjn99_state-diff-exponents-configurable.md
+++ b/changelog/syjn99_state-diff-exponents-configurable.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Make `StateDiffExponents` configurable with CLI option (`--state-diff-exponents`).

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -156,6 +156,7 @@ var appFlags = []cli.Flag{
 	dasFlags.BackfillOldestSlot,
 	dasFlags.BlobRetentionEpochFlag,
 	flags.BatchVerifierLimit,
+	flags.StateDiffExponents,
 }
 
 func init() {

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -131,6 +131,7 @@ var appHelpFlagGroups = []flagGroup{
 			storage.BlobStorageLayout,
 			storage.BlobStoragePathFlag,
 			storage.DataColumnStoragePathFlag,
+			flags.StateDiffExponents,
 		},
 	},
 	{ // Flags relevant to configuring local block production or external builders such as mev-boost.


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

`StateDiffExponents` was supposed to be configurable with command-line option, but actually it wasn't registered as flags of `beacon-chain`. This PR registers `--state-diff-exponents` in flag and help(usage) as well.

```
db OPTIONS:
   --state-diff-exponents value [ --state-diff-exponents value ]  A comma-separated list of exponents (of 2) in decreasing order, defining the state diff hierarchy levels. The last exponent must be greater than or equal to 5. (default: 21, 18, 16, 13, 11, 9, 5)
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
