### PR TITLE
fix: replace errors.Wrapf(nil) with errors.Errorf in version fallback branches

### DIFF
--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -99,7 +99,7 @@ func (s *Service) ComputeValidatorPerformance(
 		}
 		validatorSummary = vp
 	} else {
-		return nil, &RpcError{Err: errors.Wrapf(err, "head state version %d not supported", headState.Version()), Reason: Internal}
+		return nil, &RpcError{Err: errors.Errorf("head state version %d not supported", headState.Version()), Reason: Internal}
 	}
 
 	responseCap := len(req.Indices) + len(req.PublicKeys)
@@ -273,7 +273,7 @@ func (s *Service) IndividualVotes(
 		}
 	} else {
 		return nil, &RpcError{
-			Err:    errors.Wrapf(err, "invalid state type retrieved with a version of %d", st.Version()),
+			Err:    errors.Errorf("invalid state type retrieved with a version of %d", st.Version()),
 			Reason: Internal,
 		}
 	}

--- a/changelog/Forostovec_fix-nil-err.md
+++ b/changelog/Forostovec_fix-nil-err.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- replace errors.Wrapf(nil) with errors.Errorf in version fallback branches [#16343](https://github.com/OffchainLabs/prysm/pull/16343)


### PR DESCRIPTION
 `ComputeValidatorPerformance` and `IndividualVotes` in validator.go use `errors.Wrapf(err, ...)` in defensive else branches where err is always nil. `pkg/errors.Wrapf(nil, ...)` returns nil, so `RpcError.Err` becomes nil. Callers like validator_performance.go:41 do `rpcError.Err.Error()` on this — which is a nil pointer dereference panic.
Replaced `errors.Wrapf(err, ...)` with `errors.Errorf(...)` in two places (lines 102 and 276), matching the existing correct pattern already used in ValidatorParticipation (line 798) for the same version-switch logic.