### PR TITLE
refactor: remove gometalinter refs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@com_github_atlassian_bazel_tools//gometalinter:def.bzl", "gometalinter")
 load("@com_github_atlassian_bazel_tools//goimports:def.bzl", "goimports")
 load("@io_kubernetes_build//defs:run_in_workspace.bzl", "workspace_binary")
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
@@ -53,15 +52,6 @@ alias(
     name = "cast_grpc_proto_compiler",
     actual = "@com_github_prysmaticlabs_protoc_gen_go_cast//:go_cast_grpc",
     visibility = ["//visibility:public"],
-)
-
-gometalinter(
-    name = "gometalinter",
-    config = "//:.gometalinter.json",
-    paths = [
-        "./...",
-    ],
-    prefix = prefix,
 )
 
 goimports(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -423,10 +423,6 @@ load("@prysm//testing/endtoend:deps.bzl", "e2e_deps")
 
 e2e_deps()
 
-load("@com_github_atlassian_bazel_tools//gometalinter:deps.bzl", "gometalinter_dependencies")
-
-gometalinter_dependencies()
-
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies(go_sdk = "go_sdk")

--- a/changelog/farazdagi_remove-gometalinter-refs.md
+++ b/changelog/farazdagi_remove-gometalinter-refs.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Removed deprecated gometalinter references from Bazel configuration.


### PR DESCRIPTION
**What type of PR is this?**

Refactor/Cleanup

**What does this PR do? Why is it needed?**

- [gometalinter](https://github.com/alecthomas/gometalinter) project is deprecated (has been forever so)
- in #2100 it has been removed from the Prysm project
- while not being used `gometalinter` references still existed in Bazel config. Since `gometalinter.json` was removed in PR-2100, the `bazel run //:gometalinter` will err unless config file re-created, hence it appears we have a dead code.

**Which issues(s) does this PR fix?**

No issue, simple cleanup

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
