### PR TITLE
fix: stop SlotIntervalTicker goroutine leaks

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -94,6 +94,7 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 		for {
 			select {
 			case <-s.ctx.Done():
+				ticker.Done()
 				return
 			case slotInterval := <-ticker.C():
 				if slotInterval.Interval > 0 {

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -49,6 +49,7 @@ func (s *Service) prepareForkChoiceAtts() {
 			}
 		case <-s.ctx.Done():
 			log.Debug("Context closed, exiting routine")
+			ticker.Done()
 			return
 		}
 	}

--- a/changelog/galoretka_fix-leak.md
+++ b/changelog/galoretka_fix-leak.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- stop SlotIntervalTicker goroutine leaks [#16241](https://github.com/OffchainLabs/prysm/pull/16241)


### PR DESCRIPTION
`SlotIntervalTicker` was created in `prepareForkChoiceAtts` and in the fork-choice attestation processing routine without ever calling `Done()` when the service context was cancelled. Once the consuming goroutine exits on `ctx.Done()`, the ticker keeps running and eventually blocks on sending to its channel, leaving a leaked goroutine behind.

This change wires the lifetime of the `SlotIntervalTicker` to the corresponding service contexts by calling `ticker.Done()` on 
`ctx.Done()` in both call sites. This keeps the behaviour of the routines unchanged while ensuring the ticker goroutines exit cleanly on shutdown, consistent with how regular `SlotTicker` is handled elsewhere in the codebase.