### PR TITLE
Use a separate context when updating the NSC

### DIFF
--- a/changelog/potuz_fcu_ctx.md
+++ b/changelog/potuz_fcu_ctx.md
@@ -1,0 +1,2 @@
+### Changed
+- Use a separate context when updating the slot cache. 


### PR DESCRIPTION
There is a race condition introduced in #16149 in which the update to the NSC happens with a context that may be cancelled by the time the routine is called. This PR starts a new context with a deadline to call the routine in the background.

fixes #16205


