### PR TITLE
api: reduce gzip compression level

### DIFF
--- a/api/server/middleware/middleware.go
+++ b/api/server/middleware/middleware.go
@@ -92,7 +92,11 @@ func AcceptEncodingHeaderHandler() Middleware {
 				return
 			}
 
-			gz := gzip.NewWriter(w)
+			gz, err := gzip.NewWriterLevel(w, gzip.BestSpeed)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
 			gzipRW := &gzipResponseWriter{gz: gz, ResponseWriter: w}
 			defer func() {
 				if !gzipRW.zip {

--- a/changelog/pvl-gzip-best-speed.md
+++ b/changelog/pvl-gzip-best-speed.md
@@ -1,0 +1,3 @@
+### Changed 
+
+- Gzip compression for the API method to get all validators is changed to BestSpeed to reduce the burden on the beacon node. This is typically 4 to 6x faster compression with only a 15% larger output.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This is a small optimization on the GetValidators endpoint for the beacon API. The default compression level was [level 6](https://cs.opensource.google/go/go/+/refs/tags/go1.26.0:src/compress/flate/deflate.go;l=591) and best speed is level 1. When serving this endpoint, gzip was almost 40% of my CPU profile. 

**Which issues(s) does this PR fix?**

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
