### PR TITLE
perf: reduce heap allocations in IsEmptyExecutionData

### DIFF
--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -797,34 +797,42 @@ var (
 	PayloadToHeaderFulu    = PayloadToHeaderDeneb
 )
 
+// Pre-allocated zero-value slices to avoid repeated allocations in IsEmptyExecutionData.
+// These are safe for concurrent read access since they are never modified.
+var (
+	zeroRoot         = make([]byte, fieldparams.RootLength)
+	zeroFeeRecipient = make([]byte, fieldparams.FeeRecipientLength)
+	zeroLogsBloom    = make([]byte, fieldparams.LogsBloomLength)
+)
+
 // IsEmptyExecutionData checks if an execution data is empty underneath. If a single field has
 // a non-zero value, this function will return false.
 func IsEmptyExecutionData(data interfaces.ExecutionData) (bool, error) {
 	if data == nil {
 		return true, nil
 	}
-	if !bytes.Equal(data.ParentHash(), make([]byte, fieldparams.RootLength)) {
+	if !bytes.Equal(data.ParentHash(), zeroRoot) {
 		return false, nil
 	}
-	if !bytes.Equal(data.FeeRecipient(), make([]byte, fieldparams.FeeRecipientLength)) {
+	if !bytes.Equal(data.FeeRecipient(), zeroFeeRecipient) {
 		return false, nil
 	}
-	if !bytes.Equal(data.StateRoot(), make([]byte, fieldparams.RootLength)) {
+	if !bytes.Equal(data.StateRoot(), zeroRoot) {
 		return false, nil
 	}
-	if !bytes.Equal(data.ReceiptsRoot(), make([]byte, fieldparams.RootLength)) {
+	if !bytes.Equal(data.ReceiptsRoot(), zeroRoot) {
 		return false, nil
 	}
-	if !bytes.Equal(data.LogsBloom(), make([]byte, fieldparams.LogsBloomLength)) {
+	if !bytes.Equal(data.LogsBloom(), zeroLogsBloom) {
 		return false, nil
 	}
-	if !bytes.Equal(data.PrevRandao(), make([]byte, fieldparams.RootLength)) {
+	if !bytes.Equal(data.PrevRandao(), zeroRoot) {
 		return false, nil
 	}
-	if !bytes.Equal(data.BaseFeePerGas(), make([]byte, fieldparams.RootLength)) {
+	if !bytes.Equal(data.BaseFeePerGas(), zeroRoot) {
 		return false, nil
 	}
-	if !bytes.Equal(data.BlockHash(), make([]byte, fieldparams.RootLength)) {
+	if !bytes.Equal(data.BlockHash(), zeroRoot) {
 		return false, nil
 	}
 


### PR DESCRIPTION
## Summary

This PR optimizes `IsEmptyExecutionData` by replacing inline `make()` calls with pre-allocated package-level zero-value byte slices.

## Problem

The current implementation allocates new byte slices on every comparison:
```go
if !bytes.Equal(data.ParentHash(), make([]byte, fieldparams.RootLength)) {
    return false, nil
}
```

This results in **8 heap allocations per call** that are immediately discarded, adding unnecessary GC pressure during block processing.

## Solution

Pre-allocate zero-value byte slices at package level:
```go
var (
    zeroRoot         = make([]byte, fieldparams.RootLength)
    zeroFeeRecipient = make([]byte, fieldparams.FeeRecipientLength)
    zeroLogsBloom    = make([]byte, fieldparams.LogsBloomLength)
)
```

These slices are only used for read comparisons via `bytes.Equal`, making them safe for concurrent access.

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Allocations per call | 8 | 0 |

## Testing

- No behavior change, purely an optimization
- Existing tests pass