### PR TITLE
avoid copying the finalized state when computing cgc

### DIFF
--- a/beacon-chain/core/peerdas/validator.go
+++ b/beacon-chain/core/peerdas/validator.go
@@ -73,18 +73,18 @@ func PopulateFromSidecar(sidecar blocks.VerifiedRODataColumn) *SidecarReconstruc
 
 // ValidatorsCustodyRequirement returns the number of custody groups regarding the validator indices attached to the beacon node.
 // https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/validator.md#validator-custody
-func ValidatorsCustodyRequirement(state beaconState.ReadOnlyBeaconState, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
+func ValidatorsCustodyRequirement(finalized beaconState.ReadOnlyBalances, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
 	totalNodeBalance := uint64(0)
+	cfg := params.BeaconConfig()
 	for index := range validatorsIndex {
-		validator, err := state.ValidatorAtIndexReadOnly(index)
+		bal, err := finalized.BalanceAtIndex(index)
 		if err != nil {
 			return 0, errors.Wrapf(err, "validator at index %v", index)
 		}
 
-		totalNodeBalance += validator.EffectiveBalance()
+		totalNodeBalance += min(uint64(bal), cfg.MaxEffectiveBalance)
 	}
 
-	cfg := params.BeaconConfig()
 	numberOfCustodyGroups := cfg.NumberOfCustodyGroups
 	validatorCustodyRequirement := cfg.ValidatorCustodyRequirement
 	balancePerAdditionalCustodyGroup := cfg.BalancePerAdditionalCustodyGroup

--- a/beacon-chain/core/peerdas/validator.go
+++ b/beacon-chain/core/peerdas/validator.go
@@ -74,22 +74,21 @@ func PopulateFromSidecar(sidecar blocks.VerifiedRODataColumn) *SidecarReconstruc
 // ValidatorsCustodyRequirement returns the number of custody groups regarding the validator indices attached to the beacon node.
 // https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/validator.md#validator-custody
 func ValidatorsCustodyRequirement(finalized beaconState.ReadOnlyBalances, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
-	totalNodeBalance := uint64(0)
 	cfg := params.BeaconConfig()
+	idxs := make([]primitives.ValidatorIndex, 0, len(validatorsIndex))
 	for index := range validatorsIndex {
-		bal, err := finalized.BalanceAtIndex(index)
-		if err != nil {
-			return 0, errors.Wrapf(err, "validator at index %v", index)
-		}
-
-		totalNodeBalance += min(uint64(bal), cfg.MaxEffectiveBalance)
+		idxs = append(idxs, index)
+	}
+	totalBalance, _, err := finalized.EffectiveBalances(idxs)
+	if err != nil {
+		return 0, errors.Wrap(err, "effective balances")
 	}
 
 	numberOfCustodyGroups := cfg.NumberOfCustodyGroups
 	validatorCustodyRequirement := cfg.ValidatorCustodyRequirement
 	balancePerAdditionalCustodyGroup := cfg.BalancePerAdditionalCustodyGroup
 
-	count := totalNodeBalance / balancePerAdditionalCustodyGroup
+	count := totalBalance / balancePerAdditionalCustodyGroup
 	return min(max(count, validatorCustodyRequirement), numberOfCustodyGroups), nil
 }
 

--- a/beacon-chain/core/peerdas/validator.go
+++ b/beacon-chain/core/peerdas/validator.go
@@ -79,7 +79,7 @@ func ValidatorsCustodyRequirement(st beaconState.ReadOnlyBalances, validatorsInd
 	for index := range validatorsIndex {
 		idxs = append(idxs, index)
 	}
-	totalBalance, _, err := st.EffectiveBalances(idxs)
+	totalBalance, err := st.EffectiveBalanceSum(idxs)
 	if err != nil {
 		return 0, errors.Wrap(err, "effective balances")
 	}

--- a/beacon-chain/core/peerdas/validator.go
+++ b/beacon-chain/core/peerdas/validator.go
@@ -73,13 +73,13 @@ func PopulateFromSidecar(sidecar blocks.VerifiedRODataColumn) *SidecarReconstruc
 
 // ValidatorsCustodyRequirement returns the number of custody groups regarding the validator indices attached to the beacon node.
 // https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/validator.md#validator-custody
-func ValidatorsCustodyRequirement(finalized beaconState.ReadOnlyBalances, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
+func ValidatorsCustodyRequirement(st beaconState.ReadOnlyBalances, validatorsIndex map[primitives.ValidatorIndex]bool) (uint64, error) {
 	cfg := params.BeaconConfig()
 	idxs := make([]primitives.ValidatorIndex, 0, len(validatorsIndex))
 	for index := range validatorsIndex {
 		idxs = append(idxs, index)
 	}
-	totalBalance, _, err := finalized.EffectiveBalances(idxs)
+	totalBalance, _, err := st.EffectiveBalances(idxs)
 	if err != nil {
 		return 0, errors.Wrap(err, "effective balances")
 	}

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -152,6 +152,7 @@ type ReadOnlyBalances interface {
 	Balances() []uint64
 	BalanceAtIndex(idx primitives.ValidatorIndex) (uint64, error)
 	BalancesLength() int
+	EffectiveBalances([]primitives.ValidatorIndex) (uint64, []uint64, error)
 }
 
 // ReadOnlyCheckpoint defines a struct which only has read access to checkpoint methods.

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -152,7 +152,7 @@ type ReadOnlyBalances interface {
 	Balances() []uint64
 	BalanceAtIndex(idx primitives.ValidatorIndex) (uint64, error)
 	BalancesLength() int
-	EffectiveBalances([]primitives.ValidatorIndex) (uint64, []uint64, error)
+	EffectiveBalanceSum([]primitives.ValidatorIndex) (uint64, error)
 }
 
 // ReadOnlyCheckpoint defines a struct which only has read access to checkpoint methods.

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
+	"github.com/pkg/errors"
 )
 
 // Validators participating in consensus on the beacon chain.
@@ -89,11 +90,11 @@ func (b *BeaconState) EffectiveBalances(idxs []primitives.ValidatorIndex) (uint6
 	var sum uint64
 	for i := range idxs {
 		if b.validatorsMultiValue == nil {
-			return 0, nil, state.ErrNilValidatorsInState
+			return 0, nil, errors.Wrap(state.ErrNilValidatorsInState, "nil validators multi-value slice")
 		}
 		v, err := b.validatorsMultiValue.At(b, uint64(idxs[i]))
 		if err != nil {
-			return 0, nil, err
+			return 0, nil, errors.Wrap(err, "validators multi value at index")
 		}
 		balances[i] = v.EffectiveBalance
 		sum += v.EffectiveBalance

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -80,6 +80,27 @@ func (b *BeaconState) ValidatorAtIndex(idx primitives.ValidatorIndex) (*ethpb.Va
 	return b.validatorAtIndex(idx)
 }
 
+// EffectiveBalances returns the sum of the effective balances of the given list of validator indices, the eb of each given validator, or an
+// error if one of the indices is out of bounds, or the state wasn't correctly initialized.
+func (b *BeaconState) EffectiveBalances(idxs []primitives.ValidatorIndex) (uint64, []uint64, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+	balances := make([]uint64, len(idxs))
+	var sum uint64
+	for i := range idxs {
+		if b.validatorsMultiValue == nil {
+			return 0, nil, state.ErrNilValidatorsInState
+		}
+		v, err := b.validatorsMultiValue.At(b, uint64(idxs[i]))
+		if err != nil {
+			return 0, nil, err
+		}
+		balances[i] = v.EffectiveBalance
+		sum += v.EffectiveBalance
+	}
+	return sum, balances, nil
+}
+
 func (b *BeaconState) validatorAtIndex(idx primitives.ValidatorIndex) (*ethpb.Validator, error) {
 	if b.validatorsMultiValue == nil {
 		return &ethpb.Validator{}, nil

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -83,23 +83,21 @@ func (b *BeaconState) ValidatorAtIndex(idx primitives.ValidatorIndex) (*ethpb.Va
 
 // EffectiveBalances returns the sum of the effective balances of the given list of validator indices, the eb of each given validator, or an
 // error if one of the indices is out of bounds, or the state wasn't correctly initialized.
-func (b *BeaconState) EffectiveBalances(idxs []primitives.ValidatorIndex) (uint64, []uint64, error) {
+func (b *BeaconState) EffectiveBalanceSum(idxs []primitives.ValidatorIndex) (uint64, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	balances := make([]uint64, len(idxs))
 	var sum uint64
 	for i := range idxs {
 		if b.validatorsMultiValue == nil {
-			return 0, nil, errors.Wrap(state.ErrNilValidatorsInState, "nil validators multi-value slice")
+			return 0, errors.Wrap(state.ErrNilValidatorsInState, "nil validators multi-value slice")
 		}
 		v, err := b.validatorsMultiValue.At(b, uint64(idxs[i]))
 		if err != nil {
-			return 0, nil, errors.Wrap(err, "validators multi value at index")
+			return 0, errors.Wrap(err, "validators multi value at index")
 		}
-		balances[i] = v.EffectiveBalance
 		sum += v.EffectiveBalance
 	}
-	return sum, balances, nil
+	return sum, nil
 }
 
 func (b *BeaconState) validatorAtIndex(idx primitives.ValidatorIndex) (*ethpb.Validator, error) {

--- a/beacon-chain/state/stategen/mock/mock.go
+++ b/beacon-chain/state/stategen/mock/mock.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stategen"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 )
 
@@ -13,6 +14,8 @@ type StateManager struct {
 	StatesByRoot map[[32]byte]state.BeaconState
 	StatesBySlot map[primitives.Slot]state.BeaconState
 }
+
+var _ stategen.StateManager = (*StateManager)(nil)
 
 // NewService --
 func NewService() *StateManager {
@@ -100,4 +103,9 @@ func (m *StateManager) AddStateForSlot(state state.BeaconState, slot primitives.
 // DeleteStateFromCaches --
 func (m *StateManager) DeleteStateFromCaches(context.Context, [32]byte) error {
 	return nil
+}
+
+// FinalizedReadOnlyBalances --
+func (m *StateManager) FinalizedReadOnlyBalances() stategen.NilCheckableReadOnlyBalances {
+	panic("unimplemented")
 }

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -27,6 +27,11 @@ var defaultHotStateDBInterval primitives.Slot = 128
 
 var populatePubkeyCacheOnce sync.Once
 
+type NilCheckableReadOnlyBalances interface {
+	state.ReadOnlyBalances
+	IsNil() bool
+}
+
 // StateManager represents a management object that handles the internal
 // logic of maintaining both hot and cold states in DB.
 type StateManager interface {
@@ -43,6 +48,7 @@ type StateManager interface {
 	ActiveNonSlashedBalancesByRoot(context.Context, [32]byte) ([]uint64, error)
 	StateByRootIfCachedNoCopy(blockRoot [32]byte) state.BeaconState
 	StateByRootInitialSync(ctx context.Context, blockRoot [32]byte) (state.BeaconState, error)
+	FinalizedReadOnlyBalances() NilCheckableReadOnlyBalances
 }
 
 // State is a concrete implementation of StateManager.
@@ -200,4 +206,9 @@ func (s *State) FinalizedState() state.BeaconState {
 	s.finalizedInfo.lock.RLock()
 	defer s.finalizedInfo.lock.RUnlock()
 	return s.finalizedInfo.state.Copy()
+}
+
+// Returns the finalized state as a ReadOnlyBalances so that it can be used read-only without copying.
+func (s *State) FinalizedReadOnlyBalances() NilCheckableReadOnlyBalances {
+	return s.finalizedInfo.state
 }

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -27,6 +27,8 @@ var defaultHotStateDBInterval primitives.Slot = 128
 
 var populatePubkeyCacheOnce sync.Once
 
+// NilCheckableReadOnlyBalances adds the IsNil method to ReadOnlyBalances
+// to allow checking if the underlying state value is nil.
 type NilCheckableReadOnlyBalances interface {
 	state.ReadOnlyBalances
 	IsNil() bool

--- a/beacon-chain/sync/custody.go
+++ b/beacon-chain/sync/custody.go
@@ -185,7 +185,7 @@ func (s *Service) validatorsCustodyRequirement() (uint64, error) {
 	}
 
 	// Retrieve the finalized state.
-	finalizedState := s.cfg.stateGen.FinalizedState()
+	finalizedState := s.cfg.stateGen.FinalizedReadOnlyBalances()
 	if finalizedState == nil || finalizedState.IsNil() {
 		return 0, nilFinalizedStateError
 	}

--- a/changelog/kasey_copy-free-balance-lookup.md
+++ b/changelog/kasey_copy-free-balance-lookup.md
@@ -1,0 +1,2 @@
+### Fixed
+- Avoid copying the full finalized state every time we compute cgc.


### PR DESCRIPTION
Reviewing some (unrelated) sync code today I noticed that we are using a stategen accessor for the finalized state which copies the entire state object to look up validator balances to compute the custody_group_count. This excess memory allocation is likely causing GC pressure and increasing memory utilization.

This PR avoids state copying for this purpose by making the following changes:
- Adds a new method to the `ReadOnlyBalances` state interface: `EffectiveBalances([]primitives.ValidatorIndex) (uint64, []uint64, error)`. This method computes returns the sum of the effective balances of the given list of validator indices, a list with the individual effective balance of each requested index (where the i-th element in the return corresponds to the i-th element of the parameter), and an error - which is necessary due to index bounds checks and quirks of multi-value slice that can apparently result in the state being unusable for such lookups if not correctly initialized.
- Adds a new method to the stategen interface `FinalizedReadOnlyBalances`, which returns the finalized state asserted to the `ReadOnlyBalances` interface.
- Switches the peerdas code to use the sum given by `EffectiveBalances`.

There was some existing nil checking code in the peerdas package that I didn't want to modify, so I added a new compound interface in stategen to allow the returned state to also expose the `IsNil` method.

fixes https://github.com/OffchainLabs/prysm/issues/16354