### PR TITLE
Get parent root return parent root if parent is older than gloas

### DIFF
--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -1,8 +1,10 @@
 package blockchain
 
 import (
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensus_blocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
 
@@ -14,6 +16,14 @@ func (s *Service) getLookupParentRoot(b consensus_blocks.ROBlock) ([32]byte, err
 	bl := b.Block()
 	parentRoot := bl.ParentRoot()
 	if b.Version() < version.Gloas {
+		return parentRoot, nil
+	}
+	parentSlot, err := s.cfg.ForkChoiceStore.Slot(parentRoot)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "failed to get slot for parent root")
+	}
+
+	if slots.ToEpoch(parentSlot) < params.BeaconConfig().GloasForkEpoch {
 		return parentRoot, nil
 	}
 	blockHash, err := s.cfg.ForkChoiceStore.BlockHash(parentRoot)

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
@@ -465,6 +466,12 @@ func TestGetLookupParentRoot_PreGloas(t *testing.T) {
 }
 
 func TestGetLookupParentRoot_GloasBuildsOnEmpty(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	params.OverrideBeaconConfig(cfg)
+
 	service, req := minimalTestService(t)
 	ctx := t.Context()
 
@@ -506,6 +513,12 @@ func TestGetLookupParentRoot_GloasBuildsOnEmpty(t *testing.T) {
 }
 
 func TestGetLookupParentRoot_GloasBuildsOnFull(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	params.OverrideBeaconConfig(cfg)
+
 	service, req := minimalTestService(t)
 	ctx := t.Context()
 
@@ -544,6 +557,63 @@ func TestGetLookupParentRoot_GloasBuildsOnFull(t *testing.T) {
 	require.NoError(t, err)
 	// parentBlockHash == parentNodeBlockHash, so it builds on full => returns parentBlockHash
 	require.Equal(t, parentNodeBlockHash, got)
+}
+
+func TestGetLookupParentRoot_GloasParentPreForkEpoch(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	params.OverrideBeaconConfig(cfg)
+
+	service, req := minimalTestService(t)
+	ctx := t.Context()
+
+	parentRoot := [32]byte{1}
+	parentNodeBlockHash := [32]byte{10}
+	parentSlot, err := slots.EpochStart(params.BeaconConfig().GloasForkEpoch)
+	require.NoError(t, err)
+	parentSlot = parentSlot - 1
+
+	st, parentROBlock, err := prepareGloasForkchoiceState(
+		ctx,
+		parentSlot,
+		parentRoot,
+		params.BeaconConfig().ZeroHash,
+		parentNodeBlockHash,
+		params.BeaconConfig().ZeroHash,
+		0,
+		0,
+	)
+	require.NoError(t, err)
+	require.NoError(t, req.fcs.InsertNode(ctx, st, parentROBlock))
+
+	blockHash := [32]byte{20}
+	bid := util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			BlockHash:       blockHash[:],
+			ParentBlockHash: parentNodeBlockHash[:],
+		},
+	})
+
+	blk := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       parentSlot + 1,
+			ParentRoot: parentRoot[:],
+			Body: &ethpb.BeaconBlockBodyGloas{
+				SignedExecutionPayloadBid: bid,
+			},
+		},
+	})
+	wsb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	roblock, err := blocks.NewROBlock(wsb)
+	require.NoError(t, err)
+
+	got, err := service.getLookupParentRoot(roblock)
+	require.NoError(t, err)
+	// Parent slot is pre-fork, so always return parentRoot.
+	require.Equal(t, parentRoot, got)
 }
 
 func TestLateBlockTasks_GloasFCU(t *testing.T) {

--- a/changelog/terence_fix-gloas-parent-pre-fork.md
+++ b/changelog/terence_fix-gloas-parent-pre-fork.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Ensure Gloas pre-state lookup falls back to parent root when the parent slot is pre-fork.


### PR DESCRIPTION
This PR makes sure gloas parent pre‑state lookup falls back to the parent root when the parent slot is pre‑fork.

Example:
- GloasForkEpoch = 1, 8 slots per epoch, and we process a block at slot 9 with parent at slot 8
- Slot 8 is still pre‑Gloas. The pre‑state for slot 9 must be fetched by parent root, not by hash