### PR TITLE
Synced new block

### DIFF
--- a/beacon-chain/blockchain/log_helpers.go
+++ b/beacon-chain/blockchain/log_helpers.go
@@ -87,36 +87,32 @@ func logStateTransitionData(b interfaces.ReadOnlyBeaconBlock) error {
 func logBlockSyncStatus(block interfaces.ReadOnlyBeaconBlock, blockRoot [32]byte, justified, finalized *ethpb.Checkpoint, receivedTime time.Time, genesis time.Time, daWaitedTime time.Duration) error {
 	startTime, err := slots.StartTime(genesis, block.Slot())
 	if err != nil {
-		return err
+		return fmt.Errorf("start time: %w", err)
 	}
-	level := log.Logger.GetLevel()
-	if level >= logrus.DebugLevel {
+
+	log := log.WithFields(logrus.Fields{
+		"slot":           block.Slot(),
+		"block":          fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
+		"finalizedEpoch": finalized.Epoch,
+		"finalizedRoot":  fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
+		"epoch":          slots.ToEpoch(block.Slot()),
+	})
+
+	if log.Logger.GetLevel() >= logrus.DebugLevel {
 		parentRoot := block.ParentRoot()
-		lf := logrus.Fields{
-			"slot":                       block.Slot(),
+		log = log.WithFields(logrus.Fields{
 			"slotInEpoch":                block.Slot() % params.BeaconConfig().SlotsPerEpoch,
-			"block":                      fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
-			"epoch":                      slots.ToEpoch(block.Slot()),
 			"justifiedEpoch":             justified.Epoch,
 			"justifiedRoot":              fmt.Sprintf("0x%s...", hex.EncodeToString(justified.Root)[:8]),
-			"finalizedEpoch":             finalized.Epoch,
-			"finalizedRoot":              fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
 			"parentRoot":                 fmt.Sprintf("0x%s...", hex.EncodeToString(parentRoot[:])[:8]),
 			"version":                    version.String(block.Version()),
 			"sinceSlotStartTime":         prysmTime.Now().Sub(startTime),
 			"chainServiceProcessedTime":  prysmTime.Now().Sub(receivedTime) - daWaitedTime,
 			"dataAvailabilityWaitedTime": daWaitedTime,
-		}
-		log.WithFields(lf).Debug("Synced new block")
-	} else {
-		log.WithFields(logrus.Fields{
-			"slot":           block.Slot(),
-			"block":          fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
-			"finalizedEpoch": finalized.Epoch,
-			"finalizedRoot":  fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
-			"epoch":          slots.ToEpoch(block.Slot()),
-		}).Info("Synced new block")
+		})
 	}
+
+	log.Info("Synced new block")
 	return nil
 }
 

--- a/beacon-chain/blockchain/log_helpers.go
+++ b/beacon-chain/blockchain/log_helpers.go
@@ -91,22 +91,22 @@ func logBlockSyncStatus(block interfaces.ReadOnlyBeaconBlock, blockRoot [32]byte
 	}
 
 	log := log.WithFields(logrus.Fields{
-		"slot":           block.Slot(),
-		"block":          fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
-		"finalizedEpoch": finalized.Epoch,
-		"finalizedRoot":  fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
-		"epoch":          slots.ToEpoch(block.Slot()),
+		"slot":               block.Slot(),
+		"block":              fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
+		"finalizedEpoch":     finalized.Epoch,
+		"finalizedRoot":      fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
+		"epoch":              slots.ToEpoch(block.Slot()),
+		"slotInEpoch":        block.Slot() % params.BeaconConfig().SlotsPerEpoch,
+		"sinceSlotStartTime": prysmTime.Now().Sub(startTime),
 	})
 
 	if log.Logger.GetLevel() >= logrus.DebugLevel {
 		parentRoot := block.ParentRoot()
 		log = log.WithFields(logrus.Fields{
-			"slotInEpoch":                block.Slot() % params.BeaconConfig().SlotsPerEpoch,
 			"justifiedEpoch":             justified.Epoch,
 			"justifiedRoot":              fmt.Sprintf("0x%s...", hex.EncodeToString(justified.Root)[:8]),
 			"parentRoot":                 fmt.Sprintf("0x%s...", hex.EncodeToString(parentRoot[:])[:8]),
 			"version":                    version.String(block.Version()),
-			"sinceSlotStartTime":         prysmTime.Now().Sub(startTime),
 			"chainServiceProcessedTime":  prysmTime.Now().Sub(receivedTime) - daWaitedTime,
 			"dataAvailabilityWaitedTime": daWaitedTime,
 		})

--- a/changelog/manu-synced-new-block.md
+++ b/changelog/manu-synced-new-block.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Always use `INFO` for the "Synced new block" log, but add additional data if the verbosity is set to `debug` or higher.
+- Add `slotInEpoch` and `sinceSlotStartTime` fields to the "Synced new block" INFO log.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Before this PR, the `Synced new block` is an `INFO` log if the corresponding package has a lower than `DEBUG` verbosity, and is a `DEBUG` log in the contrary. The `DEBUG` log has more fields than the corresponding `INFO` log.

This PR:
1. Sets the `Synced new block` log as an `INFO` log in all cases, but adds more fields in case the verbosity is equal or higher than `DEBUG`
2. Adds `slotInEpoch` and `sinceSlotStartTime` fields even if the verbosity is lower than `DEBUG`, since these data are useful for a normal user.


`--verbosity=debug`
```
v7.1.2:
[2026-02-02 14:52:01.91] DEBUG blockchain: Synced new block block=0x626451bf... chainServiceProcessedTime=608.38543ms dataAvailabilityWaitedTime=19.758µs epoch=72475 finalizedEpoch=72473 finalizedRoot=0xa6c9a383... justifiedEpoch=72474 justifiedRoot=0x3cf6d073... parentRoot=0x55a3f97e... sinceSlotStartTime=1.917780288s slot=2319210 slotInEpoch=10 version=fulu
```

`--verbosity=info`
```
v7.1.2:
[2026-02-02 15:20:53.98]  INFO blockchain: Synced new block block=0xd0eddabc... epoch=72479 finalizedEpoch=72477 finalizedRoot=0xf7289ce3... slot=2319347
```

**Other notes for review**

**Acknowledgements**

- [ ] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [ ] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [ ] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
