### PR TITLE
Gloas/pending payload dependent root

### DIFF
--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -286,6 +286,25 @@ func TestQueuePendingPayloadEnvelope_SelfBuildIgnoredOutsideLookahead(t *testing
 	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
 }
 
+func TestQueuePendingPayloadEnvelope_SelfBuildInLookaheadVerifiesSignature(t *testing.T) {
+	ctx := context.Background()
+	s, _, _, root := setupExecutionPayloadEnvelopeService(t, 1, 1)
+	selfBuild := params.BeaconConfig().BuilderIndexSelfBuild
+
+	blockHash := [32]byte{0x02}
+	signedEnv := testSignedExecutionPayloadEnvelope(t, 1, selfBuild, root, blockHash)
+	e, err := blocks.WrappedROSignedExecutionPayloadEnvelope(signedEnv)
+	require.NoError(t, err)
+	env, err := e.Envelope()
+	require.NoError(t, err)
+
+	// Self-build in the same epoch (lookahead) still verifies the signature.
+	v := &mockExecutionPayloadEnvelopeVerifier{errSignature: errors.New("bad signature")}
+	result, err := s.queuePendingPayloadEnvelope(ctx, v, env, signedEnv)
+	require.NotNil(t, err)
+	require.Equal(t, pubsub.ValidationReject, result)
+}
+
 func TestQueuePendingPayloadEnvelope_RejectBadSignature(t *testing.T) {
 	ctx := context.Background()
 	s, _, _, root := setupExecutionPayloadEnvelopeService(t, 1, 1)

--- a/beacon-chain/sync/pending_payload_envelope_test.go
+++ b/beacon-chain/sync/pending_payload_envelope_test.go
@@ -242,6 +242,50 @@ func TestPrunePendingPayloadEnvelopes(t *testing.T) {
 	require.Equal(t, true, ok)
 }
 
+func TestQueuePendingPayloadEnvelope_SelfBuildIgnoredOutsideLookahead(t *testing.T) {
+	ctx := context.Background()
+	cfg := params.BeaconConfig()
+	selfBuild := cfg.BuilderIndexSelfBuild
+	// Place the envelope in epoch 2 so the head state (epoch 0) is outside
+	// the proposer lookahead window.
+	envelopeSlot := primitives.Slot(2 * cfg.SlotsPerEpoch)
+
+	db := dbtest.SetupDB(t)
+	chainService := &mock.ChainService{
+		Genesis:             time.Unix(time.Now().Unix()-int64(uint64(envelopeSlot)*cfg.SecondsPerSlot), 0),
+		FinalizedCheckPoint: &ethpb.Checkpoint{},
+		DB:                  db,
+	}
+	st, err := util.NewBeaconStateFulu()
+	require.NoError(t, err)
+	chainService.State = st
+
+	s := &Service{
+		seenPayloadEnvelopeCache: lruwrpr.New(10),
+		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+		cfg: &config{
+			chain: chainService,
+			clock: startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot),
+		},
+	}
+
+	root := [32]byte{0x01}
+	blockHash := [32]byte{0x02}
+	signedEnv := testSignedExecutionPayloadEnvelope(t, envelopeSlot, selfBuild, root, blockHash)
+	e, err := blocks.WrappedROSignedExecutionPayloadEnvelope(signedEnv)
+	require.NoError(t, err)
+	env, err := e.Envelope()
+	require.NoError(t, err)
+
+	// Signature verification would fail, but self-build outside the lookahead
+	// should skip it and return Ignore without queuing.
+	v := &mockExecutionPayloadEnvelopeVerifier{errSignature: errors.New("bad signature")}
+	result, err := s.queuePendingPayloadEnvelope(ctx, v, env, signedEnv)
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+	require.Equal(t, 0, len(s.pendingPayloadEnvelopes))
+}
+
 func TestQueuePendingPayloadEnvelope_RejectBadSignature(t *testing.T) {
 	ctx := context.Background()
 	s, _, _, root := setupExecutionPayloadEnvelopeService(t, 1, 1)

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
@@ -137,20 +138,28 @@ func (s *Service) queuePendingPayloadEnvelope(
 	env interfaces.ROExecutionPayloadEnvelope,
 	signedEnvelope *ethpb.SignedExecutionPayloadEnvelope,
 ) (pubsub.ValidationResult, error) {
-	if env.Slot() != s.cfg.clock.CurrentSlot() {
+	currentSlot := s.cfg.clock.CurrentSlot()
+	if env.Slot() != currentSlot {
 		return pubsub.ValidationIgnore, nil
 	}
 	st, err := s.cfg.chain.HeadStateReadOnly(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	if err := v.VerifySignature(st); err != nil {
-		return pubsub.ValidationReject, err
-	}
-	root := env.BeaconBlockRoot()
+	currentEpoch := slots.ToEpoch(currentSlot)
+	stateEpoch := slots.ToEpoch(st.Slot())
+	proposerInLookahead := (stateEpoch == currentEpoch || stateEpoch+1 == currentEpoch)
 	builderIdx := uint64(env.BuilderIndex())
 	isSelfBuild := builderIdx == uint64(params.BeaconConfig().BuilderIndexSelfBuild)
-
+	if !isSelfBuild || proposerInLookahead {
+		if err := v.VerifySignature(st); err != nil {
+			return pubsub.ValidationReject, err
+		}
+	} else {
+		log.Debug("Ignoring payload envelope from self-build outside of the Lookahead window")
+		return pubsub.ValidationIgnore, nil
+	}
+	root := env.BeaconBlockRoot()
 	s.pendingEnvelopeLock.Lock()
 	inner, rootExists := s.pendingPayloadEnvelopes[root]
 	if !rootExists {

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -237,6 +237,7 @@ func setupExecutionPayloadEnvelopeService(t *testing.T, envelopeSlot, blockSlot 
 	state, err := util.NewBeaconStateFulu()
 	require.NoError(t, err)
 	require.NoError(t, db.SaveState(ctx, state, root))
+	chainService.State = state
 
 	blockHash := bytesutil.ToBytes32(bid.Message.BlockHash)
 	env := testSignedExecutionPayloadEnvelope(t, envelopeSlot, primitives.BuilderIndex(bid.Message.BuilderIndex), root, blockHash)

--- a/changelog/potuz_validate_on_lookahead.md
+++ b/changelog/potuz_validate_on_lookahead.md
@@ -1,0 +1,2 @@
+### Ignored
+- Verify signature only if not self-building or proposer is in lookahead. 


### PR DESCRIPTION
Only verify the envelope's signature before putting in the queue if non-self-building or the proposer is in the lookahead. Otherwise just ignore. 

This still can cause a false rejection in a very edgy case of a builder that is chosen exactly after being active and we are syncing from afar. 