### PR TITLE
fix: enable timely attestation flags on altair+ forks

### DIFF
--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -99,7 +99,7 @@ func (s *Service) processIncludedAttestation(ctx context.Context, state state.Be
 			inclusionSlotGauge.WithLabelValues(fmt.Sprintf("%d", idx)).Set(float64(latestPerf.inclusionSlot))
 			aggregatedPerf.totalDistance += uint64(latestPerf.inclusionSlot - latestPerf.attestedSlot)
 
-			if state.Version() == version.Altair {
+			if state.Version() >= version.Altair {
 				targetIdx := params.BeaconConfig().TimelyTargetFlagIndex
 				sourceIdx := params.BeaconConfig().TimelySourceFlagIndex
 				headIdx := params.BeaconConfig().TimelyHeadFlagIndex

--- a/changelog/MoNyAvA-fix-timely-flags.md
+++ b/changelog/MoNyAvA-fix-timely-flags.md
@@ -1,0 +1,3 @@
+### Fix
+
+- enable timely attestation flags on altair+ forks [#16297](https://github.com/OffchainLabs/prysm/pull/16297)


### PR DESCRIPTION
Before this change, the validator monitor only computed timely attestation flags and related metrics when state.Version() == version.Altair. On later forks (Bellatrix, Capella, Deneb, Electra, …) timely Head/Source/Target flags and their Prometheus counters were never updated, so logs and metrics did not reflect actual participation quality after Altair.

This change updates the fork guard in process_attestation.go to treat all forks from Altair onwards (state.Version() >= version.Altair) as supporting participation flags. As a result, the monitor now correctly reads participation and updates timely flags and metrics for all post-Phase0 fork versions.