### PR TITLE
Use `InitializeFromProtoUnsafeXXX` instead of `InitializeFromProtoXXX` when possible. (Nishant's optimization)

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -630,7 +630,7 @@ func prepareForkchoiceState(
 	}
 
 	base.BlockRoots[0] = append(base.BlockRoots[0], blockRoot[:]...)
-	st, err := state_native.InitializeFromProtoBellatrix(base)
+	st, err := state_native.InitializeFromProtoUnsafeBellatrix(base)
 	if err != nil {
 		return nil, blocks.ROBlock{}, err
 	}

--- a/beacon-chain/core/transition/state-bellatrix.go
+++ b/beacon-chain/core/transition/state-bellatrix.go
@@ -224,7 +224,7 @@ func OptimizedGenesisBeaconStateBellatrix(genesisTime uint64, preState state.Bea
 		BodyRoot:   bodyRoot[:],
 	}
 
-	ist, err := state_native.InitializeFromProtoBellatrix(st)
+	ist, err := state_native.InitializeFromProtoUnsafeBellatrix(st)
 	if err != nil {
 		return nil, err
 	}
@@ -276,5 +276,5 @@ func EmptyGenesisStateBellatrix() (state.BeaconState, error) {
 		},
 	}
 
-	return state_native.InitializeFromProtoBellatrix(st)
+	return state_native.InitializeFromProtoUnsafeBellatrix(st)
 }

--- a/beacon-chain/core/transition/state.go
+++ b/beacon-chain/core/transition/state.go
@@ -217,7 +217,7 @@ func OptimizedGenesisBeaconState(genesisTime uint64, preState state.BeaconState,
 		BodyRoot:   bodyRoot[:],
 	}
 
-	return state_native.InitializeFromProtoPhase0(st)
+	return state_native.InitializeFromProtoUnsafePhase0(st)
 }
 
 // EmptyGenesisState returns an empty beacon state object.
@@ -259,7 +259,7 @@ func EmptyGenesisState() (state.BeaconState, error) {
 		Eth1DataVotes:    []*ethpb.Eth1Data{},
 		Eth1DepositIndex: 0,
 	}
-	return state_native.InitializeFromProtoPhase0(st)
+	return state_native.InitializeFromProtoUnsafePhase0(st)
 }
 
 // IsValidGenesisState gets called whenever there's a deposit event,

--- a/changelog/manu_initialize_unsafe.md
+++ b/changelog/manu_initialize_unsafe.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use `InitializeFromProtoUnsafeXXX` instead of `InitializeFromProtoXXX` when possible.

--- a/runtime/interop/premine-state.go
+++ b/runtime/interop/premine-state.go
@@ -104,7 +104,7 @@ func (s *PremineGenesisConfig) empty() (state.BeaconState, error) {
 
 	switch s.Version {
 	case version.Phase0:
-		e, err = state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
+		e, err = state_native.InitializeFromProtoUnsafePhase0(&ethpb.BeaconState{
 			BlockRoots:  bRoots,
 			StateRoots:  sRoots,
 			RandaoMixes: mixes,
@@ -115,7 +115,7 @@ func (s *PremineGenesisConfig) empty() (state.BeaconState, error) {
 			return nil, err
 		}
 	case version.Altair:
-		e, err = state_native.InitializeFromProtoAltair(&ethpb.BeaconStateAltair{
+		e, err = state_native.InitializeFromProtoUnsafeAltair(&ethpb.BeaconStateAltair{
 			BlockRoots:       bRoots,
 			StateRoots:       sRoots,
 			RandaoMixes:      mixes,
@@ -127,7 +127,7 @@ func (s *PremineGenesisConfig) empty() (state.BeaconState, error) {
 			return nil, err
 		}
 	case version.Bellatrix:
-		e, err = state_native.InitializeFromProtoBellatrix(&ethpb.BeaconStateBellatrix{
+		e, err = state_native.InitializeFromProtoUnsafeBellatrix(&ethpb.BeaconStateBellatrix{
 			BlockRoots:       bRoots,
 			StateRoots:       sRoots,
 			RandaoMixes:      mixes,
@@ -139,7 +139,7 @@ func (s *PremineGenesisConfig) empty() (state.BeaconState, error) {
 			return nil, err
 		}
 	case version.Capella:
-		e, err = state_native.InitializeFromProtoCapella(&ethpb.BeaconStateCapella{
+		e, err = state_native.InitializeFromProtoUnsafeCapella(&ethpb.BeaconStateCapella{
 			BlockRoots:       bRoots,
 			StateRoots:       sRoots,
 			RandaoMixes:      mixes,
@@ -151,19 +151,19 @@ func (s *PremineGenesisConfig) empty() (state.BeaconState, error) {
 			return nil, err
 		}
 	case version.Deneb:
-		e, err = state_native.InitializeFromProtoDeneb(&ethpb.BeaconStateDeneb{})
+		e, err = state_native.InitializeFromProtoUnsafeDeneb(&ethpb.BeaconStateDeneb{})
 		if err != nil {
 			return nil, err
 		}
 	case version.Electra:
-		e, err = state_native.InitializeFromProtoElectra(&ethpb.BeaconStateElectra{
+		e, err = state_native.InitializeFromProtoUnsafeElectra(&ethpb.BeaconStateElectra{
 			DepositRequestsStartIndex: params.BeaconConfig().UnsetDepositRequestsStartIndex,
 		})
 		if err != nil {
 			return nil, err
 		}
 	case version.Fulu:
-		e, err = state_native.InitializeFromProtoFulu(&ethpb.BeaconStateFulu{
+		e, err = state_native.InitializeFromProtoUnsafeFulu(&ethpb.BeaconStateFulu{
 			DepositRequestsStartIndex: params.BeaconConfig().UnsetDepositRequestsStartIndex,
 		})
 		if err != nil {

--- a/testing/benchmark/pregen.go
+++ b/testing/benchmark/pregen.go
@@ -53,7 +53,7 @@ func PreGenState1Epoch() (state.BeaconState, error) {
 	if err := beaconState.UnmarshalSSZ(beaconBytes); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoPhase0(beaconState)
+	return state_native.InitializeFromProtoUnsafePhase0(beaconState)
 }
 
 // PreGenstateFullEpochs unmarshals the pre-generated beacon state after 2 epoch of full block processing and returns it.
@@ -70,7 +70,7 @@ func PreGenstateFullEpochs() (state.BeaconState, error) {
 	if err := beaconState.UnmarshalSSZ(beaconBytes); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoPhase0(beaconState)
+	return state_native.InitializeFromProtoUnsafePhase0(beaconState)
 }
 
 // PreGenFullBlock unmarshals the pre-generated signed beacon block containing an epochs worth of attestations and returns it.

--- a/testing/spectest/shared/altair/epoch_processing/helpers.go
+++ b/testing/spectest/shared/altair/epoch_processing/helpers.go
@@ -35,7 +35,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoAltair(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeAltair(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/altair/finality/finality.go
+++ b/testing/spectest/shared/altair/finality/finality.go
@@ -43,7 +43,7 @@ func RunFinalityTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateAltair{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoAltair(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeAltair(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/altair/fork/transition.go
+++ b/testing/spectest/shared/altair/fork/transition.go
@@ -92,7 +92,7 @@ func RunForkTransitionTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconState{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoPhase0(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafePhase0(beaconStateBase)
 			require.NoError(t, err)
 
 			bc := params.BeaconConfig().Copy()

--- a/testing/spectest/shared/altair/fork/upgrade_to_altair.go
+++ b/testing/spectest/shared/altair/fork/upgrade_to_altair.go
@@ -38,7 +38,7 @@ func RunUpgradeToAltair(t *testing.T, config string) {
 			if err := preStateBase.UnmarshalSSZ(preStateSSZ); err != nil {
 				t.Fatalf("Failed to unmarshal: %v", err)
 			}
-			preState, err := state_native.InitializeFromProtoPhase0(preStateBase)
+			preState, err := state_native.InitializeFromProtoUnsafePhase0(preStateBase)
 			require.NoError(t, err)
 			postState, err := altair.UpgradeToAltair(context.Background(), preState)
 			require.NoError(t, err)

--- a/testing/spectest/shared/altair/operations/helpers.go
+++ b/testing/spectest/shared/altair/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoAltair(base)
+	return state_native.InitializeFromProtoUnsafeAltair(base)
 }
 
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {

--- a/testing/spectest/shared/altair/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/altair/rewards/rewards_penalties.go
@@ -69,7 +69,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	require.NoError(t, err, "Failed to decompress")
 	preBeaconStateBase := &ethpb.BeaconStateAltair{}
 	require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-	preBeaconState, err := state_native.InitializeFromProtoAltair(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeAltair(preBeaconStateBase)
 	require.NoError(t, err)
 
 	vp, bp, err := altair.InitializePrecomputeValidators(ctx, preBeaconState)

--- a/testing/spectest/shared/altair/sanity/block_processing.go
+++ b/testing/spectest/shared/altair/sanity/block_processing.go
@@ -45,7 +45,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateAltair{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoAltair(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeAltair(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/altair/sanity/slot_processing.go
+++ b/testing/spectest/shared/altair/sanity/slot_processing.go
@@ -38,7 +38,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconStateAltair{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoAltair(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafeAltair(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/bellatrix/epoch_processing/helpers.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/helpers.go
@@ -35,7 +35,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoBellatrix(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeBellatrix(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/bellatrix/finality/finality.go
+++ b/testing/spectest/shared/bellatrix/finality/finality.go
@@ -43,7 +43,7 @@ func RunFinalityTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateBellatrix{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoBellatrix(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeBellatrix(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/bellatrix/fork/transition.go
+++ b/testing/spectest/shared/bellatrix/fork/transition.go
@@ -86,7 +86,7 @@ func RunForkTransitionTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateAltair{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoAltair(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeAltair(beaconStateBase)
 			require.NoError(t, err)
 
 			bc := params.BeaconConfig().Copy()

--- a/testing/spectest/shared/bellatrix/fork/upgrade_to_bellatrix.go
+++ b/testing/spectest/shared/bellatrix/fork/upgrade_to_bellatrix.go
@@ -37,7 +37,7 @@ func RunUpgradeToBellatrix(t *testing.T, config string) {
 			if err := preStateBase.UnmarshalSSZ(preStateSSZ); err != nil {
 				t.Fatalf("Failed to unmarshal: %v", err)
 			}
-			preState, err := state_native.InitializeFromProtoAltair(preStateBase)
+			preState, err := state_native.InitializeFromProtoUnsafeAltair(preStateBase)
 			require.NoError(t, err)
 			postState, err := execution.UpgradeToBellatrix(preState)
 			require.NoError(t, err)

--- a/testing/spectest/shared/bellatrix/operations/helpers.go
+++ b/testing/spectest/shared/bellatrix/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoBellatrix(base)
+	return state_native.InitializeFromProtoUnsafeBellatrix(base)
 }
 
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {

--- a/testing/spectest/shared/bellatrix/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/bellatrix/rewards/rewards_penalties.go
@@ -73,7 +73,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	require.NoError(t, err, "Failed to decompress")
 	preBeaconStateBase := &ethpb.BeaconStateBellatrix{}
 	require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-	preBeaconState, err := state_native.InitializeFromProtoBellatrix(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeBellatrix(preBeaconStateBase)
 	require.NoError(t, err)
 
 	vp, bp, err := altair.InitializePrecomputeValidators(ctx, preBeaconState)

--- a/testing/spectest/shared/bellatrix/sanity/block_processing.go
+++ b/testing/spectest/shared/bellatrix/sanity/block_processing.go
@@ -45,7 +45,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateBellatrix{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoBellatrix(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeBellatrix(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/bellatrix/sanity/slot_processing.go
+++ b/testing/spectest/shared/bellatrix/sanity/slot_processing.go
@@ -37,7 +37,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconStateBellatrix{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoBellatrix(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafeBellatrix(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/capella/epoch_processing/helpers.go
+++ b/testing/spectest/shared/capella/epoch_processing/helpers.go
@@ -35,7 +35,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoCapella(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeCapella(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/capella/finality/finality.go
+++ b/testing/spectest/shared/capella/finality/finality.go
@@ -43,7 +43,7 @@ func RunFinalityTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateCapella{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoCapella(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeCapella(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/capella/fork/transition.go
+++ b/testing/spectest/shared/capella/fork/transition.go
@@ -86,7 +86,7 @@ func RunForkTransitionTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateBellatrix{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoBellatrix(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeBellatrix(beaconStateBase)
 			require.NoError(t, err)
 
 			bc := params.BeaconConfig().Copy()

--- a/testing/spectest/shared/capella/fork/upgrade_to_capella.go
+++ b/testing/spectest/shared/capella/fork/upgrade_to_capella.go
@@ -37,7 +37,7 @@ func RunUpgradeToCapella(t *testing.T, config string) {
 			if err := preStateBase.UnmarshalSSZ(preStateSSZ); err != nil {
 				t.Fatalf("Failed to unmarshal: %v", err)
 			}
-			preState, err := state_native.InitializeFromProtoBellatrix(preStateBase)
+			preState, err := state_native.InitializeFromProtoUnsafeBellatrix(preStateBase)
 			require.NoError(t, err)
 			postState, err := capella.UpgradeToCapella(preState)
 			require.NoError(t, err)

--- a/testing/spectest/shared/capella/operations/helpers.go
+++ b/testing/spectest/shared/capella/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoCapella(base)
+	return state_native.InitializeFromProtoUnsafeCapella(base)
 }
 
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {

--- a/testing/spectest/shared/capella/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/capella/rewards/rewards_penalties.go
@@ -73,7 +73,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	require.NoError(t, err, "Failed to decompress")
 	preBeaconStateBase := &ethpb.BeaconStateCapella{}
 	require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-	preBeaconState, err := state_native.InitializeFromProtoCapella(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeCapella(preBeaconStateBase)
 	require.NoError(t, err)
 
 	vp, bp, err := altair.InitializePrecomputeValidators(ctx, preBeaconState)

--- a/testing/spectest/shared/capella/sanity/block_processing.go
+++ b/testing/spectest/shared/capella/sanity/block_processing.go
@@ -45,7 +45,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateCapella{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoCapella(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeCapella(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/capella/sanity/slot_processing.go
+++ b/testing/spectest/shared/capella/sanity/slot_processing.go
@@ -37,7 +37,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconStateCapella{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoCapella(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafeCapella(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/capella/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/capella/ssz_static/ssz_static.go
@@ -22,7 +22,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	switch object.(type) {
 	case *ethpb.BeaconStateCapella:
 		htrs = append(htrs, func(s any) ([32]byte, error) {
-			beaconState, err := state_native.InitializeFromProtoCapella(s.(*ethpb.BeaconStateCapella))
+			beaconState, err := state_native.InitializeFromProtoUnsafeCapella(s.(*ethpb.BeaconStateCapella))
 			require.NoError(t, err)
 			return beaconState.HashTreeRoot(context.Background())
 		})

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -483,7 +483,7 @@ func errAssertionForStep(step Step, expect error) func(t *testing.T, err error) 
 func unmarshalPhase0State(t *testing.T, raw []byte) state.BeaconState {
 	base := &ethpb.BeaconState{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoPhase0(base)
+	st, err := state_native.InitializeFromProtoUnsafePhase0(base)
 	require.NoError(t, err)
 	return st
 }
@@ -511,7 +511,7 @@ func unmarshalSignedPhase0Block(t *testing.T, raw []byte) interfaces.ReadOnlySig
 func unmarshalAltairState(t *testing.T, raw []byte) state.BeaconState {
 	base := &ethpb.BeaconStateAltair{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoAltair(base)
+	st, err := state_native.InitializeFromProtoUnsafeAltair(base)
 	require.NoError(t, err)
 	return st
 }
@@ -539,7 +539,7 @@ func unmarshalSignedAltairBlock(t *testing.T, raw []byte) interfaces.ReadOnlySig
 func unmarshalBellatrixState(t *testing.T, raw []byte) state.BeaconState {
 	base := &ethpb.BeaconStateBellatrix{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoBellatrix(base)
+	st, err := state_native.InitializeFromProtoUnsafeBellatrix(base)
 	require.NoError(t, err)
 	return st
 }
@@ -567,7 +567,7 @@ func unmarshalSignedBellatrixBlock(t *testing.T, raw []byte) interfaces.ReadOnly
 func unmarshalCapellaState(t *testing.T, raw []byte) state.BeaconState {
 	base := &ethpb.BeaconStateCapella{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoCapella(base)
+	st, err := state_native.InitializeFromProtoUnsafeCapella(base)
 	require.NoError(t, err)
 	return st
 }
@@ -595,7 +595,7 @@ func unmarshalSignedCapellaBlock(t *testing.T, raw []byte) interfaces.ReadOnlySi
 func unmarshalDenebState(t *testing.T, raw []byte) state.BeaconState {
 	base := &ethpb.BeaconStateDeneb{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoDeneb(base)
+	st, err := state_native.InitializeFromProtoUnsafeDeneb(base)
 	require.NoError(t, err)
 	return st
 }
@@ -623,7 +623,7 @@ func unmarshalSignedDenebBlock(t *testing.T, raw []byte) interfaces.SignedBeacon
 func unmarshalElectraState(t *testing.T, raw []byte) state.BeaconState {
 	base := &ethpb.BeaconStateElectra{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoElectra(base)
+	st, err := state_native.InitializeFromProtoUnsafeElectra(base)
 	require.NoError(t, err)
 	return st
 }
@@ -651,7 +651,7 @@ func unmarshalSignedElectraBlock(t *testing.T, raw []byte) interfaces.SignedBeac
 func unmarshalFuluState(t *testing.T, raw []byte) state.BeaconState {
 	base := &ethpb.BeaconStateFulu{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
-	st, err := state_native.InitializeFromProtoFulu(base)
+	st, err := state_native.InitializeFromProtoUnsafeFulu(base)
 	require.NoError(t, err)
 	return st
 }

--- a/testing/spectest/shared/common/light_client/single_merkle_proof.go
+++ b/testing/spectest/shared/common/light_client/single_merkle_proof.go
@@ -63,32 +63,32 @@ func runLightClientSingleMerkleProofTestBeaconState(t *testing.T, testFolderPath
 	case version.Altair:
 		beaconStateBase := &ethpb.BeaconStateAltair{}
 		require.NoError(t, beaconStateBase.UnmarshalSSZ(beaconStateSSZ), "Failed to unmarshal")
-		beaconState, err = state_native.InitializeFromProtoAltair(beaconStateBase)
+		beaconState, err = state_native.InitializeFromProtoUnsafeAltair(beaconStateBase)
 		require.NoError(t, err)
 	case version.Bellatrix:
 		beaconStateBase := &ethpb.BeaconStateBellatrix{}
 		require.NoError(t, beaconStateBase.UnmarshalSSZ(beaconStateSSZ), "Failed to unmarshal")
-		beaconState, err = state_native.InitializeFromProtoBellatrix(beaconStateBase)
+		beaconState, err = state_native.InitializeFromProtoUnsafeBellatrix(beaconStateBase)
 		require.NoError(t, err)
 	case version.Capella:
 		beaconStateBase := &ethpb.BeaconStateCapella{}
 		require.NoError(t, beaconStateBase.UnmarshalSSZ(beaconStateSSZ), "Failed to unmarshal")
-		beaconState, err = state_native.InitializeFromProtoCapella(beaconStateBase)
+		beaconState, err = state_native.InitializeFromProtoUnsafeCapella(beaconStateBase)
 		require.NoError(t, err)
 	case version.Deneb:
 		beaconStateBase := &ethpb.BeaconStateDeneb{}
 		require.NoError(t, beaconStateBase.UnmarshalSSZ(beaconStateSSZ), "Failed to unmarshal")
-		beaconState, err = state_native.InitializeFromProtoDeneb(beaconStateBase)
+		beaconState, err = state_native.InitializeFromProtoUnsafeDeneb(beaconStateBase)
 		require.NoError(t, err)
 	case version.Electra:
 		beaconStateBase := &ethpb.BeaconStateElectra{}
 		require.NoError(t, beaconStateBase.UnmarshalSSZ(beaconStateSSZ), "Failed to unmarshal")
-		beaconState, err = state_native.InitializeFromProtoElectra(beaconStateBase)
+		beaconState, err = state_native.InitializeFromProtoUnsafeElectra(beaconStateBase)
 		require.NoError(t, err)
 	case version.Fulu:
 		beaconStateBase := &ethpb.BeaconStateFulu{}
 		require.NoError(t, beaconStateBase.UnmarshalSSZ(beaconStateSSZ), "Failed to unmarshal")
-		beaconState, err = state_native.InitializeFromProtoFulu(beaconStateBase)
+		beaconState, err = state_native.InitializeFromProtoUnsafeFulu(beaconStateBase)
 		require.NoError(t, err)
 	default:
 		t.Fatalf("Unsupported version: %d", v)

--- a/testing/spectest/shared/deneb/epoch_processing/helpers.go
+++ b/testing/spectest/shared/deneb/epoch_processing/helpers.go
@@ -33,7 +33,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoDeneb(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeDeneb(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/deneb/finality/finality.go
+++ b/testing/spectest/shared/deneb/finality/finality.go
@@ -40,7 +40,7 @@ func RunFinalityTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateDeneb{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoDeneb(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeDeneb(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/deneb/fork/transition.go
+++ b/testing/spectest/shared/deneb/fork/transition.go
@@ -86,7 +86,7 @@ func RunForkTransitionTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateCapella{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoCapella(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeCapella(beaconStateBase)
 			require.NoError(t, err)
 
 			bc := params.BeaconConfig().Copy()

--- a/testing/spectest/shared/deneb/fork/upgrade_to_deneb.go
+++ b/testing/spectest/shared/deneb/fork/upgrade_to_deneb.go
@@ -36,7 +36,7 @@ func RunUpgradeToDeneb(t *testing.T, config string) {
 			if err := preStateBase.UnmarshalSSZ(preStateSSZ); err != nil {
 				t.Fatalf("Failed to unmarshal: %v", err)
 			}
-			preState, err := state_native.InitializeFromProtoCapella(preStateBase)
+			preState, err := state_native.InitializeFromProtoUnsafeCapella(preStateBase)
 			require.NoError(t, err)
 			postState, err := deneb.UpgradeToDeneb(preState)
 			require.NoError(t, err)

--- a/testing/spectest/shared/deneb/operations/helpers.go
+++ b/testing/spectest/shared/deneb/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoDeneb(base)
+	return state_native.InitializeFromProtoUnsafeDeneb(base)
 }
 
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {

--- a/testing/spectest/shared/deneb/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/deneb/rewards/rewards_penalties.go
@@ -65,7 +65,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	require.NoError(t, err, "Failed to decompress")
 	preBeaconStateBase := &ethpb.BeaconStateDeneb{}
 	require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-	preBeaconState, err := state_native.InitializeFromProtoDeneb(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeDeneb(preBeaconStateBase)
 	require.NoError(t, err)
 
 	vp, bp, err := altair.InitializePrecomputeValidators(ctx, preBeaconState)

--- a/testing/spectest/shared/deneb/sanity/block_processing.go
+++ b/testing/spectest/shared/deneb/sanity/block_processing.go
@@ -44,7 +44,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateDeneb{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoDeneb(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeDeneb(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/deneb/sanity/slot_processing.go
+++ b/testing/spectest/shared/deneb/sanity/slot_processing.go
@@ -33,7 +33,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconStateDeneb{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoDeneb(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafeDeneb(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/deneb/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/deneb/ssz_static/ssz_static.go
@@ -25,7 +25,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	}
 
 	htrs = append(htrs, func(s any) ([32]byte, error) {
-		beaconState, err := state_native.InitializeFromProtoDeneb(s.(*ethpb.BeaconStateDeneb))
+		beaconState, err := state_native.InitializeFromProtoUnsafeDeneb(s.(*ethpb.BeaconStateDeneb))
 		require.NoError(t, err)
 		return beaconState.HashTreeRoot(context.Background())
 	})

--- a/testing/spectest/shared/electra/epoch_processing/helpers.go
+++ b/testing/spectest/shared/electra/epoch_processing/helpers.go
@@ -35,7 +35,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoElectra(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeElectra(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/electra/finality/finality.go
+++ b/testing/spectest/shared/electra/finality/finality.go
@@ -42,7 +42,7 @@ func RunFinalityTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateElectra{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoElectra(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeElectra(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/electra/fork/transition.go
+++ b/testing/spectest/shared/electra/fork/transition.go
@@ -83,7 +83,7 @@ func RunForkTransitionTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateDeneb{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoDeneb(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeDeneb(beaconStateBase)
 			require.NoError(t, err)
 
 			bc := params.BeaconConfig().Copy()

--- a/testing/spectest/shared/electra/fork/upgrade_to_electra.go
+++ b/testing/spectest/shared/electra/fork/upgrade_to_electra.go
@@ -36,7 +36,7 @@ func RunUpgradeToElectra(t *testing.T, config string) {
 			if err := preStateBase.UnmarshalSSZ(preStateSSZ); err != nil {
 				t.Fatalf("Failed to unmarshal: %v", err)
 			}
-			preState, err := state_native.InitializeFromProtoDeneb(preStateBase)
+			preState, err := state_native.InitializeFromProtoUnsafeDeneb(preStateBase)
 			require.NoError(t, err)
 			postState, err := electra.UpgradeToElectra(preState)
 			require.NoError(t, err)

--- a/testing/spectest/shared/electra/operations/helpers.go
+++ b/testing/spectest/shared/electra/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoElectra(base)
+	return state_native.InitializeFromProtoUnsafeElectra(base)
 }
 
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {

--- a/testing/spectest/shared/electra/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/electra/rewards/rewards_penalties.go
@@ -65,7 +65,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	require.NoError(t, err, "Failed to decompress")
 	preBeaconStateBase := &ethpb.BeaconStateElectra{}
 	require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-	preBeaconState, err := state_native.InitializeFromProtoElectra(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeElectra(preBeaconStateBase)
 	require.NoError(t, err)
 
 	vp, bp, err := electra.InitializePrecomputeValidators(ctx, preBeaconState)

--- a/testing/spectest/shared/electra/sanity/block_processing.go
+++ b/testing/spectest/shared/electra/sanity/block_processing.go
@@ -48,7 +48,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateElectra{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoElectra(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeElectra(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/electra/sanity/slot_processing.go
+++ b/testing/spectest/shared/electra/sanity/slot_processing.go
@@ -33,7 +33,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconStateElectra{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoElectra(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafeElectra(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/electra/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/electra/ssz_static/ssz_static.go
@@ -25,7 +25,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	}
 
 	htrs = append(htrs, func(s any) ([32]byte, error) {
-		beaconState, err := state_native.InitializeFromProtoElectra(s.(*ethpb.BeaconStateElectra))
+		beaconState, err := state_native.InitializeFromProtoUnsafeElectra(s.(*ethpb.BeaconStateElectra))
 		require.NoError(t, err)
 		return beaconState.HashTreeRoot(context.Background())
 	})

--- a/testing/spectest/shared/fulu/epoch_processing/helpers.go
+++ b/testing/spectest/shared/fulu/epoch_processing/helpers.go
@@ -35,7 +35,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoFulu(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeFulu(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/fulu/finality/finality.go
+++ b/testing/spectest/shared/fulu/finality/finality.go
@@ -42,7 +42,7 @@ func RunFinalityTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateFulu{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoFulu(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeFulu(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/fulu/fork/transition.go
+++ b/testing/spectest/shared/fulu/fork/transition.go
@@ -83,7 +83,7 @@ func RunForkTransitionTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateElectra{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoElectra(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeElectra(beaconStateBase)
 			require.NoError(t, err)
 
 			bc := params.BeaconConfig().Copy()

--- a/testing/spectest/shared/fulu/fork/upgrade_to_fulu.go
+++ b/testing/spectest/shared/fulu/fork/upgrade_to_fulu.go
@@ -36,7 +36,7 @@ func RunUpgradeToFulu(t *testing.T, config string) {
 			if err := preStateBase.UnmarshalSSZ(preStateSSZ); err != nil {
 				t.Fatalf("Failed to unmarshal: %v", err)
 			}
-			preState, err := state_native.InitializeFromProtoElectra(preStateBase)
+			preState, err := state_native.InitializeFromProtoUnsafeElectra(preStateBase)
 			require.NoError(t, err)
 			postState, err := fulu.UpgradeToFulu(t.Context(), preState)
 			require.NoError(t, err)

--- a/testing/spectest/shared/fulu/operations/helpers.go
+++ b/testing/spectest/shared/fulu/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoFulu(base)
+	return state_native.InitializeFromProtoUnsafeFulu(base)
 }
 
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {

--- a/testing/spectest/shared/fulu/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/fulu/rewards/rewards_penalties.go
@@ -65,7 +65,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	require.NoError(t, err, "Failed to decompress")
 	preBeaconStateBase := &ethpb.BeaconStateFulu{}
 	require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-	preBeaconState, err := state_native.InitializeFromProtoFulu(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeFulu(preBeaconStateBase)
 	require.NoError(t, err)
 
 	vp, bp, err := electra.InitializePrecomputeValidators(ctx, preBeaconState)

--- a/testing/spectest/shared/fulu/sanity/block_processing.go
+++ b/testing/spectest/shared/fulu/sanity/block_processing.go
@@ -49,7 +49,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconStateFulu{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoFulu(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafeFulu(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/fulu/sanity/slot_processing.go
+++ b/testing/spectest/shared/fulu/sanity/slot_processing.go
@@ -33,7 +33,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconStateFulu{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoFulu(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafeFulu(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/fulu/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/fulu/ssz_static/ssz_static.go
@@ -25,7 +25,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	}
 
 	htrs = append(htrs, func(s any) ([32]byte, error) {
-		beaconState, err := state_native.InitializeFromProtoFulu(s.(*ethpb.BeaconStateFulu))
+		beaconState, err := state_native.InitializeFromProtoUnsafeFulu(s.(*ethpb.BeaconStateFulu))
 		require.NoError(t, err)
 		return beaconState.HashTreeRoot(context.Background())
 	})

--- a/testing/spectest/shared/gloas/epoch_processing/helpers.go
+++ b/testing/spectest/shared/gloas/epoch_processing/helpers.go
@@ -35,7 +35,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoGloas(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafeGloas(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/gloas/operations/helpers.go
+++ b/testing/spectest/shared/gloas/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoGloas(base)
+	return state_native.InitializeFromProtoUnsafeGloas(base)
 }
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {
 	base := &ethpb.BeaconBlockGloas{}

--- a/testing/spectest/shared/gloas/sanity/slot_processing.go
+++ b/testing/spectest/shared/gloas/sanity/slot_processing.go
@@ -33,7 +33,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconStateGloas{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoGloas(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafeGloas(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/gloas/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/gloas/ssz_static/ssz_static.go
@@ -26,7 +26,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	}
 
 	htrs = append(htrs, func(s any) ([32]byte, error) {
-		beaconState, err := state_native.InitializeFromProtoGloas(s.(*ethpb.BeaconStateGloas))
+		beaconState, err := state_native.InitializeFromProtoUnsafeGloas(s.(*ethpb.BeaconStateGloas))
 		require.NoError(t, err)
 
 		return beaconState.HashTreeRoot(context.Background())

--- a/testing/spectest/shared/phase0/epoch_processing/helpers.go
+++ b/testing/spectest/shared/phase0/epoch_processing/helpers.go
@@ -33,7 +33,7 @@ func RunEpochOperationTest(
 	if err := preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
-	preBeaconState, err := state_native.InitializeFromProtoPhase0(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafePhase0(preBeaconStateBase)
 	require.NoError(t, err)
 
 	// If the post.ssz is not present, it means the test should fail on our end.

--- a/testing/spectest/shared/phase0/finality/runner.go
+++ b/testing/spectest/shared/phase0/finality/runner.go
@@ -45,7 +45,7 @@ func RunFinalityTest(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconState{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoPhase0(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafePhase0(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/phase0/operations/helpers.go
+++ b/testing/spectest/shared/phase0/operations/helpers.go
@@ -13,7 +13,7 @@ func sszToState(b []byte) (state.BeaconState, error) {
 	if err := base.UnmarshalSSZ(b); err != nil {
 		return nil, err
 	}
-	return state_native.InitializeFromProtoPhase0(base)
+	return state_native.InitializeFromProtoUnsafePhase0(base)
 }
 
 func sszToBlock(b []byte) (interfaces.SignedBeaconBlock, error) {

--- a/testing/spectest/shared/phase0/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/phase0/rewards/rewards_penalties.go
@@ -79,7 +79,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	require.NoError(t, err, "Failed to decompress")
 	preBeaconStateBase := &ethpb.BeaconState{}
 	require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-	preBeaconState, err := state_native.InitializeFromProtoPhase0(preBeaconStateBase)
+	preBeaconState, err := state_native.InitializeFromProtoUnsafePhase0(preBeaconStateBase)
 	require.NoError(t, err)
 
 	vp, bp, err := precompute.New(ctx, preBeaconState)

--- a/testing/spectest/shared/phase0/sanity/block_processing.go
+++ b/testing/spectest/shared/phase0/sanity/block_processing.go
@@ -45,7 +45,7 @@ func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 			require.NoError(t, err, "Failed to decompress")
 			beaconStateBase := &ethpb.BeaconState{}
 			require.NoError(t, beaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoPhase0(beaconStateBase)
+			beaconState, err := state_native.InitializeFromProtoUnsafePhase0(beaconStateBase)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "meta.yaml")

--- a/testing/spectest/shared/phase0/sanity/slot_processing.go
+++ b/testing/spectest/shared/phase0/sanity/slot_processing.go
@@ -37,7 +37,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			base := &ethpb.BeaconState{}
 			require.NoError(t, base.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
-			beaconState, err := state_native.InitializeFromProtoPhase0(base)
+			beaconState, err := state_native.InitializeFromProtoUnsafePhase0(base)
 			require.NoError(t, err)
 
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")

--- a/testing/spectest/shared/phase0/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/phase0/ssz_static/ssz_static.go
@@ -21,7 +21,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	switch object.(type) {
 	case *ethpb.BeaconState:
 		htrs = append(htrs, func(s any) ([32]byte, error) {
-			beaconState, err := state_native.InitializeFromProtoPhase0(s.(*ethpb.BeaconState))
+			beaconState, err := state_native.InitializeFromProtoUnsafePhase0(s.(*ethpb.BeaconState))
 			require.NoError(t, err)
 			return beaconState.HashTreeRoot(context.TODO())
 		})

--- a/testing/util/altair.go
+++ b/testing/util/altair.go
@@ -213,7 +213,7 @@ func buildGenesisBeaconState(genesisTime uint64, preState state.BeaconState, eth
 		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
 	}
 
-	return state_native.InitializeFromProtoAltair(st)
+	return state_native.InitializeFromProtoUnsafeAltair(st)
 }
 
 func emptyGenesisState() (state.BeaconState, error) {
@@ -240,7 +240,7 @@ func emptyGenesisState() (state.BeaconState, error) {
 		Eth1DataVotes:    []*ethpb.Eth1Data{},
 		Eth1DepositIndex: 0,
 	}
-	return state_native.InitializeFromProtoAltair(st)
+	return state_native.InitializeFromProtoUnsafeAltair(st)
 }
 
 // NewBeaconBlockAltair creates a beacon block with minimum marshalable fields.

--- a/testing/util/bellatrix_state.go
+++ b/testing/util/bellatrix_state.go
@@ -84,7 +84,7 @@ func emptyGenesisStateBellatrix() (state.BeaconState, error) {
 
 		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeader{},
 	}
-	return state_native.InitializeFromProtoBellatrix(st)
+	return state_native.InitializeFromProtoUnsafeBellatrix(st)
 }
 
 func buildGenesisBeaconStateBellatrix(genesisTime time.Time, preState state.BeaconState, eth1Data *ethpb.Eth1Data) (state.BeaconState, error) {
@@ -250,7 +250,7 @@ func buildGenesisBeaconStateBellatrix(genesisTime time.Time, preState state.Beac
 		TransactionsRoot: make([]byte, 32),
 	}
 
-	bs, err := state_native.InitializeFromProtoBellatrix(st)
+	bs, err := state_native.InitializeFromProtoUnsafeBellatrix(st)
 	if err != nil {
 		return nil, err
 	}

--- a/testing/util/capella_state.go
+++ b/testing/util/capella_state.go
@@ -82,7 +82,7 @@ func emptyGenesisStateCapella() (state.BeaconState, error) {
 
 		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderCapella{},
 	}
-	return state_native.InitializeFromProtoCapella(st)
+	return state_native.InitializeFromProtoUnsafeCapella(st)
 }
 
 func buildGenesisBeaconStateCapella(genesisTime uint64, preState state.BeaconState, eth1Data *ethpb.Eth1Data) (state.BeaconState, error) {
@@ -250,5 +250,5 @@ func buildGenesisBeaconStateCapella(genesisTime uint64, preState state.BeaconSta
 		WithdrawalsRoot:  make([]byte, 32),
 	}
 
-	return state_native.InitializeFromProtoCapella(st)
+	return state_native.InitializeFromProtoUnsafeCapella(st)
 }

--- a/testing/util/deneb_state.go
+++ b/testing/util/deneb_state.go
@@ -82,7 +82,7 @@ func emptyGenesisStateDeneb() (state.BeaconState, error) {
 
 		LatestExecutionPayloadHeader: &enginev1.ExecutionPayloadHeaderDeneb{},
 	}
-	return state_native.InitializeFromProtoDeneb(st)
+	return state_native.InitializeFromProtoUnsafeDeneb(st)
 }
 
 func buildGenesisBeaconStateDeneb(genesisTime uint64, preState state.BeaconState, eth1Data *ethpb.Eth1Data) (state.BeaconState, error) {
@@ -250,5 +250,5 @@ func buildGenesisBeaconStateDeneb(genesisTime uint64, preState state.BeaconState
 		WithdrawalsRoot:  make([]byte, 32),
 	}
 
-	return state_native.InitializeFromProtoDeneb(st)
+	return state_native.InitializeFromProtoUnsafeDeneb(st)
 }

--- a/testing/util/electra_state.go
+++ b/testing/util/electra_state.go
@@ -111,7 +111,7 @@ func emptyGenesisStateElectra() (state.BeaconState, error) {
 		ExitBalanceToConsume:          primitives.Gwei(0),
 		ConsolidationBalanceToConsume: primitives.Gwei(0),
 	}
-	return state_native.InitializeFromProtoElectra(st)
+	return state_native.InitializeFromProtoUnsafeElectra(st)
 }
 
 func buildGenesisBeaconStateElectra(genesisTime uint64, preState state.BeaconState, eth1Data *ethpb.Eth1Data, opts ...ElectraStateOption) (state.BeaconState, error) {
@@ -301,5 +301,5 @@ func buildGenesisBeaconStateElectra(genesisTime uint64, preState state.BeaconSta
 		WithdrawalsRoot:  make([]byte, 32),
 	}
 
-	return state_native.InitializeFromProtoElectra(st)
+	return state_native.InitializeFromProtoUnsafeElectra(st)
 }

--- a/testing/util/fulu_state.go
+++ b/testing/util/fulu_state.go
@@ -106,7 +106,7 @@ func emptyGenesisStateFulu() (state.BeaconState, error) {
 		// Fulu specific field
 		ProposerLookahead: []uint64{},
 	}
-	return state_native.InitializeFromProtoFulu(st)
+	return state_native.InitializeFromProtoUnsafeFulu(st)
 }
 
 func buildGenesisBeaconStateFulu(genesisTime uint64, preState state.BeaconState, eth1Data *ethpb.Eth1Data) (state.BeaconState, error) {
@@ -293,7 +293,7 @@ func buildGenesisBeaconStateFulu(genesisTime uint64, preState state.BeaconState,
 	}
 
 	// Calculate proposer lookahead for genesis
-	preFuluSt, err := state_native.InitializeFromProtoFulu(st)
+	preFuluSt, err := state_native.InitializeFromProtoUnsafeFulu(st)
 	if err != nil {
 		return nil, err
 	}
@@ -304,5 +304,5 @@ func buildGenesisBeaconStateFulu(genesisTime uint64, preState state.BeaconState,
 
 	// Fulu specific field
 	st.ProposerLookahead = proposerLookahead
-	return state_native.InitializeFromProtoFulu(st)
+	return state_native.InitializeFromProtoUnsafeFulu(st)
 }

--- a/tools/pcli/main.go
+++ b/tools/pcli/main.go
@@ -384,7 +384,7 @@ func benchmarkHash(sszPath string, sszType string) {
 		}
 		deserializeDuration := time.Since(startDeserialize)
 
-		stateTrieState, err := state_native.InitializeFromProtoCapella(st)
+		stateTrieState, err := state_native.InitializeFromProtoUnsafeCapella(st)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION


**What type of PR is this?**
Optimisation

**What does this PR do? Why is it needed?**
Use `InitializeFromProtoUnsafeXXX` instead of `InitializeFromProtoXXX` when possible. (@nisdas' change)
This change avoids useless copies.

The difference between these two methods is the latest copies the input state. However, if the input state is guaranteed not to be modified after the use of this function (and, in particular, if the input state is not used at all after the use of this function), then copying it is unnecessarry. ==> Using the "unsafe" method is fine in this case.

**Other notes for review**
As a reviewer, you should ensure that when the unsafe method is used, then the input state is never modified after the use of the function.

This PR is much easier to review directly in VSCode, because it displays more context by default.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
