### PR TITLE
Remove headstate from fcuArgs

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -136,7 +136,6 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *fcuConfig) (*
 				return nil, nil
 			}
 			pid, err := s.notifyForkchoiceUpdate(ctx, &fcuConfig{
-				headState:  st,
 				headRoot:   r,
 				headBlock:  b,
 				attributes: arg.attributes,

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -11,7 +11,6 @@ import (
 	mockExecution "github.com/OffchainLabs/prysm/v7/beacon-chain/execution/testing"
 	forkchoicetypes "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/types"
 	bstate "github.com/OffchainLabs/prysm/v7/beacon-chain/state"
-	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
 	"github.com/OffchainLabs/prysm/v7/config/features"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
@@ -73,11 +72,7 @@ func Test_NotifyForkchoiceUpdate_GetPayloadAttrErrorCanContinue(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, st, bellatrixBlkRoot))
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, bellatrixBlkRoot))
 
-	// Intentionally generate a bad state such that `hash_tree_root` fails during `process_slot`
-	s, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{})
-	require.NoError(t, err)
 	arg := &fcuConfig{
-		headState: s,
 		headRoot:  [32]byte{},
 		headBlock: b,
 	}
@@ -233,8 +228,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 			require.NoError(t, beaconDB.SaveState(ctx, st, tt.finalizedRoot))
 			require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, tt.finalizedRoot))
 			arg := &fcuConfig{
-				headState: st,
-				headRoot:  tt.headRoot,
+						headRoot:  tt.headRoot,
 				headBlock: tt.blk,
 			}
 			_, err = service.notifyForkchoiceUpdate(ctx, arg)
@@ -314,7 +308,6 @@ func Test_NotifyForkchoiceUpdate_NIlLVH(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, st, bra))
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, bra))
 	a := &fcuConfig{
-		headState: st,
 		headBlock: wbd,
 		headRoot:  brd,
 	}
@@ -452,7 +445,6 @@ func Test_NotifyForkchoiceUpdateRecursive_DoublyLinkedTree(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, st, bra))
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, bra))
 	a := &fcuConfig{
-		headState: st,
 		headBlock: wbg,
 		headRoot:  brg,
 	}

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -46,7 +46,6 @@ func (s *Service) getStateAndBlock(ctx context.Context, r [32]byte) (state.Beaco
 }
 
 type fcuConfig struct {
-	headState     state.BeaconState
 	headBlock     interfaces.ReadOnlySignedBeaconBlock
 	headRoot      [32]byte
 	proposingSlot primitives.Slot
@@ -64,7 +63,8 @@ func (s *Service) sendFCU(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) {
 		s.updateCachesPostBlockProcessing(cfg)
 		s.ForkChoicer().Lock()
 	}
-	if err := s.getFCUArgs(cfg, fcuArgs); err != nil {
+	headState, err := s.getFCUArgs(cfg, fcuArgs)
+	if err != nil {
 		log.WithError(err).Error("Could not get forkchoice update argument")
 		return
 	}
@@ -81,10 +81,10 @@ func (s *Service) sendFCU(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) {
 	}
 
 	if s.isNewHead(fcuArgs.headRoot) {
-		if err := s.saveHead(cfg.ctx, fcuArgs.headRoot, fcuArgs.headBlock, fcuArgs.headState); err != nil {
+		if err := s.saveHead(cfg.ctx, fcuArgs.headRoot, fcuArgs.headBlock, headState); err != nil {
 			log.WithError(err).Error("Could not save head")
 		}
-		s.pruneAttsFromPool(s.ctx, fcuArgs.headState, fcuArgs.headBlock)
+		s.pruneAttsFromPool(s.ctx, headState, fcuArgs.headBlock)
 	}
 }
 

--- a/beacon-chain/blockchain/forkchoice_update_execution_test.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution_test.go
@@ -92,7 +92,6 @@ func TestService_forkchoiceUpdateWithExecution_exceptionalCases(t *testing.T) {
 	}
 	service.cfg.PayloadIDCache.Set(2, [32]byte{2}, [8]byte{1})
 	args := &fcuConfig{
-		headState:     st,
 		headRoot:      r1,
 		headBlock:     wsb,
 		proposingSlot: service.CurrentSlot() + 1,
@@ -146,7 +145,6 @@ func TestService_forkchoiceUpdateWithExecution_SameHeadRootNewProposer(t *testin
 	service.head.state = st
 	service.cfg.PayloadIDCache.Set(service.CurrentSlot()+1, [32]byte{} /* root */, [8]byte{})
 	args := &fcuConfig{
-		headState:     st,
 		headBlock:     sb,
 		headRoot:      r,
 		proposingSlot: service.CurrentSlot() + 1,

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -170,7 +170,7 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 	// Forward an event capturing a new chain head over a common event feed
 	// done in a goroutine to avoid blocking the critical runtime main routine.
 	go func() {
-		if err := s.notifyNewHeadEvent(ctx, newHeadSlot, headState, newStateRoot[:], newHeadRoot[:]); err != nil {
+		if err := s.notifyNewHeadEvent(ctx, newHeadSlot, newStateRoot[:], newHeadRoot[:]); err != nil {
 			log.WithError(err).Error("Could not notify event feed of new chain head")
 		}
 	}()
@@ -322,7 +322,6 @@ func (s *Service) hasHeadState() bool {
 func (s *Service) notifyNewHeadEvent(
 	ctx context.Context,
 	newHeadSlot primitives.Slot,
-	newHeadState state.BeaconState,
 	newHeadStateRoot,
 	newHeadRoot []byte,
 ) error {

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -152,7 +152,6 @@ func TestSaveHead_Different_Reorg(t *testing.T) {
 
 func Test_notifyNewHeadEvent(t *testing.T) {
 	t.Run("genesis_state_root", func(t *testing.T) {
-		bState, _ := util.DeterministicGenesisState(t, 10)
 		srv := testServiceWithDB(t)
 		srv.SetGenesisTime(time.Now())
 		notifier := srv.cfg.StateNotifier.(*mock.MockStateNotifier)
@@ -165,7 +164,7 @@ func Test_notifyNewHeadEvent(t *testing.T) {
 		st, blk, err = prepareForkchoiceState(t.Context(), 1, newHeadRoot, [32]byte{}, [32]byte{}, &ethpb.Checkpoint{}, &ethpb.Checkpoint{})
 		require.NoError(t, err)
 		require.NoError(t, srv.cfg.ForkChoiceStore.InsertNode(t.Context(), st, blk))
-		require.NoError(t, srv.notifyNewHeadEvent(t.Context(), 1, bState, newHeadStateRoot[:], newHeadRoot[:]))
+		require.NoError(t, srv.notifyNewHeadEvent(t.Context(), 1, newHeadStateRoot[:], newHeadRoot[:]))
 		events := notifier.ReceivedEvents()
 		require.Equal(t, 1, len(events))
 
@@ -202,7 +201,7 @@ func Test_notifyNewHeadEvent(t *testing.T) {
 		st, blk, err = prepareForkchoiceState(t.Context(), 0, newHeadRoot, [32]byte{}, [32]byte{}, &ethpb.Checkpoint{}, &ethpb.Checkpoint{})
 		require.NoError(t, err)
 		require.NoError(t, srv.cfg.ForkChoiceStore.InsertNode(t.Context(), st, blk))
-		err = srv.notifyNewHeadEvent(t.Context(), epoch2Start, bState, newHeadStateRoot[:], newHeadRoot[:])
+		err = srv.notifyNewHeadEvent(t.Context(), epoch2Start, newHeadStateRoot[:], newHeadRoot[:])
 		require.NoError(t, err)
 		events := notifier.ReceivedEvents()
 		require.Equal(t, 1, len(events))
@@ -220,7 +219,6 @@ func Test_notifyNewHeadEvent(t *testing.T) {
 		require.DeepSSZEqual(t, wanted, eventHead)
 	})
 	t.Run("epoch transition", func(t *testing.T) {
-		bState, _ := util.DeterministicGenesisState(t, 10)
 		srv := testServiceWithDB(t)
 		srv.SetGenesisTime(time.Now())
 		notifier := srv.cfg.StateNotifier.(*mock.MockStateNotifier)
@@ -234,7 +232,7 @@ func Test_notifyNewHeadEvent(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, srv.cfg.ForkChoiceStore.InsertNode(t.Context(), st, blk))
 		newHeadSlot := params.BeaconConfig().SlotsPerEpoch
-		require.NoError(t, srv.notifyNewHeadEvent(t.Context(), newHeadSlot, bState, newHeadStateRoot[:], newHeadRoot[:]))
+		require.NoError(t, srv.notifyNewHeadEvent(t.Context(), newHeadSlot, newHeadStateRoot[:], newHeadRoot[:]))
 		events := notifier.ReceivedEvents()
 		require.Equal(t, 1, len(events))
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -970,7 +970,6 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	s.headLock.RUnlock()
 
 	fcuArgs := &fcuConfig{
-		headState:  headState,
 		headRoot:   headRoot,
 		headBlock:  headBlock,
 		attributes: attribute,

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -37,22 +37,24 @@ func (s *Service) CurrentSlot() primitives.Slot {
 	return slots.CurrentSlot(s.genesisTime)
 }
 
-// getFCUArgs returns the arguments to call forkchoice update
-func (s *Service) getFCUArgs(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) error {
-	if err := s.getFCUArgsEarlyBlock(cfg, fcuArgs); err != nil {
-		return err
+// getFCUArgs returns the arguments to call forkchoice update.
+// It returns the head state separately so it is not pinned by goroutines
+// that only need the fcuConfig for the engine call.
+func (s *Service) getFCUArgs(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) (state.BeaconState, error) {
+	headState, err := s.getFCUArgsEarlyBlock(cfg, fcuArgs)
+	if err != nil {
+		return nil, err
 	}
-	fcuArgs.attributes = s.getPayloadAttribute(cfg.ctx, fcuArgs.headState, fcuArgs.proposingSlot, cfg.headRoot[:])
-	return nil
+	fcuArgs.attributes = s.getPayloadAttribute(cfg.ctx, headState, fcuArgs.proposingSlot, cfg.headRoot[:])
+	return headState, nil
 }
 
-func (s *Service) getFCUArgsEarlyBlock(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) error {
+func (s *Service) getFCUArgsEarlyBlock(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) (state.BeaconState, error) {
 	if cfg.roblock.Root() == cfg.headRoot {
-		fcuArgs.headState = cfg.postState
 		fcuArgs.headBlock = cfg.roblock
 		fcuArgs.headRoot = cfg.headRoot
 		fcuArgs.proposingSlot = s.CurrentSlot() + 1
-		return nil
+		return cfg.postState, nil
 	}
 	return s.fcuArgsNonCanonicalBlock(cfg, fcuArgs)
 }
@@ -79,16 +81,15 @@ func (s *Service) logNonCanonicalBlockReceived(blockRoot [32]byte, headRoot [32]
 
 // fcuArgsNonCanonicalBlock returns the arguments to the FCU call when the
 // incoming block is non-canonical, that is, based on the head root.
-func (s *Service) fcuArgsNonCanonicalBlock(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) error {
+func (s *Service) fcuArgsNonCanonicalBlock(cfg *postBlockProcessConfig, fcuArgs *fcuConfig) (state.BeaconState, error) {
 	headState, headBlock, err := s.getStateAndBlock(cfg.ctx, cfg.headRoot)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	fcuArgs.headState = headState
 	fcuArgs.headBlock = headBlock
 	fcuArgs.headRoot = cfg.headRoot
 	fcuArgs.proposingSlot = s.CurrentSlot() + 1
-	return nil
+	return headState, nil
 }
 
 // sendStateFeedOnBlock sends an event that a new block has been synced

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2418,13 +2418,13 @@ func Test_getFCUArgs(t *testing.T) {
 	}
 	// error branch
 	fcuArgs := &fcuConfig{}
-	err = s.getFCUArgs(cfg, fcuArgs)
+	_, err = s.getFCUArgs(cfg, fcuArgs)
 	require.ErrorContains(t, "block does not exist", err)
 
 	// canonical branch
 	cfg.headRoot = cfg.roblock.Root()
 	fcuArgs = &fcuConfig{}
-	err = s.getFCUArgs(cfg, fcuArgs)
+	_, err = s.getFCUArgs(cfg, fcuArgs)
 	require.NoError(t, err)
 	require.Equal(t, cfg.roblock.Root(), fcuArgs.headRoot)
 }

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -150,7 +150,6 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 	}
 	newAttHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 	fcuArgs := &fcuConfig{
-		headState:     headState,
 		headRoot:      newHeadRoot,
 		headBlock:     headBlock,
 		proposingSlot: proposingSlot,
@@ -162,10 +161,10 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 		}
 		go s.forkchoiceUpdateWithExecution(s.ctx, fcuArgs)
 	}
-	if err := s.saveHead(s.ctx, fcuArgs.headRoot, fcuArgs.headBlock, fcuArgs.headState); err != nil {
+	if err := s.saveHead(s.ctx, newHeadRoot, headBlock, headState); err != nil {
 		log.WithError(err).Error("Could not save head")
 	}
-	s.pruneAttsFromPool(s.ctx, fcuArgs.headState, fcuArgs.headBlock)
+	s.pruneAttsFromPool(s.ctx, headState, headBlock)
 }
 
 // This processes fork choice attestations from the pool to account for validator votes and fork choice.

--- a/changelog/potuz_remove_headstate.md
+++ b/changelog/potuz_remove_headstate.md
@@ -1,0 +1,2 @@
+### Changed
+- Remove headState from fcuArgs.


### PR DESCRIPTION
Remove headState from fcuArgs to avoid pinning this state on long routines and remove it also from notifyNewPayload that didn't even use it. 