### PR TITLE
Fix Gloas fork version using `MetaDataV1` instead of `MetaDataV2`

### DIFF
--- a/beacon-chain/p2p/types/object_mapping.go
+++ b/beacon-chain/p2p/types/object_mapping.go
@@ -113,7 +113,7 @@ func InitializeDataMaps() {
 			return wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}), nil
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().GloasForkVersion): func() (metadata.Metadata, error) {
-			return wrapper.WrappedMetadataV1(&ethpb.MetaDataV1{}), nil
+			return wrapper.WrappedMetadataV2(&ethpb.MetaDataV2{}), nil
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().FuluForkVersion): func() (metadata.Metadata, error) {
 			return wrapper.WrappedMetadataV2(&ethpb.MetaDataV2{}), nil

--- a/beacon-chain/p2p/types/object_mapping_test.go
+++ b/beacon-chain/p2p/types/object_mapping_test.go
@@ -104,7 +104,7 @@ func TestInitializeDataMaps_Gloas(t *testing.T) {
 	require.Equal(t, true, ok)
 	md, err := mdFunc()
 	require.NoError(t, err)
-	assert.NotNil(t, md.MetadataObjV1())
+	assert.NotNil(t, md.MetadataObjV2())
 
 	attFunc, ok := AttestationMap[gloasVersion]
 	require.Equal(t, true, ok)

--- a/changelog/fix-gloas-metadata-v2.md
+++ b/changelog/fix-gloas-metadata-v2.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed Gloas fork version returning `MetaDataV1` instead of `MetaDataV2` in `InitializeDataMaps`, which caused metadata negotiation to fail during p2p handshake on Gloas nodes.


### PR DESCRIPTION
Fix Gloas metadata version negotiation (MetaDataV1 → MetaDataV2)