### PR TITLE
Use parent hash to select correct gloas pre state for state root

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -31,6 +31,7 @@ type ChainInfoFetcher interface {
 	ForkFetcher
 	HeadDomainFetcher
 	ForkchoiceFetcher
+	LookupParentRootFetcher
 }
 
 // ForkchoiceFetcher defines a common interface for methods that access directly
@@ -120,6 +121,12 @@ type FinalizationFetcher interface {
 type OptimisticModeFetcher interface {
 	IsOptimistic(ctx context.Context) (bool, error)
 	IsOptimisticForRoot(ctx context.Context, root [32]byte) (bool, error)
+}
+
+// LookupParentRootFetcher defines a minimal interface for retrieving the lookup parent root
+// for a given block (used to select the correct pre-state for Gloas blocks).
+type LookupParentRootFetcher interface {
+	GetLookupParentRoot(consensus_blocks.ROBlock) ([32]byte, error)
 }
 
 // FinalizedCheckpt returns the latest finalized checkpoint from chain store.

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -6,11 +6,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// getLookupParentRoot returns the root that serves as key to generate the parent state for the passed beacon block.
+// GetLookupParentRoot returns the root that serves as key to generate the parent state for the passed beacon block.
 // if it is based on empty or it is pre-Gloas, it is the parent root of the block, otherwise if it is based on full it is
 // the parent hash.
 // The caller of this function should not hold a lock on forkchoice.
-func (s *Service) getLookupParentRoot(b consensus_blocks.ROBlock) ([32]byte, error) {
+func (s *Service) GetLookupParentRoot(b consensus_blocks.ROBlock) ([32]byte, error) {
 	bl := b.Block()
 	parentRoot := bl.ParentRoot()
 	if b.Version() < version.Gloas {

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -459,7 +459,7 @@ func TestGetLookupParentRoot_PreGloas(t *testing.T) {
 	roblock, err := blocks.NewROBlock(wsb)
 	require.NoError(t, err)
 
-	got, err := service.getLookupParentRoot(roblock)
+	got, err := service.GetLookupParentRoot(roblock)
 	require.NoError(t, err)
 	require.Equal(t, parentRoot, got)
 }
@@ -499,7 +499,7 @@ func TestGetLookupParentRoot_GloasBuildsOnEmpty(t *testing.T) {
 	roblock, err := blocks.NewROBlock(wsb)
 	require.NoError(t, err)
 
-	got, err := service.getLookupParentRoot(roblock)
+	got, err := service.GetLookupParentRoot(roblock)
 	require.NoError(t, err)
 	// parentBlockHash != parentNodeBlockHash, so it builds on empty => returns parentRoot
 	require.Equal(t, parentRoot, got)
@@ -540,7 +540,7 @@ func TestGetLookupParentRoot_GloasBuildsOnFull(t *testing.T) {
 	roblock, err := blocks.NewROBlock(wsb)
 	require.NoError(t, err)
 
-	got, err := service.getLookupParentRoot(roblock)
+	got, err := service.GetLookupParentRoot(roblock)
 	require.NoError(t, err)
 	// parentBlockHash == parentNodeBlockHash, so it builds on full => returns parentBlockHash
 	require.Equal(t, parentNodeBlockHash, got)

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -200,7 +200,7 @@ func (s *Service) getBlockPreState(ctx context.Context, b consensus_blocks.ROBlo
 	ctx, span := trace.StartSpan(ctx, "blockChain.getBlockPreState")
 	defer span.End()
 
-	accessRoot, err := s.getLookupParentRoot(b)
+	accessRoot, err := s.GetLookupParentRoot(b)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get lookup parent root")
 	}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -84,6 +84,10 @@ func (s *ChainService) Ancestor(ctx context.Context, root []byte, slot primitive
 	return r[:], err
 }
 
+func (s *ChainService) GetLookupParentRoot(b blocks.ROBlock) ([32]byte, error) {
+	return b.Block().ParentRoot(), nil
+}
+
 // StateNotifier mocks the same method in the chain service.
 func (s *ChainService) StateNotifier() statefeed.Notifier {
 	if s.stateNotifier == nil {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -968,6 +968,7 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		PeerManager:               p2pService,
 		MetadataProvider:          p2pService,
 		ChainInfoFetcher:          chainService,
+		LookupParentRootFetcher:   chainService,
 		HeadFetcher:               chainService,
 		CanonicalFetcher:          chainService,
 		ForkFetcher:               chainService,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -640,23 +640,17 @@ func (vs *Server) computeStateRoot(ctx context.Context, block interfaces.SignedB
 		return nil, errors.Wrap(err, "could not retrieve beacon state")
 	}
 	if block.Version() >= version.Gloas && beaconState.Version() >= version.Gloas {
-		bid, err := block.Block().Body().SignedExecutionPayloadBid()
+		roBlock, err := blocks.NewROBlock(block)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not retrieve signed execution payload bid")
+			return nil, errors.Wrap(err, "could not create read-only block")
 		}
-
-		parentHash := [32]byte{}
-		copy(parentHash[:], bid.Message.ParentBlockHash)
-		parentBid, err := beaconState.LatestExecutionPayloadBid()
+		r, err := vs.ChainInfoFetcher.GetLookupParentRoot(roBlock)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not retrieve latest block hash")
+			return nil, errors.Wrap(err, "could not determine lookup parent root")
 		}
-		parentBidHash := parentBid.BlockHash()
-		if parentHash == parentBidHash {
-			beaconState, err = vs.StateGen.StateByRoot(ctx, parentHash)
-			if err != nil {
-				return nil, errors.Wrap(err, "could not retrieve beacon state by parent block hash")
-			}
+		beaconState, err = vs.StateGen.StateByRoot(ctx, r)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not retrieve beacon state by lookup parent root")
 		}
 	}
 	root, err := transition.CalculateStateRoot(

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -639,6 +639,26 @@ func (vs *Server) computeStateRoot(ctx context.Context, block interfaces.SignedB
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve beacon state")
 	}
+	if block.Version() >= version.Gloas && beaconState.Version() >= version.Gloas {
+		bid, err := block.Block().Body().SignedExecutionPayloadBid()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not retrieve signed execution payload bid")
+		}
+
+		parentHash := [32]byte{}
+		copy(parentHash[:], bid.Message.ParentBlockHash)
+		parentBid, err := beaconState.LatestExecutionPayloadBid()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not retrieve latest block hash")
+		}
+		parentBidHash := parentBid.BlockHash()
+		if parentHash == parentBidHash {
+			beaconState, err = vs.StateGen.StateByRoot(ctx, parentHash)
+			if err != nil {
+				return nil, errors.Wrap(err, "could not retrieve beacon state by parent block hash")
+			}
+		}
+	}
 	root, err := transition.CalculateStateRoot(
 		ctx,
 		beaconState,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	executionPayloadEnvelope   *ethpb.ExecutionPayloadEnvelope
 	HeadFetcher                blockchain.HeadFetcher
 	ForkFetcher                blockchain.ForkFetcher
+	ChainInfoFetcher           blockchain.ChainInfoFetcher
 	ForkchoiceFetcher          blockchain.ForkchoiceFetcher
 	GenesisFetcher             blockchain.GenesisFetcher
 	FinalizationFetcher        blockchain.FinalizationFetcher
@@ -86,6 +87,7 @@ type Server struct {
 	ClockWaiter                startup.ClockWaiter
 	CoreService                *core.Service
 	AttestationStateFetcher    blockchain.AttestationStateFetcher
+	LookupParentRootFetcher    blockchain.LookupParentRootFetcher
 	GraffitiInfo               *execution.GraffitiInfo
 }
 

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -81,6 +81,7 @@ type Config struct {
 	BeaconMonitoringPort      int
 	BeaconDB                  db.HeadAccessDatabase
 	ChainInfoFetcher          blockchain.ChainInfoFetcher
+	LookupParentRootFetcher   blockchain.LookupParentRootFetcher
 	HeadFetcher               blockchain.HeadFetcher
 	CanonicalFetcher          blockchain.CanonicalFetcher
 	ForkFetcher               blockchain.ForkFetcher
@@ -223,6 +224,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		AttPool:                 s.cfg.AttestationsPool,
 		ExitPool:                s.cfg.ExitPool,
 		HeadFetcher:             s.cfg.HeadFetcher,
+		ChainInfoFetcher:        s.cfg.ChainInfoFetcher,
 		ForkFetcher:             s.cfg.ForkFetcher,
 		ForkchoiceFetcher:       s.cfg.ForkchoiceFetcher,
 		GenesisFetcher:          s.cfg.GenesisFetcher,
@@ -258,6 +260,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		PayloadIDCache:          s.cfg.PayloadIDCache,
 		AttestationStateFetcher: s.cfg.AttestationReceiver,
 		GraffitiInfo:            s.cfg.GraffitiInfo,
+		LookupParentRootFetcher: s.cfg.LookupParentRootFetcher,
 	}
 	s.validatorServer = validatorServer
 	nodeServer := &nodev1alpha1.Server{

--- a/changelog/terence_gloas_compute_state_root_parent_hash.md
+++ b/changelog/terence_gloas_compute_state_root_parent_hash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use the parent hash to select the correct Gloas parent state when computing state root.


### PR DESCRIPTION
Fix Gloas proposer state‑root computation to select the correct parent state using the bid’s parent block hash. This prevents state‑root calculation from using an incorrect pre‑envelope state when the parent is full