### PR TITLE
validator: remove redundant fmt.Sprintf in test logger

### DIFF
--- a/validator/client/runner_test.go
+++ b/validator/client/runner_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"math/bits"
 	"math/rand"
 	"runtime/debug"
@@ -345,7 +344,7 @@ type tlogger struct {
 }
 
 func (t tlogger) Write(p []byte) (n int, err error) {
-	t.t.Log(fmt.Sprintf("%s", p))
+	t.t.Log(string(p))
 	return len(p), nil
 }
 


### PR DESCRIPTION
Simplified byte-to-string conversion in `tlogger.Write()` helper function.