### PR TITLE
Remove priting the prefix field

### DIFF
--- a/changelog/bastin_remove-prefix-print.md
+++ b/changelog/bastin_remove-prefix-print.md
@@ -1,0 +1,3 @@
+### Changed
+
+- remove printing of the `prefix` field in legacy logs.

--- a/runtime/logging/logrus-prefixed-formatter/formatter.go
+++ b/runtime/logging/logrus-prefixed-formatter/formatter.go
@@ -334,7 +334,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		_, err = fmt.Fprintf(b, "%s %s%s "+messageFormat, colorScheme.TimestampColor(timestamp), level, prefix, message)
 	}
 	for _, k := range keys {
-		if k != "package" {
+		if k != "package" && k != "prefix" {
 			v := entry.Data[k]
 
 			format := "%+v"


### PR DESCRIPTION
**What does this PR do? Why is it needed?**
Removes printing the `prefix` field for logs. 

most of our packages have been updated to use the automatic `package` field, but some less-often-used ones still use the `prefix` field. This PR removes printing those additional `prefix` fields.

before:
```
[2026-01-26 15:03:56.22]  INFO execution: Finished reading JWT secret from ../eth/jwt.hex prefix=execution
``` 

after:
```
[2026-01-26 15:04:50.36]  INFO execution: Finished reading JWT secret from ../eth/jwt.hex
```