### PR TITLE
Fix use latest block hash for gloas parent hash

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -273,6 +273,13 @@ var errNoTerminalBlockHash = errors.New("no terminal block hash")
 //
 // Otherwise, the terminal block hash is fetched based on the slot's time, and an error is returned if it doesn't exist.
 func (vs *Server) getParentBlockHash(ctx context.Context, st state.BeaconState, slot primitives.Slot) ([]byte, error) {
+	if st.Version() >= version.Gloas {
+		latestBlockHash, err := st.LatestBlockHash()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get latest block hash")
+		}
+		return latestBlockHash[:], nil
+	}
 	if st.Version() >= version.Capella {
 		return getParentBlockHashPostCapella(st)
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
@@ -176,6 +176,20 @@ func TestServer_getExecutionPayload(t *testing.T) {
 	}
 }
 
+func TestServer_getParentBlockHash_Gloas(t *testing.T) {
+	want := bytesutil.ToBytes32([]byte("gloas-parent-hash"))
+	st, err := util.NewBeaconStateGloas(func(state *ethpb.BeaconStateGloas) error {
+		state.LatestBlockHash = want[:]
+		return nil
+	})
+	require.NoError(t, err)
+
+	vs := &Server{}
+	got, err := vs.getParentBlockHash(context.Background(), st, 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, want[:], got)
+}
+
 func TestServer_getExecutionPayloadContextTimeout(t *testing.T) {
 	beaconDB := dbTest.SetupDB(t)
 	nonTransitionSt, _ := util.DeterministicGenesisStateBellatrix(t, 1)

--- a/changelog/terence_fix-gloas-parent-block-hash.md
+++ b/changelog/terence_fix-gloas-parent-block-hash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use the Gloas `LatestBlockHash` when deriving the parent block hash for payload construction.


### PR DESCRIPTION
Fix parent block hash look up in Gloas case, which we should be using state's latest block hash instead of normal capella path