### PR TITLE
add path field for ephemeral log file initialization

### DIFF
--- a/changelog/bastin_path-ephemeral-log.md
+++ b/changelog/bastin_path-ephemeral-log.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Added a field `path` for the ephemeral log file initialization log.

--- a/io/logs/logutil.go
+++ b/io/logs/logutil.go
@@ -103,7 +103,7 @@ func ConfigureEphemeralLogFile(datadirPath string, app string) error {
 		AllowedLevels: logrus.AllLevels[:ephemeralLogFileVerbosity+1],
 	})
 
-	logrus.Debug("Ephemeral log file initialized")
+	logrus.WithField("path", logFilePath).Debug("Ephemeral log file initialized")
 	return nil
 }
 


### PR DESCRIPTION
**What does this PR do? Why is it needed?**
Add a field `path` to the initialization log of ephemeral-logfile feature:

before:
```
[2026-01-26 19:49:34.64] DEBUG Ephemeral log file initialized
```

after:
```
[2026-01-26 19:49:34.64] DEBUG Ephemeral log file initialized path=../eth/datadir/logs/beacon-chain.log
```