### PR TITLE
sync: remove unnecessary SignatureBatch.Copy() in batch verifier

### DIFF
--- a/beacon-chain/sync/batch_verifier.go
+++ b/beacon-chain/sync/batch_verifier.go
@@ -58,7 +58,7 @@ func (s *Service) validateWithBatchVerifier(ctx context.Context, message string,
 	defer span.End()
 
 	resChan := make(chan error)
-	verificationSet := &signatureVerifier{set: set.Copy(), resChan: resChan}
+	verificationSet := &signatureVerifier{set: set, resChan: resChan}
 	s.signatureChan <- verificationSet
 
 	resErr := <-resChan
@@ -85,10 +85,9 @@ func verifyBatch(verifierBatch []*signatureVerifier) {
 	if len(verifierBatch) == 0 {
 		return
 	}
-	aggSet := verifierBatch[0].set
-
-	for i := 1; i < len(verifierBatch); i++ {
-		aggSet = aggSet.Join(verifierBatch[i].set)
+	aggSet := bls.NewSet()
+	for _, v := range verifierBatch {
+		aggSet = aggSet.Join(v.set)
 	}
 	var verificationErr error
 

--- a/beacon-chain/sync/batch_verifier_test.go
+++ b/beacon-chain/sync/batch_verifier_test.go
@@ -86,3 +86,70 @@ func TestValidateWithBatchVerifier(t *testing.T) {
 		})
 	}
 }
+
+// Regression test: verifyBatch must not mutate caller-provided SignatureBatch sets.
+// Since validateWithBatchVerifier no longer copies the set, any mutation in the
+// aggregation/dedup path would corrupt the caller's data.
+func TestVerifyBatch_DoesNotMutateInputSets(t *testing.T) {
+	_, keys, err := util.DeterministicDepositsAndKeys(10)
+	assert.NoError(t, err)
+
+	msg1 := [32]byte{'A'}
+	msg2 := [32]byte{'B'}
+
+	sig0 := keys[0].Sign(msg1[:])
+	sig1 := keys[1].Sign(msg2[:])
+	sig2 := keys[2].Sign(msg1[:]) // Same message as sig0 — triggers AggregateBatch
+
+	set0 := &bls.SignatureBatch{
+		Messages:     [][32]byte{msg1},
+		PublicKeys:   []bls.PublicKey{keys[0].PublicKey()},
+		Signatures:   [][]byte{sig0.Marshal()},
+		Descriptions: []string{"sig0"},
+	}
+	set1 := &bls.SignatureBatch{
+		Messages:     [][32]byte{msg2},
+		PublicKeys:   []bls.PublicKey{keys[1].PublicKey()},
+		Signatures:   [][]byte{sig1.Marshal()},
+		Descriptions: []string{"sig1"},
+	}
+	set2 := &bls.SignatureBatch{
+		Messages:     [][32]byte{msg1},
+		PublicKeys:   []bls.PublicKey{keys[2].PublicKey()},
+		Signatures:   [][]byte{sig2.Marshal()},
+		Descriptions: []string{"sig2"},
+	}
+	// Duplicate of set0 to exercise RemoveDuplicates.
+	set3 := &bls.SignatureBatch{
+		Messages:     [][32]byte{msg1},
+		PublicKeys:   []bls.PublicKey{keys[0].PublicKey()},
+		Signatures:   [][]byte{sig0.Marshal()},
+		Descriptions: []string{"sig0-dup"},
+	}
+
+	// Snapshot original state.
+	orig0 := set0.Copy()
+	orig1 := set1.Copy()
+	orig2 := set2.Copy()
+	orig3 := set3.Copy()
+
+	batch := []*signatureVerifier{
+		{set: set0, resChan: make(chan error, 1)},
+		{set: set1, resChan: make(chan error, 1)},
+		{set: set2, resChan: make(chan error, 1)},
+		{set: set3, resChan: make(chan error, 1)},
+	}
+
+	verifyBatch(batch)
+
+	// Drain results — verification should succeed.
+	for _, v := range batch {
+		assert.NoError(t, <-v.resChan)
+	}
+
+	// Assert caller-provided sets were not mutated.
+	assert.DeepEqual(t, orig0, set0)
+	assert.DeepEqual(t, orig1, set1)
+	assert.DeepEqual(t, orig2, set2)
+	assert.DeepEqual(t, orig3, set3)
+}

--- a/changelog/pvl-go-rm-copy.md
+++ b/changelog/pvl-go-rm-copy.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed unnecessary copy of signature set from the verification pipeline.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This copy is unnecessary. There is no code path which mutates or would mutate the signature set. Some local profiling indicates this would reduce GC pressure somewhat. It was about 8.5% of the allocations on my mainnet node.

**Which issues(s) does this PR fix?**

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
