### PR TITLE
Fix/pruner checkpoint update order

### DIFF
--- a/beacon-chain/db/pruner/pruner.go
+++ b/beacon-chain/db/pruner/pruner.go
@@ -169,13 +169,13 @@ func (p *Service) prune(slot primitives.Slot) error {
 
 	earliestAvailableSlot := pruneUpto + 1
 
-	// Update pruning checkpoint.
-	p.prunedUpto = pruneUpto
-
 	// Update the earliest available slot after pruning
 	if err := p.updateEarliestAvailableSlot(earliestAvailableSlot); err != nil {
 		return errors.Wrap(err, "update earliest available slot")
 	}
+
+	// Update pruning checkpoint only after earliest available slot is successfully updated.
+	p.prunedUpto = pruneUpto
 
 	log.WithFields(logrus.Fields{
 		"prunedUpto":            pruneUpto,

--- a/beacon-chain/db/pruner/pruner_test.go
+++ b/beacon-chain/db/pruner/pruner_test.go
@@ -366,6 +366,10 @@ func TestPruner_UpdateEarliestSlotError(t *testing.T) {
 	// Should have called UpdateEarliestAvailableSlot
 	assert.Equal(t, 1, mockCustody.updateCallCount, "UpdateEarliestAvailableSlot should be called")
 
+	// prunedUpto must NOT advance when updateEarliestAvailableSlot fails,
+	// so the pruner retries on the next tick instead of skipping.
+	assert.Equal(t, primitives.Slot(0), p.prunedUpto, "prunedUpto should not advance when updateEarliestAvailableSlot fails")
+
 	// Check that error was logged by the prune function
 	found := false
 	for _, entry := range hook.AllEntries() {

--- a/changelog/MozirDmitriy_fix-pruner-checkpoint.md
+++ b/changelog/MozirDmitriy_fix-pruner-checkpoint.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Update prunedUpto only after successful metadata persist


### PR DESCRIPTION
Previously, `p.prunedUpto` was advanced before [updateEarliestAvailableSlot]https://github.com/OffchainLabs/prysm/blob/db2bb5505cc4364072900fdf1b75e262931f9f45/beacon-chain/db/pruner/pruner.go#L192-L210
was called. If the metadata update failed (e.g. due to a disk I/O error), the pruner would skip retrying because `prunedUpto` already indicated the range was handled. This left a window where data was deleted but the p2p layer still advertised the old `earliestAvailableSlot` in StatusV2 messages, potentially causing peers to request non-existent data.

Moved the `prunedUpto` assignment after [updateEarliestAvailableSlot] sothat on failure the pruner naturally retries on the next epoch tick. Added a regression assertion to the existing error-path test.