### PR TITLE
Preserve canonical block order when streaming reconstructed blinded batches

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -163,29 +163,15 @@ func (s *Service) writeBlockBatchToStream(ctx context.Context, batch blockBatch,
 
 	canonical := batch.canonical()
 
-	// First pass: collect all blinded blocks that need reconstruction.
 	blinded := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
 	for _, b := range canonical {
-		if err := blocks.BeaconBlockIsNil(b); err != nil {
-			continue
-		}
 		if b.IsBlinded() {
-			log.WithFields(logrus.Fields{
-				"slot":    b.Block().Slot(),
-				"version": b.Version(),
-			}).Debug("[BBR-server] IsBlinded=true, queuing for reconstruction")
 			blinded = append(blinded, b.ReadOnlySignedBeaconBlock)
 		}
 	}
 
-	// Reconstruct blinded blocks before writing anything to the stream,
-	// so that all blocks can be written in canonical (ascending slot) order.
-	// Writing non-blinded blocks first and reconstructed blocks second would
-	// deliver them out of order (e.g. slots 8-63 before slots 0-7 at a fork
-	// boundary), breaking the client's chain-continuity check.
 	reconstructedBySlot := make(map[primitives.Slot]interfaces.SignedBeaconBlock)
 	if len(blinded) > 0 {
-		log.WithField("blindedCount", len(blinded)).Debug("[BBR-server] reconstructing blinded blocks before stream write")
 		reconstructed, err := s.cfg.executionReconstructor.ReconstructFullBellatrixBlockBatch(ctx, blinded)
 		if err != nil {
 			log.WithError(err).Error("Could not reconstruct full bellatrix block batch from blinded bodies")
@@ -202,13 +188,8 @@ func (s *Service) writeBlockBatchToStream(ctx context.Context, batch blockBatch,
 		}
 	}
 
-	// Second pass: write all canonical blocks in ascending slot order,
-	// substituting reconstructed full blocks for blinded ones.
+
 	for _, b := range canonical {
-		if err := blocks.BeaconBlockIsNil(b); err != nil {
-			log.WithField("slot", b.Block().Slot()).WithError(err).Debug("[BBR-server] block is nil, skipping")
-			continue
-		}
 		var toWrite interfaces.ReadOnlySignedBeaconBlock
 		if b.IsBlinded() {
 			full, ok := reconstructedBySlot[b.Block().Slot()]
@@ -220,7 +201,6 @@ func (s *Service) writeBlockBatchToStream(ctx context.Context, batch blockBatch,
 		} else {
 			toWrite = b
 		}
-		log.WithField("slot", b.Block().Slot()).Debug("[BBR-server] writing block to stream")
 		if chunkErr := s.chunkBlockWriter(stream, toWrite); chunkErr != nil {
 			log.WithError(chunkErr).Debug("Could not send a chunked response")
 			return chunkErr

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -284,6 +284,127 @@ func TestRPCBeaconBlocksByRange_ReconstructsPayloads(t *testing.T) {
 	}
 }
 
+func TestWriteBlockBatchToStream_ReconstructedBlocksPreserveCanonicalOrder(t *testing.T) {
+	p1 := p2ptest.NewTestP2P(t)
+	p2 := p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+	require.Equal(t, 1, len(p1.BHost.Network().Peers()))
+
+	clock := startup.NewClock(time.Unix(0, 0), [32]byte{})
+
+	makePayload := func(tag byte) *enginev1.ExecutionPayload {
+		blockHash := bytesutil.PadTo([]byte{tag}, fieldparams.RootLength)
+		return &enginev1.ExecutionPayload{
+			ParentHash:    bytesutil.PadTo([]byte{'p', tag}, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     bytesutil.PadTo([]byte{'s', tag}, fieldparams.RootLength),
+			ReceiptsRoot:  bytesutil.PadTo([]byte{'r', tag}, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    blockHash,
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     nil,
+			BlockHash:     blockHash,
+			BaseFeePerGas: bytesutil.PadTo([]byte{'b', tag}, fieldparams.RootLength),
+			Transactions:  nil,
+		}
+	}
+
+	makeBlindedROBlock := func(slot primitives.Slot, payload *enginev1.ExecutionPayload) blocks.ROBlock {
+		blinded := util.NewBlindedBeaconBlockBellatrix()
+		blinded.Block.Slot = slot
+		wrappedPayload, err := blocks.WrappedExecutionPayload(payload)
+		require.NoError(t, err)
+		header, err := blocks.PayloadToHeader(wrappedPayload)
+		require.NoError(t, err)
+		blinded.Block.Body.ExecutionPayloadHeader = header
+		signed, err := blocks.NewSignedBeaconBlock(blinded)
+		require.NoError(t, err)
+		root, err := blinded.Block.HashTreeRoot()
+		require.NoError(t, err)
+		ro, err := blocks.NewROBlockWithRoot(signed, root)
+		require.NoError(t, err)
+		return ro
+	}
+
+	makeFullROBlock := func(slot primitives.Slot) blocks.ROBlock {
+		full := util.NewBeaconBlockBellatrix()
+		full.Block.Slot = slot
+		signed, err := blocks.NewSignedBeaconBlock(full)
+		require.NoError(t, err)
+		root, err := full.Block.HashTreeRoot()
+		require.NoError(t, err)
+		ro, err := blocks.NewROBlockWithRoot(signed, root)
+		require.NoError(t, err)
+		return ro
+	}
+
+	payload1 := makePayload(0x11)
+	payload3 := makePayload(0x33)
+	block1 := makeBlindedROBlock(1, payload1)
+	block2 := makeFullROBlock(2)
+	block3 := makeBlindedROBlock(3, payload3)
+
+	mockEngine := &mockExecution.EngineClient{
+		ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
+			bytesutil.ToBytes32(payload1.BlockHash): payload1,
+			bytesutil.ToBytes32(payload3.BlockHash): payload3,
+		},
+	}
+
+	r := &Service{cfg: &config{p2p: p1, clock: clock, executionReconstructor: mockEngine}}
+	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+
+	slotsCh := make(chan []primitives.Slot, 1)
+	errCh := make(chan error, 1)
+	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+		got := make([]primitives.Slot, 0, 3)
+		for i := 0; i < 3; i++ {
+			expectSuccess(t, stream)
+			blk := util.NewBeaconBlockBellatrix()
+			if err := p2.Encoding().DecodeWithMaxLength(stream, blk); err != nil {
+				errCh <- err
+				return
+			}
+			wrapped, err := blocks.NewSignedBeaconBlock(blk)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if wrapped.IsBlinded() {
+				errCh <- errors.New("expected reconstructed full block, got blinded block")
+				return
+			}
+			got = append(got, wrapped.Block().Slot())
+		}
+		slotsCh <- got
+	})
+
+	stream, err := p1.BHost.NewStream(t.Context(), p2.BHost.ID(), pcl)
+	require.NoError(t, err)
+
+	err = r.writeBlockBatchToStream(
+		t.Context(),
+		blockBatch{lin: []blocks.ROBlock{block1, block2, block3}},
+		stream,
+	)
+	require.NoError(t, err)
+	require.NoError(t, stream.Close())
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case got := <-slotsCh:
+		assert.DeepEqual(t, []primitives.Slot{1, 2, 3}, got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for streamed blocks")
+	}
+
+	require.Equal(t, uint64(2), mockEngine.NumReconstructedPayloads)
+}
+
 func TestRPCBeaconBlocksByRange_RPCHandlerReturnsSortedBlocks(t *testing.T) {
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)

--- a/changelog/t_write-block-batch-stream-order.md
+++ b/changelog/t_write-block-batch-stream-order.md
@@ -1,0 +1,2 @@
+### Fixed
+- Preserve canonical slot order in `BeaconBlocksByRange` responses by reconstructing blinded blocks before writing the batch stream.


### PR DESCRIPTION
## Summary
- reconstruct blinded blocks before writing any chunk so `writeBlockBatchToStream` preserves canonical slot order across mixed blinded/full batches
- keep response behavior unchanged for fully unblinded batches while substituting reconstructed blocks by slot for blinded entries
- add a targeted unit test that streams a mixed batch and verifies slots are delivered in order (`1,2,3`) and blinded blocks are reconstructed
- add changelog entry for the by-range stream ordering fix

## Why
When a batch contained both non-blinded and blinded blocks, writing non-blinded blocks first and reconstructed blinded blocks second could produce out-of-order responses around fork boundaries. Clients expect a strictly continuous canonical sequence, so the stream must preserve slot order.

## Testing
- `go test ./beacon-chain/sync -run TestWriteBlockBatchToStream_ReconstructedBlocksPreserveCanonicalOrder -count=1`
- `go test ./beacon-chain/sync -run \"TestRPCBeaconBlocksByRange_ReconstructsPayloads|TestWriteBlockBatchToStream_ReconstructedBlocksPreserveCanonicalOrder\" -count=1`