### PR TITLE
Fix `clang-format.yml` workflow

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,6 @@
 name: Protobuf Format
 
-on: 
+on:
   push:
     branches: [ '*' ]
   pull_request:
@@ -12,10 +12,14 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-4
     steps:
-      - uses: actions/checkout@v2
-      # Is this step failing for you? 
+      - uses: actions/checkout@v6
+      # Is this step failing for you?
       # Run: clang-format -i proto/**/*.proto
       # See: https://clang.llvm.org/docs/ClangFormat.html
-      - uses: RafikFarhad/clang-format-github-action@v3
-        with:
-          sources: "proto/**/*.proto"
+      - name: Install clang-format
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y clang-format
+      - name: Check protobuf formatting
+        run: |
+          clang-format --style=LLVM --dry-run --Werror proto/**/*.proto

--- a/changelog/syjn99_clang-format-ci-fix.md
+++ b/changelog/syjn99_clang-format-ci-fix.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Fix `clang-format.yml` by not using broken third party plugin

--- a/proto/engine/v1/execution_engine.proto
+++ b/proto/engine/v1/execution_engine.proto
@@ -28,7 +28,7 @@ message ExecutionPayload {
   bytes parent_hash = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
   bytes fee_recipient = 2 [ (ethereum.eth.ext.ssz_size) = "20" ];
   bytes state_root = 3 [ (ethereum.eth.ext.ssz_size) = "32" ];
-    bytes receipts_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
+  bytes receipts_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
   bytes logs_bloom = 5 [ (ethereum.eth.ext.ssz_size) = "logs_bloom.size" ];
   bytes prev_randao = 6 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 block_number = 7;
@@ -254,10 +254,10 @@ message BlobsBundle {
   ];
 }
 
-// BlobsBundleV2 is retrieved through engine-api from the execution layer client.
-// It consists of the necessary components for constructing data column sidecars
-// objects to gossip through p2p.
-// It is introduced in Fulu network upgrade.
+// BlobsBundleV2 is retrieved through engine-api from the execution layer
+// client. It consists of the necessary components for constructing data column
+// sidecars objects to gossip through p2p. It is introduced in Fulu network
+// upgrade.
 message BlobsBundleV2 {
   repeated bytes kzg_commitments = 1 [
     (ethereum.eth.ext.ssz_size) = "?,48",
@@ -266,7 +266,8 @@ message BlobsBundleV2 {
 
   repeated bytes proofs = 2 [
     (ethereum.eth.ext.ssz_size) = "?,48",
-    (ethereum.eth.ext.ssz_max) = "max_cell_proofs_length.size" // Changed in EIP-7594
+    (ethereum.eth.ext.ssz_max) =
+        "max_cell_proofs_length.size" // Changed in EIP-7594
   ];
 
   repeated bytes blobs = 3 [
@@ -281,17 +282,18 @@ message Blob {
   bytes data = 1 [ (ethereum.eth.ext.ssz_size) = "blob.size" ];
 }
 
-// BlobAndProofV2 consists of the blob and the cell proofs for each cell in the blob.
+// BlobAndProofV2 consists of the blob and the cell proofs for each cell in the
+// blob.
 message BlobAndProof {
   bytes blob = 1 [ (ethereum.eth.ext.ssz_size) = "blob.size" ];
   bytes kzg_proof = 2 [ (ethereum.eth.ext.ssz_size) = "48" ];
 }
 
-// BlobAndProofV2 consists of the blob and the cell proofs for each cell in the blob.
-// It is introduced in Fulu network upgrade.
+// BlobAndProofV2 consists of the blob and the cell proofs for each cell in the
+// blob. It is introduced in Fulu network upgrade.
 message BlobAndProofV2 {
   bytes blob = 1 [ (ethereum.eth.ext.ssz_size) = "blob.size" ];
-  repeated bytes kzg_proofs = 2 [ 
+  repeated bytes kzg_proofs = 2 [
     (ethereum.eth.ext.ssz_size) = "48",
     (ethereum.eth.ext.ssz_max) = "max_cell_proofs_length.size"
   ];

--- a/proto/eth/v1/attestation.proto
+++ b/proto/eth/v1/attestation.proto
@@ -30,8 +30,7 @@ message Attestation {
   // the same vote and have been aggregated into this attestation.
   bytes aggregation_bits = 1 [
     (ethereum.eth.ext.ssz_max) = "2048",
-    (ethereum.eth.ext.cast_type) =
-        "github.com/OffchainLabs/go-bitfield.Bitlist"
+    (ethereum.eth.ext.cast_type) = "github.com/OffchainLabs/go-bitfield.Bitlist"
   ];
 
   AttestationData data = 2;

--- a/proto/eth/v1/data_columns.proto
+++ b/proto/eth/v1/data_columns.proto
@@ -25,12 +25,22 @@ option java_outer_classname = "DataColumnsProto";
 option java_package = "org.ethereum.eth.v1alpha1";
 option php_namespace = "Ethereum\\Eth\\v1alpha1";
 
-
 message DataColumnSidecar {
   uint64 index = 1;
-  repeated bytes column = 2 [(ethereum.eth.ext.ssz_size) = "?,bytes_per_cell.size", (ethereum.eth.ext.ssz_max)  = "max_blob_commitments.size"];
-  repeated bytes kzg_commitments = 3 [(ethereum.eth.ext.ssz_size) = "?,48", (ethereum.eth.ext.ssz_max)  = "max_blob_commitments.size"];
-  repeated bytes kzg_proofs = 4 [(ethereum.eth.ext.ssz_size) = "?,48", (ethereum.eth.ext.ssz_max)  = "max_blob_commitments.size"];
+  repeated bytes column = 2 [
+    (ethereum.eth.ext.ssz_size) = "?,bytes_per_cell.size",
+    (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"
+  ];
+  repeated bytes kzg_commitments = 3 [
+    (ethereum.eth.ext.ssz_size) = "?,48",
+    (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"
+  ];
+  repeated bytes kzg_proofs = 4 [
+    (ethereum.eth.ext.ssz_size) = "?,48",
+    (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"
+  ];
   SignedBeaconBlockHeader signed_block_header = 5;
-  repeated bytes kzg_commitments_inclusion_proof = 6  [(ethereum.eth.ext.ssz_size) = "kzg_commitments_inclusion_proof_depth.size,32"];
+  repeated bytes kzg_commitments_inclusion_proof = 6
+      [ (ethereum.eth.ext.ssz_size) =
+            "kzg_commitments_inclusion_proof_depth.size,32" ];
 }

--- a/proto/prysm/v1alpha1/attestation.proto
+++ b/proto/prysm/v1alpha1/attestation.proto
@@ -56,8 +56,7 @@ message Attestation {
   // the same vote and have been aggregated into this attestation.
   bytes aggregation_bits = 1 [
     (ethereum.eth.ext.ssz_max) = "2048",
-    (ethereum.eth.ext.cast_type) =
-        "github.com/OffchainLabs/go-bitfield.Bitlist"
+    (ethereum.eth.ext.cast_type) = "github.com/OffchainLabs/go-bitfield.Bitlist"
   ];
 
   AttestationData data = 2;
@@ -129,7 +128,8 @@ message AggregateAttestationAndProofElectra {
   // The aggregated attestation that was submitted.
   AttestationElectra aggregate = 2;
 
-  // 96 byte selection proof signed by the aggregator, which is the signature of the slot to aggregate.
+  // 96 byte selection proof signed by the aggregator, which is the signature of
+  // the slot to aggregate.
   bytes selection_proof = 3 [ (ethereum.eth.ext.ssz_size) = "96" ];
 }
 
@@ -138,8 +138,7 @@ message AttestationElectra {
   // the same vote and have been aggregated into this attestation.
   bytes aggregation_bits = 1 [
     (ethereum.eth.ext.ssz_max) = "max_attesting_indices.size",
-    (ethereum.eth.ext.cast_type) =
-        "github.com/OffchainLabs/go-bitfield.Bitlist"
+    (ethereum.eth.ext.cast_type) = "github.com/OffchainLabs/go-bitfield.Bitlist"
   ];
 
   AttestationData data = 2;

--- a/proto/prysm/v1alpha1/beacon_block.proto
+++ b/proto/prysm/v1alpha1/beacon_block.proto
@@ -198,7 +198,6 @@ message BeaconBlockBody {
       [ (ethereum.eth.ext.ssz_max) = "16" ];
 }
 
-
 // Attestor slashings are proofs that a slashable offense has been committed by
 // attesting to two conflicting pieces of information by the same validator.
 message AttesterSlashing {
@@ -217,7 +216,6 @@ message IndexedAttestation {
   // 96 bytes aggregate signature.
   bytes signature = 3 [ (ethereum.eth.ext.ssz_size) = "96" ];
 }
-
 
 message SignedValidatorRegistrationsV1 {
   option deprecated = true;
@@ -323,7 +321,6 @@ message BeaconBlockBodyAltair {
   // New in Altair network upgrade.
   SyncAggregate sync_aggregate = 9;
 }
-
 
 // ----------------------------------------------------------------------------
 // Bellatrix
@@ -826,16 +823,19 @@ message BuilderBidDeneb {
 }
 
 message BuilderBidElectra {
-    ethereum.engine.v1.ExecutionPayloadHeaderDeneb header = 1;
-    repeated bytes blob_kzg_commitments = 2 [(ethereum.eth.ext.ssz_size) = "?,48", (ethereum.eth.ext.ssz_max)  = "max_blob_commitments.size"];
-    ethereum.engine.v1.ExecutionRequests execution_requests = 3;
-    bytes value = 4 [(ethereum.eth.ext.ssz_size) = "32"];
-    bytes pubkey = 5 [(ethereum.eth.ext.ssz_size) = "48"];
+  ethereum.engine.v1.ExecutionPayloadHeaderDeneb header = 1;
+  repeated bytes blob_kzg_commitments = 2 [
+    (ethereum.eth.ext.ssz_size) = "?,48",
+    (ethereum.eth.ext.ssz_max) = "max_blob_commitments.size"
+  ];
+  ethereum.engine.v1.ExecutionRequests execution_requests = 3;
+  bytes value = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
+  bytes pubkey = 5 [ (ethereum.eth.ext.ssz_size) = "48" ];
 }
 
 message SignedBuilderBidElectra {
-    BuilderBidElectra message = 1 ;
-    bytes signature = 2 [(ethereum.eth.ext.ssz_size) = "96"];
+  BuilderBidElectra message = 1;
+  bytes signature = 2 [ (ethereum.eth.ext.ssz_size) = "96" ];
 }
 
 message BlobSidecars {

--- a/proto/prysm/v1alpha1/beacon_core_types.proto
+++ b/proto/prysm/v1alpha1/beacon_core_types.proto
@@ -1,4 +1,5 @@
-// Common beacon chain types shared between beacon blocks, beacon state, and other components
+// Common beacon chain types shared between beacon blocks, beacon state, and
+// other components
 
 syntax = "proto3";
 
@@ -136,7 +137,7 @@ message AttesterSlashingElectra {
 
 message IndexedAttestationElectra {
   repeated uint64 attesting_indices = 1
-  [ (ethereum.eth.ext.ssz_max) = "max_attesting_indices.size" ];
+      [ (ethereum.eth.ext.ssz_max) = "max_attesting_indices.size" ];
 
   AttestationData data = 2;
 
@@ -170,7 +171,7 @@ message Fork {
 // beacon chain.
 message SyncCommittee {
   repeated bytes pubkeys = 1
-  [ (ethereum.eth.ext.ssz_size) = "sync_committee_bits.size,48" ];
+      [ (ethereum.eth.ext.ssz_size) = "sync_committee_bits.size,48" ];
   bytes aggregate_pubkey = 2 [ (ethereum.eth.ext.ssz_size) = "48" ];
 }
 

--- a/proto/prysm/v1alpha1/beacon_state.proto
+++ b/proto/prysm/v1alpha1/beacon_state.proto
@@ -83,8 +83,7 @@ message PendingAttestation {
   // the same vote and have been aggregated into this attestation.
   bytes aggregation_bits = 1 [
     (ethereum.eth.ext.ssz_max) = "2048",
-    (ethereum.eth.ext.cast_type) =
-        "github.com/OffchainLabs/go-bitfield.Bitlist"
+    (ethereum.eth.ext.cast_type) = "github.com/OffchainLabs/go-bitfield.Bitlist"
   ];
   AttestationData data = 2;
   // The difference of when attestation gets created and get included on chain.

--- a/proto/prysm/v1alpha1/data_columns.proto
+++ b/proto/prysm/v1alpha1/data_columns.proto
@@ -47,5 +47,5 @@ message DataColumnSidecar {
 
 message DataColumnsByRootIdentifier {
   bytes block_root = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
-  repeated uint64 columns = 2  [ (ethereum.eth.ext.ssz_max) = "128" ];
+  repeated uint64 columns = 2 [ (ethereum.eth.ext.ssz_max) = "128" ];
 }

--- a/proto/prysm/v1alpha1/gloas.proto
+++ b/proto/prysm/v1alpha1/gloas.proto
@@ -16,8 +16,8 @@ option go_package = "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1;eth";
 // Gloas Fork Specification
 // =============================================================================
 // This file implements the Gloas fork of the Ethereum consensus specification
-// Reference: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md
-
+// Reference:
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md
 
 // ExecutionPayloadBid represents an execution payload bid in the Gloas fork.
 //
@@ -42,8 +42,8 @@ message ExecutionPayloadBid {
   bytes fee_recipient = 5 [ (ethereum.eth.ext.ssz_size) = "20" ];
   uint64 gas_limit = 6;
   uint64 builder_index = 7 [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/"
-      "consensus-types/primitives.BuilderIndex" ];
+                                 "github.com/OffchainLabs/prysm/v7/"
+                                 "consensus-types/primitives.BuilderIndex" ];
   uint64 slot = 8 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"
@@ -73,7 +73,8 @@ message SignedExecutionPayloadBid {
   bytes signature = 2 [ (ethereum.eth.ext.ssz_size) = "96" ];
 }
 
-// PayloadAttestationData contains the core data for Payload Timeliness Committee (PTC) attestations.
+// PayloadAttestationData contains the core data for Payload Timeliness
+// Committee (PTC) attestations.
 //
 // Spec:
 // class PayloadAttestationData(Container):
@@ -91,7 +92,8 @@ message PayloadAttestationData {
   bool blob_data_available = 4;
 }
 
-// PayloadAttestation represents an aggregated attestation from the Payload Timeliness Committee (PTC).
+// PayloadAttestation represents an aggregated attestation from the Payload
+// Timeliness Committee (PTC).
 //
 // Spec:
 // class PayloadAttestation(Container):
@@ -107,7 +109,8 @@ message PayloadAttestation {
   bytes signature = 3 [ (ethereum.eth.ext.ssz_size) = "96" ];
 }
 
-// PayloadAttestationMessage represents an individual payload attestation message.
+// PayloadAttestationMessage represents an individual payload attestation
+// message.
 //
 // Spec:
 // class PayloadAttestationMessage(Container):
@@ -116,23 +119,24 @@ message PayloadAttestation {
 //     signature: BLSSignature
 message PayloadAttestationMessage {
   uint64 validator_index = 1
-  [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/consensus-types/"
-      "primitives.ValidatorIndex" ];
+      [ (ethereum.eth.ext.cast_type) =
+            "github.com/OffchainLabs/prysm/v7/consensus-types/"
+            "primitives.ValidatorIndex" ];
   PayloadAttestationData data = 2;
   bytes signature = 3 [ (ethereum.eth.ext.ssz_size) = "96" ];
 }
 
 // BeaconBlockGloas represents a beacon block in the Gloas fork.
-// The block structure remains the same but contains a modified BeaconBlockBodyGloas.
+// The block structure remains the same but contains a modified
+// BeaconBlockBodyGloas.
 message BeaconBlockGloas {
   uint64 slot = 1 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"
   ];
   uint64 proposer_index = 2 [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/"
-      "consensus-types/primitives.ValidatorIndex" ];
+                                  "github.com/OffchainLabs/prysm/v7/"
+                                  "consensus-types/primitives.ValidatorIndex" ];
   bytes parent_root = 3 [ (ethereum.eth.ext.ssz_size) = "32" ];
   bytes state_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
   BeaconBlockBodyGloas body = 5;
@@ -148,35 +152,36 @@ message BeaconBlockGloas {
 //     eth1_data: Eth1Data
 //     graffiti: Bytes32
 //     proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-//     attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]
-//     attestations: List[Attestation, MAX_ATTESTATIONS_ELECTRA]
-//     deposits: List[Deposit, MAX_DEPOSITS]
+//     attester_slashings: List[AttesterSlashing,
+//     MAX_ATTESTER_SLASHINGS_ELECTRA] attestations: List[Attestation,
+//     MAX_ATTESTATIONS_ELECTRA] deposits: List[Deposit, MAX_DEPOSITS]
 //     voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
 //     sync_aggregate: SyncAggregate
-//     bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-//     signed_execution_payload_bid: SignedExecutionPayloadBid
-//     payload_attestations: List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]
+//     bls_to_execution_changes: List[SignedBLSToExecutionChange,
+//     MAX_BLS_TO_EXECUTION_CHANGES] signed_execution_payload_bid:
+//     SignedExecutionPayloadBid payload_attestations: List[PayloadAttestation,
+//     MAX_PAYLOAD_ATTESTATIONS]
 message BeaconBlockBodyGloas {
   bytes randao_reveal = 1 [ (ethereum.eth.ext.ssz_size) = "96" ];
   Eth1Data eth1_data = 2;
   bytes graffiti = 3 [ (ethereum.eth.ext.ssz_size) = "32" ];
   repeated ProposerSlashing proposer_slashings = 4
-  [ (ethereum.eth.ext.ssz_max) = "16" ];
+      [ (ethereum.eth.ext.ssz_max) = "16" ];
   repeated AttesterSlashingElectra attester_slashings = 5
-  [ (ethereum.eth.ext.ssz_max) = "1" ];
+      [ (ethereum.eth.ext.ssz_max) = "1" ];
   repeated AttestationElectra attestations = 6
-  [ (ethereum.eth.ext.ssz_max) = "8" ];
+      [ (ethereum.eth.ext.ssz_max) = "8" ];
   repeated Deposit deposits = 7 [ (ethereum.eth.ext.ssz_max) = "16" ];
   repeated SignedVoluntaryExit voluntary_exits = 8
-  [ (ethereum.eth.ext.ssz_max) = "16" ];
+      [ (ethereum.eth.ext.ssz_max) = "16" ];
   SyncAggregate sync_aggregate = 9;
   repeated SignedBLSToExecutionChange bls_to_execution_changes = 10
-  [ (ethereum.eth.ext.ssz_max) = "16" ];
+      [ (ethereum.eth.ext.ssz_max) = "16" ];
 
   // New in Gloas
   SignedExecutionPayloadBid signed_execution_payload_bid = 11;
   repeated PayloadAttestation payload_attestations = 12
-  [ (ethereum.eth.ext.ssz_max) = "payload_attestation.size" ];
+      [ (ethereum.eth.ext.ssz_max) = "payload_attestation.size" ];
 }
 
 // SignedBeaconBlockGloas represents a signed beacon block in the Gloas fork.
@@ -200,10 +205,12 @@ message SignedBeaconBlockGloas {
 //     next_withdrawal_builder_index: BuilderIndex
 //     # [New in Gloas:EIP7732]
 //     execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
-//     builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
-//     builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
+//     builder_pending_payments: Vector[BuilderPendingPayment, 2 *
+//     SLOTS_PER_EPOCH] builder_pending_withdrawals:
+//     List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
 //     latest_block_hash: Hash32
-//     payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+//     payload_expected_withdrawals: List[Withdrawal,
+//     MAX_WITHDRAWALS_PER_PAYLOAD]
 message BeaconStateGloas {
   // Versioning [1001-2000]
   uint64 genesis_time = 1001;
@@ -217,9 +224,9 @@ message BeaconStateGloas {
   // History [2001-3000]
   BeaconBlockHeader latest_block_header = 2001;
   repeated bytes block_roots = 2002
-  [ (ethereum.eth.ext.ssz_size) = "block_roots.size" ];
+      [ (ethereum.eth.ext.ssz_size) = "block_roots.size" ];
   repeated bytes state_roots = 2003
-  [ (ethereum.eth.ext.ssz_size) = "state_roots.size" ];
+      [ (ethereum.eth.ext.ssz_size) = "state_roots.size" ];
   repeated bytes historical_roots = 2004 [
     (ethereum.eth.ext.ssz_size) = "?,32",
     (ethereum.eth.ext.ssz_max) = "16777216"
@@ -228,28 +235,28 @@ message BeaconStateGloas {
   // Eth1 [3001-4000]
   Eth1Data eth1_data = 3001;
   repeated Eth1Data eth1_data_votes = 3002
-  [ (ethereum.eth.ext.ssz_max) = "eth1_data_votes.size" ];
+      [ (ethereum.eth.ext.ssz_max) = "eth1_data_votes.size" ];
   uint64 eth1_deposit_index = 3003;
 
   // Registry [4001-5000]
   repeated Validator validators = 4001
-  [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
+      [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
   repeated uint64 balances = 4002
-  [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
+      [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
 
   // Randomness [5001-6000]
   repeated bytes randao_mixes = 5001
-  [ (ethereum.eth.ext.ssz_size) = "randao_mixes.size" ];
+      [ (ethereum.eth.ext.ssz_size) = "randao_mixes.size" ];
 
   // Slashings [6001-7000]
   repeated uint64 slashings = 6001
-  [ (ethereum.eth.ext.ssz_size) = "slashings.size" ];
+      [ (ethereum.eth.ext.ssz_size) = "slashings.size" ];
 
   // Participation [7001-8000]
   bytes previous_epoch_participation = 7001
-  [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
+      [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
   bytes current_epoch_participation = 7002
-  [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
+      [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
 
   // Finality [8001-9000]
   bytes justification_bits = 8001 [
@@ -263,21 +270,22 @@ message BeaconStateGloas {
 
   // Fields introduced in Altair fork [9001-10000]
   repeated uint64 inactivity_scores = 9001
-  [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
+      [ (ethereum.eth.ext.ssz_max) = "1099511627776" ];
   SyncCommittee current_sync_committee = 9002;
   SyncCommittee next_sync_committee = 9003;
 
-  // Note: latest_execution_payload_header replaced with ExecutionPayloadBid in Gloas
+  // Note: latest_execution_payload_header replaced with ExecutionPayloadBid in
+  // Gloas
   ExecutionPayloadBid latest_execution_payload_bid = 10001;
 
   // Fields introduced in Capella fork [11001-12000]
   uint64 next_withdrawal_index = 11001;
   uint64 next_withdrawal_validator_index = 11002
-  [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/consensus-types/"
-      "primitives.ValidatorIndex" ];
+      [ (ethereum.eth.ext.cast_type) =
+            "github.com/OffchainLabs/prysm/v7/consensus-types/"
+            "primitives.ValidatorIndex" ];
   repeated HistoricalSummary historical_summaries = 11003
-  [ (ethereum.eth.ext.ssz_max) = "16777216" ];
+      [ (ethereum.eth.ext.ssz_max) = "16777216" ];
 
   // Fields introduced in Electra fork [12001-13000]
   uint64 deposit_requests_start_index = 12001;
@@ -302,31 +310,32 @@ message BeaconStateGloas {
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"
   ];
   repeated PendingDeposit pending_deposits = 12007
-  [ (ethereum.eth.ext.ssz_max) = "pending_deposits_limit" ];
+      [ (ethereum.eth.ext.ssz_max) = "pending_deposits_limit" ];
   repeated PendingPartialWithdrawal pending_partial_withdrawals = 12008
-  [ (ethereum.eth.ext.ssz_max) = "pending_partial_withdrawals_limit" ];
+      [ (ethereum.eth.ext.ssz_max) = "pending_partial_withdrawals_limit" ];
   repeated PendingConsolidation pending_consolidations = 12009
-  [ (ethereum.eth.ext.ssz_max) = "pending_consolidations_limit" ];
+      [ (ethereum.eth.ext.ssz_max) = "pending_consolidations_limit" ];
 
   // Fields introduced in Fulu fork [13001-14000]
   repeated uint64 proposer_lookahead = 13001
-  [ (ethereum.eth.ext.ssz_size) = "proposer_lookahead_size" ];
+      [ (ethereum.eth.ext.ssz_size) = "proposer_lookahead_size" ];
 
   // Fields introduced in Gloas fork [14001-15000]
   repeated Builder builders = 14001
-  [ (ethereum.eth.ext.ssz_max) = "builder_registry_limit" ];
+      [ (ethereum.eth.ext.ssz_max) = "builder_registry_limit" ];
   uint64 next_withdrawal_builder_index = 14002
-  [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/consensus-types/"
-      "primitives.BuilderIndex" ];
-  bytes execution_payload_availability = 14003 [
-    (ethereum.eth.ext.ssz_size) = "execution_payload_availability.size"
-  ];
-  repeated BuilderPendingPayment builder_pending_payments = 14004 [(ethereum.eth.ext.ssz_size) = "builder_pending_payments.size"];
-  repeated BuilderPendingWithdrawal builder_pending_withdrawals = 14005 [(ethereum.eth.ext.ssz_max) = "1048576"];
+      [ (ethereum.eth.ext.cast_type) =
+            "github.com/OffchainLabs/prysm/v7/consensus-types/"
+            "primitives.BuilderIndex" ];
+  bytes execution_payload_availability = 14003
+      [ (ethereum.eth.ext.ssz_size) = "execution_payload_availability.size" ];
+  repeated BuilderPendingPayment builder_pending_payments = 14004
+      [ (ethereum.eth.ext.ssz_size) = "builder_pending_payments.size" ];
+  repeated BuilderPendingWithdrawal builder_pending_withdrawals = 14005
+      [ (ethereum.eth.ext.ssz_max) = "1048576" ];
   bytes latest_block_hash = 14006 [ (ethereum.eth.ext.ssz_size) = "32" ];
   repeated ethereum.engine.v1.Withdrawal payload_expected_withdrawals = 14007
-  [ (ethereum.eth.ext.ssz_max) = "withdrawal.size" ];
+      [ (ethereum.eth.ext.ssz_max) = "withdrawal.size" ];
 }
 
 // BuilderPendingPayment represents a pending payment to a builder.
@@ -357,13 +366,14 @@ message BuilderPendingWithdrawal {
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Gwei"
   ];
   uint64 builder_index = 3
-  [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/consensus-types/"
-      "primitives.BuilderIndex" ];
+      [ (ethereum.eth.ext.cast_type) =
+            "github.com/OffchainLabs/prysm/v7/consensus-types/"
+            "primitives.BuilderIndex" ];
 }
 
 // DataColumnSidecarGloas represents a data column sidecar in the Gloas fork.
-// Note: signed_block_header and kzg_commitments_inclusion_proof fields have been removed in Gloas.
+// Note: signed_block_header and kzg_commitments_inclusion_proof fields have
+// been removed in Gloas.
 //
 // Spec:
 // class DataColumnSidecar(Container):
@@ -386,12 +396,12 @@ message DataColumnSidecarGloas {
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"
   ];
-  bytes beacon_block_root = 6 [(ethereum.eth.ext.ssz_size) = "32"];
+  bytes beacon_block_root = 6 [ (ethereum.eth.ext.ssz_size) = "32" ];
 }
 
 // ExecutionPayloadEnvelope wraps an execution payload with builder index.
-// This is used in the Gloas fork to associate execution payloads with their builders
-// and provide additional context needed for payload processing.
+// This is used in the Gloas fork to associate execution payloads with their
+// builders and provide additional context needed for payload processing.
 //
 // Spec:
 // class ExecutionPayloadEnvelope(Container):
@@ -405,8 +415,8 @@ message ExecutionPayloadEnvelope {
   ethereum.engine.v1.ExecutionPayloadDeneb payload = 1;
   ethereum.engine.v1.ExecutionRequests execution_requests = 2;
   uint64 builder_index = 3 [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/"
-      "consensus-types/primitives.BuilderIndex" ];
+                                 "github.com/OffchainLabs/prysm/v7/"
+                                 "consensus-types/primitives.BuilderIndex" ];
   bytes beacon_block_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 slot = 5 [
     (ethereum.eth.ext.cast_type) =
@@ -415,8 +425,9 @@ message ExecutionPayloadEnvelope {
   bytes state_root = 6 [ (ethereum.eth.ext.ssz_size) = "32" ];
 }
 
-// SignedExecutionPayloadEnvelope wraps an execution payload envelope with a signature.
-// The signature is provided by the builder who created the execution payload.
+// SignedExecutionPayloadEnvelope wraps an execution payload envelope with a
+// signature. The signature is provided by the builder who created the execution
+// payload.
 //
 // Spec:
 // class SignedExecutionPayloadEnvelope(Container):
@@ -428,14 +439,15 @@ message SignedExecutionPayloadEnvelope {
 }
 
 // BlindedExecutionPayloadEnvelope is a storage-only envelope that replaces the
-// full execution payload with its block hash for space savings. The full payload
-// can be retrieved from the EL via engine_getPayloadBodiesByHash using the block_hash.
+// full execution payload with its block hash for space savings. The full
+// payload can be retrieved from the EL via engine_getPayloadBodiesByHash using
+// the block_hash.
 message BlindedExecutionPayloadEnvelope {
   bytes block_hash = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
   ethereum.engine.v1.ExecutionRequests execution_requests = 2;
   uint64 builder_index = 3 [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/"
-      "consensus-types/primitives.BuilderIndex" ];
+                                 "github.com/OffchainLabs/prysm/v7/"
+                                 "consensus-types/primitives.BuilderIndex" ];
   bytes beacon_block_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 slot = 5 [
     (ethereum.eth.ext.cast_type) =
@@ -444,7 +456,8 @@ message BlindedExecutionPayloadEnvelope {
   bytes state_root = 6 [ (ethereum.eth.ext.ssz_size) = "32" ];
 }
 
-// SignedBlindedExecutionPayloadEnvelope wraps a blinded execution payload envelope with a signature.
+// SignedBlindedExecutionPayloadEnvelope wraps a blinded execution payload
+// envelope with a signature.
 message SignedBlindedExecutionPayloadEnvelope {
   BlindedExecutionPayloadEnvelope message = 1;
   bytes signature = 2 [ (ethereum.eth.ext.ssz_size) = "96" ];

--- a/proto/prysm/v1alpha1/p2p_messages.proto
+++ b/proto/prysm/v1alpha1/p2p_messages.proto
@@ -13,13 +13,13 @@ option java_package = "org.ethereum.eth.v1alpha1";
 option php_namespace = "Ethereum\\Eth\\v1alpha1";
 
 message Status {
-  bytes fork_digest = 1 [(ethereum.eth.ext.ssz_size) = "4"];
-  bytes finalized_root = 2 [(ethereum.eth.ext.ssz_size) = "32"];
+  bytes fork_digest = 1 [ (ethereum.eth.ext.ssz_size) = "4" ];
+  bytes finalized_root = 2 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 finalized_epoch = 3 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"
   ];
-  bytes head_root = 4 [(ethereum.eth.ext.ssz_size) = "32"];
+  bytes head_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 head_slot = 5 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"
@@ -27,18 +27,18 @@ message Status {
 }
 
 message StatusV2 {
-  bytes fork_digest = 1 [(ethereum.eth.ext.ssz_size) = "4"];
-  bytes finalized_root = 2 [(ethereum.eth.ext.ssz_size) = "32"];
+  bytes fork_digest = 1 [ (ethereum.eth.ext.ssz_size) = "4" ];
+  bytes finalized_root = 2 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 finalized_epoch = 3 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"
   ];
-  bytes head_root = 4 [(ethereum.eth.ext.ssz_size) = "32"];
+  bytes head_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
   uint64 head_slot = 5 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"
   ];
-   uint64 earliest_available_slot = 6 [
+  uint64 earliest_available_slot = 6 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"
   ];
@@ -54,8 +54,8 @@ message BeaconBlocksByRangeRequest {
 }
 
 message ENRForkID {
-  bytes current_fork_digest = 1 [(ethereum.eth.ext.ssz_size) = "4"];
-  bytes next_fork_version = 2 [(ethereum.eth.ext.ssz_size) = "4"];
+  bytes current_fork_digest = 1 [ (ethereum.eth.ext.ssz_size) = "4" ];
+  bytes next_fork_version = 2 [ (ethereum.eth.ext.ssz_size) = "4" ];
   uint64 next_fork_epoch = 3 [
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"
@@ -156,7 +156,7 @@ message DataColumnSidecarsByRangeRequest {
         "github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Slot"
   ];
   uint64 count = 2;
-  repeated uint64 columns = 3 [(ethereum.eth.ext.ssz_max) = "128"];
+  repeated uint64 columns = 3 [ (ethereum.eth.ext.ssz_max) = "128" ];
 }
 
 /*

--- a/proto/prysm/v1alpha1/validator.proto
+++ b/proto/prysm/v1alpha1/validator.proto
@@ -65,8 +65,9 @@ service BeaconNodeValidator {
   //   Proposer - the validator that creates a beacon chain block.
   //   Attester — a validator that is part of a committee that needs to sign off
   //   on a beacon chain
-  //   Sync Committee - a special group of validators that ensure lightclients and effectively sync with Ethereum
-  //   and continues in this role for 256 epochs if selected
+  //   Sync Committee - a special group of validators that ensure lightclients
+  //   and effectively sync with Ethereum and continues in this role for 256
+  //   epochs if selected
   // The server returns a list of duties which are the actions should be
   // performed by validators for a given epoch. Validator duties should be
   // polled every epoch, but due to chain reorg of >MIN_SEED_LOOKAHEAD could
@@ -74,8 +75,9 @@ service BeaconNodeValidator {
   // recommended to poll at every slot to ensure validator is fully aware of any
   // sudden chain reorg.
   //
-  // GetDutiesV2 differs from GetDuties through the removal of the full committee list in favor of adding
-  // committee_length and validator_committee_index fields which significantly saves on marshalling
+  // GetDutiesV2 differs from GetDuties through the removal of the full
+  // committee list in favor of adding committee_length and
+  // validator_committee_index fields which significantly saves on marshalling
   rpc GetDutiesV2(DutiesRequest) returns (DutiesV2Response) {
     option deprecated = true;
     option (google.api.http) = {
@@ -139,12 +141,13 @@ service BeaconNodeValidator {
   //
   // The status response can be one of the following:
   //	DEPOSITED - validator's deposit has been recognized by Ethereum 1, not
-  //yet recognized by Ethereum. 	PENDING - validator is in Ethereum's activation
-  //queue. 	ACTIVE - validator is active. 	EXITING - validator has initiated an an
-  //exit request, or has dropped below the ejection balance and is being kicked
-  //out. 	EXITED - validator is no longer validating. 	SLASHING - validator has
-  //been kicked out due to meeting a slashing condition. 	UNKNOWN_STATUS -
-  //validator does not have a known status in the network.
+  // yet recognized by Ethereum. 	PENDING - validator is in Ethereum's
+  // activation queue. 	ACTIVE - validator is active. 	EXITING - validator has
+  // initiated an an exit request, or has dropped below the ejection balance and
+  // is being kicked out. 	EXITED - validator is no longer validating.
+  // SLASHING - validator has been kicked out due to meeting a slashing
+  // condition. 	UNKNOWN_STATUS - validator does not have a known status
+  // in the network.
   rpc ValidatorStatus(ValidatorStatusRequest)
       returns (ValidatorStatusResponse) {
     option deprecated = true;
@@ -718,7 +721,7 @@ message DutiesResponse {
 
   bytes previous_duty_dependent_root = 4 [ (ethereum.eth.ext.ssz_size) = "32" ];
   bytes current_duty_dependent_root = 5 [ (ethereum.eth.ext.ssz_size) = "32" ];
-  
+
   message Duty {
     // The committee a validator is assigned to.
     repeated uint64 committee = 1
@@ -782,9 +785,9 @@ message DutiesV2Response {
 
     // The index of the committee which the given validator has an assignment
     uint64 committee_index = 2
-    [ (ethereum.eth.ext.cast_type) =
-    "github.com/OffchainLabs/prysm/v7/consensus-types/"
-        "primitives.CommitteeIndex" ];
+        [ (ethereum.eth.ext.cast_type) =
+              "github.com/OffchainLabs/prysm/v7/consensus-types/"
+              "primitives.CommitteeIndex" ];
 
     // The number of committees in the duty's slot.
     uint64 committees_at_slot = 3;
@@ -813,9 +816,9 @@ message DutiesV2Response {
 
     // The index of the validator in the beacon state.
     uint64 validator_index = 9
-    [ (ethereum.eth.ext.cast_type) =
-    "github.com/OffchainLabs/prysm/v7/consensus-types/"
-        "primitives.ValidatorIndex" ];
+        [ (ethereum.eth.ext.cast_type) =
+              "github.com/OffchainLabs/prysm/v7/consensus-types/"
+              "primitives.ValidatorIndex" ];
 
     // Whether the validator belongs in the sync committee and has to perform
     // sync committee duty.
@@ -994,18 +997,16 @@ message ValidatorParticipation {
   uint64 previous_epoch_head_attesting_gwei = 10;
 }
 
-// ValidatorIdentity gives information about the state of a validator at a certain
-// epoch.
+// ValidatorIdentity gives information about the state of a validator at a
+// certain epoch.
 message ValidatorIdentity {
   // The validator's index in the beacon state.
   uint64 index = 1 [ (ethereum.eth.ext.cast_type) =
-  "github.com/OffchainLabs/prysm/v7/consensus-types/"
-      "primitives.ValidatorIndex" ];
+                         "github.com/OffchainLabs/prysm/v7/consensus-types/"
+                         "primitives.ValidatorIndex" ];
 
   // The validator's 48 byte BLS public key.
-  bytes pubkey = 2 [
-    (ethereum.eth.ext.ssz_size) = "48"
-  ];
+  bytes pubkey = 2 [ (ethereum.eth.ext.ssz_size) = "48" ];
 
   // Epoch when the validator was activated. This field may be zero if the
   // validator was present in the Ethereum proof of stake genesis. This field is

--- a/proto/ssz_query/response.proto
+++ b/proto/ssz_query/response.proto
@@ -7,21 +7,21 @@ import "proto/eth/ext/options.proto";
 option go_package = "github.com/OffchainLabs/prysm/v7/proto/ssz_query";
 
 message SSZQueryProof {
-    bytes leaf = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
-    uint64 gindex = 2;
-    repeated bytes proofs = 3 [
-        (ethereum.eth.ext.ssz_size) = "?,32",
-        (ethereum.eth.ext.ssz_max) = "64,?" 
-    ];
+  bytes leaf = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
+  uint64 gindex = 2;
+  repeated bytes proofs = 3 [
+    (ethereum.eth.ext.ssz_size) = "?,32",
+    (ethereum.eth.ext.ssz_max) = "64,?"
+  ];
 }
 
 message SSZQueryResponse {
-    bytes root = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
-    bytes result = 2 [ (ethereum.eth.ext.ssz_max) = "1073741824" ];
+  bytes root = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
+  bytes result = 2 [ (ethereum.eth.ext.ssz_max) = "1073741824" ];
 }
 
 message SSZQueryResponseWithProof {
-    bytes root = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
-    bytes result = 2 [ (ethereum.eth.ext.ssz_max) = "1073741824" ];
-    SSZQueryProof proof = 3;
+  bytes root = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];
+  bytes result = 2 [ (ethereum.eth.ext.ssz_max) = "1073741824" ];
+  SSZQueryProof proof = 3;
 }

--- a/proto/ssz_query/testing/test_containers.proto
+++ b/proto/ssz_query/testing/test_containers.proto
@@ -6,40 +6,52 @@ import "proto/eth/ext/options.proto";
 
 option go_package = "github.com/OffchainLabs/prysm/v7/proto/ssz_query/testing;testing";
 
-
 // ===== FIXED-SIZE TEST CONTAINERS =====
-// These containers are designed to test SSZ query functionality with comprehensive coverage
-// of all fixed-size SSZ types according to the SSZ specification.
+// These containers are designed to test SSZ query functionality with
+// comprehensive coverage of all fixed-size SSZ types according to the SSZ
+// specification.
 
 // FixedNestedContainer - nested container for testing nested field access
-// Tests: nested container navigation, field offset calculations within nested structures
+// Tests: nested container navigation, field offset calculations within nested
+// structures
 message FixedNestedContainer {
-  uint64 value1 = 1;  // Test: uint64 basic type, offset calculation in nested context
-  bytes value2 = 2 [ (ethereum.eth.ext.ssz_size) = "32" ];  // Test: fixed-size bytes in nested container
+  uint64 value1 =
+      1; // Test: uint64 basic type, offset calculation in nested context
+  bytes value2 = 2 [ (ethereum.eth.ext.ssz_size) =
+                         "32" ]; // Test: fixed-size bytes in nested container
 }
 
 // FixedTestContainer - comprehensive fixed-size container for SSZ query testing
-// Tests: All basic fixed-size SSZ types, nested containers, vectors, offset/length calculations
-// Total size: 565 bytes (4+8+1+32+40+192+160+8+64+56)
+// Tests: All basic fixed-size SSZ types, nested containers, vectors,
+// offset/length calculations Total size: 565 bytes
+// (4+8+1+32+40+192+160+8+64+56)
 message FixedTestContainer {
-  // Basic integer types - test different integer sizes and their SSZ serialization
-  uint32 field_uint32 = 1;  // Test: uint32 basic type, offset: 0
-  uint64 field_uint64 = 2;  // Test: uint64 basic type, offset: 4
-  
-  // Boolean type - test boolean serialization (1 byte in SSZ)
-  bool field_bool = 3;      // Test: boolean basic type, offset: 12
-  
-  // Fixed-size bytes - test byte array
-  bytes field_bytes32 = 4 [ (ethereum.eth.ext.ssz_size) = "32" ]; // Test: 32-byte array, offset: 13
-  
-  // Nested container - test container nesting and field access
-  FixedNestedContainer nested = 5;  // Test: nested container navigation (8+32=40 bytes), offset: 45
-  
-  // Vector type - test fixed-size array of basic elements  
-  repeated uint64 vector_field = 6 [ (ethereum.eth.ext.ssz_size) = "24" ];  // Test: Vector[24] of uint64 (24*8=192 bytes), offset: 85
+  // Basic integer types - test different integer sizes and their SSZ
+  // serialization
+  uint32 field_uint32 = 1; // Test: uint32 basic type, offset: 0
+  uint64 field_uint64 = 2; // Test: uint64 basic type, offset: 4
 
-  // 2D bytes type - test 2-dimensional byte arrays, common in blockchain state roots (e.g., beacon_state.block_roots)
-  repeated bytes two_dimension_bytes_field = 7 [ (ethereum.eth.ext.ssz_size) = "5,32" ]; // Test: Vector[Bytes32, 5] (32*5=160 bytes), offset: 277
+  // Boolean type - test boolean serialization (1 byte in SSZ)
+  bool field_bool = 3; // Test: boolean basic type, offset: 12
+
+  // Fixed-size bytes - test byte array
+  bytes field_bytes32 = 4
+      [ (ethereum.eth.ext.ssz_size) = "32" ]; // Test: 32-byte array, offset: 13
+
+  // Nested container - test container nesting and field access
+  FixedNestedContainer nested =
+      5; // Test: nested container navigation (8+32=40 bytes), offset: 45
+
+  // Vector type - test fixed-size array of basic elements
+  repeated uint64 vector_field = 6
+      [ (ethereum.eth.ext.ssz_size) =
+            "24" ]; // Test: Vector[24] of uint64 (24*8=192 bytes), offset: 85
+
+  // 2D bytes type - test 2-dimensional byte arrays, common in blockchain state
+  // roots (e.g., beacon_state.block_roots)
+  repeated bytes two_dimension_bytes_field = 7
+      [ (ethereum.eth.ext.ssz_size) =
+            "5,32" ]; // Test: Vector[Bytes32, 5] (32*5=160 bytes), offset: 277
 
   // Bitvector types - test bitfield serialization
   bytes bitvector64_field = 8 [
@@ -53,17 +65,20 @@ message FixedTestContainer {
     (ethereum.eth.ext.cast_type) =
         "github.com/OffchainLabs/go-bitfield.Bitvector512"
   ]; // Test: Bitvector512 (64 bytes), offset: 445
-  
+
   // Additional bytes field - test field ordering and offset calculation
-  bytes trailing_field = 10 [ (ethereum.eth.ext.ssz_size) = "56" ]; // Test: trailing field after vector, offset: 509
+  bytes trailing_field = 10
+      [ (ethereum.eth.ext.ssz_size) =
+            "56" ]; // Test: trailing field after vector, offset: 509
 }
 
 // ===== VARIABLE-SIZE TEST CONTAINERS =====
 
 // VariableNestedContainer - nested container for testing nested field access
-// Tests: nested container navigation, field offset calculations within nested structures
+// Tests: nested container navigation, field offset calculations within nested
+// structures
 message VariableNestedContainer {
-  uint64 value1 = 1;  
+  uint64 value1 = 1;
   repeated uint64 field_list_uint64 = 2 [ (ethereum.eth.ext.ssz_max) = "100" ];
   repeated bytes nested_list_field = 3 [
     (ethereum.eth.ext.ssz_size) = "?,?",
@@ -71,44 +86,55 @@ message VariableNestedContainer {
   ];
 }
 
-
 // Mock of AttesterSlashingElectra
 message VariableOuterContainer {
   VariableNestedContainer inner_1 = 1;
   VariableNestedContainer inner_2 = 2;
 }
 
-// VariableTestContainer - comprehensive variable-size container for SSZ query testing
-// Tests: Variable-size lists, offsets in variable containers, mixed fixed/variable fields
+// VariableTestContainer - comprehensive variable-size container for SSZ query
+// testing Tests: Variable-size lists, offsets in variable containers, mixed
+// fixed/variable fields
 message VariableTestContainer {
   // Fixed-size leading field - test fixed field before variable fields
   // Acts as a baseline to verify offset calculations start correctly
-  bytes leading_field = 1 [ (ethereum.eth.ext.ssz_size) = "32" ];  // Test: fixed 32-byte field at start, offset: 0
+  bytes leading_field = 1
+      [ (ethereum.eth.ext.ssz_size) =
+            "32" ]; // Test: fixed 32-byte field at start, offset: 0
 
   // Variable-size list of basic type - test list with primitive elements
   // SSZ uses 4-byte offset pointer, actual data stored after all fixed fields
-  repeated uint64 field_list_uint64 = 2 [ (ethereum.eth.ext.ssz_max) = "2048" ];  // Test: List[uint64, 2048] (max 2048 elements)
-  
-  // Variable-size list of containers - test list with composite elements  
+  repeated uint64 field_list_uint64 = 2
+      [ (ethereum.eth.ext.ssz_max) =
+            "2048" ]; // Test: List[uint64, 2048] (max 2048 elements)
+
+  // Variable-size list of containers - test list with composite elements
   // Each container is fixed-size (40 bytes), but list itself is variable
-  repeated FixedNestedContainer field_list_container = 3 [ (ethereum.eth.ext.ssz_max) = "128" ];  // Test: List[FixedNestedContainer, 128]
+  repeated FixedNestedContainer field_list_container = 3
+      [ (ethereum.eth.ext.ssz_max) =
+            "128" ]; // Test: List[FixedNestedContainer, 128]
 
   // Variable-size list of bytes32 - test list with fixed-size byte arrays
   // e.g., beacon_state.historical_roots
-  repeated bytes field_list_bytes32 = 4 [ (ethereum.eth.ext.ssz_size) = "?,32", (ethereum.eth.ext.ssz_max) = "100"]; // Test: List[Bytes32, 100]
+  repeated bytes field_list_bytes32 = 4 [
+    (ethereum.eth.ext.ssz_size) = "?,32",
+    (ethereum.eth.ext.ssz_max) = "100"
+  ]; // Test: List[Bytes32, 100]
 
-  // Variable nested container - test nested container access within variable container
+  // Variable nested container - test nested container access within variable
+  // container
   VariableNestedContainer nested = 5;
 
   // List of variable-sized containers
-  // e.g., BeaconBlockBody.attester_slashings 
-  repeated VariableOuterContainer variable_container_list = 6 [ (ethereum.eth.ext.ssz_max) = "10" ]; // Test: List[VariableOuterContainer, 10]
+  // e.g., BeaconBlockBody.attester_slashings
+  repeated VariableOuterContainer variable_container_list = 6
+      [ (ethereum.eth.ext.ssz_max) =
+            "10" ]; // Test: List[VariableOuterContainer, 10]
 
   // Bitlist type - test bitlist serialization
   bytes bitlist_field = 7 [
     (ethereum.eth.ext.ssz_max) = "2048",
-    (ethereum.eth.ext.cast_type) =
-        "github.com/OffchainLabs/go-bitfield.Bitlist"
+    (ethereum.eth.ext.cast_type) = "github.com/OffchainLabs/go-bitfield.Bitlist"
   ];
 
   // 2D bytes list - test list of bytelists.
@@ -120,5 +146,8 @@ message VariableTestContainer {
 
   // Fixed-size trailing field - test fixed field after variable fields
   // Verifies correct offset calculation after variable-size fields
-  bytes trailing_field = 9 [ (ethereum.eth.ext.ssz_size) = "56" ];  // Test: fixed 56-byte field at end, offset: 32 + 4 + 4 + 4 + 4 + 4 + 4 + 4 = 60
+  bytes trailing_field = 9
+      [ (ethereum.eth.ext.ssz_size) =
+            "56" ]; // Test: fixed 56-byte field at end, offset: 32 + 4 + 4 + 4
+                    // + 4 + 4 + 4 + 4 = 60
 }


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

CI - Protobuf Format actually always return **0**, so the formatting check always become no-op.

```
/entrypoint.sh: line 44: local: `proto/testing/test.proto': invalid variable name for name reference
```

This corresponds to the actual [source code](https://github.com/RafikFarhad/clang-format-github-action/blob/27cc2adf6e733d30c8ce3ca3944f3b2c7b13e1f5/entrypoint.sh#L44). I think it's better to use `clang-format` natively rather than fixing the upstream dependency.

This PR also formats `*.proto` files with LLVM style.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
