### PR TITLE
fix: correct beacon_processed_deposits_total off-by-one

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -325,7 +325,7 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 	beaconFinalizedEpoch.Set(float64(postState.FinalizedCheckpointEpoch()))
 	beaconFinalizedRoot.Set(float64(bytesutil.ToLowInt64(postState.FinalizedCheckpoint().Root)))
 	currentEth1DataDepositCount.Set(float64(postState.Eth1Data().DepositCount))
-	processedDepositsCount.Set(float64(postState.Eth1DepositIndex() + 1))
+	processedDepositsCount.Set(float64(postState.Eth1DepositIndex()))
 
 	var b *precompute.Balance
 	var v []*precompute.Validator

--- a/changelog/yyhrnk_fix-off-by-one.md
+++ b/changelog/yyhrnk_fix-off-by-one.md
@@ -1,0 +1,3 @@
+### Fix
+
+- fix beacon_processed_deposits_total off-by-one


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**

`Eth1DepositIndex()` already represents the number of processed deposits according to both the embedded consensus spec and the surrounding transition logic, where outstanding deposits are computed as `eth1_data.deposit_count -eth1_deposit_index`. The `beacon_processed_deposits_total` metric was incorrectly adding 1 to this value, causing it to overreport the number of processed deposits in all states (e.g. reporting 1 when no deposits have been processed yet). This change makes the metric use `Eth1DepositIndex()` directly so that it accurately reflects the true count of processed deposits and stays consistent with the rest of the codebase and spec.

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
