### PR TITLE
fix: move test-only JWT helper to test file

### DIFF
--- a/changelog/move-jwt-test-helper.md
+++ b/changelog/move-jwt-test-helper.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Moved the test-only JWT helper `createTokenString` out of production code and into `*_test.go` to avoid shipping unused logic and dependencies in `validator/rpc`.

--- a/validator/rpc/auth_token.go
+++ b/validator/rpc/auth_token.go
@@ -17,7 +17,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	"github.com/fsnotify/fsnotify"
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 )
 
@@ -195,15 +194,4 @@ func readAuthTokenFile(r io.Reader) ([]byte, string, error) {
 			"Tokens can be generated through the `validator web generate-auth-token` command")
 	}
 	return secret, token, nil
-}
-
-// Creates a JWT token string using the JWT key.
-func createTokenString(jwtKey []byte) (string, error) {
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{})
-	// Sign and get the complete encoded token as a string using the secret
-	tokenString, err := token.SignedString(jwtKey)
-	if err != nil {
-		return "", err
-	}
-	return tokenString, nil
 }

--- a/validator/rpc/auth_token_test.go
+++ b/validator/rpc/auth_token_test.go
@@ -27,6 +27,18 @@ func setupWalletDir(t testing.TB) string {
 	return walletDir
 }
 
+// Creates a JWT token string using the JWT key.
+// Test-only helper: production code does not need to ship this thin wrapper.
+func createTokenString(jwtKey []byte) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{})
+	// Sign and get the complete encoded token as a string using the secret
+	tokenString, err := token.SignedString(jwtKey)
+	if err != nil {
+		return "", err
+	}
+	return tokenString, nil
+}
+
 func TestServer_AuthenticateUsingExistingToken(t *testing.T) {
 	// Initializing for the first time, there is no auth token file in
 	// the wallet directory, so we generate a jwt token and secret from scratch.


### PR DESCRIPTION
Moves the `createTokenString` function from `validator/rpc/auth_token.go` to `validator/rpc/auth_token_test.go` since it's only used by tests. This removes unused production code and eliminates the unnecessary `golang-jwt/jwt/v4` dependency from the production build of the `validator/rpc` package.
The `createTokenString` helper function was defined in production code but never called outside of tests. This PR moves it to the test file where it belongs, following Go best practices of keeping test-only utilities in `*_test.go` files.

