### PR TITLE
Gloas/late block tasks right fcu

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -389,6 +389,48 @@ func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.Beacon
 	return nil
 }
 
+// refreshCaches updates the next slot state cache and epoch boundary caches.
+// Before Fulu this is done synchronously, after Fulu it is deferred to a goroutine.
+func (s *Service) refreshCaches(ctx context.Context, currentSlot primitives.Slot, headRoot [32]byte, headState state.BeaconState, accessRoot [32]byte) {
+	lastRoot, lastState := transition.LastCachedState()
+	if lastState == nil {
+		lastRoot, lastState = headRoot[:], headState
+	}
+	if lastState.Version() < version.Fulu {
+		s.updateCachesAndEpochBoundary(ctx, currentSlot, headState, accessRoot, lastRoot, lastState)
+	} else {
+		defer func() {
+			go func() {
+				ctx, cancel := context.WithTimeout(s.ctx, slotDeadline)
+				defer cancel()
+				s.updateCachesAndEpochBoundary(ctx, currentSlot, headState, accessRoot, lastRoot, lastState)
+			}()
+		}()
+	}
+}
+
+// updateCachesAndEpochBoundary updates the next slot state cache and handles
+// epoch boundary processing. If the lastRoot matches accessRoot, the cached
+// last state is reused; otherwise, the head state is advanced instead.
+func (s *Service) updateCachesAndEpochBoundary(ctx context.Context, currentSlot primitives.Slot, headState state.BeaconState, accessRoot [32]byte, lastRoot []byte, lastState state.BeaconState) {
+	if bytes.Equal(lastRoot, accessRoot[:]) {
+		// Happy case, the last advanced state is head, we thus keep it
+		lastState.CopyAllTries()
+		if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
+			log.WithError(err).Debug("Could not update next slot state cache")
+		}
+	} else {
+		// Last advanced state was not head, we do not advance this but rather use headstate
+		headState.CopyAllTries()
+		if err := transition.UpdateNextSlotCache(ctx, accessRoot[:], headState); err != nil {
+			log.WithError(err).Debug("Could not update next slot state cache")
+		}
+	}
+	if err := s.handleEpochBoundary(ctx, currentSlot, headState, accessRoot[:]); err != nil {
+		log.WithError(err).Error("Could not update epoch boundary caches")
+	}
+}
+
 // Epoch boundary tasks: it copies the headState and updates the epoch boundary
 // caches. The caller of this function must not hold a lock in forkchoice store.
 func (s *Service) handleEpochBoundary(ctx context.Context, slot primitives.Slot, headState state.BeaconState, blockRoot []byte) error {
@@ -993,56 +1035,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 			accessRoot = headRoot
 		}
 	}
-	lastRoot, lastState := transition.LastCachedState()
-	if lastState == nil {
-		lastRoot, lastState = headRoot[:], headState
-	}
-	// Before Fulu we need to process the next slot to find out if we are proposing.
-	if lastState.Version() < version.Fulu {
-		if bytes.Equal(lastRoot, accessRoot[:]) {
-			// Happy case, the last advanced state is head, we thus keep it
-			// Copy all the field tries in our cached state in the event of late
-			// blocks.
-			lastState.CopyAllTries()
-			if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
-				log.WithError(err).Debug("Could not update next slot state cache")
-			}
-		} else {
-			// Last advanced state was not head, we do not advance this but rather use headstate
-			headState.CopyAllTries()
-			if err := transition.UpdateNextSlotCache(ctx, accessRoot[:], headState); err != nil {
-				log.WithError(err).Debug("Could not update next slot state cache")
-			}
-		}
-		if err := s.handleEpochBoundary(ctx, currentSlot, headState, accessRoot[:]); err != nil {
-			log.WithError(err).Error("Could not update epoch boundary caches")
-		}
-	} else {
-		// After Fulu, we can update the caches asynchronously after sending FCU to the engine
-		defer func() {
-			go func() {
-				ctx, cancel := context.WithTimeout(s.ctx, slotDeadline)
-				defer cancel()
-				if bytes.Equal(lastRoot, accessRoot[:]) {
-					// Happy case, the last advanced state is head, we thus keep it
-					// Copy all the field tries in our cached state in the event of late
-					lastState.CopyAllTries()
-					if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
-						log.WithError(err).Debug("Could not update next slot state cache")
-					}
-				} else {
-					// Last advanced state was not head, we do not advance this but rather use headstate
-					headState.CopyAllTries()
-					if err := transition.UpdateNextSlotCache(ctx, accessRoot[:], headState); err != nil {
-						log.WithError(err).Debug("Could not update next slot state cache")
-					}
-				}
-				if err := s.handleEpochBoundary(ctx, currentSlot, headState, accessRoot[:]); err != nil {
-					log.WithError(err).Error("Could not update epoch boundary caches")
-				}
-			}()
-		}()
-	}
+	s.refreshCaches(ctx, currentSlot, headRoot, headState, accessRoot)
 	// return early if we already started building a block for the current
 	// head root
 	_, has := s.cfg.PayloadIDCache.PayloadID(s.CurrentSlot()+1, headRoot)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -981,19 +982,39 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	headRoot := s.headRoot()
 	headState := s.headState(ctx)
 	s.headLock.RUnlock()
+	var accessRoot [32]byte
+	isFull, err := headState.IsParentBlockFull()
+	if err != nil || !isFull {
+		accessRoot = headRoot
+	} else {
+		accessRoot, err = headState.LatestBlockHash()
+		if err != nil {
+			log.WithError(err).Debug("could not perform late block tasks: failed to retrieve latest block hash, using head root as access root")
+			accessRoot = headRoot
+		}
+	}
 	lastRoot, lastState := transition.LastCachedState()
 	if lastState == nil {
 		lastRoot, lastState = headRoot[:], headState
 	}
 	// Before Fulu we need to process the next slot to find out if we are proposing.
 	if lastState.Version() < version.Fulu {
-		// Copy all the field tries in our cached state in the event of late
-		// blocks.
-		lastState.CopyAllTries()
-		if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
-			log.WithError(err).Debug("Could not update next slot state cache")
+		if bytes.Equal(lastRoot, accessRoot[:]) {
+			// Happy case, the last advanced state is head, we thus keep it
+			// Copy all the field tries in our cached state in the event of late
+			// blocks.
+			lastState.CopyAllTries()
+			if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
+				log.WithError(err).Debug("Could not update next slot state cache")
+			}
+		} else {
+			// Last advanced state was not head, we do not advance this but rather use headstate
+			headState.CopyAllTries()
+			if err := transition.UpdateNextSlotCache(ctx, accessRoot[:], headState); err != nil {
+				log.WithError(err).Debug("Could not update next slot state cache")
+			}
 		}
-		if err := s.handleEpochBoundary(ctx, currentSlot, headState, headRoot[:]); err != nil {
+		if err := s.handleEpochBoundary(ctx, currentSlot, headState, accessRoot[:]); err != nil {
 			log.WithError(err).Error("Could not update epoch boundary caches")
 		}
 	} else {
@@ -1002,11 +1023,21 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 			go func() {
 				ctx, cancel := context.WithTimeout(s.ctx, slotDeadline)
 				defer cancel()
-				lastState.CopyAllTries()
-				if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
-					log.WithError(err).Debug("Could not update next slot state cache")
+				if bytes.Equal(lastRoot, accessRoot[:]) {
+					// Happy case, the last advanced state is head, we thus keep it
+					// Copy all the field tries in our cached state in the event of late
+					lastState.CopyAllTries()
+					if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
+						log.WithError(err).Debug("Could not update next slot state cache")
+					}
+				} else {
+					// Last advanced state was not head, we do not advance this but rather use headstate
+					headState.CopyAllTries()
+					if err := transition.UpdateNextSlotCache(ctx, accessRoot[:], headState); err != nil {
+						log.WithError(err).Debug("Could not update next slot state cache")
+					}
 				}
-				if err := s.handleEpochBoundary(ctx, currentSlot, headState, headRoot[:]); err != nil {
+				if err := s.handleEpochBoundary(ctx, currentSlot, headState, accessRoot[:]); err != nil {
 					log.WithError(err).Error("Could not update epoch boundary caches")
 				}
 			}()

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -399,12 +399,10 @@ func (s *Service) refreshCaches(ctx context.Context, currentSlot primitives.Slot
 	if lastState.Version() < version.Fulu {
 		s.updateCachesAndEpochBoundary(ctx, currentSlot, headState, accessRoot, lastRoot, lastState)
 	} else {
-		defer func() {
-			go func() {
-				ctx, cancel := context.WithTimeout(s.ctx, slotDeadline)
-				defer cancel()
-				s.updateCachesAndEpochBoundary(ctx, currentSlot, headState, accessRoot, lastRoot, lastState)
-			}()
+		go func() {
+			ctx, cancel := context.WithTimeout(s.ctx, slotDeadline)
+			defer cancel()
+			s.updateCachesAndEpochBoundary(ctx, currentSlot, headState, accessRoot, lastRoot, lastState)
 		}()
 	}
 }

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -3639,3 +3639,61 @@ func TestHandleBlockPayloadAttestations(t *testing.T) {
 		require.NoError(t, s.handleBlockPayloadAttestations(ctx, wsb.Block(), headState))
 	})
 }
+
+func TestUpdateCachesAndEpochBoundary_MatchingRoots(t *testing.T) {
+	service := testServiceNoDB(t)
+	st, _ := util.DeterministicGenesisState(t, 1)
+	accessRoot := [32]byte{'a'}
+
+	service.updateCachesAndEpochBoundary(t.Context(), 1, st, accessRoot, accessRoot[:], st)
+
+	cached := transition.NextSlotState(accessRoot[:], 1)
+	require.NotNil(t, cached)
+	require.Equal(t, primitives.Slot(1), cached.Slot())
+}
+
+func TestUpdateCachesAndEpochBoundary_DifferentRoots(t *testing.T) {
+	service := testServiceNoDB(t)
+	headState, _ := util.DeterministicGenesisState(t, 1)
+	lastState, _ := util.DeterministicGenesisState(t, 1)
+	accessRoot := [32]byte{'a'}
+	lastRoot := [32]byte{'b'}
+
+	service.updateCachesAndEpochBoundary(t.Context(), 1, headState, accessRoot, lastRoot[:], lastState)
+
+	// Cache should be keyed by accessRoot, not lastRoot.
+	cached := transition.NextSlotState(accessRoot[:], 1)
+	require.NotNil(t, cached)
+	require.Equal(t, primitives.Slot(1), cached.Slot())
+
+	cached = transition.NextSlotState(lastRoot[:], 1)
+	require.Equal(t, true, cached == nil)
+}
+
+func TestRefreshCaches_NoCachedState(t *testing.T) {
+	service := testServiceNoDB(t)
+	st, _ := util.DeterministicGenesisState(t, 1)
+	headRoot := [32]byte{'h'}
+
+	service.refreshCaches(t.Context(), 1, headRoot, st, headRoot)
+
+	cached := transition.NextSlotState(headRoot[:], 1)
+	require.NotNil(t, cached)
+	require.Equal(t, primitives.Slot(1), cached.Slot())
+}
+
+func TestRefreshCaches_CachedStateMatchesAccessRoot(t *testing.T) {
+	service := testServiceNoDB(t)
+	st, _ := util.DeterministicGenesisState(t, 1)
+	accessRoot := [32]byte{'a'}
+	headRoot := [32]byte{'h'}
+
+	// Pre-populate the cache with accessRoot.
+	require.NoError(t, transition.UpdateNextSlotCache(t.Context(), accessRoot[:], st))
+
+	service.refreshCaches(t.Context(), 1, headRoot, st, accessRoot)
+
+	cached := transition.NextSlotState(accessRoot[:], 1)
+	require.NotNil(t, cached)
+	require.Equal(t, primitives.Slot(1), cached.Slot())
+}

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -131,9 +131,16 @@ func (s *Service) postPayloadHeadUpdate(ctx context.Context, envelope interfaces
 	s.head.state = st
 	s.headLock.Unlock()
 
-	if err := transition.UpdateNextSlotCache(ctx, blockHash[:], st); err != nil {
-		log.WithError(err).Error("Could not update next slot cache")
-	}
+	go func() {
+		ctx, cancel := context.WithTimeout(s.ctx, slotDeadline)
+		defer cancel()
+		if err := transition.UpdateNextSlotCache(ctx, blockHash[:], st); err != nil {
+			log.WithError(err).Error("Could not update next slot cache")
+		}
+		if err := s.handleEpochBoundary(ctx, envelope.Slot(), st, blockHash[:]); err != nil {
+			log.WithError(err).Error("Could not handle epoch boundary")
+		}
+	}()
 
 	attr := s.getPayloadAttribute(ctx, st, envelope.Slot()+1, headRoot)
 	if s.inRegularSync() {

--- a/changelog/potuz_gloas_late_block_tasks.md
+++ b/changelog/potuz_gloas_late_block_tasks.md
@@ -1,0 +1,3 @@
+### Added
+- Change which state is updated on late block tasks. 
+- Take care of epoch boundary transition on payload arrival. 


### PR DESCRIPTION
This PR changes how we update the next slot cache on late blocks. 

- When the latest saved state in the NSC agrees with the head root, then we update this latest state because it will be useful.  Otherwise we instead update the headstate and put it as latest. 
- This also keys the insertion in the NSC post-Gloas with the right blockhash instead of blockroot if the headstate is based on full. This exploits a dangerous feature of `IsParentBlockFull` documented in its godoc. 

This PR also updates the cache and the epoch boundary when we process the payload. 