### PR TITLE
feat: add periodic progress logging to blob and data column cache warm-up

### DIFF
--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -24,6 +24,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/io/file"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
 )
@@ -194,6 +195,7 @@ func (dcs *DataColumnStorage) WarmCache() {
 	}
 
 	// Iterate through periods
+	periodsProcessed := 0
 	for _, periodFileInfo := range periodFileInfos {
 		if !periodFileInfo.IsDir() {
 			continue
@@ -235,6 +237,13 @@ func (dcs *DataColumnStorage) WarmCache() {
 
 			highestStoredEpoch = max(highestStoredEpoch, epochHighest)
 		}
+
+		periodsProcessed++
+		log.WithFields(logrus.Fields{
+			"period":    periodPath,
+			"progress":  fmt.Sprintf("%d/%d", periodsProcessed, len(periodFileInfos)),
+			"elapsed":   time.Since(start),
+		}).Info("Data column filesystem cache warm-up in progress")
 	}
 
 	// Prune the cache and the filesystem

--- a/beacon-chain/db/filesystem/layout.go
+++ b/beacon-chain/db/filesystem/layout.go
@@ -105,6 +105,8 @@ func warmCache(l fsLayout, cache *blobStorageSummaryCache) error {
 	if err != nil {
 		return errors.Wrap(errCacheWarmFailed, err.Error())
 	}
+	count := 0
+	lastLog := time.Now()
 	for ident, err := iter.next(); !errors.Is(err, io.EOF); ident, err = iter.next() {
 		if errors.Is(err, errIdentFailure) {
 			idf := &identificationError{}
@@ -118,6 +120,11 @@ func warmCache(l fsLayout, cache *blobStorageSummaryCache) error {
 		}
 		if err := cache.ensure(ident); err != nil {
 			return fmt.Errorf("%w: failed to write cache entry for %s: %w", errCacheWarmFailed, l.sszPath(ident), err)
+		}
+		count++
+		if time.Since(lastLog) > 30*time.Second {
+			log.WithField("entries", count).Info("Blob filesystem cache warm-up in progress")
+			lastLog = time.Now()
 		}
 	}
 	return nil

--- a/changelog/jiayaoqijia_cache-warmup-progress.md
+++ b/changelog/jiayaoqijia_cache-warmup-progress.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Added periodic progress logging to blob and data column cache warm-up to give operators visibility during long warm-up operations.


### PR DESCRIPTION
## Summary

Closes #16054.

The blob and data column filesystem cache warm-up can take hours on large stores, but currently only logs a start message with no further progress updates. Operators are left wondering if the node is stuck.

This PR adds periodic progress logging to both warm-up paths:

- **Blob cache warm-up** (`warmCache` in `layout.go`): Logs the number of processed entries every 30 seconds.
- **Data column cache warm-up** (`WarmCache` in `data_column.go`): Logs after each period directory is processed, showing progress as `completed/total` and elapsed time.

## Changes

- `beacon-chain/db/filesystem/layout.go`: Add counter and 30-second periodic logging in `warmCache()`.
- `beacon-chain/db/filesystem/data_column.go`: Add per-period progress logging in `WarmCache()`.

## Test plan

- [x] `go build ./beacon-chain/db/filesystem/...` — compiles cleanly
- [x] `go test ./beacon-chain/db/filesystem/...` — all tests pass
- Manually verified log output format is consistent with existing Prysm logging patterns (uses `logrus.Fields` and `log.WithField`/`log.WithFields`)