### PR TITLE
Implement parallel verification for KZG proofs in VerifyCellKZGProofBatch

### DIFF
--- a/beacon-chain/blockchain/kzg/BUILD.bazel
+++ b/beacon-chain/blockchain/kzg/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_ethereum_go_ethereum//crypto/kzg4844:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/beacon-chain/blockchain/kzg/kzg.go
+++ b/beacon-chain/blockchain/kzg/kzg.go
@@ -1,7 +1,10 @@
 package kzg
 
 import (
+	"runtime"
+
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	ckzg4844 "github.com/ethereum/c-kzg-4844/v2/bindings/go"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
@@ -24,6 +27,9 @@ type Cell [BytesPerCell]byte
 
 // Commitment represent a KZG commitment to a Blob.
 type Commitment [48]byte
+
+// errInvalidProof is returned when KZG proof verification fails.
+var errInvalidProof = errors.New("invalid KZG proof")
 
 // Proof represents a KZG proof that attests to the validity of a Blob or parts of it.
 type Proof [BytesPerProof]byte
@@ -103,16 +109,69 @@ func ComputeCellsAndKZGProofs(blob *Blob) ([]Cell, []Proof, error) {
 	return cells, proofs, nil
 }
 
-// VerifyCellKZGProofBatch verifies the KZG proofs for a given slice of commitments, cells indices, cells and proofs.
-// Note: It is way more efficient to call once this function with big slices than calling it multiple times with small slices.
-func VerifyCellKZGProofBatch(commitmentsBytes []Bytes48, cellIndices []uint64, cells []Cell, proofsBytes []Bytes48) (bool, error) {
-	// Convert `Cell` type to `ckzg4844.Cell`
-	ckzgCells := make([]ckzg4844.Cell, len(cells))
+// chunkBounds represents the start and end indices of a chunk.
+type chunkBounds struct {
+	start, end int
+}
 
+// VerifyCellKZGProofBatch verifies the KZG proofs for a given slice of commitments, cells indices, cells and proofs.
+// The verification is parallelized across CPU cores by splitting the input into chunks.
+func VerifyCellKZGProofBatch(commitmentsBytes []Bytes48, cellIndices []uint64, cells []Cell, proofsBytes []Bytes48) (bool, error) {
+	count := len(cells)
+
+	// Validate all input slices have the same length
+	if len(commitmentsBytes) != count || len(cellIndices) != count || len(proofsBytes) != count {
+		return false, errors.New("input slices must have equal length")
+	}
+
+	// Convert `Cell` type to `ckzg4844.Cell`
+	ckzgCells := make([]ckzg4844.Cell, count)
 	for i := range cells {
 		copy(ckzgCells[i][:], cells[i][:])
 	}
-	return ckzg4844.VerifyCellKZGProofBatch(commitmentsBytes, cellIndices, ckzgCells, proofsBytes)
+
+	if count == 0 {
+		return true, nil
+	}
+
+	workerCount := min(count, runtime.GOMAXPROCS(0))
+	chunks := computeChunkBounds(count, workerCount)
+
+	var wg errgroup.Group
+	for workerIdx := range workerCount {
+		bounds := chunks[workerIdx]
+
+		wg.Go(func() error {
+			// Verify this chunk
+			valid, err := ckzg4844.VerifyCellKZGProofBatch(
+				commitmentsBytes[bounds.start:bounds.end],
+				cellIndices[bounds.start:bounds.end],
+				ckzgCells[bounds.start:bounds.end],
+				proofsBytes[bounds.start:bounds.end],
+			)
+
+			if err != nil {
+				return err
+			}
+
+			if !valid {
+				return errInvalidProof
+			}
+
+			return nil
+		})
+	}
+
+	// Wait for all workers to complete
+	if err := wg.Wait(); err != nil {
+		if errors.Is(err, errInvalidProof) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 // RecoverCells recovers the complete cells from a given set of cell indices and partial cells.
@@ -163,4 +222,31 @@ func RecoverCellsAndKZGProofs(cellIndices []uint64, partialCells []Cell) ([]Cell
 	}
 
 	return cells, proofs, nil
+}
+
+// computeChunkBounds calculates evenly distributed chunk boundaries for parallel processing.
+// It splits itemsCount into chunks, distributing any remainder across the first chunks.
+func computeChunkBounds(itemsCount, workerCount int) []chunkBounds {
+	actualWorkers := min(itemsCount, workerCount)
+
+	if actualWorkers == 0 {
+		return []chunkBounds{}
+	}
+
+	chunkSize := itemsCount / actualWorkers
+	remainder := itemsCount % actualWorkers
+
+	chunks := make([]chunkBounds, 0, actualWorkers)
+	offset := 0
+	for i := range actualWorkers {
+		size := chunkSize
+		if i < remainder {
+			size++
+		}
+
+		chunks = append(chunks, chunkBounds{start: offset, end: offset + size})
+		offset += size
+	}
+
+	return chunks
 }

--- a/beacon-chain/blockchain/kzg/kzg_test.go
+++ b/beacon-chain/blockchain/kzg/kzg_test.go
@@ -111,6 +111,48 @@ func TestVerifyCellKZGProofBatch(t *testing.T) {
 		require.NotNil(t, err)
 		require.Equal(t, false, valid)
 	})
+
+	t.Run("empty inputs should return true", func(t *testing.T) {
+		// Empty slices should be considered valid
+		commitmentsBytes := []Bytes48{}
+		cellIndices := []uint64{}
+		cells := []Cell{}
+		proofsBytes := []Bytes48{}
+
+		valid, err := VerifyCellKZGProofBatch(commitmentsBytes, cellIndices, cells, proofsBytes)
+		require.NoError(t, err)
+		require.Equal(t, true, valid)
+	})
+
+	t.Run("mismatched input lengths should fail", func(t *testing.T) {
+		randBlob := random.GetRandBlob(123)
+		var blob Blob
+		copy(blob[:], randBlob[:])
+
+		commitment, err := BlobToKZGCommitment(&blob)
+		require.NoError(t, err)
+
+		cells, proofs, err := ComputeCellsAndKZGProofs(&blob)
+		require.NoError(t, err)
+
+		// Create mismatched length inputs
+		cellIndices := []uint64{0, 1, 2}
+		selectedCells := []Cell{cells[0], cells[1], cells[2]}
+		commitmentsBytes := make([]Bytes48, 3)
+		for i := range commitmentsBytes {
+			copy(commitmentsBytes[i][:], commitment[:])
+		}
+
+		// Only 2 proofs instead of 3
+		proofsBytes := make([]Bytes48, 2)
+		copy(proofsBytes[0][:], proofs[0][:])
+		copy(proofsBytes[1][:], proofs[1][:])
+
+		valid, err := VerifyCellKZGProofBatch(commitmentsBytes, cellIndices, selectedCells, proofsBytes)
+		require.NotNil(t, err)
+		require.Equal(t, false, valid)
+		require.Equal(t, "input slices must have equal length", err.Error())
+	})
 }
 
 func TestRecoverCells(t *testing.T) {
@@ -232,5 +274,43 @@ func TestBlobToKZGCommitment(t *testing.T) {
 		commitment2, err := BlobToKZGCommitment(&blob)
 		require.NoError(t, err)
 		require.Equal(t, commitment, commitment2)
+	})
+}
+
+func TestComputeChunkBounds(t *testing.T) {
+	t.Run("evenly divisible items", func(t *testing.T) {
+		chunks := computeChunkBounds(100, 4)
+		require.Equal(t, 4, len(chunks))
+		require.Equal(t, chunkBounds{start: 0, end: 25}, chunks[0])
+		require.Equal(t, chunkBounds{start: 25, end: 50}, chunks[1])
+		require.Equal(t, chunkBounds{start: 50, end: 75}, chunks[2])
+		require.Equal(t, chunkBounds{start: 75, end: 100}, chunks[3])
+	})
+
+	t.Run("items with remainder distributed to first chunks", func(t *testing.T) {
+		chunks := computeChunkBounds(10, 3)
+		require.Equal(t, 3, len(chunks))
+		require.Equal(t, chunkBounds{start: 0, end: 4}, chunks[0])  // gets extra item
+		require.Equal(t, chunkBounds{start: 4, end: 7}, chunks[1])  // gets extra item
+		require.Equal(t, chunkBounds{start: 7, end: 10}, chunks[2]) // normal size
+	})
+
+	t.Run("fewer items than workers returns min(items, workers) chunks", func(t *testing.T) {
+		chunks := computeChunkBounds(3, 5)
+		require.Equal(t, 3, len(chunks)) // Only 3 chunks, not 5
+		require.Equal(t, chunkBounds{start: 0, end: 1}, chunks[0])
+		require.Equal(t, chunkBounds{start: 1, end: 2}, chunks[1])
+		require.Equal(t, chunkBounds{start: 2, end: 3}, chunks[2])
+	})
+
+	t.Run("single worker gets all items", func(t *testing.T) {
+		chunks := computeChunkBounds(100, 1)
+		require.Equal(t, 1, len(chunks))
+		require.Equal(t, chunkBounds{start: 0, end: 100}, chunks[0])
+	})
+
+	t.Run("no items produces no chunks", func(t *testing.T) {
+		chunks := computeChunkBounds(0, 4)
+		require.Equal(t, 0, len(chunks)) // No chunks when no items
 	})
 }

--- a/changelog/manu_parallelize_kzg_verification.md
+++ b/changelog/manu_parallelize_kzg_verification.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Parallelized KZG proof batch verification across CPU cores.


### PR DESCRIPTION
**What type of PR is this?**
Optimization

**What does this PR do? Why is it needed?**
Alternate take:
- https://github.com/OffchainLabs/prysm/pull/16240

Calling `n` times `ckzg4844.VerifyCellKZGProofBatch` sequentially cell by cell with a single CPU is slower than calling this function `1` time with `n` cells (batching), which is itself slower than calling this function cell by cell in parallel, one CPU managing each call.

For incoming data column sidecars via gossip, in the initial implementation, Prysm used to call the `ckzg4844.VerifyCellKZGProofBatch`  function once per incoming sidecar, resulting to, in the worst case, 128 calls in parallel. While this method takes advantage of the multi core architecture, it does not take advantage of the batching properties of the `ckzg4844.VerifyCellKZGProofBatch` function.

Then, from:
- https://github.com/OffchainLabs/prysm/pull/15617

Prysm starts to batch all incoming data column sidecars, then calls only once `ckzg4844.VerifyCellKZGProofBatch` by batch. While this method takes advantage of the batching properties of the `ckzg4844.VerifyCellKZGProofBatch` function, it does not take advantage of the multi core architecture.

This PR combines both approaches, taking advantages of both the batching properties of the `ckzg4844.VerifyCellKZGProofBatch` function, and the multi core architecture.

**Test configuration:**
- Using the `--disable-get-blobs-v2` and `--supernode` flags
- On [VPS 3000 G11](https://www.netcup.com/en/server/vps)

**4H average**
**4H average**
| Impl. | CPU usage| Sidecar gossip verif. dur. | DA waiting time | Chain service proc. time | Total | 
|--------|--------|--------|--------|--------|--------|
| `develop` | 132% | 185 ms | 82.2 ms | **457 ms** | 539 ms |
| This PR  | 144% | 76.5 ms | 21.7 ms | 473 ms | **495 ms** |
| https://github.com/OffchainLabs/prysm/pull/16240 | **117%** | **26 ms** | **16.3 ms** | 479 ms | **495 ms** |
 
**Before this PR:**
<img width="950" height="1296" alt="image" src="https://github.com/user-attachments/assets/3631679c-b4ca-4ea3-9164-6a7bbf0b5517" />

**With this PR:**
<img width="942" height="1327" alt="image" src="https://github.com/user-attachments/assets/421bc505-a7ea-4173-93eb-81271579c708" />

Metrics:
- `beacon_data_column_sidecar_gossip_verification_milliseconds`
- `da_waited_time_milliseconds`

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
