### PR TITLE
Allow a flag to be hidden and hide the `--disable-get-blobs-v2` flag.

### DIFF
--- a/changelog/manu_disable_get_blobs_v2_hidden.md
+++ b/changelog/manu_disable_get_blobs_v2_hidden.md
@@ -1,0 +1,2 @@
+### Removed
+- `--disable-get-blobs-v2` flag from help.

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -364,7 +364,8 @@ var (
 	}
 	// DisableGetBlobsV2 disables the engine_getBlobsV2 usage.
 	DisableGetBlobsV2 = &cli.BoolFlag{
-		Name:  "disable-get-blobs-v2",
-		Usage: "Disables the engine_getBlobsV2 usage.",
+		Name:   "disable-get-blobs-v2",
+		Usage:  "Disables the engine_getBlobsV2 usage.",
+		Hidden: true,
 	}
 )

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -169,7 +169,6 @@ var appHelpFlagGroups = []flagGroup{
 			flags.ExecutionJWTSecretFlag,
 			flags.JwtId,
 			flags.InteropMockEth1DataVotesFlag,
-			flags.DisableGetBlobsV2,
 		},
 	},
 	{ // Flags relevant to configuring beacon chain monitoring.
@@ -246,18 +245,10 @@ func init() {
 	originalHelpPrinter := cli.HelpPrinter
 	cli.HelpPrinter = func(w io.Writer, tmpl string, data any) {
 		if tmpl == appHelpTemplate {
-			filteredGroups := make([]flagGroup, 0, len(appHelpFlagGroups))
 			for _, group := range appHelpFlagGroups {
-				visibleFlags := make([]cli.Flag, 0, len(group.Flags))
-				for _, flag := range group.Flags {
-					if vf, ok := flag.(cli.VisibleFlag); !ok || vf.IsVisible() {
-						visibleFlags = append(visibleFlags, flag)
-					}
-				}
-				sort.Sort(cli.FlagsByName(visibleFlags))
-				filteredGroups = append(filteredGroups, flagGroup{Name: group.Name, Flags: visibleFlags})
+				sort.Sort(cli.FlagsByName(group.Flags))
 			}
-			originalHelpPrinter(w, tmpl, helpData{data, filteredGroups})
+			originalHelpPrinter(w, tmpl, helpData{data, appHelpFlagGroups})
 		} else {
 			originalHelpPrinter(w, tmpl, data)
 		}

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -246,10 +246,18 @@ func init() {
 	originalHelpPrinter := cli.HelpPrinter
 	cli.HelpPrinter = func(w io.Writer, tmpl string, data any) {
 		if tmpl == appHelpTemplate {
+			filteredGroups := make([]flagGroup, 0, len(appHelpFlagGroups))
 			for _, group := range appHelpFlagGroups {
-				sort.Sort(cli.FlagsByName(group.Flags))
+				visibleFlags := make([]cli.Flag, 0, len(group.Flags))
+				for _, flag := range group.Flags {
+					if vf, ok := flag.(cli.VisibleFlag); !ok || vf.IsVisible() {
+						visibleFlags = append(visibleFlags, flag)
+					}
+				}
+				sort.Sort(cli.FlagsByName(visibleFlags))
+				filteredGroups = append(filteredGroups, flagGroup{Name: group.Name, Flags: visibleFlags})
 			}
-			originalHelpPrinter(w, tmpl, helpData{data, appHelpFlagGroups})
+			originalHelpPrinter(w, tmpl, helpData{data, filteredGroups})
 		} else {
 			originalHelpPrinter(w, tmpl, data)
 		}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Allow a flag to be hidden and hide the `--disable-get-blobs-v2` flag.

This flag is still usable, but does not show up any more in the help.
This flag is used for internal purpose only, so no need to expose it publicly.

**Why do we need to modify the `cli.HelpPrinter` function whereas other flags like `--aggregate-first-interval` are hidden just by using the `Hidden: true` property?**

The `Hidden: true` property on the flag definition doesn't work by itself because `usage.go` uses a custom help template that bypasses the standard urfave/cli help rendering.

**Acknowledgements**
- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
