### PR TITLE
refactor(container): optimize thread-safe map Keys() method

### DIFF
--- a/container/thread-safe/map.go
+++ b/container/thread-safe/map.go
@@ -30,10 +30,9 @@ func (m *Map[K, V]) Do(fn func(mp map[K]V)) {
 // Keys returns the keys of a thread-safe map.
 func (m *Map[K, V]) Keys() (r []K) {
 	m.View(func(mp map[K]V) {
-		r = make([]K, 0, len(m.items))
+		r = make([]K, 0, len(mp))
 		for k := range mp {
-			key := k
-			r = append(r, key)
+			r = append(r, k)
 		}
 	})
 	return r


### PR DESCRIPTION
Optimizes the `Map.Keys()` method in the thread-safe container package by removing redundant operations.