### PR TITLE
Use proposer lookahead for data column verification

### DIFF
--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -687,6 +687,12 @@ func sbrNotFound(t *testing.T, expectedRoot [32]byte) *mockStateByRooter {
 	}}
 }
 
+func sbrReturnsState(st state.BeaconState) *mockStateByRooter {
+	return &mockStateByRooter{sbr: func(_ context.Context, _ [32]byte) (state.BeaconState, error) {
+		return st, nil
+	}}
+}
+
 func sbrForValOverride(idx primitives.ValidatorIndex, val *ethpb.Validator) *mockStateByRooter {
 	return sbrForValOverrideWithT(nil, idx, val)
 }

--- a/changelog/potuz_dcs_pc_removal.md
+++ b/changelog/potuz_dcs_pc_removal.md
@@ -1,0 +1,2 @@
+### Changed
+- Use lookahead to validate data column sidecar proposer index.

--- a/testing/util/deneb.go
+++ b/testing/util/deneb.go
@@ -44,6 +44,13 @@ func WithProposerSigning(idx primitives.ValidatorIndex, sk bls.SecretKey, valRoo
 	}
 }
 
+// WithProposer sets the proposer index for the generated block without signing.
+func WithProposer(idx primitives.ValidatorIndex) DenebBlockGeneratorOption {
+	return func(g *denebBlockGenerator) {
+		g.proposer = idx
+	}
+}
+
 func WithPayloadSetter(p *enginev1.ExecutionPayloadDeneb) DenebBlockGeneratorOption {
 	return func(g *denebBlockGenerator) {
 		g.payload = p


### PR DESCRIPTION
Replace the proposer indices cache usage in data column sidecar verification with direct state lookahead access. Since data column sidecars require the Fulu fork, the state always has a ProposerLookahead field that provides O(1) proposer index lookups for current and next epoch.

This simplifies SidecarProposerExpected() by removing:
- Checkpoint-based proposer cache lookup
- Singleflight wrapper (not needed for O(1) access)
- Target root computation for cache keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

