### PR TITLE
Add --low-valcount-sweep feature flag for withdrawal sweep bound

### DIFF
--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/state:go_default_library",
+        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types:go_default_library",

--- a/beacon-chain/core/blocks/withdrawals.go
+++ b/beacon-chain/core/blocks/withdrawals.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
@@ -212,8 +213,12 @@ func ProcessWithdrawals(st state.BeaconState, executionData interfaces.Execution
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get next withdrawal validator index")
 		}
-		bound := min(uint64(st.NumValidators()), params.BeaconConfig().MaxValidatorsPerWithdrawalsSweep)
-		nextValidatorIndex += primitives.ValidatorIndex(bound)
+		if features.Get().LowValcountSweep {
+			bound := min(uint64(st.NumValidators()), params.BeaconConfig().MaxValidatorsPerWithdrawalsSweep)
+			nextValidatorIndex += primitives.ValidatorIndex(bound)
+		} else {
+			nextValidatorIndex += primitives.ValidatorIndex(params.BeaconConfig().MaxValidatorsPerWithdrawalsSweep)
+		}
 		nextValidatorIndex = nextValidatorIndex % primitives.ValidatorIndex(st.NumValidators())
 	} else {
 		nextValidatorIndex = expectedWithdrawals[len(expectedWithdrawals)-1].ValidatorIndex + 1

--- a/changelog/potuz_low_valcount.md
+++ b/changelog/potuz_low_valcount.md
@@ -1,0 +1,2 @@
+### Added
+- Add a feature flag to pass spectests with low validator count. 

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -80,6 +80,7 @@ type Flags struct {
 	SaveInvalidBlob  bool // SaveInvalidBlob saves invalid blob to temp.
 
 	EnableDiscoveryReboot bool // EnableDiscoveryReboot allows the node to have its local listener to be rebooted in the event of discovery issues.
+	LowValcountSweep      bool // LowValcountSweep bounds withdrawal sweep by validator count.
 
 	// KeystoreImportDebounceInterval specifies the time duration the validator waits to reload new keys if they have
 	// changed on disk. This feature is for advanced use cases only.
@@ -283,6 +284,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.IsSet(ignoreUnviableAttestations.Name) && ctx.Bool(ignoreUnviableAttestations.Name) {
 		logEnabled(ignoreUnviableAttestations)
 		cfg.IgnoreUnviableAttestations = true
+	}
+	if ctx.Bool(lowValcountSweep.Name) {
+		logEnabled(lowValcountSweep)
+		cfg.LowValcountSweep = true
 	}
 
 	if ctx.IsSet(EnableStateDiff.Name) {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -211,6 +211,13 @@ var (
 		Name:  "ignore-unviable-attestations",
 		Usage: "Ignores attestations whose target state is not viable with respect to the current head (avoid expensive state replay from lagging attesters).",
 	}
+	// lowValcountSweep bounds withdrawal sweep by validator count.
+	lowValcountSweep = &cli.BoolFlag{
+		Name:   "low-valcount-sweep",
+		Usage:  "Uses validator count bound for withdrawal sweep when validator count is less than MaxValidatorsPerWithdrawalsSweep.",
+		Value:  false,
+		Hidden: true,
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -272,6 +279,7 @@ var BeaconChainFlags = combinedFlags([]cli.Flag{
 	enableExperimentalAttestationPool,
 	forceHeadFlag,
 	blacklistRoots,
+	lowValcountSweep,
 }, deprecatedBeaconFlags, deprecatedFlags, upcomingDeprecation)
 
 func combinedFlags(flags ...[]cli.Flag) []cli.Flag {

--- a/testing/spectest/utils/BUILD.bazel
+++ b/testing/spectest/utils/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v7/testing/spectest/utils",
     visibility = ["//testing/spectest:__subpackages__"],
     deps = [
+        "//config/features:go_default_library",
         "//config/params:go_default_library",
         "//io/file:go_default_library",
         "//testing/require:go_default_library",

--- a/testing/spectest/utils/config.go
+++ b/testing/spectest/utils/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 )
 
@@ -13,6 +14,12 @@ import (
 // Provides reset function allowing to get back to the previous configuration at the end of a test.
 func SetConfig(t testing.TB, config string) error {
 	params.SetupTestConfigCleanup(t)
+
+	resetFeatures := features.InitWithReset(&features.Flags{
+		LowValcountSweep: true,
+	})
+	t.Cleanup(resetFeatures)
+
 	switch config {
 	case "minimal":
 		params.OverrideBeaconConfig(params.MinimalSpecConfig().Copy())


### PR DESCRIPTION
Gate the withdrawal sweep optimization (using min of validator count and MaxValidatorsPerWithdrawalsSweep) behind a hidden feature flag that defaults to false. Enable the flag for spectests to match consensus spec.

The backported changes were from [4788](https://github.com/ethereum/consensus-specs/pull/4788)