### PR TITLE
fix: slashing `waitforclock` panic

### DIFF
--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -60,6 +60,9 @@ func (p *PoolService) run() {
 	}
 
 	p.waitForChainInitialization()
+	if p.clock == nil {
+		return
+	}
 
 	electraTime, err := slots.StartTime(p.clock.GenesisTime(), electraSlot)
 	if err != nil {
@@ -84,6 +87,7 @@ func (p *PoolService) waitForChainInitialization() {
 	clock, err := p.cw.WaitForClock(p.ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not receive chain start notification")
+		return
 	}
 	p.clock = clock
 	log.WithField("genesisTime", clock.GenesisTime()).Info(

--- a/beacon-chain/slasher/service.go
+++ b/beacon-chain/slasher/service.go
@@ -87,6 +87,9 @@ func (s *Service) Start() {
 
 func (s *Service) run() {
 	s.waitForChainInitialization()
+	if s.genesisTime.IsZero() {
+		return
+	}
 	s.waitForSync(s.genesisTime)
 
 	log.Info("Completed chain sync, starting slashing detection")
@@ -202,6 +205,7 @@ func (s *Service) waitForChainInitialization() {
 	clock, err := s.serviceCfg.ClockWaiter.WaitForClock(s.ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not receive chain start notification")
+		return
 	}
 	s.genesisTime = clock.GenesisTime()
 	log.WithField("genesisTime", s.genesisTime).Info(

--- a/changelog/galoretka_fix-panic.md
+++ b/changelog/galoretka_fix-panic.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- avoid panic on WaitForClock cancellation in slashing services [#16312](https://github.com/OffchainLabs/prysm/pull/16312)


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

WaitForClock returns a nil clock and a non-nil error when the service context is canceled before the clock is set. Both the slashing pool service and the slasher service were logging this error but still unconditionally dereferencing the clock (calling GenesisTime), which could lead to a nil pointer panic during shutdown or early cancellation before genesis.

This change makes waitForChainInitialization in both services return early on WaitForClock errors and updates their run loops to bail out if the clock / genesisTime was not initialized, preventing panics when the context is canceled before the clock becomes available.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
