### PR TITLE
WithMaxExportBatchSize is specified twice

### DIFF
--- a/changelog/jrhea_duplicate_tracer_provider_setting.md
+++ b/changelog/jrhea_duplicate_tracer_provider_setting.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Don't call trace.WithMaxExportBatchSize(trace.DefaultMaxExportBatchSize) twice.

--- a/monitoring/tracing/tracer.go
+++ b/monitoring/tracing/tracer.go
@@ -44,8 +44,7 @@ func Setup(ctx context.Context, serviceName, processName, endpoint string, sampl
 		trace.WithBatcher(
 			exporter,
 			trace.WithMaxExportBatchSize(trace.DefaultMaxExportBatchSize),
-			trace.WithBatchTimeout(trace.DefaultScheduleDelay*time.Millisecond),
-			trace.WithMaxExportBatchSize(trace.DefaultMaxExportBatchSize),
+			trace.WithBatchTimeout(trace.DefaultScheduleDelay*time.Millisecond)
 		),
 		trace.WithResource(
 			resource.NewWithAttributes(

--- a/monitoring/tracing/tracer.go
+++ b/monitoring/tracing/tracer.go
@@ -44,7 +44,7 @@ func Setup(ctx context.Context, serviceName, processName, endpoint string, sampl
 		trace.WithBatcher(
 			exporter,
 			trace.WithMaxExportBatchSize(trace.DefaultMaxExportBatchSize),
-			trace.WithBatchTimeout(trace.DefaultScheduleDelay*time.Millisecond)
+			trace.WithBatchTimeout(trace.DefaultScheduleDelay*time.Millisecond),
 		),
 		trace.WithResource(
 			resource.NewWithAttributes(


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**

It's just a simple fix.  I was looking at how prysm uses OpenTelemetry and I noticed it.

**Which issues(s) does this PR fix?**

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
