### PR TITLE
Update consensus node weight to return both empty and full

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -64,11 +64,11 @@ func (s *Service) getFCUArgsEarlyBlock(cfg *postBlockProcessConfig) (*fcuConfig,
 // block is not the head of the chain. It requires the caller holds a lock on
 // Forkchoice.
 func (s *Service) logNonCanonicalBlockReceived(blockRoot [32]byte, headRoot [32]byte) {
-	receivedWeight, err := s.cfg.ForkChoiceStore.Weight(blockRoot)
+	receivedWeight, err := s.cfg.ForkChoiceStore.ConsensusNodeWeight(blockRoot)
 	if err != nil {
 		log.WithField("root", fmt.Sprintf("%#x", blockRoot)).Warn("Could not determine node weight")
 	}
-	headWeight, err := s.cfg.ForkChoiceStore.Weight(headRoot)
+	headWeight, err := s.cfg.ForkChoiceStore.ConsensusNodeWeight(headRoot)
 	if err != nil {
 		log.WithField("root", fmt.Sprintf("%#x", headRoot)).Warn("Could not determine node weight")
 	}

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -624,9 +624,19 @@ func (f *ForkChoice) SetBalancesByRooter(handler forkchoice.BalancesByRooter) {
 	f.balancesByRoot = handler
 }
 
-// Weight returns the weight of the given root if found on the store.
-// For Gloas blocks, the consensus node weight is returned (which includes both empty and full payload node weights).
+// Weight returns the payload-node weight of the given root if found on the store.
+// For Gloas, this is the node weight used for forkchoice on the payload tree.
 func (f *ForkChoice) Weight(root [32]byte) (uint64, error) {
+	n, ok := f.store.emptyNodeByRoot[root]
+	if !ok || n == nil {
+		return 0, ErrNilNode
+	}
+	return n.weight, nil
+}
+
+// ConsensusNodeWeight returns the consensus-node weight for the given root if found on the store.
+// For Gloas blocks, this includes both empty and full payload node weights.
+func (f *ForkChoice) ConsensusNodeWeight(root [32]byte) (uint64, error) {
 	n, ok := f.store.emptyNodeByRoot[root]
 	if !ok || n == nil {
 		return 0, ErrNilNode

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -624,13 +624,14 @@ func (f *ForkChoice) SetBalancesByRooter(handler forkchoice.BalancesByRooter) {
 	f.balancesByRoot = handler
 }
 
-// Weight returns the weight of the given root if found on the store
+// Weight returns the weight of the given root if found on the store.
+// For Gloas blocks, the consensus node weight is returned (which includes both empty and full payload node weights).
 func (f *ForkChoice) Weight(root [32]byte) (uint64, error) {
 	n, ok := f.store.emptyNodeByRoot[root]
 	if !ok || n == nil {
 		return 0, ErrNilNode
 	}
-	return n.weight, nil
+	return n.node.weight, nil
 }
 
 // updateJustifiedBalances updates the validators balances on the justified checkpoint pointed by root.

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -90,6 +90,7 @@ type FastGetter interface {
 	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	UnrealizedJustifiedPayloadBlockHash() [32]byte
 	Weight(root [32]byte) (uint64, error)
+	ConsensusNodeWeight(root [32]byte) (uint64, error)
 	ParentRoot(root [32]byte) ([32]byte, error)
 	BlockHash(root [32]byte) ([32]byte, error)
 	CanonicalNodeAtSlot(slot primitives.Slot) ([32]byte, bool)

--- a/beacon-chain/forkchoice/ro.go
+++ b/beacon-chain/forkchoice/ro.go
@@ -135,6 +135,13 @@ func (ro *ROForkChoice) Weight(root [32]byte) (uint64, error) {
 	return ro.getter.Weight(root)
 }
 
+// ConsensusNodeWeight delegates to the underlying forkchoice call, under a lock.
+func (ro *ROForkChoice) ConsensusNodeWeight(root [32]byte) (uint64, error) {
+	ro.l.RLock()
+	defer ro.l.RUnlock()
+	return ro.getter.ConsensusNodeWeight(root)
+}
+
 // IsOptimistic delegates to the underlying forkchoice call, under a lock.
 func (ro *ROForkChoice) IsOptimistic(root [32]byte) (bool, error) {
 	ro.l.RLock()

--- a/beacon-chain/forkchoice/ro_test.go
+++ b/beacon-chain/forkchoice/ro_test.go
@@ -32,6 +32,7 @@ const (
 	highestReceivedBlockRootCalled
 	receivedBlocksLastEpochCalled
 	weightCalled
+	consensusNodeWeightCalled
 	isOptimisticCalled
 	shouldOverrideFCUCalled
 	slotCalled
@@ -128,6 +129,11 @@ func TestROLocking(t *testing.T) {
 			name: "weightCalled",
 			call: weightCalled,
 			cb:   func(g FastGetter) { _, err := g.Weight([32]byte{}); _discard(t, err) },
+		},
+		{
+			name: "consensusNodeWeightCalled",
+			call: consensusNodeWeightCalled,
+			cb:   func(g FastGetter) { _, err := g.ConsensusNodeWeight([32]byte{}); _discard(t, err) },
 		},
 		{
 			name: "isOptimisticCalled",
@@ -268,6 +274,11 @@ func (ro *mockROForkchoice) ReceivedBlocksLastEpoch() (uint64, error) {
 
 func (ro *mockROForkchoice) Weight(_ [32]byte) (uint64, error) {
 	ro.calls = append(ro.calls, weightCalled)
+	return 0, nil
+}
+
+func (ro *mockROForkchoice) ConsensusNodeWeight(_ [32]byte) (uint64, error) {
+	ro.calls = append(ro.calls, consensusNodeWeightCalled)
 	return 0, nil
 }
 

--- a/changelog/terence_gloas_forkchoice_weight.md
+++ b/changelog/terence_gloas_forkchoice_weight.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Return the consensus-node weight for Gloas blocks (empty + full payload).


### PR DESCRIPTION
This PR separates two different weight semantics that were previously conflated in `Weight`
`Weight(root)` now consistently returns payload-node weight
`ConsensusNodeWeight(root)` is added for consensus-node weight (includes empty + full payload effects in Gloas).
The "Head block is not the received block" log path now uses `ConsensusNodeWeight`, so log output matches intended interpretation