### PR TITLE
Use delay in fetchOriginDataColumnSidecars

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -510,6 +510,13 @@ func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock, delay ti
 		}
 
 		logFunc("Failed to fetch some origin data column sidecars, retrying later")
+
+		// Wait before retrying, respecting context cancellation.
+		select {
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		case <-time.After(delay):
+		}
 	}
 }
 

--- a/changelog/satushh-delay.md
+++ b/changelog/satushh-delay.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use delay in fetchOriginDataColumnSidecars. Currently it is simply logged. 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Actually use the `delay` in fetchOriginDataColumnSidecars. Currently it is only logged without actually waiting. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
