### PR TITLE
Add helper to get canonical node information

### DIFF
--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@ -136,6 +136,13 @@ func (s *Service) hashForGenesisBlock(ctx context.Context, root [32]byte) ([]byt
 	return bytesutil.SafeCopyBytes(header.BlockHash()), nil
 }
 
+// CanonicalNodeAtSlot wraps the corresponding method in forkchoice
+func (s *Service) CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool) {
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
+	return s.cfg.ForkChoiceStore.CanonicalNodeAtSlot(slot)
+}
+
 // DependentRoot wraps the corresponding method in forkchoice
 func (s *Service) DependentRoot(epoch primitives.Epoch) ([32]byte, error) {
 	s.cfg.ForkChoiceStore.RLock()

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -16,6 +16,25 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CanonicalNodeAtSlot returns the full node that exists at the given slot in the canonical chain.
+// The boolean indicates whether the payload was present for the returned blockroot.
+// If the slot for the given blockroot is the current wall clock slot, it returns the pending node, that is, it sets the boolean to false.
+// If the slot is in the past the boolean indicates between full or empty.
+func (f *ForkChoice) CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool) {
+	s := f.store
+	n := s.headNode
+	for ; n != nil && n.slot > slot; n = n.parent.node {
+	}
+	if n == nil {
+		return [32]byte{}, false
+	}
+	if n.slot == s.currentSlot() {
+		return n.root, false
+	}
+	pn := s.choosePayloadContent(n)
+	return pn.node.root, pn.full
+}
+
 func (s *Store) resolveParentPayloadStatus(block interfaces.ReadOnlyBeaconBlock, parent **PayloadNode, blockHash *[32]byte) error {
 	sb, err := block.Body().SignedExecutionPayloadBid()
 	if err != nil {

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -23,7 +23,12 @@ import (
 func (f *ForkChoice) CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool) {
 	s := f.store
 	n := s.headNode
-	for ; n != nil && n.slot > slot; n = n.parent.node {
+	for n != nil && n.slot > slot {
+		if n.parent == nil {
+			n = nil
+		} else {
+			n = n.parent.node
+		}
 	}
 	if n == nil {
 		return [32]byte{}, false

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -1292,3 +1292,91 @@ func TestGloasDeepForkWeightPropagation(t *testing.T) {
 	assert.Equal(t, uint64(70), emptyB.weight)
 	assert.Equal(t, uint64(50), fullB.weight)
 }
+
+func TestCanonicalNodeAtSlot(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	// Insert block A at slot 1 building on genesis.
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	st, blk, err := prepareGloasForkchoiceState(ctx, 1, rootA, zeroHash, blockHashA, zeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	// Insert payload for A.
+	pe, err := prepareGloasForkchoicePayload(rootA)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	// Insert block B at slot 2 building on A(full).
+	rootB := indexToHash(2)
+	blockHashB := indexToHash(101)
+	driftGenesisTime(f, 2, 0)
+	require.NoError(t, f.NewSlot(ctx, 2))
+	st, blk, err = prepareGloasForkchoiceState(ctx, 2, rootB, rootA, blockHashB, blockHashA, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	// Compute head so headNode is set.
+	headRoot, err := f.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, rootB, headRoot)
+
+	// Slot 0 (genesis): should return the genesis root.
+	root, full := f.CanonicalNodeAtSlot(0)
+	assert.Equal(t, zeroHash, root)
+	assert.Equal(t, true, full)
+
+	// Slot 1: A has a payload, should return full=true.
+	root, full = f.CanonicalNodeAtSlot(1)
+	assert.Equal(t, rootA, root)
+	assert.Equal(t, true, full)
+
+	// Slot 2 is the current wall clock slot, so it returns the pending node (full=false).
+	root, full = f.CanonicalNodeAtSlot(2)
+	assert.Equal(t, rootB, root)
+	assert.Equal(t, false, full)
+}
+
+func TestCanonicalNodeAtSlot_EmptyPayload(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	// Insert block A at slot 1 without a payload.
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	st, blk, err := prepareGloasForkchoiceState(ctx, 1, rootA, zeroHash, blockHashA, zeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	// Insert block B at slot 2 building on A(empty).
+	rootB := indexToHash(2)
+	blockHashB := indexToHash(101)
+	driftGenesisTime(f, 2, 0)
+	require.NoError(t, f.NewSlot(ctx, 2))
+	st, blk, err = prepareGloasForkchoiceState(ctx, 2, rootB, rootA, blockHashB, zeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	headRoot, err := f.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, rootB, headRoot)
+
+	// Slot 1: A has no payload, so full should be false.
+	root, full := f.CanonicalNodeAtSlot(1)
+	assert.Equal(t, rootA, root)
+	assert.Equal(t, false, full)
+}
+
+func TestCanonicalNodeAtSlot_NilHead(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+
+	// headNode is nil before calling Head.
+	f.store.headNode = nil
+	root, full := f.CanonicalNodeAtSlot(0)
+	assert.Equal(t, [32]byte{}, root)
+	assert.Equal(t, false, full)
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -1380,3 +1380,22 @@ func TestCanonicalNodeAtSlot_NilHead(t *testing.T) {
 	assert.Equal(t, [32]byte{}, root)
 	assert.Equal(t, false, full)
 }
+
+func TestCanonicalNodeAtSlot_NilParent(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	// Compute head so headNode is set to genesis.
+	_, err := f.Head(ctx)
+	require.NoError(t, err)
+
+	// Simulate a checkpoint-synced tree where the root is at a nonzero slot.
+	// The genesis node's parent is nil, so walking past it must not panic.
+	genesisNode := f.store.emptyNodeByRoot[zeroHash].node
+	genesisNode.slot = 5
+	f.store.headNode = genesisNode
+	root, full := f.CanonicalNodeAtSlot(3)
+	assert.Equal(t, [32]byte{}, root)
+	assert.Equal(t, false, full)
+}

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -92,6 +92,7 @@ type FastGetter interface {
 	Weight(root [32]byte) (uint64, error)
 	ParentRoot(root [32]byte) ([32]byte, error)
 	BlockHash(root [32]byte) ([32]byte, error)
+	CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool)
 }
 
 // Setter allows to set forkchoice information

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -190,3 +190,10 @@ func (ro *ROForkChoice) BlockHash(root [32]byte) ([32]byte, error) {
 	defer ro.l.RUnlock()
 	return ro.getter.BlockHash(root)
 }
+
+// CanonicalNodeAtSlot delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool) {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.CanonicalNodeAtSlot(slot)
+}

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -41,6 +41,7 @@ const (
 	blockHashCalled
 	dependentRootCalled
 	dependentRootForEpochCalled
+	canonicalNodeAtSlotCalled
 )
 
 func _discard(t *testing.T, e error) {
@@ -152,6 +153,11 @@ func TestROLocking(t *testing.T) {
 			name: "dependentRootCalled",
 			call: dependentRootCalled,
 			cb:   func(g FastGetter) { _, err := g.DependentRoot(0); _discard(t, err) },
+		},
+		{
+			name: "canonicalNodeAtSlotCalled",
+			call: canonicalNodeAtSlotCalled,
+			cb:   func(g FastGetter) { g.CanonicalNodeAtSlot(0) },
 		},
 	}
 	for _, c := range cases {
@@ -306,4 +312,9 @@ func (ro *mockROForkchoice) ParentRoot(_ [32]byte) ([32]byte, error) {
 func (ro *mockROForkchoice) BlockHash(_ [32]byte) ([32]byte, error) {
 	ro.calls = append(ro.calls, blockHashCalled)
 	return [32]byte{}, nil
+}
+
+func (ro *mockROForkchoice) CanonicalNodeAtSlot(_ primitives.Slot) ([32]byte, bool) {
+	ro.calls = append(ro.calls, canonicalNodeAtSlotCalled)
+	return [32]byte{}, false
 }

--- a/changelog/potuz_gloas_canonical_node.md
+++ b/changelog/potuz_gloas_canonical_node.md
@@ -1,0 +1,2 @@
+### Added
+- Added helper to get canonical node (including head) with full payload information post-Gloas.


### PR DESCRIPTION
This adds a new helper to obtain head information from forkchoice. 

⚠️ It does not recompute Head as that is expensive. It uses the cached head node from forkchoice. 

An attester calls it by passing the attestation slot. It will return the right combination of the beacon block root and the payload content. Attester needs to set committee index to 0 if false and 1 if true. 

A proposer calls it by passing the current slot. It will tell it whether to build on full or empty. 