### PR TITLE
Gloas/forkchoice gloas weights

### DIFF
--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -429,9 +429,9 @@ func Test_NotifyForkchoiceUpdateRecursive_DoublyLinkedTree(t *testing.T) {
 
 	// Insert Attestations to D, F and G so that they have higher weight than D
 	// Ensure G is head
-	fcs.ProcessAttestation(ctx, []uint64{0}, brd, 1)
-	fcs.ProcessAttestation(ctx, []uint64{1}, brf, 1)
-	fcs.ProcessAttestation(ctx, []uint64{2}, brg, 1)
+	fcs.ProcessAttestation(ctx, []uint64{0}, brd, 1, true)
+	fcs.ProcessAttestation(ctx, []uint64{1}, brf, 1, true)
+	fcs.ProcessAttestation(ctx, []uint64{2}, brg, 1, true)
 	fcs.SetBalancesByRooter(service.cfg.StateGen.ActiveNonSlashedBalancesByRoot)
 	jc := &forkchoicetypes.Checkpoint{Epoch: 0, Root: bra}
 	require.NoError(t, fcs.UpdateJustifiedCheckpoint(ctx, jc))

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -429,9 +429,9 @@ func Test_NotifyForkchoiceUpdateRecursive_DoublyLinkedTree(t *testing.T) {
 
 	// Insert Attestations to D, F and G so that they have higher weight than D
 	// Ensure G is head
-	fcs.ProcessAttestation(ctx, []uint64{0}, brd, 1, true)
-	fcs.ProcessAttestation(ctx, []uint64{1}, brf, 1, true)
-	fcs.ProcessAttestation(ctx, []uint64{2}, brg, 1, true)
+	fcs.ProcessAttestation(ctx, []uint64{0}, brd, params.BeaconConfig().SlotsPerEpoch, true)
+	fcs.ProcessAttestation(ctx, []uint64{1}, brf, params.BeaconConfig().SlotsPerEpoch, true)
+	fcs.ProcessAttestation(ctx, []uint64{2}, brg, params.BeaconConfig().SlotsPerEpoch, true)
 	fcs.SetBalancesByRooter(service.cfg.StateGen.ActiveNonSlashedBalancesByRoot)
 	jc := &forkchoicetypes.Checkpoint{Epoch: 0, Root: bra}
 	require.NoError(t, fcs.UpdateJustifiedCheckpoint(ctx, jc))

--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -96,7 +96,11 @@ func (s *Service) OnAttestation(ctx context.Context, a ethpb.Att, disparity time
 	// We assume trusted attestation in this function has verified signature.
 
 	// Update forkchoice store with the new attestation for updating weight.
-	s.cfg.ForkChoiceStore.ProcessAttestation(ctx, indexedAtt.GetAttestingIndices(), bytesutil.ToBytes32(a.GetData().BeaconBlockRoot), a.GetData().Target.Epoch)
-
+	attData := a.GetData()
+	payloadStatus := true
+	if attData.Target.Epoch >= params.BeaconConfig().GloasForkEpoch {
+		payloadStatus = attData.CommitteeIndex == 1
+	}
+	s.cfg.ForkChoiceStore.ProcessAttestation(ctx, indexedAtt.GetAttestingIndices(), bytesutil.ToBytes32(attData.BeaconBlockRoot), attData.Slot, payloadStatus)
 	return nil
 }

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -402,7 +402,11 @@ func (s *Service) handleBlockAttestations(ctx context.Context, blk interfaces.Re
 		}
 		r := bytesutil.ToBytes32(a.GetData().BeaconBlockRoot)
 		if s.cfg.ForkChoiceStore.HasNode(r) {
-			s.cfg.ForkChoiceStore.ProcessAttestation(ctx, indices, r, a.GetData().Target.Epoch)
+			payloadStatus := true
+			if a.GetData().Target.Epoch >= params.BeaconConfig().GloasForkEpoch {
+				payloadStatus = a.GetData().CommitteeIndex == 1
+			}
+			s.cfg.ForkChoiceStore.ProcessAttestation(ctx, indices, r, a.GetData().Slot, payloadStatus)
 		} else if features.Get().EnableExperimentalAttestationPool {
 			if err = s.cfg.AttestationCache.Add(a); err != nil {
 				return err

--- a/beacon-chain/forkchoice/doubly-linked-tree/ffg_update_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/ffg_update_test.go
@@ -161,7 +161,7 @@ func TestFFGUpdates_TwoBranches(t *testing.T) {
 	//               7   8
 	//               |   |
 	//               9  10
-	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(1), 0)
+	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(1), 0, true)
 
 	// With the additional vote to the left branch, the head should be 9:
 	//           0  <-- start
@@ -191,7 +191,7 @@ func TestFFGUpdates_TwoBranches(t *testing.T) {
 	//               7   8
 	//               |   |
 	//               9  10
-	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(2), 0)
+	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(2), 0, true)
 
 	// With the additional vote to the right branch, the head should be 10:
 	//           0  <-- start

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -428,15 +428,23 @@ func (f *ForkChoice) InsertSlashedIndex(_ context.Context, index primitives.Vali
 		return
 	}
 
-	node, ok := f.store.emptyNodeByRoot[f.votes[index].currentRoot]
-	if !ok || node == nil {
+	v := f.votes[index]
+	pn, pending := f.store.resolveVoteNode(v.currentRoot, v.currentSlot, v.currentPayloadStatus)
+	if pn == nil {
 		return
 	}
-
-	if node.balance < f.balances[index] {
-		node.balance = 0
+	if pending {
+		if pn.node.balance < f.balances[index] {
+			pn.node.balance = 0
+		} else {
+			pn.node.balance -= f.balances[index]
+		}
+		return
+	}
+	if pn.balance < f.balances[index] {
+		pn.balance = 0
 	} else {
-		node.balance -= f.balances[index]
+		pn.balance -= f.balances[index]
 	}
 }
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -80,24 +80,25 @@ func (f *ForkChoice) Head(
 
 // ProcessAttestation processes attestation for vote accounting, it iterates around validator indices
 // and update their votes accordingly.
-func (f *ForkChoice) ProcessAttestation(ctx context.Context, validatorIndices []uint64, blockRoot [32]byte, targetEpoch primitives.Epoch) {
+func (f *ForkChoice) ProcessAttestation(ctx context.Context, validatorIndices []uint64, blockRoot [32]byte, slot primitives.Slot, payloadStatus bool) {
 	_, span := trace.StartSpan(ctx, "doublyLinkedForkchoice.ProcessAttestation")
 	defer span.End()
 
 	for _, index := range validatorIndices {
 		// Validator indices will grow the vote cache.
+		newVote := false
 		for index >= uint64(len(f.votes)) {
 			f.votes = append(f.votes, Vote{currentRoot: params.BeaconConfig().ZeroHash, nextRoot: params.BeaconConfig().ZeroHash})
+			newVote = true
 		}
 
-		// Newly allocated vote if the root fields are untouched.
-		newVote := f.votes[index].nextRoot == params.BeaconConfig().ZeroHash &&
-			f.votes[index].currentRoot == params.BeaconConfig().ZeroHash
-
 		// Vote gets updated if it's newly allocated or high target epoch.
-		if newVote || targetEpoch > f.votes[index].nextEpoch {
-			f.votes[index].nextEpoch = targetEpoch
+		targetEpoch := slots.ToEpoch(slot)
+		nextEpoch := slots.ToEpoch(f.votes[index].nextSlot)
+		if newVote || targetEpoch > nextEpoch {
+			f.votes[index].nextSlot = slot
 			f.votes[index].nextRoot = blockRoot
+			f.votes[index].nextPayloadStatus = payloadStatus
 		}
 	}
 
@@ -311,40 +312,57 @@ func (f *ForkChoice) updateBalances() error {
 		if vote.currentRoot != vote.nextRoot || oldBalance != newBalance {
 			// Ignore the vote if the root is not in fork choice
 			// store, that means we have not seen the block before.
-			nextNode, ok := f.store.emptyNodeByRoot[vote.nextRoot]
-			if ok && vote.nextRoot != zHash {
-				// Protection against nil node
-				if nextNode == nil {
-					return errors.Wrap(ErrNilNode, "could not update balances")
-				}
-				nextNode.balance += newBalance
+			pn, pending := f.store.resolveVoteNode(vote.nextRoot, vote.nextSlot, vote.nextPayloadStatus)
+			if pn == nil {
+				// TODO: check cl-spec #4918
+				continue
+			}
+			if pending {
+				pn.node.balance += newBalance
+			} else {
+				pn.balance += newBalance
 			}
 
-			currentNode, ok := f.store.emptyNodeByRoot[vote.currentRoot]
-			if ok && vote.currentRoot != zHash {
-				// Protection against nil node
-				if currentNode == nil {
-					return errors.Wrap(ErrNilNode, "could not update balances")
-				}
-				if currentNode.balance < oldBalance {
+			pn, pending = f.store.resolveVoteNode(vote.currentRoot, vote.currentSlot, vote.currentPayloadStatus)
+			if pn == nil {
+				continue
+			}
+			if pending {
+				if pn.node.balance < oldBalance {
 					log.WithFields(logrus.Fields{
 						"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
 						"oldBalance":                 oldBalance,
-						"nodeBalance":                currentNode.balance,
-						"nodeWeight":                 currentNode.weight,
+						"nodeBalance":                pn.node.balance,
+						"nodeWeight":                 pn.node.weight,
 						"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
 						"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
 						"previousProposerBoostScore": f.store.previousProposerBoostScore,
 					}).Warning("node with invalid balance, setting it to zero")
-					currentNode.balance = 0
+					pn.node.balance = 0
 				} else {
-					currentNode.balance -= oldBalance
+					pn.node.balance -= oldBalance
+				}
+			} else {
+				if pn.balance < oldBalance {
+					log.WithFields(logrus.Fields{
+						"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
+						"oldBalance":                 oldBalance,
+						"nodeBalance":                pn.balance,
+						"nodeWeight":                 pn.weight,
+						"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
+						"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
+						"previousProposerBoostScore": f.store.previousProposerBoostScore,
+					}).Warning("node with invalid balance, setting it to zero")
+					pn.balance = 0
+				} else {
+					pn.balance -= oldBalance
 				}
 			}
 		}
-
 		// Rotate the validator vote.
 		f.votes[index].currentRoot = vote.nextRoot
+		f.votes[index].currentSlot = vote.nextSlot
+		f.votes[index].currentPayloadStatus = vote.nextPayloadStatus
 	}
 	f.balances = newBalances
 	return nil

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -309,7 +309,7 @@ func (f *ForkChoice) updateBalances() error {
 		}
 
 		// Update only if the validator's balance or vote has changed.
-		if vote.currentRoot != vote.nextRoot || oldBalance != newBalance {
+		if vote.currentRoot != vote.nextRoot || oldBalance != newBalance || vote.currentPayloadStatus != vote.nextPayloadStatus {
 			// Add new balance to the next vote target if the root is known.
 			pn, pending := f.store.resolveVoteNode(vote.nextRoot, vote.nextSlot, vote.nextPayloadStatus)
 			if pn != nil && vote.nextRoot != zHash {

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -310,52 +310,49 @@ func (f *ForkChoice) updateBalances() error {
 
 		// Update only if the validator's balance or vote has changed.
 		if vote.currentRoot != vote.nextRoot || oldBalance != newBalance {
-			// Ignore the vote if the root is not in fork choice
-			// store, that means we have not seen the block before.
+			// Add new balance to the next vote target if the root is known.
 			pn, pending := f.store.resolveVoteNode(vote.nextRoot, vote.nextSlot, vote.nextPayloadStatus)
-			if pn == nil {
-				// TODO: check cl-spec #4918
-				continue
-			}
-			if pending {
-				pn.node.balance += newBalance
-			} else {
-				pn.balance += newBalance
+			if pn != nil && vote.nextRoot != zHash {
+				if pending {
+					pn.node.balance += newBalance
+				} else {
+					pn.balance += newBalance
+				}
 			}
 
+			// Subtract old balance from the current vote target if the root is known.
 			pn, pending = f.store.resolveVoteNode(vote.currentRoot, vote.currentSlot, vote.currentPayloadStatus)
-			if pn == nil {
-				continue
-			}
-			if pending {
-				if pn.node.balance < oldBalance {
-					log.WithFields(logrus.Fields{
-						"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
-						"oldBalance":                 oldBalance,
-						"nodeBalance":                pn.node.balance,
-						"nodeWeight":                 pn.node.weight,
-						"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
-						"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
-						"previousProposerBoostScore": f.store.previousProposerBoostScore,
-					}).Warning("node with invalid balance, setting it to zero")
-					pn.node.balance = 0
+			if pn != nil && vote.currentRoot != zHash {
+				if pending {
+					if pn.node.balance < oldBalance {
+						log.WithFields(logrus.Fields{
+							"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
+							"oldBalance":                 oldBalance,
+							"nodeBalance":                pn.node.balance,
+							"nodeWeight":                 pn.node.weight,
+							"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
+							"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
+							"previousProposerBoostScore": f.store.previousProposerBoostScore,
+						}).Warning("node with invalid balance, setting it to zero")
+						pn.node.balance = 0
+					} else {
+						pn.node.balance -= oldBalance
+					}
 				} else {
-					pn.node.balance -= oldBalance
-				}
-			} else {
-				if pn.balance < oldBalance {
-					log.WithFields(logrus.Fields{
-						"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
-						"oldBalance":                 oldBalance,
-						"nodeBalance":                pn.balance,
-						"nodeWeight":                 pn.weight,
-						"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
-						"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
-						"previousProposerBoostScore": f.store.previousProposerBoostScore,
-					}).Warning("node with invalid balance, setting it to zero")
-					pn.balance = 0
-				} else {
-					pn.balance -= oldBalance
+					if pn.balance < oldBalance {
+						log.WithFields(logrus.Fields{
+							"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
+							"oldBalance":                 oldBalance,
+							"nodeBalance":                pn.balance,
+							"nodeWeight":                 pn.weight,
+							"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
+							"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
+							"previousProposerBoostScore": f.store.previousProposerBoostScore,
+						}).Warning("node with invalid balance, setting it to zero")
+						pn.balance = 0
+					} else {
+						pn.balance -= oldBalance
+					}
 				}
 			}
 		}

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -93,9 +93,9 @@ func TestForkChoice_UpdateBalancesPositiveChange(t *testing.T) {
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 
 	f.votes = []Vote{
-		{indexToHash(1), indexToHash(1), 0},
-		{indexToHash(2), indexToHash(2), 0},
-		{indexToHash(3), indexToHash(3), 0},
+		{indexToHash(1), indexToHash(1), 0, 0, true, true},
+		{indexToHash(2), indexToHash(2), 0, 0, true, true},
+		{indexToHash(3), indexToHash(3), 0, 0, true, true},
 	}
 
 	// Each node gets one unique vote. The weight should look like 103 <- 102 <- 101 because
@@ -127,9 +127,9 @@ func TestForkChoice_UpdateBalancesNegativeChange(t *testing.T) {
 
 	f.balances = []uint64{100, 100, 100}
 	f.votes = []Vote{
-		{indexToHash(1), indexToHash(1), 0},
-		{indexToHash(2), indexToHash(2), 0},
-		{indexToHash(3), indexToHash(3), 0},
+		{indexToHash(1), indexToHash(1), 0, 0, true, true},
+		{indexToHash(2), indexToHash(2), 0, 0, true, true},
+		{indexToHash(3), indexToHash(3), 0, 0, true, true},
 	}
 
 	f.justifiedBalances = []uint64{10, 20, 30}
@@ -158,9 +158,9 @@ func TestForkChoice_UpdateBalancesUnderflow(t *testing.T) {
 
 	f.balances = []uint64{125, 125, 125}
 	f.votes = []Vote{
-		{indexToHash(1), indexToHash(1), 0},
-		{indexToHash(2), indexToHash(2), 0},
-		{indexToHash(3), indexToHash(3), 0},
+		{indexToHash(1), indexToHash(1), 0, 0, true, true},
+		{indexToHash(2), indexToHash(2), 0, 0, true, true},
+		{indexToHash(3), indexToHash(3), 0, 0, true, true},
 	}
 
 	f.justifiedBalances = []uint64{10, 20, 30}
@@ -332,8 +332,8 @@ func TestForkChoice_RemoveEquivocating(t *testing.T) {
 	require.Equal(t, [32]byte{'c'}, head)
 
 	// Insert two attestations for block b, one for c it becomes head
-	f.ProcessAttestation(ctx, []uint64{1, 2}, [32]byte{'b'}, 1)
-	f.ProcessAttestation(ctx, []uint64{3}, [32]byte{'c'}, 1)
+	f.ProcessAttestation(ctx, []uint64{1, 2}, [32]byte{'b'}, 1, true)
+	f.ProcessAttestation(ctx, []uint64{3}, [32]byte{'c'}, 1, true)
 	f.justifiedBalances = []uint64{100, 200, 200, 300}
 	head, err = f.Head(ctx)
 	require.NoError(t, err)

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -103,9 +103,9 @@ func TestForkChoice_UpdateBalancesPositiveChange(t *testing.T) {
 	f.justifiedBalances = []uint64{10, 20, 30}
 	require.NoError(t, f.updateBalances())
 	s := f.store
-	assert.Equal(t, uint64(10), s.emptyNodeByRoot[indexToHash(1)].balance)
-	assert.Equal(t, uint64(20), s.emptyNodeByRoot[indexToHash(2)].balance)
-	assert.Equal(t, uint64(30), s.emptyNodeByRoot[indexToHash(3)].balance)
+	assert.Equal(t, uint64(10), s.fullNodeByRoot[indexToHash(1)].balance)
+	assert.Equal(t, uint64(20), s.fullNodeByRoot[indexToHash(2)].balance)
+	assert.Equal(t, uint64(30), s.fullNodeByRoot[indexToHash(3)].balance)
 }
 
 func TestForkChoice_UpdateBalancesNegativeChange(t *testing.T) {
@@ -121,9 +121,9 @@ func TestForkChoice_UpdateBalancesNegativeChange(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 	s := f.store
-	s.emptyNodeByRoot[indexToHash(1)].balance = 100
-	s.emptyNodeByRoot[indexToHash(2)].balance = 100
-	s.emptyNodeByRoot[indexToHash(3)].balance = 100
+	s.fullNodeByRoot[indexToHash(1)].balance = 100
+	s.fullNodeByRoot[indexToHash(2)].balance = 100
+	s.fullNodeByRoot[indexToHash(3)].balance = 100
 
 	f.balances = []uint64{100, 100, 100}
 	f.votes = []Vote{
@@ -134,9 +134,9 @@ func TestForkChoice_UpdateBalancesNegativeChange(t *testing.T) {
 
 	f.justifiedBalances = []uint64{10, 20, 30}
 	require.NoError(t, f.updateBalances())
-	assert.Equal(t, uint64(10), s.emptyNodeByRoot[indexToHash(1)].balance)
-	assert.Equal(t, uint64(20), s.emptyNodeByRoot[indexToHash(2)].balance)
-	assert.Equal(t, uint64(30), s.emptyNodeByRoot[indexToHash(3)].balance)
+	assert.Equal(t, uint64(10), s.fullNodeByRoot[indexToHash(1)].balance)
+	assert.Equal(t, uint64(20), s.fullNodeByRoot[indexToHash(2)].balance)
+	assert.Equal(t, uint64(30), s.fullNodeByRoot[indexToHash(3)].balance)
 }
 
 func TestForkChoice_UpdateBalancesUnderflow(t *testing.T) {
@@ -152,9 +152,9 @@ func TestForkChoice_UpdateBalancesUnderflow(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 	s := f.store
-	s.emptyNodeByRoot[indexToHash(1)].balance = 100
-	s.emptyNodeByRoot[indexToHash(2)].balance = 100
-	s.emptyNodeByRoot[indexToHash(3)].balance = 100
+	s.fullNodeByRoot[indexToHash(1)].balance = 100
+	s.fullNodeByRoot[indexToHash(2)].balance = 100
+	s.fullNodeByRoot[indexToHash(3)].balance = 100
 
 	f.balances = []uint64{125, 125, 125}
 	f.votes = []Vote{
@@ -165,9 +165,9 @@ func TestForkChoice_UpdateBalancesUnderflow(t *testing.T) {
 
 	f.justifiedBalances = []uint64{10, 20, 30}
 	require.NoError(t, f.updateBalances())
-	assert.Equal(t, uint64(0), s.emptyNodeByRoot[indexToHash(1)].balance)
-	assert.Equal(t, uint64(0), s.emptyNodeByRoot[indexToHash(2)].balance)
-	assert.Equal(t, uint64(5), s.emptyNodeByRoot[indexToHash(3)].balance)
+	assert.Equal(t, uint64(0), s.fullNodeByRoot[indexToHash(1)].balance)
+	assert.Equal(t, uint64(0), s.fullNodeByRoot[indexToHash(2)].balance)
+	assert.Equal(t, uint64(5), s.fullNodeByRoot[indexToHash(3)].balance)
 }
 
 func TestForkChoice_IsCanonical(t *testing.T) {
@@ -332,8 +332,8 @@ func TestForkChoice_RemoveEquivocating(t *testing.T) {
 	require.Equal(t, [32]byte{'c'}, head)
 
 	// Insert two attestations for block b, one for c it becomes head
-	f.ProcessAttestation(ctx, []uint64{1, 2}, [32]byte{'b'}, 1, true)
-	f.ProcessAttestation(ctx, []uint64{3}, [32]byte{'c'}, 1, true)
+	f.ProcessAttestation(ctx, []uint64{1, 2}, [32]byte{'b'}, params.BeaconConfig().SlotsPerEpoch, true)
+	f.ProcessAttestation(ctx, []uint64{3}, [32]byte{'c'}, params.BeaconConfig().SlotsPerEpoch, true)
 	f.justifiedBalances = []uint64{100, 200, 200, 300}
 	head, err = f.Head(ctx)
 	require.NoError(t, err)
@@ -341,21 +341,21 @@ func TestForkChoice_RemoveEquivocating(t *testing.T) {
 
 	// Process b's slashing, c is now head
 	f.InsertSlashedIndex(ctx, 1)
-	require.Equal(t, uint64(200), f.store.emptyNodeByRoot[[32]byte{'b'}].balance)
+	require.Equal(t, uint64(200), f.store.fullNodeByRoot[[32]byte{'b'}].balance)
 	f.justifiedBalances = []uint64{100, 200, 200, 300}
 	head, err = f.Head(ctx)
-	require.Equal(t, uint64(200), f.store.emptyNodeByRoot[[32]byte{'b'}].weight)
-	require.Equal(t, uint64(300), f.store.emptyNodeByRoot[[32]byte{'c'}].weight)
+	require.Equal(t, uint64(200), f.store.fullNodeByRoot[[32]byte{'b'}].weight)
+	require.Equal(t, uint64(300), f.store.fullNodeByRoot[[32]byte{'c'}].weight)
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'c'}, head)
 
 	// Process b's slashing again, should be a noop
 	f.InsertSlashedIndex(ctx, 1)
-	require.Equal(t, uint64(200), f.store.emptyNodeByRoot[[32]byte{'b'}].balance)
+	require.Equal(t, uint64(200), f.store.fullNodeByRoot[[32]byte{'b'}].balance)
 	f.justifiedBalances = []uint64{100, 200, 200, 300}
 	head, err = f.Head(ctx)
-	require.Equal(t, uint64(200), f.store.emptyNodeByRoot[[32]byte{'b'}].weight)
-	require.Equal(t, uint64(300), f.store.emptyNodeByRoot[[32]byte{'c'}].weight)
+	require.Equal(t, uint64(200), f.store.fullNodeByRoot[[32]byte{'b'}].weight)
+	require.Equal(t, uint64(300), f.store.fullNodeByRoot[[32]byte{'c'}].weight)
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'c'}, head)
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -322,7 +322,7 @@ func (f *ForkChoice) updateNewFullNodeWeight(fn *PayloadNode) {
 			fn.balance += f.balances[index]
 		}
 	}
-	fn.balance = fn.weight
+	fn.weight = fn.balance
 }
 
 func (s *Store) resolveVoteNode(r [32]byte, slot primitives.Slot, payloadStatus bool) (*PayloadNode, bool) {

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -312,5 +312,29 @@ func (f *ForkChoice) InsertPayload(pe interfaces.ROExecutionPayloadEnvelope) err
 		children:   make([]*Node, 0),
 	}
 	s.fullNodeByRoot[root] = fn
+	f.updateNewFullNodeWeight(fn)
 	return nil
+}
+
+func (f *ForkChoice) updateNewFullNodeWeight(fn *PayloadNode) {
+	for index, vote := range f.votes {
+		if vote.currentRoot == fn.node.root && vote.nextPayloadStatus && index < len(f.balances) {
+			fn.balance += f.balances[index]
+		}
+	}
+	fn.balance = fn.weight
+}
+
+func (s *Store) resolveVoteNode(r [32]byte, slot primitives.Slot, payloadStatus bool) (*PayloadNode, bool) {
+	en := s.emptyNodeByRoot[r]
+	if en == nil {
+		return nil, true
+	}
+	if payloadStatus {
+		return s.fullNodeByRoot[r], false
+	} else if slot == en.node.slot {
+		return en, true
+	} else {
+		return en, false
+	}
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -325,6 +325,8 @@ func (f *ForkChoice) updateNewFullNodeWeight(fn *PayloadNode) {
 	fn.weight = fn.balance
 }
 
+// resolveVoteNode returns the node that should receive the balance of a vote. It returns always a PayloadNode, but the boolean indicates
+// whether the vote should be applied to the pending node (true) or not.
 func (s *Store) resolveVoteNode(r [32]byte, slot primitives.Slot, payloadStatus bool) (*PayloadNode, bool) {
 	en := s.emptyNodeByRoot[r]
 	if en == nil {

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -334,9 +334,6 @@ func (s *Store) resolveVoteNode(r [32]byte, slot primitives.Slot, payloadStatus 
 	}
 	if payloadStatus {
 		return s.fullNodeByRoot[r], false
-	} else if slot == en.node.slot {
-		return en, true
-	} else {
-		return en, false
 	}
+	return en, slot == en.node.slot
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/proposer_boost_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/proposer_boost_test.go
@@ -64,7 +64,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NoError(t, f.InsertNode(ctx, state, blkRoot))
-		f.ProcessAttestation(ctx, []uint64{0}, newRoot, fEpoch)
+		f.ProcessAttestation(ctx, []uint64{0}, newRoot, primitives.Slot(fEpoch), true)
 		headRoot, err = f.Head(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, newRoot, headRoot, "Incorrect head for justified epoch at slot 1")
@@ -90,7 +90,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NoError(t, f.InsertNode(ctx, state, blkRoot))
-		f.ProcessAttestation(ctx, []uint64{1}, newRoot, fEpoch)
+		f.ProcessAttestation(ctx, []uint64{1}, newRoot, primitives.Slot(fEpoch), true)
 		headRoot, err = f.Head(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, newRoot, headRoot, "Incorrect head for justified epoch at slot 2")
@@ -118,7 +118,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NoError(t, f.InsertNode(ctx, state, blkRoot))
-		f.ProcessAttestation(ctx, []uint64{2}, newRoot, fEpoch)
+		f.ProcessAttestation(ctx, []uint64{2}, newRoot, primitives.Slot(fEpoch), true)
 		headRoot, err = f.Head(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, newRoot, headRoot, "Incorrect head for justified epoch at slot 3")
@@ -147,7 +147,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NoError(t, f.InsertNode(ctx, state, blkRoot))
-		f.ProcessAttestation(ctx, []uint64{3}, newRoot, fEpoch)
+		f.ProcessAttestation(ctx, []uint64{3}, newRoot, primitives.Slot(fEpoch), true)
 		headRoot, err = f.Head(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, newRoot, headRoot, "Incorrect head for justified epoch at slot 3")
@@ -177,7 +177,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 
 		// Regression: process attestations for C, check that it
 		// becomes head, we need two attestations to have C.weight = 30 > 24 = D.weight
-		f.ProcessAttestation(ctx, []uint64{4, 5}, indexToHash(3), fEpoch)
+		f.ProcessAttestation(ctx, []uint64{4, 5}, indexToHash(3), primitives.Slot(fEpoch), true)
 		headRoot, err = f.Head(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, indexToHash(3), headRoot, "Incorrect head for justified epoch at slot 4")
@@ -238,10 +238,10 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 
 		// The maliciously withheld block has one vote.
 		votes := []uint64{1}
-		f.ProcessAttestation(ctx, votes, maliciouslyWithheldBlock, fEpoch)
+		f.ProcessAttestation(ctx, votes, maliciouslyWithheldBlock, primitives.Slot(fEpoch), true)
 		// The honest block has one vote.
 		votes = []uint64{2}
-		f.ProcessAttestation(ctx, votes, honestBlock, fEpoch)
+		f.ProcessAttestation(ctx, votes, honestBlock, primitives.Slot(fEpoch), true)
 
 		// Ensure the head is STILL C, the honest block, as the honest block had proposer boost.
 		r, err = f.Head(ctx)
@@ -307,7 +307,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 		// An attestation is received for B that has more voting power than C with the proposer boost,
 		// allowing B to then become the head if their attestation has enough adversarial votes.
 		votes := []uint64{1, 2}
-		f.ProcessAttestation(ctx, votes, maliciouslyWithheldBlock, fEpoch)
+		f.ProcessAttestation(ctx, votes, maliciouslyWithheldBlock, primitives.Slot(fEpoch), true)
 
 		// Expect the head to have switched to B.
 		r, err = f.Head(ctx)
@@ -382,7 +382,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 
 		// An attestation for C is received at slot N+3.
 		votes := []uint64{1}
-		f.ProcessAttestation(ctx, votes, c, fEpoch)
+		f.ProcessAttestation(ctx, votes, c, primitives.Slot(fEpoch), true)
 
 		// A block D, building on B, is received at slot N+3. It should not be able to win without boosting.
 		dSlot := primitives.Slot(3)
@@ -422,7 +422,7 @@ func TestForkChoice_BoostProposerRoot_PreventsExAnteAttack(t *testing.T) {
 		require.NoError(t, f.InsertNode(ctx, state, blkRoot))
 
 		votes = []uint64{2}
-		f.ProcessAttestation(ctx, votes, d2, fEpoch)
+		f.ProcessAttestation(ctx, votes, d2, primitives.Slot(fEpoch), true)
 		// Ensure D becomes the head thanks to boosting.
 		r, err = f.Head(ctx)
 		require.NoError(t, err)

--- a/beacon-chain/forkchoice/doubly-linked-tree/reorg_late_blocks_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/reorg_late_blocks_test.go
@@ -26,7 +26,7 @@ func TestForkChoice_ShouldOverrideFCU(t *testing.T) {
 	for i := range attesters {
 		attesters[i] = uint64(i + 64)
 	}
-	f.ProcessAttestation(ctx, attesters, blk.Root(), 0)
+	f.ProcessAttestation(ctx, attesters, blk.Root(), 0, true)
 
 	orphanLateBlockFirstThreshold := time.Duration(params.BeaconConfig().SecondsPerSlot/params.BeaconConfig().IntervalsPerSlot) * time.Second
 	driftGenesisTime(f, 2, orphanLateBlockFirstThreshold+time.Second)
@@ -124,7 +124,7 @@ func TestForkChoice_GetProposerHead(t *testing.T) {
 	for i := range attesters {
 		attesters[i] = uint64(i + 64)
 	}
-	f.ProcessAttestation(ctx, attesters, blk.Root(), 0)
+	f.ProcessAttestation(ctx, attesters, blk.Root(), 0, true)
 
 	driftGenesisTime(f, 3, 1*time.Second)
 	childRoot := [32]byte{'b'}

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -78,7 +78,10 @@ type PayloadNode struct {
 
 // Vote defines an individual validator's vote.
 type Vote struct {
-	currentRoot [fieldparams.RootLength]byte // current voting root.
-	nextRoot    [fieldparams.RootLength]byte // next voting root.
-	nextEpoch   primitives.Epoch             // epoch of next voting period.
+	currentRoot          [fieldparams.RootLength]byte // current voting root.
+	nextRoot             [fieldparams.RootLength]byte // next voting root.
+	nextSlot             primitives.Slot              // slot of the next voting period.
+	currentSlot          primitives.Slot              // slot of the current voting period.
+	nextPayloadStatus    bool                         // whether the next vote is for a full or empty payload
+	currentPayloadStatus bool                         // whether the current vote is for a full or empty payload
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification_test.go
@@ -76,7 +76,7 @@ func TestStore_LongFork(t *testing.T) {
 	require.NoError(t, f.store.setUnrealizedJustifiedEpoch([32]byte{'c'}, 2))
 
 	// Add an attestation to c, it is head
-	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'c'}, 1, true)
+	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'c'}, params.BeaconConfig().SlotsPerEpoch, true)
 	f.justifiedBalances = []uint64{100}
 	c := f.store.emptyNodeByRoot[[32]byte{'c'}]
 	require.Equal(t, primitives.Epoch(2), slots.ToEpoch(c.node.slot))
@@ -98,8 +98,8 @@ func TestStore_LongFork(t *testing.T) {
 	headRoot, err = f.Head(ctx)
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'c'}, headRoot)
-	require.Equal(t, uint64(0), f.store.emptyNodeByRoot[[32]byte{'d'}].weight)
-	require.Equal(t, uint64(100), f.store.emptyNodeByRoot[[32]byte{'c'}].weight)
+	require.Equal(t, uint64(0), f.store.emptyNodeByRoot[[32]byte{'d'}].node.weight)
+	require.Equal(t, uint64(100), f.store.emptyNodeByRoot[[32]byte{'c'}].node.weight)
 }
 
 //	Epoch 1                Epoch 2               Epoch 3
@@ -153,7 +153,7 @@ func TestStore_NoDeadLock(t *testing.T) {
 	require.NoError(t, f.store.setUnrealizedJustifiedEpoch([32]byte{'h'}, 2))
 	require.NoError(t, f.store.setUnrealizedFinalizedEpoch([32]byte{'h'}, 1))
 	// Add an attestation for h
-	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, 1, true)
+	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, params.BeaconConfig().SlotsPerEpoch, true)
 
 	// Epoch 3
 	// Current Head is H
@@ -225,7 +225,7 @@ func TestStore_ForkNextEpoch(t *testing.T) {
 	require.NoError(t, f.InsertNode(ctx, state, blkRoot))
 
 	// Insert an attestation to H, H is head
-	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, 1, true)
+	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, params.BeaconConfig().SlotsPerEpoch, true)
 	f.justifiedBalances = []uint64{100}
 	headRoot, err := f.Head(ctx)
 	require.NoError(t, err)
@@ -243,8 +243,8 @@ func TestStore_ForkNextEpoch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'d'}, headRoot)
 	require.Equal(t, primitives.Epoch(2), f.JustifiedCheckpoint().Epoch)
-	require.Equal(t, uint64(0), f.store.emptyNodeByRoot[[32]byte{'d'}].weight)
-	require.Equal(t, uint64(100), f.store.emptyNodeByRoot[[32]byte{'h'}].weight)
+	require.Equal(t, uint64(0), f.store.emptyNodeByRoot[[32]byte{'d'}].node.weight)
+	require.Equal(t, uint64(100), f.store.emptyNodeByRoot[[32]byte{'h'}].node.weight)
 	// Set current epoch to 3, and H's unrealized checkpoint. Check it's head
 	driftGenesisTime(f, 99, 0)
 	require.NoError(t, f.store.setUnrealizedJustifiedEpoch([32]byte{'h'}, 2))
@@ -252,8 +252,8 @@ func TestStore_ForkNextEpoch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'h'}, headRoot)
 	require.Equal(t, primitives.Epoch(2), f.JustifiedCheckpoint().Epoch)
-	require.Equal(t, uint64(0), f.store.emptyNodeByRoot[[32]byte{'d'}].weight)
-	require.Equal(t, uint64(100), f.store.emptyNodeByRoot[[32]byte{'h'}].weight)
+	require.Equal(t, uint64(0), f.store.emptyNodeByRoot[[32]byte{'d'}].node.weight)
+	require.Equal(t, uint64(100), f.store.emptyNodeByRoot[[32]byte{'h'}].node.weight)
 }
 
 func TestStore_PullTips_Heuristics(t *testing.T) {

--- a/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification_test.go
@@ -76,7 +76,7 @@ func TestStore_LongFork(t *testing.T) {
 	require.NoError(t, f.store.setUnrealizedJustifiedEpoch([32]byte{'c'}, 2))
 
 	// Add an attestation to c, it is head
-	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'c'}, 1)
+	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'c'}, 1, true)
 	f.justifiedBalances = []uint64{100}
 	c := f.store.emptyNodeByRoot[[32]byte{'c'}]
 	require.Equal(t, primitives.Epoch(2), slots.ToEpoch(c.node.slot))
@@ -153,7 +153,7 @@ func TestStore_NoDeadLock(t *testing.T) {
 	require.NoError(t, f.store.setUnrealizedJustifiedEpoch([32]byte{'h'}, 2))
 	require.NoError(t, f.store.setUnrealizedFinalizedEpoch([32]byte{'h'}, 1))
 	// Add an attestation for h
-	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, 1)
+	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, 1, true)
 
 	// Epoch 3
 	// Current Head is H
@@ -225,7 +225,7 @@ func TestStore_ForkNextEpoch(t *testing.T) {
 	require.NoError(t, f.InsertNode(ctx, state, blkRoot))
 
 	// Insert an attestation to H, H is head
-	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, 1)
+	f.ProcessAttestation(ctx, []uint64{0}, [32]byte{'h'}, 1, true)
 	f.justifiedBalances = []uint64{100}
 	headRoot, err := f.Head(ctx)
 	require.NoError(t, err)

--- a/beacon-chain/forkchoice/doubly-linked-tree/vote_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/vote_test.go
@@ -46,7 +46,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//            0
 	//           / \
 	//          2  1 <- +vote, new head
-	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(1), 2, true)
+	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(1), 2*params.BeaconConfig().SlotsPerEpoch, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(1), r, "Incorrect head for with justified epoch at 1")
@@ -55,7 +55,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//                     0
 	//                    / \
 	// vote, new head -> 2  1
-	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(2), 2, true)
+	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(2), 2*params.BeaconConfig().SlotsPerEpoch, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(2), r, "Incorrect head for with justified epoch at 1")
@@ -80,7 +80,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//  head -> 2  1 <- old vote
 	//             |
 	//             3 <- new vote
-	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(3), 3, true)
+	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(3), 3*params.BeaconConfig().SlotsPerEpoch, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(2), r, "Incorrect head for with justified epoch at 1")
@@ -91,7 +91,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	// old vote -> 2  1 <- new vote
 	//                |
 	//                3 <- head
-	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(1), 3, true)
+	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(1), 3*params.BeaconConfig().SlotsPerEpoch, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(3), r, "Incorrect head for with justified epoch at 1")
@@ -150,7 +150,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	assert.Equal(t, indexToHash(6), r, "Incorrect head for with justified epoch at 3")
 
 	// Moved 2 votes to block 5:
-	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(5), 4, true)
+	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(5), 4*params.BeaconConfig().SlotsPerEpoch, true)
 
 	// Inset blocks 7 and 8
 	// 6 should still be the head, even though 5 has all the votes.
@@ -227,7 +227,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 
 	// Move two votes for 10, verify it's head
 
-	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(10), 5, true)
+	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(10), 5*params.BeaconConfig().SlotsPerEpoch, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(10), r, "Incorrect head for with justified epoch at 3")
@@ -235,7 +235,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	// Add 3 more validators to the system.
 	f.justifiedBalances = []uint64{1, 1, 1, 1, 1}
 	// The new validators voted for 9
-	f.ProcessAttestation(t.Context(), []uint64{2, 3, 4}, indexToHash(9), 5, true)
+	f.ProcessAttestation(t.Context(), []uint64{2, 3, 4}, indexToHash(9), 5*params.BeaconConfig().SlotsPerEpoch, true)
 	// The new head should be 9.
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)

--- a/beacon-chain/forkchoice/doubly-linked-tree/vote_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/vote_test.go
@@ -46,7 +46,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//            0
 	//           / \
 	//          2  1 <- +vote, new head
-	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(1), 2)
+	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(1), 2, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(1), r, "Incorrect head for with justified epoch at 1")
@@ -55,7 +55,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//                     0
 	//                    / \
 	// vote, new head -> 2  1
-	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(2), 2)
+	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(2), 2, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(2), r, "Incorrect head for with justified epoch at 1")
@@ -80,7 +80,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//  head -> 2  1 <- old vote
 	//             |
 	//             3 <- new vote
-	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(3), 3)
+	f.ProcessAttestation(t.Context(), []uint64{0}, indexToHash(3), 3, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(2), r, "Incorrect head for with justified epoch at 1")
@@ -91,7 +91,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	// old vote -> 2  1 <- new vote
 	//                |
 	//                3 <- head
-	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(1), 3)
+	f.ProcessAttestation(t.Context(), []uint64{1}, indexToHash(1), 3, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(3), r, "Incorrect head for with justified epoch at 1")
@@ -150,7 +150,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	assert.Equal(t, indexToHash(6), r, "Incorrect head for with justified epoch at 3")
 
 	// Moved 2 votes to block 5:
-	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(5), 4)
+	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(5), 4, true)
 
 	// Inset blocks 7 and 8
 	// 6 should still be the head, even though 5 has all the votes.
@@ -227,7 +227,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 
 	// Move two votes for 10, verify it's head
 
-	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(10), 5)
+	f.ProcessAttestation(t.Context(), []uint64{0, 1}, indexToHash(10), 5, true)
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(10), r, "Incorrect head for with justified epoch at 3")
@@ -235,7 +235,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	// Add 3 more validators to the system.
 	f.justifiedBalances = []uint64{1, 1, 1, 1, 1}
 	// The new validators voted for 9
-	f.ProcessAttestation(t.Context(), []uint64{2, 3, 4}, indexToHash(9), 5)
+	f.ProcessAttestation(t.Context(), []uint64{2, 3, 4}, indexToHash(9), 5, true)
 	// The new head should be 9.
 	r, err = f.Head(t.Context())
 	require.NoError(t, err)

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -56,7 +56,7 @@ type PayloadProcessor interface {
 
 // AttestationProcessor processes the attestation that's used for accounting fork choice.
 type AttestationProcessor interface {
-	ProcessAttestation(context.Context, []uint64, [32]byte, primitives.Epoch)
+	ProcessAttestation(context.Context, []uint64, [32]byte, primitives.Slot, bool)
 }
 
 // Getter returns fork choice related information.

--- a/changelog/potuz_gloas_attestation_payload_status.md
+++ b/changelog/potuz_gloas_attestation_payload_status.md
@@ -1,0 +1,2 @@
+### Added
+- Process Gloas attestations in forkchoice.

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -141,7 +141,8 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 	if c.Head != nil {
 		r, err := bb.service.HeadRoot(ctx)
 		require.NoError(t, err)
-		require.Equal(t, true, bytes.Equal(common.FromHex(c.Head.Root), r))
+		wantedRoot := common.FromHex(c.Head.Root)
+		require.Equal(t, true, bytes.Equal(wantedRoot, r), fmt.Sprintf("Roots differ. wanted %#x, got %#x", wantedRoot, r))
 		require.Equal(t, primitives.Slot(c.Head.Slot), bb.service.HeadSlot())
 	}
 	if c.JustifiedCheckPoint != nil {

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -1,6 +1,7 @@
 package forkchoice
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -140,7 +141,7 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 	if c.Head != nil {
 		r, err := bb.service.HeadRoot(ctx)
 		require.NoError(t, err)
-		require.DeepEqual(t, common.FromHex(c.Head.Root), r)
+		require.Equal(t, true, bytes.Equal(common.FromHex(c.Head.Root), r))
 		require.Equal(t, primitives.Slot(c.Head.Slot), bb.service.HeadSlot())
 	}
 	if c.JustifiedCheckPoint != nil {


### PR DESCRIPTION
This PR changes attestation weight counting so that they are compatible with Gloas. 

Same slot attestations are added to the pending node, otherwise attestations are added to the full payload status node. This PR also deals with updating the balances and weight transfer. Notice that due to our current limitations on how we account for weights, we will mimic the spec status as if https://github.com/ethereum/consensus-specs/pull/4918 were merged. Counting for these attestations would be quite difficult otherwise in Prysm. 