### PR TITLE
refactor: remove unused parameters from p2p message id

### DIFF
--- a/beacon-chain/p2p/message_id.go
+++ b/beacon-chain/p2p/message_id.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/encoder"
 	"github.com/OffchainLabs/prysm/v7/config/params"
-	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/hash"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/math"
@@ -22,7 +21,7 @@ import (
 //	Otherwise, set `message-id` to the first 20 bytes of the `SHA256` hash of
 //	the concatenation of `MESSAGE_DOMAIN_INVALID_SNAPPY` with the raw message data,
 //	i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + message.data)[:20]`.
-func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
+func MsgID(pmsg *pubsubpb.Message) string {
 	if pmsg == nil || pmsg.Data == nil || pmsg.Topic == nil {
 		// Impossible condition that should
 		// never be hit.
@@ -47,7 +46,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 		return bytesutil.UnsafeCastToString(msg)
 	}
 	if fEpoch >= params.BeaconConfig().AltairForkEpoch {
-		return postAltairMsgID(pmsg, fEpoch)
+		return postAltairMsgID(pmsg)
 	}
 	decodedData, err := encoder.DecodeSnappy(pmsg.Data, params.BeaconConfig().MaxPayloadSize)
 	if err != nil {
@@ -71,7 +70,7 @@ func MsgID(genesisValidatorsRoot []byte, pmsg *pubsubpb.Message) string {
 // + message.topic + snappy_decompress(message.data))[:20]. Otherwise, set message-id to the first 20 bytes of the SHA256 hash of the concatenation
 // of the following data: MESSAGE_DOMAIN_INVALID_SNAPPY, the length of the topic byte string (encoded as little-endian uint64),
 // the topic byte string, and the raw message data: i.e. SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + uint_to_bytes(uint64(len(message.topic))) + message.topic + message.data)[:20].
-func postAltairMsgID(pmsg *pubsubpb.Message, fEpoch primitives.Epoch) string {
+func postAltairMsgID(pmsg *pubsubpb.Message) string {
 	topic := *pmsg.Topic
 	topicLen := len(topic)
 	topicLenBytes := bytesutil.Uint64ToBytesLittleEndian(uint64(topicLen)) // topicLen cannot be negative

--- a/beacon-chain/p2p/message_id_test.go
+++ b/beacon-chain/p2p/message_id_test.go
@@ -19,21 +19,20 @@ import (
 func TestMsgID_HashesCorrectly(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	clock := startup.NewClock(time.Now(), bytesutil.ToBytes32([]byte{'A'}))
-	valRoot := clock.GenesisValidatorsRoot()
 	d := params.ForkDigest(clock.CurrentEpoch())
 	tpc := fmt.Sprintf(p2p.BlockSubnetTopicFormat, d)
 	invalidSnappy := [32]byte{'J', 'U', 'N', 'K'}
 	pMsg := &pubsubpb.Message{Data: invalidSnappy[:], Topic: &tpc}
 	hashedData := hash.Hash(append(params.BeaconConfig().MessageDomainInvalidSnappy[:], pMsg.Data...))
 	msgID := string(hashedData[:20])
-	assert.Equal(t, msgID, p2p.MsgID(valRoot[:], pMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, p2p.MsgID(pMsg), "Got incorrect msg id")
 
 	validObj := [32]byte{'v', 'a', 'l', 'i', 'd'}
 	enc := snappy.Encode(nil, validObj[:])
 	nMsg := &pubsubpb.Message{Data: enc, Topic: &tpc}
 	hashedData = hash.Hash(append(params.BeaconConfig().MessageDomainValidSnappy[:], validObj[:]...))
 	msgID = string(hashedData[:20])
-	assert.Equal(t, msgID, p2p.MsgID(valRoot[:], nMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, p2p.MsgID(nMsg), "Got incorrect msg id")
 }
 
 func TestMessageIDFunction_HashesCorrectlyAltair(t *testing.T) {
@@ -51,7 +50,7 @@ func TestMessageIDFunction_HashesCorrectlyAltair(t *testing.T) {
 	combinedObj = append(combinedObj, pMsg.Data...)
 	hashedData := hash.Hash(combinedObj)
 	msgID := string(hashedData[:20])
-	assert.Equal(t, msgID, p2p.MsgID(params.BeaconConfig().GenesisValidatorsRoot[:], pMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, p2p.MsgID(pMsg), "Got incorrect msg id")
 
 	validObj := [32]byte{'v', 'a', 'l', 'i', 'd'}
 	enc := snappy.Encode(nil, validObj[:])
@@ -62,7 +61,7 @@ func TestMessageIDFunction_HashesCorrectlyAltair(t *testing.T) {
 	combinedObj = append(combinedObj, validObj[:]...)
 	hashedData = hash.Hash(combinedObj)
 	msgID = string(hashedData[:20])
-	assert.Equal(t, msgID, p2p.MsgID(params.BeaconConfig().GenesisValidatorsRoot[:], nMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, p2p.MsgID(nMsg), "Got incorrect msg id")
 }
 
 func TestMessageIDFunction_HashesCorrectlyBellatrix(t *testing.T) {
@@ -80,7 +79,7 @@ func TestMessageIDFunction_HashesCorrectlyBellatrix(t *testing.T) {
 	combinedObj = append(combinedObj, pMsg.Data...)
 	hashedData := hash.Hash(combinedObj)
 	msgID := string(hashedData[:20])
-	assert.Equal(t, msgID, p2p.MsgID(params.BeaconConfig().GenesisValidatorsRoot[:], pMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, p2p.MsgID(pMsg), "Got incorrect msg id")
 
 	validObj := [32]byte{'v', 'a', 'l', 'i', 'd'}
 	enc := snappy.Encode(nil, validObj[:])
@@ -91,7 +90,7 @@ func TestMessageIDFunction_HashesCorrectlyBellatrix(t *testing.T) {
 	combinedObj = append(combinedObj, validObj[:]...)
 	hashedData = hash.Hash(combinedObj)
 	msgID = string(hashedData[:20])
-	assert.Equal(t, msgID, p2p.MsgID(params.BeaconConfig().GenesisValidatorsRoot[:], nMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, p2p.MsgID(nMsg), "Got incorrect msg id")
 }
 
 func TestMsgID_WithNilTopic(t *testing.T) {
@@ -104,6 +103,6 @@ func TestMsgID_WithNilTopic(t *testing.T) {
 	invalid := make([]byte, 20)
 	copy(invalid, "invalid")
 
-	res := p2p.MsgID([]byte{0x01}, msg)
+	res := p2p.MsgID(msg)
 	assert.Equal(t, res, string(invalid))
 }

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -161,7 +161,7 @@ func (s *Service) pubsubOptions() []pubsub.Option {
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
 		pubsub.WithNoAuthor(),
 		pubsub.WithMessageIdFn(func(pmsg *pubsubpb.Message) string {
-			return MsgID(s.genesisValidatorsRoot, pmsg)
+			return MsgID(pmsg)
 		}),
 		pubsub.WithSubscriptionFilter(filt),
 		pubsub.WithPeerOutboundQueueSize(int(s.cfg.QueueSize)),

--- a/changelog/bashmunta-clean-up.md
+++ b/changelog/bashmunta-clean-up.md
@@ -1,0 +1,3 @@
+### Refactored
+
+- Remove unused parameters from p2p message id [#16319](https://github.com/OffchainLabs/prysm/pull/16319)


### PR DESCRIPTION
Reason: MsgID and postAltairMsgID exposed parameters that were not used in the message-id computation, which made the API misleading and left dead code paths in tests and pubsub options.
Changes: Simplified MsgID and postAltairMsgID signatures and updated all internal call sites and tests to use the lean API without genesisValidatorsRoot or epoch arguments, keeping the actual message-id hashing logic unchanged.