### PR TITLE
fix: remove dead GetSpec error path

### DIFF
--- a/beacon-chain/rpc/eth/config/handlers.go
+++ b/beacon-chain/rpc/eth/config/handlers.go
@@ -65,11 +65,7 @@ func GetSpec(w http.ResponseWriter, r *http.Request) {
 	_, span := trace.StartSpan(r.Context(), "config.GetSpec")
 	defer span.End()
 
-	data, err := prepareConfigSpec()
-	if err != nil {
-		httputil.HandleError(w, "Could not prepare config spec: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
+	data := prepareConfigSpec()
 	httputil.WriteJson(w, &structs.GetSpecResponse{Data: data})
 }
 
@@ -159,7 +155,7 @@ func convertValueForJSON(v reflect.Value, tag string) any {
 	}
 }
 
-func prepareConfigSpec() (map[string]any, error) {
+func prepareConfigSpec() map[string]any {
 	data := make(map[string]any)
 	config := *params.BeaconConfig()
 
@@ -181,7 +177,7 @@ func prepareConfigSpec() (map[string]any, error) {
 		data[tag] = convertValueForJSON(val, tag)
 	}
 
-	return data, nil
+	return data
 }
 
 func shouldSkip(tField reflect.StructField) bool {

--- a/changelog/MozirDmitriy_remove-spec-error.md
+++ b/changelog/MozirDmitriy_remove-spec-error.md
@@ -1,0 +1,3 @@
+### Fix
+
+- remove dead GetSpec error path


### PR DESCRIPTION
The `prepareConfigSpec` function never returns an error, so the error handling in `GetSpec` was dead code and could never trigger a 500 response.
Simplified `prepareConfigSpec` to return only the data map and removed the unreachable error handling in `GetSpec` to reflect actual behavior.