### PR TITLE
Add DA check for Gloas

### DIFF
--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -68,6 +68,15 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 		return err
 	}
 
+	// DA check: verify data columns are available before inserting payload.
+	blk, err := s.cfg.BeaconDB.Block(ctx, root)
+	if err != nil {
+		return errors.Wrap(err, "could not retrieve block for DA check")
+	}
+	if err := s.areDataColumnsAvailable(ctx, root, blk.Block()); err != nil {
+		return errors.Wrap(err, "data availability check failed for payload envelope")
+	}
+
 	if err := s.savePostPayload(ctx, signed, preState); err != nil {
 		return err
 	}

--- a/changelog/potuz_gloas_DA_check.md
+++ b/changelog/potuz_gloas_DA_check.md
@@ -1,0 +1,2 @@
+### Added
+- Gloas DA check.


### PR DESCRIPTION
This is the simplest approach to check DA, but it requires getting the beacon block from DB. We could try to use a cache for the KZG commitments as an alternative. 