### PR TITLE
fix(p2p): close UDP connection on createListener error paths

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -528,6 +528,15 @@ func (s *Service) createListener(
 		return nil, errors.Wrap(err, "could not listen to UDP")
 	}
 
+	success := false
+	defer func() {
+		if !success {
+			if err := conn.Close(); err != nil {
+				log.WithError(err).Error("Failed to close UDP connection")
+			}
+		}
+	}()
+
 	localNode, err := s.createLocalNode(
 		privKey,
 		ipAddr,
@@ -561,6 +570,7 @@ func (s *Service) createListener(
 		return nil, errors.Wrap(err, "could not listen to discV5")
 	}
 
+	success = true
 	return listener, nil
 }
 

--- a/changelog/VolodymyrBg_fix-leak.md
+++ b/changelog/VolodymyrBg_fix-leak.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- close UDP connection on createListener error paths [#16348](https://github.com/OffchainLabs/prysm/pull/16348)


### PR DESCRIPTION
## Why

`createListener`https://github.com/OffchainLabs/prysm/blob/bb0f70ad60aca8b8a5d3b146b896f1a24dd07e18/tools/bootnode/bootnode.go#L135-L170 opens a UDP socket via `net.ListenUDP` but doesn't close it if any subsequent step fails `createLocalNode`https://github.com/OffchainLabs/prysm/blob/bb0f70ad60aca8b8a5d3b146b896f1a24dd07e18/tools/bootnode/bootnode.go#L191-L243, bootnode parsing, or `discover.ListenV5`. go-ethereum's `ListenV5` only takes ownership of the
connection on success — on error, it does not close it. This leaks a bound UDP socket on every failure, including repeated calls from `RebootListener`https://github.com/OffchainLabs/prysm/blob/bb0f70ad60aca8b8a5d3b146b896f1a24dd07e18/beacon-chain/p2p/discovery.go#L34-L37

## What

Add a deferred `conn.Close()` guarded by a success flag so the socket is released on any error path, while ownership still transfers to `UDPv5` on success.