### PR TITLE
refactor: remove unused deprecated flag template and constant

### DIFF
--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -4,18 +4,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// Deprecated flags list.
-const deprecatedUsage = "DEPRECATED. DO NOT USE."
-
-var (
-	// To deprecate a feature flag, first copy the example below, then insert deprecated flag in `deprecatedFlags`.
-	exampleDeprecatedFeatureFlag = &cli.StringFlag{
-		Name:   "name",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
-)
-
 // Deprecated flags for both the beacon node and validator client.
 var deprecatedFlags = []cli.Flag{}
 


### PR DESCRIPTION
Removes dead code from `config/features/deprecated_flags.go`: unused `deprecatedUsage` constant, unused `exampleDeprecatedFeatureFlag` template variable, obsolete instructional comment