### PR TITLE
Save head for gloas block without FCU

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -107,6 +107,11 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	}
 	if cfg.roblock.Version() < version.Gloas {
 		s.sendFCU(cfg)
+	} else {
+		// For Gloas blocks, the execution payload arrives separately via the payload envelope, but we will need to save head.
+		if err := s.saveHeadNoDB(cfg.ctx, cfg.roblock, cfg.headRoot, cfg.postState, true /* optimistic */); err != nil {
+			log.WithError(err).Error("Could not save head for gloas block")
+		}
 	}
 
 	// Pre-Fulu the caches are updated when computing the payload attributes

--- a/changelog/terence_fix-gloas-save-head.md
+++ b/changelog/terence_fix-gloas-save-head.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Save head for Gloas blocks without FCU.


### PR DESCRIPTION
Even without FCU, we still need to save head in `postBlockProcess`, but im not sure if we should save head or save head no db. Need more eyes here