### PR TITLE
Fix Gloas builders sweep when builders list is empty

### DIFF
--- a/beacon-chain/state/state-native/getters_gloas.go
+++ b/beacon-chain/state/state-native/getters_gloas.go
@@ -545,7 +545,6 @@ func (b *BeaconState) appendBuildersSweepWithdrawals(withdrawalIndex uint64, wit
 
 	builderIndex := b.nextWithdrawalBuilderIndex
 	if buildersLimit == 0 {
-		*withdrawals = ws
 		return withdrawalIndex, builderIndex, nil
 	}
 	if uint64(builderIndex) >= uint64(buildersCount) {

--- a/beacon-chain/state/state-native/getters_gloas.go
+++ b/beacon-chain/state/state-native/getters_gloas.go
@@ -544,6 +544,10 @@ func (b *BeaconState) appendBuildersSweepWithdrawals(withdrawalIndex uint64, wit
 	buildersLimit := min(buildersCount, int(cfg.MaxBuildersPerWithdrawalsSweep))
 
 	builderIndex := b.nextWithdrawalBuilderIndex
+	if buildersLimit == 0 {
+		*withdrawals = ws
+		return withdrawalIndex, builderIndex, nil
+	}
 	if uint64(builderIndex) >= uint64(buildersCount) {
 		return withdrawalIndex, builderIndex, fmt.Errorf("builder index %d out of range (builders length %d)", builderIndex, buildersCount)
 	}

--- a/beacon-chain/state/state-native/getters_gloas_test.go
+++ b/beacon-chain/state/state-native/getters_gloas_test.go
@@ -614,6 +614,20 @@ func TestAppendBuildersSweepWithdrawals(t *testing.T) {
 		require.Equal(t, int(limit+1), len(withdrawals))
 	})
 
+	t.Run("no builders returns without error", func(t *testing.T) {
+		st := &BeaconState{
+			nextWithdrawalBuilderIndex: 3,
+			builders:                   nil,
+		}
+		withdrawals := []*enginev1.Withdrawal{}
+
+		nextIndex, nextBuilderIndex, err := st.appendBuildersSweepWithdrawals(5, &withdrawals)
+		require.NoError(t, err)
+		require.Equal(t, uint64(5), nextIndex)
+		require.Equal(t, primitives.BuilderIndex(3), nextBuilderIndex)
+		require.Equal(t, 0, len(withdrawals))
+	})
+
 	t.Run("appends eligible builders, skips ineligible", func(t *testing.T) {
 		epoch := primitives.Epoch(3)
 		st := &BeaconState{

--- a/changelog/terence_fix-gloas-builders-sweep-empty.md
+++ b/changelog/terence_fix-gloas-builders-sweep-empty.md
@@ -1,0 +1,2 @@
+### Fixed
+- Avoided out-of-range errors when the builders list is empty during Gloas builders sweep withdrawals.


### PR DESCRIPTION
This PR fixes builders sweep withdrawals to no‑op when the builders list is empty, preventing out‑of‑range errors during gloas transitions and aligning behavior with the spec’s zero‑builders case


### Spec reference
```
builders_limit = min(len(state.builders), MAX_BUILDERS_PER_WITHDRAWALS_SWEEP)
...
for _ in range(builders_limit):
    builder = state.builders[builder_index]
```
When `len(state.builders) == 0`, `builders_limit == 0`, so the loop does not run and no indexing should occur.