### PR TITLE
refactor(validator): eliminate redundant ProposerSettings call in GetGasLimit

### DIFF
--- a/validator/rpc/handlers_keymanager.go
+++ b/validator/rpc/handlers_keymanager.go
@@ -741,7 +741,7 @@ func (s *Server) GetGasLimit(w http.ResponseWriter, r *http.Request) {
 				resp.Data.GasLimit = fmt.Sprintf("%d", proposerOption.BuilderConfig.GasLimit)
 			}
 		} else if settings.DefaultConfig != nil && settings.DefaultConfig.BuilderConfig != nil {
-			resp.Data.GasLimit = fmt.Sprintf("%d", s.validatorService.ProposerSettings().DefaultConfig.BuilderConfig.GasLimit)
+			resp.Data.GasLimit = fmt.Sprintf("%d", settings.DefaultConfig.BuilderConfig.GasLimit)
 		}
 	}
 	httputil.WriteJson(w, resp)


### PR DESCRIPTION
Removes a redundant `ProposerSettings()` call in the `GetGasLimit` handler by reusing the already-fetched `settings` variable.