### PR TITLE
Remove unused delay parameter from `fetchOriginDataColumnSidecars` function.

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -226,8 +226,6 @@ func (s *Service) Start() {
 
 // fetchOriginSidecars fetches origin sidecars
 func (s *Service) fetchOriginSidecars(peers []peer.ID) error {
-	const delay = 10 * time.Second // The delay between each attempt to fetch origin data column sidecars
-
 	blockRoot, err := s.cfg.DB.OriginCheckpointBlockRoot(s.ctx)
 	if errors.Is(err, db.ErrNotFoundOriginBlockRoot) {
 		return nil
@@ -260,7 +258,7 @@ func (s *Service) fetchOriginSidecars(peers []peer.ID) error {
 	blockVersion := roBlock.Version()
 
 	if blockVersion >= version.Fulu {
-		if err := s.fetchOriginDataColumnSidecars(roBlock, delay); err != nil {
+		if err := s.fetchOriginDataColumnSidecars(roBlock); err != nil {
 			return errors.Wrap(err, "fetch origin columns")
 		}
 		return nil
@@ -414,7 +412,7 @@ func (s *Service) fetchOriginBlobSidecars(pids []peer.ID, rob blocks.ROBlock) er
 	return fmt.Errorf("no connected peer able to provide blobs for checkpoint sync block %#x", r)
 }
 
-func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock, delay time.Duration) error {
+func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock) error {
 	const (
 		errorMessage     = "Failed to fetch origin data column sidecars"
 		warningIteration = 10
@@ -501,7 +499,6 @@ func (s *Service) fetchOriginDataColumnSidecars(roBlock blocks.ROBlock, delay ti
 		log := log.WithFields(logrus.Fields{
 			"attempt":        attempt,
 			"missingIndices": helpers.SortedPrettySliceFromMap(missingIndicesByRoot[root]),
-			"delay":          delay,
 		})
 
 		logFunc := log.Debug

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -687,10 +687,7 @@ func TestFetchOriginColumns(t *testing.T) {
 	cfg.BlobSchedule = []params.BlobScheduleEntry{{Epoch: 0, MaxBlobsPerBlock: 10}}
 	params.OverrideBeaconConfig(cfg)
 
-	const (
-		delay     = 0
-		blobCount = 1
-	)
+	const blobCount = 1
 
 	t.Run("block has no commitments", func(t *testing.T) {
 		service := new(Service)
@@ -702,7 +699,7 @@ func TestFetchOriginColumns(t *testing.T) {
 		roBlock, err := blocks.NewROBlock(signedBlock)
 		require.NoError(t, err)
 
-		err = service.fetchOriginDataColumnSidecars(roBlock, delay)
+		err = service.fetchOriginDataColumnSidecars(roBlock)
 		require.NoError(t, err)
 	})
 
@@ -724,7 +721,7 @@ func TestFetchOriginColumns(t *testing.T) {
 		err := storage.Save(verifiedSidecars)
 		require.NoError(t, err)
 
-		err = service.fetchOriginDataColumnSidecars(roBlock, delay)
+		err = service.fetchOriginDataColumnSidecars(roBlock)
 		require.NoError(t, err)
 	})
 
@@ -829,7 +826,7 @@ func TestFetchOriginColumns(t *testing.T) {
 			attempt++
 		})
 
-		err = service.fetchOriginDataColumnSidecars(roBlock, delay)
+		err = service.fetchOriginDataColumnSidecars(roBlock)
 		require.NoError(t, err)
 
 		// Check all corresponding sidecars are saved in the store.

--- a/changelog/manu_remove_unused_delay.md
+++ b/changelog/manu_remove_unused_delay.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Remove unused `delay` parameter from `fetchOriginDataColumnSidecars` function.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Remove unused delay parameter from `fetchOriginDataColumnSidecars` function.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
