### PR TITLE
e2e: wait for all nodes to reach mid-epoch before head compare

### DIFF
--- a/beacon-chain/rpc/eth/config/handlers_test.go
+++ b/beacon-chain/rpc/eth/config/handlers_test.go
@@ -221,7 +221,7 @@ func TestGetSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
 	data, ok := resp.Data.(map[string]any)
 	require.Equal(t, true, ok)
-	assert.Equal(t, 194, len(data))
+	assert.Equal(t, 192, len(data))
 	for k, v := range data {
 		t.Run(k, func(t *testing.T) {
 			switch k {

--- a/beacon-chain/rpc/eth/config/handlers_test.go
+++ b/beacon-chain/rpc/eth/config/handlers_test.go
@@ -221,7 +221,7 @@ func TestGetSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
 	data, ok := resp.Data.(map[string]any)
 	require.Equal(t, true, ok)
-	assert.Equal(t, 192, len(data))
+	assert.Equal(t, 194, len(data))
 	for k, v := range data {
 		t.Run(k, func(t *testing.T) {
 			switch k {

--- a/changelog/codex_fix-allnodes-have-same-head-mid-epoch.md
+++ b/changelog/codex_fix-allnodes-have-same-head-mid-epoch.md
@@ -1,0 +1,2 @@
+### Fixed
+- Wait for all nodes to reach mid-epoch before comparing heads to avoid epoch-boundary flakiness in E2E sync checks.

--- a/testing/endtoend/evaluators/node.go
+++ b/testing/endtoend/evaluators/node.go
@@ -159,7 +159,7 @@ func waitForMidEpoch(conn *grpc.ClientConn) error {
 func allNodesHaveSameHead(_ *e2etypes.EvaluationContext, conns ...*grpc.ClientConn) error {
 	// Wait until we're at least halfway into the epoch to avoid race conditions
 	// at epoch boundaries where nodes may report different epochs.
-	if err := waitForMidEpoch(conns[0]); err != nil {
+	if err := waitForAllMidEpoch(conns...); err != nil {
 		return errors.Wrap(err, "failed waiting for mid-epoch")
 	}
 
@@ -239,4 +239,15 @@ func allNodesHaveSameHead(_ *e2etypes.EvaluationContext, conns ...*grpc.ClientCo
 	}
 
 	return nil
+}
+
+func waitForAllMidEpoch(conns ...*grpc.ClientConn) error {
+	g, _ := errgroup.WithContext(context.Background())
+	for _, conn := range conns {
+		currConn := conn
+		g.Go(func() error {
+			return waitForMidEpoch(currConn)
+		})
+	}
+	return g.Wait()
 }

--- a/testing/endtoend/evaluators/node.go
+++ b/testing/endtoend/evaluators/node.go
@@ -132,14 +132,17 @@ func finishedSyncing(_ *e2etypes.EvaluationContext, conns ...*grpc.ClientConn) e
 // waitForMidEpoch waits until we're at least halfway into the current epoch
 // and 3/4 into the current slot. This prevents race conditions at epoch
 // boundaries and slot boundaries where different nodes may report different heads.
-func waitForMidEpoch(conn *grpc.ClientConn) error {
+func waitForMidEpoch(ctx context.Context, conn *grpc.ClientConn) error {
 	beaconClient := eth.NewBeaconChainClient(conn)
 	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
 	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
 	midEpochSlot := slotsPerEpoch / 2
 
 	for {
-		chainHead, err := beaconClient.GetChainHead(context.Background(), &emptypb.Empty{})
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		chainHead, err := beaconClient.GetChainHead(ctx, &emptypb.Empty{})
 		if err != nil {
 			return err
 		}
@@ -147,19 +150,25 @@ func waitForMidEpoch(conn *grpc.ClientConn) error {
 		// If we're at least halfway into the epoch, we're safe
 		if slotInEpoch >= midEpochSlot {
 			// Wait 3/4 into the slot to ensure block propagation
-			time.Sleep(time.Duration(secondsPerSlot) * time.Second * 3 / 4)
+			if err := sleepWithContext(ctx, time.Duration(secondsPerSlot)*time.Second*3/4); err != nil {
+				return err
+			}
 			return nil
 		}
 		// Wait for the remaining slots until mid-epoch
 		slotsToWait := midEpochSlot - slotInEpoch
-		time.Sleep(time.Duration(slotsToWait) * time.Duration(secondsPerSlot) * time.Second)
+		if err := sleepWithContext(ctx, time.Duration(slotsToWait)*time.Duration(secondsPerSlot)*time.Second); err != nil {
+			return err
+		}
 	}
 }
 
 func allNodesHaveSameHead(_ *e2etypes.EvaluationContext, conns ...*grpc.ClientConn) error {
+	ctx, cancel := context.WithTimeout(context.Background(), params.EpochsDuration(2, params.BeaconConfig()))
+	defer cancel()
 	// Wait until we're at least halfway into the epoch to avoid race conditions
 	// at epoch boundaries where nodes may report different epochs.
-	if err := waitForAllMidEpoch(conns...); err != nil {
+	if err := waitForAllMidEpoch(ctx, conns...); err != nil {
 		return errors.Wrap(err, "failed waiting for mid-epoch")
 	}
 
@@ -241,13 +250,24 @@ func allNodesHaveSameHead(_ *e2etypes.EvaluationContext, conns ...*grpc.ClientCo
 	return nil
 }
 
-func waitForAllMidEpoch(conns ...*grpc.ClientConn) error {
-	g, _ := errgroup.WithContext(context.Background())
+func waitForAllMidEpoch(ctx context.Context, conns ...*grpc.ClientConn) error {
+	g, gctx := errgroup.WithContext(ctx)
 	for _, conn := range conns {
 		currConn := conn
 		g.Go(func() error {
-			return waitForMidEpoch(currConn)
+			return waitForMidEpoch(gctx, currConn)
 		})
 	}
 	return g.Wait()
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }


### PR DESCRIPTION
`AllNodesHaveSameHead` only waits for mid‑epoch on node 0. In `testCheckpointSync`, the checkpoint‑sync node can still be finishing syncing while node 0 advances, so the evaluator compares heads across different epochs and flakes. We should wait for all nodes to reach the same point before comparing head epochs and roots

I also added better handling for context timeout per feedback from @Inspector-Butters 