### PR TITLE
Add startup version log

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -64,7 +64,6 @@ go_library(
         "//monitoring/tracing:go_default_library",
         "//runtime:go_default_library",
         "//runtime/prereqs:go_default_library",
-        "//runtime/version:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -66,7 +66,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/monitoring/prometheus"
 	"github.com/OffchainLabs/prysm/v7/runtime"
 	"github.com/OffchainLabs/prysm/v7/runtime/prereqs"
-	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -468,10 +467,6 @@ func (b *BeaconNode) OperationFeed() event.SubscriberSender {
 // Start the BeaconNode and kicks off every registered service.
 func (b *BeaconNode) Start() {
 	b.lock.Lock()
-
-	log.WithFields(logrus.Fields{
-		"version": version.Version(),
-	}).Info("Starting beacon node")
 
 	b.services.StartAll()
 

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -68,7 +68,6 @@ func TestNodeClose_OK(t *testing.T) {
 }
 
 func TestNodeStart_Ok(t *testing.T) {
-	hook := logTest.NewGlobal()
 	app := cli.App{}
 	tmp := fmt.Sprintf("%s/datadirtest2", t.TempDir())
 	set := flag.NewFlagSet("test", 0)
@@ -97,11 +96,9 @@ func TestNodeStart_Ok(t *testing.T) {
 	}()
 	time.Sleep(3 * time.Second)
 	node.Close()
-	require.LogsContain(t, hook, "Starting beacon node")
 }
 
 func TestNodeStart_SyncChecker(t *testing.T) {
-	hook := logTest.NewGlobal()
 	app := cli.App{}
 	tmp := fmt.Sprintf("%s/datadirtest2", t.TempDir())
 	set := flag.NewFlagSet("test", 0)
@@ -127,7 +124,6 @@ func TestNodeStart_SyncChecker(t *testing.T) {
 	time.Sleep(3 * time.Second)
 	assert.NotNil(t, node.syncChecker.Svc)
 	node.Close()
-	require.LogsContain(t, hook, "Starting beacon node")
 }
 
 // TestClearDB tests clearing the database

--- a/changelog/bastin_add-version-log-at-startup.md
+++ b/changelog/bastin_add-version-log-at-startup.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added a version log at startup to display the version of the build.

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -244,7 +244,9 @@ func before(ctx *cli.Context) error {
 	}
 
 	// Log Prysm version on startup. After initializing log-file and ephemeral log-file.
-	log.Info("Prysm Beacon Chain started. ", "[", version.Version(), "]")
+	log.WithFields(logrus.Fields{
+		"version": version.Version(),
+	}).Info("Prysm Beacon Chain started")
 
 	if err := cmd.ExpandSingleEndpointIfFile(ctx, flags.ExecutionEngineEndpoint); err != nil {
 		return errors.Wrap(err, "failed to expand single endpoint")

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -243,6 +243,9 @@ func before(ctx *cli.Context) error {
 		}
 	}
 
+	// Log Prysm version on startup. After initializing log-file and ephemeral log-file.
+	log.Info("Prysm Beacon Chain started. ", "[", version.Version(), "]")
+
 	if err := cmd.ExpandSingleEndpointIfFile(ctx, flags.ExecutionEngineEndpoint); err != nil {
 		return errors.Wrap(err, "failed to expand single endpoint")
 	}

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -221,6 +221,9 @@ func main() {
 				}
 			}
 
+			// Log Prysm version on startup. After initializing log-file and ephemeral log-file.
+			log.Info("Prysm Validator started. ", "[", version.Version(), "]")
+
 			// Fix data dir for Windows users.
 			outdatedDataDir := filepath.Join(file.HomeDir(), "AppData", "Roaming", "Eth2Validators")
 			currentDataDir := flags.DefaultValidatorDir()

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -222,7 +222,9 @@ func main() {
 			}
 
 			// Log Prysm version on startup. After initializing log-file and ephemeral log-file.
-			log.Info("Prysm Validator started. ", "[", version.Version(), "]")
+			log.WithFields(logrus.Fields{
+				"version": version.Version(),
+			}).Info("Prysm Validator started")
 
 			// Fix data dir for Windows users.
 			outdatedDataDir := filepath.Join(file.HomeDir(), "AppData", "Roaming", "Eth2Validators")

--- a/io/logs/logutil.go
+++ b/io/logs/logutil.go
@@ -31,7 +31,7 @@ func addLogWriter(w io.Writer) {
 
 // ConfigurePersistentLogging adds a log-to-file writer. File content is identical to stdout.
 func ConfigurePersistentLogging(logFileName string, format string, lvl logrus.Level, vmodule map[string]logrus.Level) error {
-	logrus.WithField("logFileName", logFileName).Info("Logs will be made persistent")
+	logrus.WithField("logFileName", logFileName).Debug("Logs will be made persistent")
 	if err := file.MkdirAll(filepath.Dir(logFileName)); err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func ConfigurePersistentLogging(logFileName string, format string, lvl logrus.Le
 	if format != "text" {
 		addLogWriter(f)
 
-		logrus.Info("File logging initialized")
+		logrus.Debug("File logging initialized")
 		return nil
 	}
 
@@ -70,7 +70,7 @@ func ConfigurePersistentLogging(logFileName string, format string, lvl logrus.Le
 		AllowedLevels: logrus.AllLevels[:max(lvl, maxVmoduleLevel)+1],
 	})
 
-	logrus.Info("File logging initialized")
+	logrus.Debug("File logging initialized")
 	return nil
 }
 
@@ -103,7 +103,7 @@ func ConfigureEphemeralLogFile(datadirPath string, app string) error {
 		AllowedLevels: logrus.AllLevels[:ephemeralLogFileVerbosity+1],
 	})
 
-	logrus.Info("Ephemeral log file initialized")
+	logrus.Debug("Ephemeral log file initialized")
 	return nil
 }
 

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -46,7 +46,6 @@ go_library(
         "//monitoring/tracing:go_default_library",
         "//runtime:go_default_library",
         "//runtime/prereqs:go_default_library",
-        "//runtime/version:go_default_library",
         "//validator/accounts/wallet:go_default_library",
         "//validator/client:go_default_library",
         "//validator/db:go_default_library",

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -30,7 +30,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v7/runtime"
 	"github.com/OffchainLabs/prysm/v7/runtime/prereqs"
-	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/validator/accounts/wallet"
 	"github.com/OffchainLabs/prysm/v7/validator/client"
 	"github.com/OffchainLabs/prysm/v7/validator/db"
@@ -123,10 +122,6 @@ func NewValidatorClient(cliCtx *cli.Context) (*ValidatorClient, error) {
 // Start every service in the validator client.
 func (c *ValidatorClient) Start() {
 	c.lock.Lock()
-
-	log.WithFields(logrus.Fields{
-		"version": version.Version(),
-	}).Info("Starting validator node")
 
 	c.services.StartAll()
 


### PR DESCRIPTION
**What does this PR do? Why is it needed?**
Adds a log mentioning the name and the version of the app: 

Beacon-chain:
```
[2026-01-26 12:03:12.91]  INFO main: Prysm Beacon Chain started. [Prysm/Unknown/Local build. Built at: Moments ago] prefix=main
```
Validator:
```
[2026-01-26 12:00:07.38]  INFO main: Prysm Validator started. [Prysm/v7.1.2/7950a249266a692551e5a910adb9a82a02c92040. Built at: 2026-01-06 18:47:23+00:00] prefix=main
```

**Note:** I've removed the previous two logs that mentioned version in favor of these new ones. I've also moved the initialization logs of persistent log file and ephemeral log file to DEBUG.

**Which issues(s) does this PR fix?**

Fixes #16259 