### PR TITLE
fix: Set Beacon Node Options after reading the config file

### DIFF
--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -610,6 +610,7 @@ func (dcs *DataColumnStorage) Clear() error {
 
 // prune clean the cache, the filesystem and mutexes.
 func (dcs *DataColumnStorage) prune() {
+	log.WithField("highestStoredEpoch", dcs.cache.HighestEpoch()).WithField("retentionEpochs", dcs.retentionEpochs).Debug("Pruning data column storage")
 	startTime := time.Now()
 	defer func() {
 		dataColumnPruneLatency.Observe(float64(time.Since(startTime).Milliseconds()))

--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -610,7 +610,6 @@ func (dcs *DataColumnStorage) Clear() error {
 
 // prune clean the cache, the filesystem and mutexes.
 func (dcs *DataColumnStorage) prune() {
-	log.WithField("highestStoredEpoch", dcs.cache.HighestEpoch()).WithField("retentionEpochs", dcs.retentionEpochs).Debug("Pruning data column storage")
 	startTime := time.Now()
 	defer func() {
 		dataColumnPruneLatency.Observe(float64(time.Since(startTime).Milliseconds()))

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -134,9 +134,18 @@ type BeaconNode struct {
 
 // New creates a new node instance, sets up configuration options, and registers
 // every required service to the node.
-func New(cliCtx *cli.Context, cancel context.CancelFunc, opts ...Option) (*BeaconNode, error) {
+func New(cliCtx *cli.Context, cancel context.CancelFunc, optFuncs []func(*cli.Context) ([]Option, error), opts ...Option) (*BeaconNode, error) {
 	if err := configureBeacon(cliCtx); err != nil {
 		return nil, errors.Wrap(err, "could not set beacon configuration options")
+	}
+	for _, of := range optFuncs {
+		ofo, err := of(cliCtx)
+		if err != nil {
+			return nil, err
+		}
+		if ofo != nil {
+			opts = append(opts, ofo...)
+		}
 	}
 	ctx := cliCtx.Context
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -138,6 +138,7 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, optFuncs []func(*cli.Co
 	if err := configureBeacon(cliCtx); err != nil {
 		return nil, errors.Wrap(err, "could not set beacon configuration options")
 	}
+
 	for _, of := range optFuncs {
 		ofo, err := of(cliCtx)
 		if err != nil {

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -59,7 +59,7 @@ func TestNodeClose_OK(t *testing.T) {
 		WithDataColumnStorage(filesystem.NewEphemeralDataColumnStorage(t)),
 	}
 
-	node, err := New(ctx, cancel, options...)
+	node, err := New(ctx, cancel, nil, options...)
 	require.NoError(t, err)
 
 	node.Close()
@@ -87,7 +87,7 @@ func TestNodeStart_Ok(t *testing.T) {
 		WithDataColumnStorage(filesystem.NewEphemeralDataColumnStorage(t)),
 	}
 
-	node, err := New(ctx, cancel, options...)
+	node, err := New(ctx, cancel, nil, options...)
 	require.NoError(t, err)
 	require.NotNil(t, node.lcStore)
 	node.services = &runtime.ServiceRegistry{}
@@ -116,7 +116,7 @@ func TestNodeStart_SyncChecker(t *testing.T) {
 		WithDataColumnStorage(filesystem.NewEphemeralDataColumnStorage(t)),
 	}
 
-	node, err := New(ctx, cancel, options...)
+	node, err := New(ctx, cancel, nil, options...)
 	require.NoError(t, err)
 	go func() {
 		node.Start()
@@ -151,7 +151,7 @@ func TestClearDB(t *testing.T) {
 		WithDataColumnStorage(filesystem.NewEphemeralDataColumnStorage(t)),
 	}
 
-	_, err = New(context, cancel, options...)
+	_, err = New(context, cancel, nil, options...)
 	require.NoError(t, err)
 	require.LogsContain(t, hook, "Removing database")
 }

--- a/changelog/aarshkshah1992_set-beacon-node-options.md
+++ b/changelog/aarshkshah1992_set-beacon-node-options.md
@@ -1,0 +1,3 @@
+### Added
+
+- Set beacon node options after reading the config file.

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -367,17 +367,8 @@ func startNode(ctx *cli.Context, cancel context.CancelFunc) error {
 		backfill.BeaconNodeOptions,
 		das.BeaconNodeOptions,
 	}
-	for _, of := range optFuncs {
-		ofo, err := of(ctx)
-		if err != nil {
-			return err
-		}
-		if ofo != nil {
-			opts = append(opts, ofo...)
-		}
-	}
 
-	beacon, err := node.New(ctx, cancel, opts...)
+	beacon, err := node.New(ctx, cancel, optFuncs, opts...)
 	if err != nil {
 		return fmt.Errorf("unable to start beacon node: %w", err)
 	}


### PR DESCRIPTION


**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR ensures that we set the beacon node options AFTER reading the config file (if one is given to override the defaults).

**Which issues(s) does this PR fix?**
It fixes the issue that Barnabas reported around the "MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS"  override not being respected (and potentially other issues resulting from setting the options before reading the config).

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
