### PR TITLE
fix: use input genesis.json timestamp in prysmctl

### DIFF
--- a/changelog/farazdagi_fix-prysmctl-timestamp.md
+++ b/changelog/farazdagi_fix-prysmctl-timestamp.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix `prysmctl testnet generate-genesis` to use the timestamp from `--geth-genesis-json-in` when `--genesis-time` is not explicitly provided.

--- a/cmd/prysmctl/testnet/generate_genesis.go
+++ b/cmd/prysmctl/testnet/generate_genesis.go
@@ -214,13 +214,6 @@ func setGlobalParams() error {
 
 func generateGenesis(ctx context.Context) (state.BeaconState, error) {
 	f := &generateGenesisStateFlags
-	if f.GenesisTime == 0 {
-		f.GenesisTime = uint64(time.Now().Unix())
-		log.Info("No genesis time specified, defaulting to now()")
-	}
-	log.Infof("Delaying genesis %v by %v seconds", f.GenesisTime, f.GenesisTimeDelay)
-	f.GenesisTime += f.GenesisTimeDelay
-	log.Infof("Genesis is now %v", f.GenesisTime)
 
 	v, err := version.FromString(f.ForkName)
 	if err != nil {
@@ -258,7 +251,28 @@ func generateGenesis(ctx context.Context) (state.BeaconState, error) {
 		if err := json.Unmarshal(gbytes, gen); err != nil {
 			return nil, err
 		}
-		// set timestamps for genesis and shanghai fork
+		// Use input file's timestamp (if `--genesis-time` is NOT explicitly provided)
+		if f.GenesisTime == 0 {
+			f.GenesisTime = gen.Timestamp
+			log.Infof("Using genesis time from input file: %d", f.GenesisTime)
+		}
+	}
+
+	// If still unset (no `--genesis-time` and no input file), default to `now()`
+	if f.GenesisTime == 0 {
+		f.GenesisTime = uint64(time.Now().Unix())
+		log.Info("No genesis time specified, defaulting to now()")
+	}
+
+	// Apply delay (if any) and expose used genesis time
+	if f.GenesisTimeDelay > 0 {
+		log.Infof("Delaying genesis %d by %d seconds", f.GenesisTime, f.GenesisTimeDelay)
+		f.GenesisTime += f.GenesisTimeDelay
+	}
+	log.Infof("Genesis time is %d", f.GenesisTime)
+
+	// Set the timestamps for genesis and forks
+	if f.GethGenesisJsonIn != "" {
 		gen.Timestamp = f.GenesisTime
 		genesis := time.Unix(int64(f.GenesisTime), 0)
 		gen.Config.ShanghaiTime = interop.GethShanghaiTime(genesis, params.BeaconConfig())
@@ -301,7 +315,7 @@ func generateGenesis(ctx context.Context) (state.BeaconState, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := os.WriteFile(f.GethGenesisJsonOut, gbytes, 0600); err != nil {
+		if err := os.WriteFile(f.GethGenesisJsonOut, gbytes, 0o600); err != nil {
 			return nil, errors.Wrapf(err, "failed to write %s", f.GethGenesisJsonOut)
 		}
 	}

--- a/cmd/prysmctl/testnet/generate_genesis_test.go
+++ b/cmd/prysmctl/testnet/generate_genesis_test.go
@@ -125,6 +125,75 @@ func Test_generateGenesis_BaseFeeValidation(t *testing.T) {
 	}
 }
 
+func Test_generateGenesis_TimestampHandling(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputTimestamp   uint64 // timestamp in input genesis.json (0 = no input file)
+		genesisTime      uint64 // --genesis-time (0 = not set)
+		genesisTimeDelay uint64 // --genesis-time-delay
+		wantTimestamp    uint64
+	}{
+		{
+			name:           "uses input file timestamp when no --genesis-time",
+			inputTimestamp: 1700000000,
+			wantTimestamp:  1700000000,
+		},
+		{
+			name:           "explicit --genesis-time overrides input file",
+			inputTimestamp: 1700000000,
+			genesisTime:    1600000000,
+			wantTimestamp:  1600000000,
+		},
+		{
+			name:             "delay applied to input file timestamp",
+			inputTimestamp:   1700000000,
+			genesisTimeDelay: 100,
+			wantTimestamp:    1700000100,
+		},
+		{
+			name:             "delay applied to explicit --genesis-time",
+			inputTimestamp:   1700000000,
+			genesisTime:      1600000000,
+			genesisTimeDelay: 50,
+			wantTimestamp:    1600000050,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalFlags := generateGenesisStateFlags
+			defer func() {
+				generateGenesisStateFlags = originalFlags
+			}()
+
+			generateGenesisStateFlags.NumValidators = 2
+			generateGenesisStateFlags.GenesisTime = tt.genesisTime
+			generateGenesisStateFlags.GenesisTimeDelay = tt.genesisTimeDelay
+			generateGenesisStateFlags.ForkName = version.String(version.Deneb)
+
+			if tt.inputTimestamp > 0 {
+				genesis := &core.Genesis{
+					Timestamp:  tt.inputTimestamp,
+					BaseFee:    big.NewInt(1000000000),
+					Difficulty: big.NewInt(0),
+					GasLimit:   15000000,
+					Alloc:      types.GenesisAlloc{},
+					Config:     &params.ChainConfig{ChainID: big.NewInt(32382)},
+				}
+				genesisJSON, err := json.Marshal(genesis)
+				require.NoError(t, err)
+				tmpFile := t.TempDir() + "/genesis.json"
+				require.NoError(t, writeFile(tmpFile, genesisJSON))
+				generateGenesisStateFlags.GethGenesisJsonIn = tmpFile
+			}
+
+			st, err := generateGenesis(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, int64(tt.wantTimestamp), st.GenesisTime().Unix())
+		})
+	}
+}
+
 func writeFile(path string, data []byte) error {
-	return os.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0o644)
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

- When no `--genesis-time` is provided we default to `now()`, instead of using `timestamp` from provided `--geth-genesis-json-in` input file
- This results in inconsistencies, especially, if the input file is not overwritten using `--geth-genesis-json-out` (say, the generator is used to produce the `genesis.ssz` file only, as described in the original issue)

**Which issues(s) does this PR fix?**

Fixes #16002

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
