### PR TITLE
Fix arm64 hashtree builds

### DIFF
--- a/changelog/potuz_hashtree_builds.md
+++ b/changelog/potuz_hashtree_builds.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix hashtree release builds.

--- a/third_party/com_github_offchainlabs_hashtree.patch
+++ b/third_party/com_github_offchainlabs_hashtree.patch
@@ -1,7 +1,7 @@
 diff -urN a/BUILD.bazel b/BUILD.bazel
 --- a/BUILD.bazel	1969-12-31 18:00:00.000000000 -0600
 +++ b/BUILD.bazel	2025-01-05 12:00:00.000000000 -0600
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,89 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(

--- a/third_party/com_github_offchainlabs_hashtree.patch
+++ b/third_party/com_github_offchainlabs_hashtree.patch
@@ -83,7 +83,10 @@ diff -urN a/BUILD.bazel b/BUILD.bazel
 +        "src/sha256_sse_x1.S",
 +    ],
 +    hdrs = ["src/hashtree.h"],
-+    copts = ["-O3", "-Wall", "-fno-integrated-as"],
++    copts = ["-O3", "-Wall"] + select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-fno-integrated-as"],
++    }),
 +    linkstatic = True,
 +    strip_include_prefix = "src",
 +    visibility = ["//visibility:public"],

--- a/third_party/com_github_offchainlabs_hashtree.patch
+++ b/third_party/com_github_offchainlabs_hashtree.patch
@@ -44,14 +44,14 @@ diff -urN a/BUILD.bazel b/BUILD.bazel
 +    name = "hashtree_arm64_syso",
 +    srcs = [":hashtree_arm64"],
 +    outs = ["hashtree_arm64.syso"],
-+    cmd = "cp $(location :hashtree_arm64) $@",
++    cmd = "cp $$(echo $(locations :hashtree_arm64) | tr ' ' '\\n' | grep -v '\\.pic\\.' | head -1) $@",
 +)
 +
 +genrule(
 +    name = "hashtree_amd64_syso",
 +    srcs = [":hashtree_amd64"],
 +    outs = ["hashtree_amd64.syso"],
-+    cmd = "cp $(location :hashtree_amd64) $@",
++    cmd = "cp $$(echo $(locations :hashtree_amd64) | tr ' ' '\\n' | grep -v '\\.pic\\.' | head -1) $@",
 +)
 +
 +cc_library(


### PR DESCRIPTION
This PR fixes release builds that fail because of hashtree's patch. Should be in conjunction with #16281