### PR TITLE
Use execution block hash as state access key post-Gloas

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -321,7 +321,7 @@ func (s *Service) pruneInvalidBlock(ctx context.Context, root, parentRoot, paren
 
 // getPayloadAttributes returns the payload attributes for the given state and slot.
 // The attribute is required to initiate a payload build process in the context of an `engine_forkchoiceUpdated` call.
-func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState, slot primitives.Slot, headRoot []byte) payloadattribute.Attributer {
+func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState, slot primitives.Slot, headRoot, accessRoot []byte) payloadattribute.Attributer {
 	emptyAttri := payloadattribute.EmptyWithVersion(st.Version())
 
 	// If it is an epoch boundary then process slots to get the right
@@ -343,7 +343,7 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 		// right proposer index pre-Fulu, either way we need to copy the state to process it.
 		st = st.Copy()
 		var err error
-		st, err = transition.ProcessSlotsUsingNextSlotCache(ctx, st, headRoot, slot)
+		st, err = transition.ProcessSlotsUsingNextSlotCache(ctx, st, accessRoot, slot)
 		if err != nil {
 			log.WithError(err).Error("Could not process slots to get payload attribute")
 			return emptyAttri

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -717,14 +717,14 @@ func Test_GetPayloadAttribute(t *testing.T) {
 	ctx := tr.ctx
 
 	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
-	attr := service.getPayloadAttribute(ctx, st, 0, []byte{})
+	attr := service.getPayloadAttribute(ctx, st, 0, []byte{}, []byte{})
 	require.Equal(t, true, attr.IsEmpty())
 
 	service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, Index: 0})
 	// Cache hit, advance state, no fee recipient
 	slot := primitives.Slot(1)
 	service.cfg.PayloadIDCache.Set(slot, [32]byte{}, [8]byte{})
-	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:])
+	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:], params.BeaconConfig().ZeroHash[:])
 	require.Equal(t, false, attr.IsEmpty())
 	require.Equal(t, params.BeaconConfig().EthBurnAddressHex, common.BytesToAddress(attr.SuggestedFeeRecipient()).String())
 
@@ -732,7 +732,7 @@ func Test_GetPayloadAttribute(t *testing.T) {
 	suggestedAddr := common.HexToAddress("123")
 	service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, FeeRecipient: primitives.ExecutionAddress(suggestedAddr), Index: 0})
 	service.cfg.PayloadIDCache.Set(slot, [32]byte{}, [8]byte{})
-	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:])
+	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:], params.BeaconConfig().ZeroHash[:])
 	require.Equal(t, false, attr.IsEmpty())
 	require.Equal(t, suggestedAddr, common.BytesToAddress(attr.SuggestedFeeRecipient()))
 }
@@ -747,7 +747,7 @@ func Test_GetPayloadAttribute_PrepareAllPayloads(t *testing.T) {
 	ctx := tr.ctx
 
 	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
-	attr := service.getPayloadAttribute(ctx, st, 0, []byte{})
+	attr := service.getPayloadAttribute(ctx, st, 0, []byte{}, []byte{})
 	require.Equal(t, false, attr.IsEmpty())
 	require.Equal(t, params.BeaconConfig().EthBurnAddressHex, common.BytesToAddress(attr.SuggestedFeeRecipient()).String())
 }
@@ -757,14 +757,14 @@ func Test_GetPayloadAttributeV2(t *testing.T) {
 	ctx := tr.ctx
 
 	st, _ := util.DeterministicGenesisStateCapella(t, 1)
-	attr := service.getPayloadAttribute(ctx, st, 0, []byte{})
+	attr := service.getPayloadAttribute(ctx, st, 0, []byte{}, []byte{})
 	require.Equal(t, true, attr.IsEmpty())
 
 	// Cache hit, advance state, no fee recipient
 	service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, Index: 0})
 	slot := primitives.Slot(1)
 	service.cfg.PayloadIDCache.Set(slot, [32]byte{}, [8]byte{})
-	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:])
+	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:], params.BeaconConfig().ZeroHash[:])
 	require.Equal(t, false, attr.IsEmpty())
 	require.Equal(t, params.BeaconConfig().EthBurnAddressHex, common.BytesToAddress(attr.SuggestedFeeRecipient()).String())
 	a, err := attr.Withdrawals()
@@ -775,7 +775,7 @@ func Test_GetPayloadAttributeV2(t *testing.T) {
 	suggestedAddr := common.HexToAddress("123")
 	service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, FeeRecipient: primitives.ExecutionAddress(suggestedAddr), Index: 0})
 	service.cfg.PayloadIDCache.Set(slot, [32]byte{}, [8]byte{})
-	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:])
+	attr = service.getPayloadAttribute(ctx, st, slot, params.BeaconConfig().ZeroHash[:], params.BeaconConfig().ZeroHash[:])
 	require.Equal(t, false, attr.IsEmpty())
 	require.Equal(t, suggestedAddr, common.BytesToAddress(attr.SuggestedFeeRecipient()))
 	a, err = attr.Withdrawals()
@@ -809,14 +809,14 @@ func Test_GetPayloadAttributeV3(t *testing.T) {
 			service, tr := minimalTestService(t, WithPayloadIDCache(cache.NewPayloadIDCache()))
 			ctx := tr.ctx
 
-			attr := service.getPayloadAttribute(ctx, test.st, 0, []byte{})
+			attr := service.getPayloadAttribute(ctx, test.st, 0, []byte{}, []byte{})
 			require.Equal(t, true, attr.IsEmpty())
 
 			// Cache hit, advance state, no fee recipient
 			slot := primitives.Slot(1)
 			service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, Index: 0})
 			service.cfg.PayloadIDCache.Set(slot, [32]byte{}, [8]byte{})
-			attr = service.getPayloadAttribute(ctx, test.st, slot, params.BeaconConfig().ZeroHash[:])
+			attr = service.getPayloadAttribute(ctx, test.st, slot, params.BeaconConfig().ZeroHash[:], params.BeaconConfig().ZeroHash[:])
 			require.Equal(t, false, attr.IsEmpty())
 			require.Equal(t, params.BeaconConfig().EthBurnAddressHex, common.BytesToAddress(attr.SuggestedFeeRecipient()).String())
 			a, err := attr.Withdrawals()
@@ -827,7 +827,7 @@ func Test_GetPayloadAttributeV3(t *testing.T) {
 			suggestedAddr := common.HexToAddress("123")
 			service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, FeeRecipient: primitives.ExecutionAddress(suggestedAddr), Index: 0})
 			service.cfg.PayloadIDCache.Set(slot, [32]byte{}, [8]byte{})
-			attr = service.getPayloadAttribute(ctx, test.st, slot, params.BeaconConfig().ZeroHash[:])
+			attr = service.getPayloadAttribute(ctx, test.st, slot, params.BeaconConfig().ZeroHash[:], params.BeaconConfig().ZeroHash[:])
 			require.Equal(t, false, attr.IsEmpty())
 			require.Equal(t, suggestedAddr, common.BytesToAddress(attr.SuggestedFeeRecipient()))
 			a, err = attr.Withdrawals()

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -30,7 +30,7 @@ func (s *Service) isNewHead(r [32]byte) bool {
 	return r != currentHeadRoot || r == [32]byte{}
 }
 
-func (s *Service) getStateAndBlock(ctx context.Context, r [32]byte) (state.BeaconState, interfaces.ReadOnlySignedBeaconBlock, error) {
+func (s *Service) getStateAndBlock(ctx context.Context, r, h [32]byte) (state.BeaconState, interfaces.ReadOnlySignedBeaconBlock, error) {
 	if !s.hasBlockInInitSyncOrDB(ctx, r) {
 		return nil, nil, errors.New("block does not exist")
 	}
@@ -38,7 +38,7 @@ func (s *Service) getStateAndBlock(ctx context.Context, r [32]byte) (state.Beaco
 	if err != nil {
 		return nil, nil, err
 	}
-	headState, err := s.cfg.StateGen.StateByRoot(ctx, r)
+	headState, err := s.cfg.StateGen.StateByRoot(ctx, h)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -18,16 +18,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (s *Service) isNewHead(r [32]byte) bool {
+func (s *Service) isNewHead(r [32]byte, full bool) bool {
 	s.headLock.RLock()
 	defer s.headLock.RUnlock()
 
 	currentHeadRoot := s.originBlockRoot
+	currentFull := false
 	if s.head != nil {
 		currentHeadRoot = s.headRoot()
+		currentFull = s.head.full
 	}
 
-	return r != currentHeadRoot || r == [32]byte{}
+	return r != currentHeadRoot || full != currentFull || r == [32]byte{}
 }
 
 func (s *Service) getStateAndBlock(ctx context.Context, r, h [32]byte) (state.BeaconState, interfaces.ReadOnlySignedBeaconBlock, error) {
@@ -70,7 +72,7 @@ func (s *Service) sendFCU(cfg *postBlockProcessConfig) {
 		return
 	}
 	// If head has not been updated and attributes are nil, we can skip the FCU.
-	if !s.isNewHead(cfg.headRoot) && (fcuArgs.attributes == nil || fcuArgs.attributes.IsEmpty()) {
+	if !s.isNewHead(cfg.headRoot, false) && (fcuArgs.attributes == nil || fcuArgs.attributes.IsEmpty()) {
 		return
 	}
 	// If we are proposing and we aim to reorg the block, we have already sent FCU with attributes on lateBlockTasks
@@ -81,7 +83,7 @@ func (s *Service) sendFCU(cfg *postBlockProcessConfig) {
 		go s.forkchoiceUpdateWithExecution(cfg.ctx, fcuArgs)
 	}
 
-	if s.isNewHead(fcuArgs.headRoot) {
+	if s.isNewHead(fcuArgs.headRoot, false) {
 		if err := s.saveHead(cfg.ctx, fcuArgs.headRoot, fcuArgs.headBlock, fcuArgs.headState); err != nil {
 			log.WithError(err).Error("Could not save head")
 		}

--- a/beacon-chain/blockchain/forkchoice_update_execution_test.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution_test.go
@@ -35,7 +35,7 @@ func TestService_isNewHead(t *testing.T) {
 func TestService_getHeadStateAndBlock(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 	service := setupBeaconChain(t, beaconDB)
-	_, _, err := service.getStateAndBlock(t.Context(), [32]byte{})
+	_, _, err := service.getStateAndBlock(t.Context(), [32]byte{}, [32]byte{})
 	require.ErrorContains(t, "block does not exist", err)
 
 	blk, err := blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{Signature: []byte{1}}))

--- a/beacon-chain/blockchain/forkchoice_update_execution_test.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution_test.go
@@ -19,17 +19,36 @@ import (
 func TestService_isNewHead(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 	service := setupBeaconChain(t, beaconDB)
-	require.Equal(t, true, service.isNewHead([32]byte{}))
 
+	// Zero root is always a new head
+	require.Equal(t, true, service.isNewHead([32]byte{}, false))
+	require.Equal(t, true, service.isNewHead([32]byte{}, true))
+
+	// Different root is a new head
 	service.head = &head{root: [32]byte{1}}
-	require.Equal(t, true, service.isNewHead([32]byte{2}))
-	require.Equal(t, false, service.isNewHead([32]byte{1}))
+	require.Equal(t, true, service.isNewHead([32]byte{2}, false))
+
+	// Same root and same full status is not a new head
+	require.Equal(t, false, service.isNewHead([32]byte{1}, false))
+
+	// Same root but different full status is a new head
+	require.Equal(t, true, service.isNewHead([32]byte{1}, true))
+
+	// Same root and both full is not a new head
+	service.head = &head{root: [32]byte{1}, full: true}
+	require.Equal(t, false, service.isNewHead([32]byte{1}, true))
+
+	// Same root, head is full but incoming is not full, is a new head
+	require.Equal(t, true, service.isNewHead([32]byte{1}, false))
 
 	// Nil head should use origin root
 	service.head = nil
 	service.originBlockRoot = [32]byte{3}
-	require.Equal(t, true, service.isNewHead([32]byte{2}))
-	require.Equal(t, false, service.isNewHead([32]byte{3}))
+	require.Equal(t, true, service.isNewHead([32]byte{2}, false))
+	require.Equal(t, false, service.isNewHead([32]byte{3}, false))
+
+	// Nil head with full=true is always a new head (originBlockRoot has full=false)
+	require.Equal(t, true, service.isNewHead([32]byte{3}, true))
 }
 
 func TestService_getHeadStateAndBlock(t *testing.T) {

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -446,6 +446,37 @@ func TestPostPayloadHeadUpdate_NotHead(t *testing.T) {
 	require.NoError(t, s.postPayloadHeadUpdate(ctx, envelope, st, root, headRoot[:]))
 }
 
+func TestPostPayloadHeadUpdate_SetsHeadFull(t *testing.T) {
+	s, _ := setupGloasService(t, &mockExecution.EngineClient{})
+	ctx := t.Context()
+
+	root := bytesutil.ToBytes32([]byte("root1"))
+	blockHash := bytesutil.ToBytes32([]byte("hash1"))
+
+	base, blk := testGloasState(t, 1, params.BeaconConfig().ZeroHash, blockHash)
+	st, err := state_native.InitializeFromProtoUnsafeGloas(base)
+	require.NoError(t, err)
+	signed, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+
+	s.head = &head{root: root, block: signed, state: st, slot: 1}
+	require.Equal(t, false, s.head.full)
+
+	env := &ethpb.ExecutionPayloadEnvelope{
+		BeaconBlockRoot: root[:],
+		Payload:         &enginev1.ExecutionPayloadDeneb{BlockHash: blockHash[:], ParentHash: make([]byte, 32)},
+		Slot:            1,
+	}
+	envelope, err := blocks.WrappedROExecutionPayloadEnvelope(env)
+	require.NoError(t, err)
+
+	require.NoError(t, s.postPayloadHeadUpdate(ctx, envelope, st, root, root[:]))
+
+	s.headLock.RLock()
+	require.Equal(t, true, s.head.full)
+	s.headLock.RUnlock()
+}
+
 func TestGetLookupParentRoot_PreGloas(t *testing.T) {
 	service, _ := minimalTestService(t)
 

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -50,6 +50,7 @@ type head struct {
 	block      interfaces.ReadOnlySignedBeaconBlock // current head block.
 	state      state.BeaconState                    // current head state.
 	slot       primitives.Slot                      // the head block slot number
+	full       bool                                 // whether the head is post-CL or post-EL after Gloas
 	optimistic bool                                 // optimistic status when saved head
 }
 
@@ -60,8 +61,18 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 	ctx, span := trace.StartSpan(ctx, "blockChain.saveHead")
 	defer span.End()
 
+	// Pre-Gloas we use empty for head because we still key states by blockroot
+	var full bool
+	var err error
+	if headState.Version() >= version.Gloas {
+		full, err = headState.IsParentBlockFull()
+		if err != nil {
+			return errors.Wrap(err, "could not determine if head is full or not")
+		}
+	}
+
 	// Do nothing if head hasn't changed.
-	if !s.isNewHead(newHeadRoot) {
+	if !s.isNewHead(newHeadRoot, full) {
 		return nil
 	}
 
@@ -157,6 +168,7 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 		state:      headState,
 		optimistic: isOptimistic,
 		slot:       headBlock.Block().Slot(),
+		full:       full,
 	}
 	if err := s.setHead(newHead); err != nil {
 		return errors.Wrap(err, "could not set head")
@@ -217,6 +229,7 @@ func (s *Service) setHead(newHead *head) error {
 		root:       newHead.root,
 		block:      bCp,
 		state:      newHead.state.Copy(),
+		full:       newHead.full,
 		optimistic: newHead.optimistic,
 		slot:       newHead.slot,
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -108,7 +108,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	}
 	if cfg.roblock.Version() < version.Gloas {
 		s.sendFCU(cfg)
-	} else if s.isNewHead(cfg.headRoot) {
+	} else if s.isNewHead(cfg.headRoot, false) { // We reach this only when the incoming block is head.
 		if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState); err != nil {
 			log.WithError(err).Error("Could not save head")
 		}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -1041,7 +1041,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		return
 	}
 
-	attribute := s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:])
+	attribute := s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:], accessRoot[:])
 	// return early if we are not proposing next slot
 	if attribute.IsEmpty() {
 		return
@@ -1057,28 +1057,28 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		if err != nil {
 			log.WithError(err).Debug("could not perform late block tasks: failed to update forkchoice with engine")
 		}
-	} else {
-		s.headLock.RLock()
-		headBlock, err := s.headBlock()
-		if err != nil {
-			s.headLock.RUnlock()
-			log.WithError(err).Debug("could not perform late block tasks: failed to retrieve head block")
-			return
-		}
+		return
+	}
+	s.headLock.RLock()
+	headBlock, err := s.headBlock()
+	if err != nil {
 		s.headLock.RUnlock()
+		log.WithError(err).Debug("could not perform late block tasks: failed to retrieve head block")
+		return
+	}
+	s.headLock.RUnlock()
 
-		fcuArgs := &fcuConfig{
-			headState:  headState,
-			headRoot:   headRoot,
-			headBlock:  headBlock,
-			attributes: attribute,
-		}
-		s.cfg.ForkChoiceStore.Lock()
-		defer s.cfg.ForkChoiceStore.Unlock()
-		_, err = s.notifyForkchoiceUpdate(ctx, fcuArgs)
-		if err != nil {
-			log.WithError(err).Debug("could not perform late block tasks: failed to update forkchoice with engine")
-		}
+	fcuArgs := &fcuConfig{
+		headState:  headState,
+		headRoot:   headRoot,
+		headBlock:  headBlock,
+		attributes: attribute,
+	}
+	s.cfg.ForkChoiceStore.Lock()
+	defer s.cfg.ForkChoiceStore.Unlock()
+	_, err = s.notifyForkchoiceUpdate(ctx, fcuArgs)
+	if err != nil {
+		log.WithError(err).Debug("could not perform late block tasks: failed to update forkchoice with engine")
 	}
 }
 

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -44,7 +44,7 @@ func (s *Service) getFCUArgs(cfg *postBlockProcessConfig) (*fcuConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	fcuArgs.attributes = s.getPayloadAttribute(cfg.ctx, fcuArgs.headState, fcuArgs.proposingSlot, cfg.headRoot[:])
+	fcuArgs.attributes = s.getPayloadAttribute(cfg.ctx, fcuArgs.headState, fcuArgs.proposingSlot, cfg.headRoot[:], cfg.headRoot[:])
 	return fcuArgs, nil
 }
 
@@ -89,7 +89,7 @@ func (s *Service) logNonCanonicalBlockReceived(blockRoot [32]byte, headRoot [32]
 // fcuArgsNonCanonicalBlock returns the arguments to the FCU call when the
 // incoming block is non-canonical, that is, based on the head root.
 func (s *Service) fcuArgsNonCanonicalBlock(cfg *postBlockProcessConfig) (*fcuConfig, error) {
-	headState, headBlock, err := s.getStateAndBlock(cfg.ctx, cfg.headRoot)
+	headState, headBlock, err := s.getStateAndBlock(cfg.ctx, cfg.headRoot, cfg.headRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -139,7 +139,7 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 		log.WithError(err).Error("Could not compute head from new attestations")
 		return
 	}
-	if !s.isNewHead(newHeadRoot) {
+	if !s.isNewHead(newHeadRoot, full) {
 		return
 	}
 	log.WithField("newHeadRoot", fmt.Sprintf("%#x", newHeadRoot)).Debug("Head changed due to attestations")
@@ -163,9 +163,19 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 		}
 		if postGloas {
 			go func() {
-				if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, newHeadBlockHash, attr); err != nil {
+				pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, newHeadBlockHash, attr)
+				if err != nil {
 					log.WithError(err).Error("Could not update forkchoice with engine")
 				}
+				if pid == nil {
+					if attr != nil {
+						log.Warn("Engine did not return a payload ID for the fork choice update with attributes")
+					}
+					return
+				}
+				var pId [8]byte
+				copy(pId[:], pid[:])
+				s.cfg.PayloadIDCache.Set(proposingSlot, newHeadRoot, pId)
 			}()
 		} else {
 			fcuArgs := &fcuConfig{

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -134,7 +134,7 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 
 	start = time.Now()
 	// return early if we haven't changed head
-	newHeadRoot, err := s.cfg.ForkChoiceStore.Head(ctx)
+	newHeadRoot, newHeadBlockHash, full, err := s.cfg.ForkChoiceStore.FullHead(ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not compute head from new attestations")
 		return
@@ -143,29 +143,45 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 		return
 	}
 	log.WithField("newHeadRoot", fmt.Sprintf("%#x", newHeadRoot)).Debug("Head changed due to attestations")
-	headState, headBlock, err := s.getStateAndBlock(ctx, newHeadRoot)
+	var accessRoot [32]byte
+	postGloas := slots.ToEpoch(proposingSlot) >= params.BeaconConfig().GloasForkEpoch
+	if full && postGloas {
+		accessRoot = newHeadBlockHash
+	} else {
+		accessRoot = newHeadRoot
+	}
+	headState, headBlock, err := s.getStateAndBlock(ctx, newHeadRoot, accessRoot)
 	if err != nil {
-		log.WithError(err).Error("Could not get head block")
+		log.WithError(err).Error("Could not get head block and state")
 		return
 	}
 	newAttHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
-	fcuArgs := &fcuConfig{
-		headState:     headState,
-		headRoot:      newHeadRoot,
-		headBlock:     headBlock,
-		proposingSlot: proposingSlot,
-	}
 	if s.inRegularSync() {
-		fcuArgs.attributes = s.getPayloadAttribute(ctx, headState, proposingSlot, newHeadRoot[:])
-		if fcuArgs.attributes != nil && s.shouldOverrideFCU(newHeadRoot, proposingSlot) {
+		attr := s.getPayloadAttribute(ctx, headState, proposingSlot, newHeadRoot[:], accessRoot[:])
+		if attr != nil && s.shouldOverrideFCU(newHeadRoot, proposingSlot) {
 			return
 		}
-		go s.forkchoiceUpdateWithExecution(s.ctx, fcuArgs)
+		if postGloas {
+			go func() {
+				if _, err := s.notifyForkchoiceUpdateGloas(s.ctx, newHeadBlockHash, attr); err != nil {
+					log.WithError(err).Error("Could not update forkchoice with engine")
+				}
+			}()
+		} else {
+			fcuArgs := &fcuConfig{
+				headState:     headState,
+				headRoot:      newHeadRoot,
+				headBlock:     headBlock,
+				proposingSlot: proposingSlot,
+				attributes:    attr,
+			}
+			go s.forkchoiceUpdateWithExecution(s.ctx, fcuArgs)
+		}
 	}
-	if err := s.saveHead(s.ctx, fcuArgs.headRoot, fcuArgs.headBlock, fcuArgs.headState); err != nil {
+	if err := s.saveHead(s.ctx, newHeadRoot, headBlock, headState); err != nil {
 		log.WithError(err).Error("Could not save head")
 	}
-	s.pruneAttsFromPool(s.ctx, fcuArgs.headState, fcuArgs.headBlock)
+	s.pruneAttsFromPool(s.ctx, headState, headBlock)
 }
 
 // This processes fork choice attestations from the pool to account for validator votes and fork choice.

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -152,7 +152,7 @@ func (s *Service) postPayloadHeadUpdate(ctx context.Context, envelope interfaces
 		}
 	}()
 
-	attr := s.getPayloadAttribute(ctx, st, envelope.Slot()+1, headRoot)
+	attr := s.getPayloadAttribute(ctx, st, envelope.Slot()+1, headRoot, blockHash[:])
 	if s.inRegularSync() {
 		go func() {
 			pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, attr)

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -139,6 +139,7 @@ func (s *Service) postPayloadHeadUpdate(ctx context.Context, envelope interfaces
 
 	s.headLock.Lock()
 	s.head.state = st
+	s.head.full = true
 	s.headLock.Unlock()
 
 	go func() {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -344,7 +344,7 @@ func (s *Service) initializeHead(ctx context.Context, st state.BeaconState) erro
 			return errors.Wrap(err, "could not get head state")
 		}
 	}
-	if err := s.setHead(&head{root, blk, st, blk.Block().Slot(), false}); err != nil {
+	if err := s.setHead(&head{root, blk, st, blk.Block().Slot(), false, false}); err != nil {
 		return errors.Wrap(err, "could not set head")
 	}
 	log.WithFields(logrus.Fields{
@@ -432,6 +432,7 @@ func (s *Service) saveGenesisData(ctx context.Context, genesisState state.Beacon
 		genesisBlk,
 		genesisState,
 		genesisBlk.Block().Slot(),
+		false,
 		false,
 	}); err != nil {
 		log.WithError(err).Fatal("Could not set head")

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -489,3 +489,23 @@ func (s *Store) removeProposerBoostFromParent() {
 	}
 	return
 }
+
+// FullHead returns the head root and the head blockhash of the chain. It also
+// returns whether the head is full or not, that is if the blockhash is for the same
+// slot as the beacon root or some previous slots.
+func (f *ForkChoice) FullHead(ctx context.Context) ([32]byte, [32]byte, bool, error) {
+	hr, err := f.Head(ctx)
+	if err != nil {
+		return [32]byte{}, [32]byte{}, false, err
+	}
+	n := f.store.headNode
+	pn := f.store.choosePayloadContent(n)
+	if pn.full {
+		return hr, pn.node.blockHash, true, nil
+	}
+	fullAncestor := f.store.fullParent(pn)
+	if fullAncestor == nil {
+		return hr, [32]byte{}, false, nil
+	}
+	return hr, fullAncestor.node.blockHash, false, nil
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -1399,3 +1399,60 @@ func TestCanonicalNodeAtSlot_NilParent(t *testing.T) {
 	assert.Equal(t, [32]byte{}, root)
 	assert.Equal(t, false, full)
 }
+
+func TestFullHead_FullPayload(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	st, blk, err := prepareGloasForkchoiceState(ctx, 1, rootA, zeroHash, blockHashA, zeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	pe, err := prepareGloasForkchoicePayload(rootA)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	driftGenesisTime(f, 1, 0)
+	require.NoError(t, f.NewSlot(ctx, 1))
+
+	hr, bh, full, err := f.FullHead(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, rootA, hr)
+	assert.Equal(t, blockHashA, bh)
+	assert.Equal(t, true, full)
+}
+
+func TestFullHead_EmptyPayload(t *testing.T) {
+	f := setupGloas(t, 0, 0)
+	ctx := t.Context()
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	// Insert block A at slot 1 with payload.
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	st, blk, err := prepareGloasForkchoiceState(ctx, 1, rootA, zeroHash, blockHashA, zeroHash, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+	pe, err := prepareGloasForkchoicePayload(rootA)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	// Insert block B at slot 2 without payload.
+	rootB := indexToHash(2)
+	blockHashB := indexToHash(101)
+	driftGenesisTime(f, 2, 0)
+	require.NoError(t, f.NewSlot(ctx, 2))
+	st, blk, err = prepareGloasForkchoiceState(ctx, 2, rootB, rootA, blockHashB, blockHashA, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	// Head is B (empty), so blockHash should come from ancestor A.
+	hr, bh, full, err := f.FullHead(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, rootB, hr)
+	assert.Equal(t, blockHashA, bh)
+	assert.Equal(t, false, full)
+}

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -39,6 +39,7 @@ type RLocker interface {
 // HeadRetriever retrieves head root and optimistic info of the current chain.
 type HeadRetriever interface {
 	Head(context.Context) ([32]byte, error)
+	FullHead(context.Context) ([32]byte, [32]byte, bool, error)
 	GetProposerHead() [32]byte
 	CachedHeadRoot() [32]byte
 }

--- a/changelog/potuz_gloas_update_head.md
+++ b/changelog/potuz_gloas_update_head.md
@@ -1,0 +1,2 @@
+### Added
+- Various modification to UpdateHead and Execution Engine paths to adapt them to Gloas.


### PR DESCRIPTION
Post-Gloas, SaveState and the next-slot cache are keyed by execution
block hash as well of beacon block root. Thread an accessRoot through
getStateAndBlock (for StateByRoot) and getPayloadAttribute (for
ProcessSlotsUsingNextSlotCache) so each caller can supply the right
key.

Add FullHead to forkchoice: it returns the head root, the block hash
of the nearest full payload (walking up to an ancestor when the head
is empty), and whether the head itself is full. This gives callers
enough information to derive the correct accessRoot.

Rework UpdateHead to call FullHead and branch on post-Gloas: the
Gloas path computes accessRoot from the full block hash and sends FCU
via notifyForkchoiceUpdateGloas; the legacy path keeps the existing
forkchoiceUpdateWithExecution flow. saveHead and pruneAttsFromPool
now use local variables instead of the removed shared fcuArgs.

Flatten the else branch in lateBlockTasks so the Gloas path returns
early and the pre-Gloas path runs at the top indentation level.

In postPayloadHeadUpdate pass the envelope's block hash as accessRoot
since the state was just saved under that key.