### PR TITLE
Unify the validation pipeline for full and partial data columns

### DIFF
--- a/beacon-chain/core/peerdas/p2p_interface.go
+++ b/beacon-chain/core/peerdas/p2p_interface.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/container/trie"
-	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/pkg/errors"
 )
@@ -198,18 +197,6 @@ func VerifyDataColumnSidecarInclusionProof(sidecar blocks.RODataColumn) error {
 		sidecar.SignedBlockHeader.Header.BodyRoot,
 		sidecar.KzgCommitments,
 		sidecar.KzgCommitmentsInclusionProof,
-	)
-}
-
-// VerifyPartialDataColumnHeaderInclusionProof verifies if the KZG commitments are included in the beacon block.
-func VerifyPartialDataColumnHeaderInclusionProof(header *ethpb.PartialDataColumnHeader) error {
-	if header.SignedBlockHeader == nil || header.SignedBlockHeader.Header == nil {
-		return ErrNilBlockHeader
-	}
-	return verifyKzgCommitmentsInclusionProof(
-		header.SignedBlockHeader.Header.BodyRoot,
-		header.KzgCommitments,
-		header.KzgCommitmentsInclusionProof,
 	)
 }
 

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/BUILD.bazel
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/partialdatacolumnbroadcaster",
     visibility = ["//visibility:public"],
     deps = [
+        "//beacon-chain/verification:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
@@ -29,6 +30,7 @@ go_test(
     srcs = ["partial_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/verification:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/BUILD.bazel
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "//beacon-chain/p2p:go_default_library",
         "//beacon-chain/p2p/encoder:go_default_library",
         "//beacon-chain/p2p/partialdatacolumnbroadcaster:go_default_library",
+        "//beacon-chain/verification:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/two_node_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/two_node_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/encoder"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/partialdatacolumnbroadcaster"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -135,20 +136,42 @@ func TestTwoNodePartialColumnExchange(t *testing.T) {
 		topic2, err := ps2.Join(topicStr, pubsub.RequestPartialMessages())
 		require.NoError(t, err)
 
-		// Header validator
-		headerValidator := func(header *ethpb.PartialDataColumnHeader) (reject bool, err error) {
-			if header == nil {
-				return false, fmt.Errorf("nil header")
+		newVerifier := func(col *blocks.PartialDataColumn, markIncluded bool) (*verification.PartialColumnVerifier, error) {
+			mock := &verification.MockDataColumnsVerifier{}
+			roCol, err := blocks.NewRODataColumn(col.DataColumnSidecar)
+			if err != nil {
+				return nil, err
 			}
-			if header.SignedBlockHeader == nil || header.SignedBlockHeader.Header == nil {
-				return true, fmt.Errorf("nil signed block header")
+			mock.AppendRODataColumns(roCol)
+			verifier := verification.NewPartialColumnVerifier(mock, col)
+			if markIncluded {
+				verifier.MarkIncludedCellsVerified()
 			}
-			if len(header.KzgCommitments) == 0 {
-				return true, fmt.Errorf("empty kzg commitments")
-			}
+			return verifier, nil
+		}
 
-			t.Log("Header validation passed")
-			return false, nil
+		partialVerifierFromHeader := func(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, bool, error) {
+			if col == nil {
+				return nil, false, fmt.Errorf("nil partial column")
+			}
+			if col.SignedBlockHeader == nil || col.SignedBlockHeader.Header == nil {
+				return nil, true, fmt.Errorf("nil signed block header")
+			}
+			if len(col.KzgCommitments) == 0 {
+				return nil, true, fmt.Errorf("empty kzg commitments")
+			}
+			verifier, err := newVerifier(col, false)
+			if err != nil {
+				return nil, true, err
+			}
+			return verifier, false, nil
+		}
+
+		partialVerifierFromTrustedColumn := func(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, error) {
+			if col == nil {
+				return nil, fmt.Errorf("nil partial column")
+			}
+			return newVerifier(col, true)
 		}
 
 		cellValidator := func(_ []blocks.CellProofBundle) error {
@@ -187,10 +210,10 @@ func TestTwoNodePartialColumnExchange(t *testing.T) {
 
 		noopHeaderHandler := func(header *ethpb.PartialDataColumnHeader, groupID string) {}
 
-		err = broadcaster1.Start(headerValidator, cellValidator, handler1, noopHeaderHandler)
+		err = broadcaster1.Start(partialVerifierFromHeader, partialVerifierFromTrustedColumn, cellValidator, handler1, noopHeaderHandler)
 		require.NoError(t, err)
 
-		err = broadcaster2.Start(headerValidator, cellValidator, handler2, noopHeaderHandler)
+		err = broadcaster2.Start(partialVerifierFromHeader, partialVerifierFromTrustedColumn, cellValidator, handler2, noopHeaderHandler)
 		require.NoError(t, err)
 
 		err = broadcaster1.Subscribe(topic1)

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/two_node_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/integrationtest/two_node_test.go
@@ -151,9 +151,6 @@ func TestTwoNodePartialColumnExchange(t *testing.T) {
 		}
 
 		partialVerifierFromHeader := func(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, bool, error) {
-			if col == nil {
-				return nil, false, fmt.Errorf("nil partial column")
-			}
 			if col.SignedBlockHeader == nil || col.SignedBlockHeader.Header == nil {
 				return nil, true, fmt.Errorf("nil signed block header")
 			}
@@ -168,9 +165,6 @@ func TestTwoNodePartialColumnExchange(t *testing.T) {
 		}
 
 		partialVerifierFromTrustedColumn := func(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, error) {
-			if col == nil {
-				return nil, fmt.Errorf("nil partial column")
-			}
 			return newVerifier(col, true)
 		}
 

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -39,12 +40,13 @@ func extractColumnIndexFromTopic(topic string) (uint64, error) {
 	return strconv.ParseUint(matches[1], 10, 64)
 }
 
-// HeaderValidator validates a PartialDataColumnHeader.
-// Returns (reject, err) where:
+// PartialVerifierFromHeader builds and validates a partial column from a new header.
+// Returns (verifier, reject, err) where:
 //   - reject=true, err!=nil: REJECT - peer should be penalized
 //   - reject=false, err!=nil: IGNORE - don't penalize, just ignore
-//   - reject=false, err=nil: valid header
-type HeaderValidator func(header *ethpb.PartialDataColumnHeader) (reject bool, err error)
+//   - reject=false, err=nil: valid verifier
+type PartialVerifierFromHeader func(col *blocks.PartialDataColumn) (verifier *verification.PartialColumnVerifier, reject bool, err error)
+type PartialVerifierFromTrustedColumn func(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, error)
 type HeaderHandler func(header *ethpb.PartialDataColumnHeader, groupID string)
 type ColumnValidator func(cells []blocks.CellProofBundle) error
 type partialColumnPubSub interface {
@@ -56,10 +58,11 @@ type PartialColumnBroadcaster struct {
 	ps   partialColumnPubSub
 	stop chan struct{}
 
-	validateHeader HeaderValidator
-	validateColumn ColumnValidator
-	handleColumn   SubHandler
-	handleHeader   HeaderHandler
+	partialVerifierFromHeader        PartialVerifierFromHeader
+	partialVerifierFromTrustedColumn PartialVerifierFromTrustedColumn
+	validateColumn                   ColumnValidator
+	handleColumn                     SubHandler
+	handleHeader                     HeaderHandler
 
 	// map groupID -> bool to signal when getBlobs has been called
 	getBlobsCalled map[string]bool
@@ -70,8 +73,8 @@ type PartialColumnBroadcaster struct {
 	concurrentValidatorSemaphore     chan struct{}
 	concurrentHeaderHandlerSemaphore chan struct{}
 
-	// map topic -> map[groupID]PartialColumn
-	partialMsgStore map[string]map[string]*blocks.PartialDataColumn
+	// map topic -> map[groupID]PartialColumnVerifier
+	partialMsgStore map[string]map[string]*verification.PartialColumnVerifier
 
 	groupTTL map[string]int8
 
@@ -155,7 +158,7 @@ type gossipForPeerResponse struct {
 func NewBroadcaster() *PartialColumnBroadcaster {
 	return &PartialColumnBroadcaster{
 		topics:           make(map[string]*pubsub.Topic),
-		partialMsgStore:  make(map[string]map[string]*blocks.PartialDataColumn),
+		partialMsgStore:  make(map[string]map[string]*verification.PartialColumnVerifier),
 		groupTTL:         make(map[string]int8),
 		validHeaderCache: make(map[string]*ethpb.PartialDataColumnHeader),
 		getBlobsCalled:   make(map[string]bool),
@@ -224,13 +227,17 @@ func (p *PartialColumnBroadcaster) AppendPubSubOpts(opts []pubsub.Option) []pubs
 // It accepts the required validator and handler functions, returning an error if any is nil.
 // The event loop is launched in a goroutine.
 func (p *PartialColumnBroadcaster) Start(
-	validateHeader HeaderValidator,
+	partialVerifierFromHeader PartialVerifierFromHeader,
+	partialVerifierFromTrustedColumn PartialVerifierFromTrustedColumn,
 	validateColumn ColumnValidator,
 	handleColumn SubHandler,
 	handleHeader HeaderHandler,
 ) error {
-	if validateHeader == nil {
-		return errors.New("no header validator provided")
+	if partialVerifierFromHeader == nil {
+		return errors.New("no header partial verifier provided")
+	}
+	if partialVerifierFromTrustedColumn == nil {
+		return errors.New("no trusted partial verifier provided")
 	}
 	if handleHeader == nil {
 		return errors.New("no header handler provided")
@@ -241,7 +248,8 @@ func (p *PartialColumnBroadcaster) Start(
 	if handleColumn == nil {
 		return errors.New("no column handler provided")
 	}
-	p.validateHeader = validateHeader
+	p.partialVerifierFromHeader = partialVerifierFromHeader
+	p.partialVerifierFromTrustedColumn = partialVerifierFromTrustedColumn
 	p.validateColumn = validateColumn
 	p.handleColumn = handleColumn
 	p.handleHeader = handleHeader
@@ -309,16 +317,24 @@ func (p *PartialColumnBroadcaster) loop() {
 	}
 }
 
-func (p *PartialColumnBroadcaster) getDataColumn(topic string, group []byte) *blocks.PartialDataColumn {
+func (p *PartialColumnBroadcaster) getPartialVerifier(topic string, group []byte) *verification.PartialColumnVerifier {
 	topicStore, ok := p.partialMsgStore[topic]
 	if !ok {
 		return nil
 	}
-	msg, ok := topicStore[string(group)]
+	verifier, ok := topicStore[string(group)]
 	if !ok {
 		return nil
 	}
-	return msg
+	return verifier
+}
+
+func (p *PartialColumnBroadcaster) getDataColumn(topic string, group []byte) *blocks.PartialDataColumn {
+	verifier := p.getPartialVerifier(topic, group)
+	if verifier == nil {
+		return nil
+	}
+	return verifier.Column
 }
 
 func (p *PartialColumnBroadcaster) handleGossipForPeer(req gossipForPeer) (partialmessages.PeerState, []byte, partialmessages.PartsMetadata, error) {
@@ -326,12 +342,12 @@ func (p *PartialColumnBroadcaster) handleGossipForPeer(req gossipForPeer) (parti
 	if !ok {
 		return req.peerState, nil, nil, errors.New("not tracking topic for group")
 	}
-	partialColumn, ok := topicStore[req.groupID]
-	if !ok || partialColumn == nil {
+	verifier, ok := topicStore[req.groupID]
+	if !ok || verifier == nil || verifier.Column == nil {
 		return req.peerState, nil, nil, errors.New("not tracking topic for group")
 	}
 	// we're not requesting a message here as this will be used to emit gossip. So, we pass requested message as false.
-	return partialColumn.ForPeer(req.remote, false, req.peerState)
+	return verifier.Column.ForPeer(req.remote, false, req.peerState)
 }
 
 func parsePartsMetadataFromPeerState(state any, expectedLength uint64) (*ethpb.PartialDataColumnPartsMetadata, error) {
@@ -432,10 +448,10 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 
 	topicID := rpcWithFrom.GetTopicID()
 	groupID := rpcWithFrom.GroupID
-	ourDataColumn := p.getDataColumn(topicID, groupID)
+	ourVerifier := p.getPartialVerifier(topicID, groupID)
 	var shouldRepublish bool
 
-	if ourDataColumn == nil && hasMessage {
+	if ourVerifier == nil && hasMessage {
 		var header *ethpb.PartialDataColumnHeader
 		// Check cache first for this group
 		if cachedHeader, ok := p.validHeaderCache[string(groupID)]; ok {
@@ -448,33 +464,6 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 			}
 
 			header = message.Header[0]
-			reject, err := p.validateHeader(header)
-			if err != nil {
-				log.WithError(err).WithField("reject", reject).Debug("Header validation failed")
-				if reject {
-					// REJECT case: penalize the peer
-					_ = p.ps.PeerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
-				}
-				// Both REJECT and IGNORE: don't process further
-				return nil
-			}
-			// Cache the valid header
-			p.validHeaderCache[string(groupID)] = header
-
-			select {
-			case p.concurrentHeaderHandlerSemaphore <- struct{}{}:
-				go func() {
-					defer func() {
-						<-p.concurrentHeaderHandlerSemaphore
-					}()
-					p.handleHeader(header, string(groupID))
-				}()
-			default:
-				log.WithFields(logrus.Fields{
-					"topic": topicID,
-					"group": groupID,
-				}).Warn("Dropping header handler, max concurrent header handlers reached")
-			}
 		}
 
 		columnIndex, err := extractColumnIndexFromTopic(topicID)
@@ -497,24 +486,57 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 			return err
 		}
 
+		verifier, reject, err := p.partialVerifierFromHeader(&newColumn)
+		if err != nil {
+			log.WithError(err).WithField("reject", reject).Debug("Header validation failed")
+			if reject {
+				// REJECT case: penalize the peer
+				_ = p.ps.PeerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
+			}
+			// Both REJECT and IGNORE: don't process further
+			return nil
+		}
+		if verifier == nil || verifier.Column == nil {
+			return errors.New("partial verifier from header is nil")
+		}
+
+		// Cache the valid header
+		p.validHeaderCache[string(groupID)] = header
+
+		select {
+		case p.concurrentHeaderHandlerSemaphore <- struct{}{}:
+			go func() {
+				defer func() {
+					<-p.concurrentHeaderHandlerSemaphore
+				}()
+				p.handleHeader(header, string(groupID))
+			}()
+		default:
+			log.WithFields(logrus.Fields{
+				"topic": topicID,
+				"group": groupID,
+			}).Warn("Dropping header handler, max concurrent header handlers reached")
+		}
+
 		// Save to store
 		topicStore, ok := p.partialMsgStore[topicID]
 		if !ok {
-			topicStore = make(map[string]*blocks.PartialDataColumn)
+			topicStore = make(map[string]*verification.PartialColumnVerifier)
 			p.partialMsgStore[topicID] = topicStore
 		}
-		topicStore[string(newColumn.GroupID())] = &newColumn
+		topicStore[string(newColumn.GroupID())] = verifier
 		p.groupTTL[string(newColumn.GroupID())] = TTLInSlots
 
-		ourDataColumn = &newColumn
+		ourVerifier = verifier
 		shouldRepublish = true
 	}
 
-	if ourDataColumn == nil {
+	if ourVerifier == nil || ourVerifier.Column == nil {
 		// We don't have a partial column for this. Can happen if we got cells
 		// without a header.
 		return nil
 	}
+	ourDataColumn := ourVerifier.Column
 
 	logger := log.WithFields(logrus.Fields{
 		"from":  rpcWithFrom.from,
@@ -591,11 +613,20 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 }
 
 func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) error {
-	ourDataColumn := p.getDataColumn(cells.topic, cells.group)
-	if ourDataColumn == nil {
+	ourVerifier := p.getPartialVerifier(cells.topic, cells.group)
+	if ourVerifier == nil || ourVerifier.Column == nil {
 		return errors.New("data column not found for verified cells")
 	}
-	extended := ourDataColumn.ExtendFromVerifiedCells(cells.cellIndices, cells.cells)
+	ourDataColumn := ourVerifier.Column
+	var extended bool
+	for i, bundle := range cells.cells {
+		if bundle.ColumnIndex != ourDataColumn.Index {
+			return errors.New("cell bundle has wrong column index")
+		}
+		if ourVerifier.ExtendFromVerifiedCell(cells.cellIndices[i], bundle.Cell, bundle.Proof) {
+			extended = true
+		}
+	}
 	log.WithFields(logrus.Fields{"duration": cells.validationTook, "extended": extended}).Debug("Extended partial message")
 
 	columnIndexStr := strconv.FormatUint(ourDataColumn.Index, 10)
@@ -607,7 +638,12 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 		// useful to us, it's likely useful to our peers and we should
 		// republish eagerly
 
-		if col, ok := ourDataColumn.Complete(); ok {
+		col, ok, err := ourVerifier.Complete()
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{"topic": cells.topic, "group": cells.group}).Error("Failed to complete partial column verifier")
+			return err
+		}
+		if ok {
 			log.WithFields(logrus.Fields{"topic": cells.topic, "group": cells.group}).Info("Completed partial column")
 			if p.handleColumn != nil {
 				go p.handleColumn(cells.topic, col)
@@ -622,7 +658,7 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 			return nil
 		}
 
-		err := p.ps.PublishPartialMessage(cells.topic, ourDataColumn, partialmessages.PublishOptions{})
+		err = p.ps.PublishPartialMessage(cells.topic, ourDataColumn, partialmessages.PublishOptions{})
 		if err != nil {
 			return err
 		}
@@ -660,24 +696,30 @@ func (p *PartialColumnBroadcaster) publish(topic string, c blocks.PartialDataCol
 	groupIDBytes := c.GroupID()
 	topicStore, ok := p.partialMsgStore[topic]
 	if !ok {
-		topicStore = make(map[string]*blocks.PartialDataColumn)
+		topicStore = make(map[string]*verification.PartialColumnVerifier)
 		p.partialMsgStore[topic] = topicStore
 	}
 
-	existing := topicStore[string(groupIDBytes)]
-	if existing != nil {
+	existingVerifier := topicStore[string(groupIDBytes)]
+	if existingVerifier != nil && existingVerifier.Column != nil {
+		existing := existingVerifier.Column
 		var extended bool
 		// Extend the existing column with cells being published here.
 		// The existing column may already contain cells received from peers. We must not overwrite it.
 		for i := range c.Included.Len() {
 			if c.Included.BitAt(i) {
-				if existing.ExtendFromVerifiedCell(uint64(i), c.Column[i], c.KzgProofs[i]) {
+				if existingVerifier.ExtendFromVerifiedCell(uint64(i), c.Column[i], c.KzgProofs[i]) {
 					extended = true
 				}
 			}
 		}
 		if extended {
-			if col, ok := existing.Complete(); ok {
+			col, ok, err := existingVerifier.Complete()
+			if err != nil {
+				log.WithError(err).WithFields(logrus.Fields{"topic": topic, "group": existing.GroupID()}).Error("Failed to complete partial column verifier")
+				return columnCompleted, err
+			}
+			if ok {
 				log.WithFields(logrus.Fields{"topic": topic, "group": existing.GroupID()}).Info("Completed partial column")
 				if p.handleColumn != nil {
 					columnCompleted = true
@@ -686,13 +728,20 @@ func (p *PartialColumnBroadcaster) publish(topic string, c blocks.PartialDataCol
 			}
 		}
 	} else {
-		topicStore[string(groupIDBytes)] = &c
-		existing = &c
+		verifier, err := p.partialVerifierFromTrustedColumn(&c)
+		if err != nil {
+			return columnCompleted, err
+		}
+		if verifier == nil || verifier.Column == nil {
+			return columnCompleted, errors.New("partial verifier from trusted column is nil")
+		}
+		topicStore[string(groupIDBytes)] = verifier
+		existingVerifier = verifier
 	}
 
 	p.groupTTL[string(groupIDBytes)] = TTLInSlots
 
-	err := p.ps.PublishPartialMessage(topic, existing, partialmessages.PublishOptions{})
+	err := p.ps.PublishPartialMessage(topic, existingVerifier.Column, partialmessages.PublishOptions{})
 	if err == nil {
 		p.getBlobsCalled[string(groupIDBytes)] = getBlobsCalled
 	}

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -453,9 +453,11 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 
 	if ourVerifier == nil && hasMessage {
 		var header *ethpb.PartialDataColumnHeader
+		headerWasCached := false
 		// Check cache first for this group
 		if cachedHeader, ok := p.validHeaderCache[string(groupID)]; ok {
 			header = cachedHeader
+			headerWasCached = true
 		} else {
 			// We haven't seen this group before. Check if we have a valid header.
 			if len(message.Header) == 0 {
@@ -486,36 +488,48 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 			return err
 		}
 
-		verifier, reject, err := p.partialVerifierFromHeader(&newColumn)
-		if err != nil {
-			log.WithError(err).WithField("reject", reject).Debug("Header validation failed")
-			if reject {
-				// REJECT case: penalize the peer
-				_ = p.ps.PeerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
+		var verifier *verification.PartialColumnVerifier
+		if headerWasCached {
+			verifier, err = p.partialVerifierFromTrustedColumn(&newColumn)
+			if err != nil {
+				return err
 			}
-			// Both REJECT and IGNORE: don't process further
-			return nil
+		} else {
+			var reject bool
+			verifier, reject, err = p.partialVerifierFromHeader(&newColumn)
+			if err != nil {
+				log.WithError(err).WithField("reject", reject).Debug("Header validation failed")
+				if reject {
+					// REJECT case: penalize the peer
+					_ = p.ps.PeerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
+				}
+				// Both REJECT and IGNORE: don't process further
+				return nil
+			}
 		}
 		if verifier == nil || verifier.Column == nil {
-			return errors.New("partial verifier from header is nil")
+			return errors.New("partial verifier is nil")
 		}
 
-		// Cache the valid header
-		p.validHeaderCache[string(groupID)] = header
+		if !headerWasCached {
+			log.Debug("Handling header as it was previously not cached for this group")
+			// Cache the valid header.
+			p.validHeaderCache[string(groupID)] = header
 
-		select {
-		case p.concurrentHeaderHandlerSemaphore <- struct{}{}:
-			go func() {
-				defer func() {
-					<-p.concurrentHeaderHandlerSemaphore
+			select {
+			case p.concurrentHeaderHandlerSemaphore <- struct{}{}:
+				go func() {
+					defer func() {
+						<-p.concurrentHeaderHandlerSemaphore
+					}()
+					p.handleHeader(header, string(groupID))
 				}()
-				p.handleHeader(header, string(groupID))
-			}()
-		default:
-			log.WithFields(logrus.Fields{
-				"topic": topicID,
-				"group": groupID,
-			}).Warn("Dropping header handler, max concurrent header handlers reached")
+			default:
+				log.WithFields(logrus.Fields{
+					"topic": topicID,
+					"group": groupID,
+				}).Warn("Dropping header handler, max concurrent header handlers reached")
+			}
 		}
 
 		// Save to store

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -343,7 +343,7 @@ func (p *PartialColumnBroadcaster) handleGossipForPeer(req gossipForPeer) (parti
 		return req.peerState, nil, nil, errors.New("not tracking topic for group")
 	}
 	verifier, ok := topicStore[req.groupID]
-	if !ok || verifier == nil || verifier.Column == nil {
+	if !ok || verifier == nil {
 		return req.peerState, nil, nil, errors.New("not tracking topic for group")
 	}
 	// we're not requesting a message here as this will be used to emit gossip. So, we pass requested message as false.
@@ -492,6 +492,11 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 		if headerWasCached {
 			verifier, err = p.partialVerifierFromTrustedColumn(&newColumn)
 			if err != nil {
+				log.WithError(err).WithFields(logrus.Fields{
+					"topic":          topicID,
+					"columnIndex":    columnIndex,
+					"numCommitments": len(header.KzgCommitments),
+				}).Error("Failed to create partial column verifier from header")
 				return err
 			}
 		} else {
@@ -506,9 +511,6 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 				// Both REJECT and IGNORE: don't process further
 				return nil
 			}
-		}
-		if verifier == nil || verifier.Column == nil {
-			return errors.New("partial verifier is nil")
 		}
 
 		if !headerWasCached {
@@ -545,7 +547,7 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 		shouldRepublish = true
 	}
 
-	if ourVerifier == nil || ourVerifier.Column == nil {
+	if ourVerifier == nil {
 		// We don't have a partial column for this. Can happen if we got cells
 		// without a header.
 		return nil
@@ -628,7 +630,7 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 
 func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) error {
 	ourVerifier := p.getPartialVerifier(cells.topic, cells.group)
-	if ourVerifier == nil || ourVerifier.Column == nil {
+	if ourVerifier == nil {
 		return errors.New("data column not found for verified cells")
 	}
 	ourDataColumn := ourVerifier.Column
@@ -715,7 +717,7 @@ func (p *PartialColumnBroadcaster) publish(topic string, c blocks.PartialDataCol
 	}
 
 	existingVerifier := topicStore[string(groupIDBytes)]
-	if existingVerifier != nil && existingVerifier.Column != nil {
+	if existingVerifier != nil {
 		existing := existingVerifier.Column
 		var extended bool
 		// Extend the existing column with cells being published here.
@@ -745,9 +747,6 @@ func (p *PartialColumnBroadcaster) publish(topic string, c blocks.PartialDataCol
 		verifier, err := p.partialVerifierFromTrustedColumn(&c)
 		if err != nil {
 			return columnCompleted, err
-		}
-		if verifier == nil || verifier.Column == nil {
-			return columnCompleted, errors.New("partial verifier from trusted column is nil")
 		}
 		topicStore[string(groupIDBytes)] = verifier
 		existingVerifier = verifier

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/go-bitfield"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
@@ -36,29 +37,38 @@ type broadcasterHarness struct {
 type callbackRecorder struct {
 	validateColumnCallCh chan []blocks.CellProofBundle
 	handleHeaderCallCh   chan headerHandlerCall
-	validateHeaderCallCh chan *ethpb.PartialDataColumnHeader
+	partialVerifierFromHeaderCallCh        chan *blocks.PartialDataColumn
+	partialVerifierFromTrustedColumnCallCh chan *blocks.PartialDataColumn
 	handleColumnCallCh   chan columnHandlerCall
 
-	validateColumnErr    error
-	validateHeaderErr    error
-	validateHeaderReject bool
+	validateColumnErr                 error
+	partialVerifierFromHeaderErr      error
+	partialVerifierFromHeaderReject   bool
+	partialVerifierFromTrustedColErr  error
 }
 
 func newCallbackRecorder(callBuffer int, validateHeaderReject bool, validateColumnErr, validateHeaderErr error) *callbackRecorder {
 	return &callbackRecorder{
 		validateColumnCallCh: make(chan []blocks.CellProofBundle, callBuffer),
 		handleHeaderCallCh:   make(chan headerHandlerCall, callBuffer),
-		validateHeaderCallCh: make(chan *ethpb.PartialDataColumnHeader, callBuffer),
+		partialVerifierFromHeaderCallCh:        make(chan *blocks.PartialDataColumn, callBuffer),
+		partialVerifierFromTrustedColumnCallCh: make(chan *blocks.PartialDataColumn, callBuffer),
 		handleColumnCallCh:   make(chan columnHandlerCall, callBuffer),
-		validateHeaderReject: validateHeaderReject,
-		validateHeaderErr:    validateHeaderErr,
-		validateColumnErr:    validateColumnErr,
+		partialVerifierFromHeaderReject: validateHeaderReject,
+		partialVerifierFromHeaderErr:    validateHeaderErr,
+		validateColumnErr:               validateColumnErr,
 	}
 }
 
-func (r *callbackRecorder) ValidateHeader(header *ethpb.PartialDataColumnHeader) (bool, error) {
-	r.validateHeaderCallCh <- header
-	return r.validateHeaderReject, r.validateHeaderErr
+func (r *callbackRecorder) PartialVerifierFromHeader(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, bool, error) {
+	r.partialVerifierFromHeaderCallCh <- col
+	return newMockPartialVerifier(col),
+		r.partialVerifierFromHeaderReject, r.partialVerifierFromHeaderErr
+}
+
+func (r *callbackRecorder) PartialVerifierFromTrustedColumn(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, error) {
+	r.partialVerifierFromTrustedColumnCallCh <- col
+	return newMockPartialVerifier(col), r.partialVerifierFromTrustedColErr
 }
 
 func (r *callbackRecorder) ValidateColumn(cells []blocks.CellProofBundle) error {
@@ -156,7 +166,8 @@ func (h *broadcasterHarness) start(cr *callbackRecorder) {
 	h.t.Helper()
 
 	err := h.broadcaster.Start(
-		cr.ValidateHeader,
+		cr.PartialVerifierFromHeader,
+		cr.PartialVerifierFromTrustedColumn,
 		cr.ValidateColumn,
 		cr.HandleColumn,
 		cr.HandleHeader,
@@ -229,6 +240,21 @@ func assertPartialColumnsEqual(t *testing.T, expected *blocks.PartialDataColumn,
 	require.DeepEqual(t, expected.GroupID(), actual.GroupID())
 	require.DeepEqual(t, expected.Included, actual.Included)
 	require.DeepEqual(t, expected.Column, actual.Column)
+}
+
+func newMockPartialVerifier(col *blocks.PartialDataColumn) *verification.PartialColumnVerifier {
+	mv := &verification.MockDataColumnsVerifier{}
+	ro, err := blocks.NewRODataColumn(col.DataColumnSidecar)
+	if err == nil {
+		mv.AppendRODataColumns(ro)
+	}
+	return verification.NewPartialColumnVerifier(mv, col)
+}
+
+func newMarkedVerifier(col *blocks.PartialDataColumn) *verification.PartialColumnVerifier {
+	v := newMockPartialVerifier(col)
+	v.MarkIncludedCellsVerified()
+	return v
 }
 
 func testBitlist(n uint64, set ...uint64) bitfield.Bitlist {
@@ -772,8 +798,7 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 					expectedHeader:  buildHeaderFromColumn(col),
 				}
 			},
-			expectHeaderValidateCall: true,
-			expectHeaderHandleCall:   true,
+			expectHeaderHandleCall: false,
 		},
 		{
 			name: "existing column with incoming cells calls validateColumn and enqueues cellsValidated request",
@@ -782,8 +807,8 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 					0: {0x11},
 				})
 				group := existing.GroupID()
-				b.partialMsgStore[validTopic] = map[string]*blocks.PartialDataColumn{
-					string(group): existing,
+				b.partialMsgStore[validTopic] = map[string]*verification.PartialColumnVerifier{
+					string(group): newMarkedVerifier(existing),
 				}
 				msg := buildSidecarWithCells(3, map[uint64][]byte{
 					1: {0x22},
@@ -820,8 +845,8 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 					0: {0x33},
 				})
 				group := existing.GroupID()
-				b.partialMsgStore[validTopic] = map[string]*blocks.PartialDataColumn{
-					string(group): existing,
+				b.partialMsgStore[validTopic] = map[string]*verification.PartialColumnVerifier{
+					string(group): newMarkedVerifier(existing),
 				}
 				msg := buildSidecarWithCells(3, map[uint64][]byte{
 					1: {0x44},
@@ -850,8 +875,8 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 					0: {0x55},
 				})
 				group := existing.GroupID()
-				b.partialMsgStore[validTopic] = map[string]*blocks.PartialDataColumn{
-					string(group): existing,
+				b.partialMsgStore[validTopic] = map[string]*verification.PartialColumnVerifier{
+					string(group): newMarkedVerifier(existing),
 				}
 				b.getBlobsCalled[string(group)] = true
 				return testSetup{
@@ -873,7 +898,8 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 			recorder := newCallbackRecorder(8, tt.validateHeaderReject, tt.validateColumnErr, tt.validateHeaderErr)
 			h := newBroadcasterHarness(t, ps)
 
-			h.broadcaster.validateHeader = recorder.ValidateHeader
+			h.broadcaster.partialVerifierFromHeader = recorder.PartialVerifierFromHeader
+			h.broadcaster.partialVerifierFromTrustedColumn = recorder.PartialVerifierFromTrustedColumn
 			h.broadcaster.validateColumn = recorder.ValidateColumn
 			h.broadcaster.handleHeader = recorder.HandleHeader
 
@@ -888,7 +914,7 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 
 			if tt.expectHeaderValidateCall {
 				select {
-				case call := <-recorder.validateHeaderCallCh:
+				case call := <-recorder.partialVerifierFromHeaderCallCh:
 					require.DeepEqual(t, setup.expectedHeader.KzgCommitments, call.KzgCommitments)
 					require.DeepEqual(t, setup.expectedHeader.KzgCommitmentsInclusionProof, call.KzgCommitmentsInclusionProof)
 					require.DeepEqual(t, setup.expectedHeader.SignedBlockHeader, call.SignedBlockHeader)
@@ -1131,8 +1157,8 @@ func TestPartialColumnBroadcaster_handleCellsValidated(t *testing.T) {
 
 			setup := tt.setup(t)
 			if setup.column != nil {
-				h.broadcaster.partialMsgStore[topic] = map[string]*blocks.PartialDataColumn{
-					string(setup.group): setup.column,
+				h.broadcaster.partialMsgStore[topic] = map[string]*verification.PartialColumnVerifier{
+					string(setup.group): newMarkedVerifier(setup.column),
 				}
 				h.broadcaster.getBlobsCalled[string(setup.group)] = setup.getBlobsCalled
 			}
@@ -1200,6 +1226,7 @@ func TestPartialColumnBroadcaster_Publish(t *testing.T) {
 	tests := []struct {
 		expectGetBlobsValue bool
 		expectHandleColumn  bool
+		expectTrustedCall   bool
 		getBlobsCalled      bool
 		expectedErrContains string
 		publishErr          error
@@ -1212,12 +1239,14 @@ func TestPartialColumnBroadcaster_Publish(t *testing.T) {
 			name:                "new group stores and publishes",
 			getBlobsCalled:      true,
 			expectGetBlobsValue: true,
+			expectTrustedCall:   true,
 			publishColumn:       column1,
 			expectedStoreColumn: column1,
 		},
 		{
 			name:                "publish error is returned to caller",
 			getBlobsCalled:      true,
+			expectTrustedCall:   true,
 			publishErr:          errors.New("publish failed"),
 			expectedErrContains: "publish failed",
 			publishColumn:       column1,
@@ -1284,8 +1313,8 @@ func TestPartialColumnBroadcaster_Publish(t *testing.T) {
 			h := newBroadcasterHarness(t, ps)
 			if tt.existingColumn != nil {
 				existing := tt.existingColumn(t)
-				h.broadcaster.partialMsgStore[topic] = map[string]*blocks.PartialDataColumn{
-					groupID: existing,
+				h.broadcaster.partialMsgStore[topic] = map[string]*verification.PartialColumnVerifier{
+					groupID: newMarkedVerifier(existing),
 				}
 			}
 
@@ -1318,6 +1347,15 @@ func TestPartialColumnBroadcaster_Publish(t *testing.T) {
 				}
 			} else {
 				require.Equal(t, false, completed)
+			}
+
+			if tt.expectTrustedCall {
+				select {
+				case call := <-recorder.partialVerifierFromTrustedColumnCallCh:
+					assertPartialColumnsEqual(t, column, call)
+				case <-t.Context().Done():
+					t.Fatalf("trusted partial verifier call not received")
+				}
 			}
 
 		})
@@ -1416,9 +1454,13 @@ func TestPartialColumnBroadcaster_Unsubscribe(t *testing.T) {
 				h.broadcaster.topics[topicName] = topic
 			}
 			if tt.setupPartialStore {
-				h.broadcaster.partialMsgStore[topicName] = map[string]*blocks.PartialDataColumn{
-					"group1": createPartialColumn(t, 2, map[uint64][]byte{0: {0x10}}),
+				h.broadcaster.partialMsgStore[topicName] = map[string]*verification.PartialColumnVerifier{
+					"group1": verification.NewPartialColumnVerifier(
+						&verification.MockDataColumnsVerifier{},
+						createPartialColumn(t, 2, map[uint64][]byte{0: {0x10}}),
+					),
 				}
+				h.broadcaster.partialMsgStore[topicName]["group1"].MarkIncludedCellsVerified()
 			}
 
 			// Assert state exists before unsubscribe.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -425,6 +425,10 @@ func (vs *Server) handleUnblindedBlock(
 			return nil, nil, nil, errors.Wrap(err, "data column sidcars")
 		}
 
+		if len(cellsPerBlob) == 0 {
+			return nil, roDataColumnSidecars, nil, nil
+		}
+
 		included := bitfield.NewBitlist(uint64(len(cellsPerBlob)))
 		included = included.Not() // all bits set to 1
 		partialColumns, err := peerdas.PartialColumns(included, cellsPerBlob, proofsPerBlob, peerdas.PopulateFromBlock(block))

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -214,6 +214,7 @@ go_test(
         "validate_bls_to_execution_change_test.go",
         "validate_data_column_test.go",
         "validate_light_client_test.go",
+        "validate_partial_header_test.go",
         "validate_proposer_slashing_test.go",
         "validate_sync_committee_message_test.go",
         "validate_sync_contribution_proof_test.go",

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -413,8 +413,11 @@ func (s *Service) waitForChainStart() {
 
 func (s *Service) startPartialColumnBroadcaster(broadcaster *partialdatacolumnbroadcaster.PartialColumnBroadcaster) error {
 	return broadcaster.Start(
-		func(header *ethpb.PartialDataColumnHeader) (bool, error) {
-			return s.validatePartialDataColumnHeader(s.ctx, header)
+		func(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, bool, error) {
+			return s.validatePartialDataColumnHeader(s.ctx, col)
+		},
+		func(col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier, error) {
+			return s.partialVerifierFromTrustedColumn(s.ctx, col)
 		},
 		func(cellsToVerify []blocks.CellProofBundle) error {
 			return peerdas.VerifyDataColumnsCellsKZGProofs(len(cellsToVerify), slices.Values(cellsToVerify))

--- a/beacon-chain/sync/validate_partial_header.go
+++ b/beacon-chain/sync/validate_partial_header.go
@@ -2,142 +2,106 @@ package sync
 
 import (
 	"context"
+	stderrors "errors"
 
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
-	"github.com/OffchainLabs/prysm/v7/config/params"
-	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
-	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
-	"github.com/OffchainLabs/prysm/v7/time/slots"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/pkg/errors"
 )
 
-var (
-	// REJECT errors - peer should be penalized
-	errHeaderEmptyCommitments       = errors.New("header has no kzg commitments")
-	errHeaderParentInvalid          = errors.New("header parent invalid")
-	errHeaderSlotNotAfterParent     = errors.New("header slot not after parent")
-	errHeaderNotFinalizedDescendant = errors.New("header not finalized descendant")
-	errHeaderInvalidInclusionProof  = errors.New("invalid inclusion proof")
-	errHeaderInvalidSignature       = errors.New("invalid proposer signature")
-	errHeaderUnexpectedProposer     = errors.New("unexpected proposer index")
+var errNilPartialDataColumn = errors.New("nil partial data column")
+var errHeaderEmptyCommitments = errors.New("header has no kzg commitments")
 
-	// IGNORE errors - don't penalize peer
-	errHeaderNil               = errors.New("nil header")
-	errHeaderFromFuture        = errors.New("header is from future slot")
-	errHeaderNotAboveFinalized = errors.New("header slot not above finalized")
-	errHeaderParentNotSeen     = errors.New("header parent not seen")
-)
-
-// validatePartialDataColumnHeader validates a PartialDataColumnHeader per the consensus spec.
-// Returns (reject, err) where reject=true means the peer should be penalized.
-// TODO: we should consolidate this with the existing DataColumn validation pipeline.
-func (s *Service) validatePartialDataColumnHeader(ctx context.Context, header *ethpb.PartialDataColumnHeader) (reject bool, err error) {
-	if header == nil || header.SignedBlockHeader == nil || header.SignedBlockHeader.Header == nil {
-		return false, errHeaderNil // IGNORE
+func (s *Service) partialVerifierFromTrustedColumn(ctx context.Context, col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier,
+	error) {
+	if col == nil || col.SignedBlockHeader == nil || col.SignedBlockHeader.Header == nil {
+		return nil, errNilPartialDataColumn
 	}
 
-	blockHeader := header.SignedBlockHeader.Header
-	headerSlot := blockHeader.Slot
-	parentRoot := bytesutil.ToBytes32(blockHeader.ParentRoot)
-
-	// [REJECT] kzg_commitments list is non-empty
-	if len(header.KzgCommitments) == 0 {
-		return true, errHeaderEmptyCommitments
+	if len(col.KzgCommitments) == 0 {
+		return nil, errHeaderEmptyCommitments
 	}
 
-	// [IGNORE] Not from future slot (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
-	currentSlot := s.cfg.clock.CurrentSlot()
-	if headerSlot > currentSlot {
-		maxDisparity := params.BeaconConfig().MaximumGossipClockDisparityDuration()
-		slotStart, err := s.cfg.clock.SlotStart(headerSlot)
-		if err != nil {
-			return false, err
+	roDataColumn, err := blocks.NewRODataColumn(col.DataColumnSidecar)
+	if err != nil {
+		return nil, err
+	}
+
+	dcv := s.newColumnsVerifier([]blocks.RODataColumn{roDataColumn}, verification.PartialColumnRequirements)
+	verifier := verification.NewPartialColumnVerifier(dcv, col)
+	verifier.MarkIncludedCellsVerified()
+
+	// mark all header checks as completed
+	verifier.SatisfyRequirement(verification.RequireNotFromFutureSlot)
+	verifier.SatisfyRequirement(verification.RequireSlotAboveFinalized)
+	verifier.SatisfyRequirement(verification.RequireSidecarParentSeen)
+	verifier.SatisfyRequirement(verification.RequireSidecarParentValid)
+	verifier.SatisfyRequirement(verification.RequireSidecarParentSlotLower)
+	verifier.SatisfyRequirement(verification.RequireSidecarDescendsFromFinalized)
+	verifier.SatisfyRequirement(verification.RequireSidecarInclusionProven)
+	verifier.SatisfyRequirement(verification.RequireSidecarProposerExpected)
+	verifier.SatisfyRequirement(verification.RequireValidProposerSignature)
+
+	return verifier, nil
+}
+
+// validatePartialDataColumn validates only the header-applicable checks for a partial data column.
+func (s *Service) validatePartialDataColumnHeader(ctx context.Context, col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier,
+	bool, error) {
+	if col == nil || col.SignedBlockHeader == nil || col.SignedBlockHeader.Header == nil {
+		return nil, false, errNilPartialDataColumn
+	}
+
+	if len(col.KzgCommitments) == 0 {
+		return nil, false, errHeaderEmptyCommitments
+	}
+
+	roDataColumn, err := blocks.NewRODataColumn(col.DataColumnSidecar)
+	if err != nil {
+		return nil, false, err
+	}
+
+	dcv := s.newColumnsVerifier([]blocks.RODataColumn{roDataColumn}, verification.PartialColumnRequirements)
+	verifier := verification.NewPartialColumnVerifier(dcv, col)
+
+	if err := verifier.NotFromFutureSlot(); err != nil {
+		return verifier, false, err
+	}
+
+	if err := verifier.SlotAboveFinalized(); err != nil {
+		return verifier, false, err
+	}
+
+	if err := verifier.SidecarParentSeen(s.hasBadBlock); err != nil {
+		return verifier, false, err
+	}
+
+	if err := verifier.SidecarParentValid(s.hasBadBlock); err != nil {
+		return verifier, true, err
+	}
+
+	if err := verifier.SidecarParentSlotLower(); err != nil {
+		if stderrors.Is(err, verification.ErrSidecarParentSlotUnavailable) {
+			return verifier, false, err
 		}
-		if s.cfg.clock.Now().Before(slotStart.Add(-maxDisparity)) {
-			return false, errHeaderFromFuture // IGNORE
-		}
+		return verifier, true, err
 	}
 
-	// [IGNORE] Slot above finalized
-	finalizedCheckpoint := s.cfg.chain.FinalizedCheckpt()
-	startSlot, err := slots.EpochStart(finalizedCheckpoint.Epoch)
-	if err != nil {
-		return false, err
-	}
-	if headerSlot <= startSlot {
-		return false, errHeaderNotAboveFinalized // IGNORE
+	if err := verifier.SidecarDescendsFromFinalized(); err != nil {
+		return verifier, true, err
 	}
 
-	// [IGNORE] Parent has been seen
-	if !s.cfg.chain.HasBlock(ctx, parentRoot) {
-		return false, errHeaderParentNotSeen // IGNORE
+	if err := verifier.SidecarInclusionProven(); err != nil {
+		return verifier, true, err
 	}
 
-	// [REJECT] Parent passes validation (not a bad block)
-	if s.hasBadBlock(parentRoot) {
-		return true, errHeaderParentInvalid
+	if err := verifier.SidecarProposerExpected(ctx); err != nil {
+		return verifier, true, err
 	}
 
-	// [REJECT] Header slot > parent slot
-	parentSlot, err := s.cfg.chain.RecentBlockSlot(parentRoot)
-	if err != nil {
-		return false, errors.Wrap(err, "get parent slot")
-	}
-	if headerSlot <= parentSlot {
-		return true, errHeaderSlotNotAfterParent
+	if err := verifier.ValidProposerSignature(ctx); err != nil {
+		return verifier, true, err
 	}
 
-	// [REJECT] Finalized checkpoint is ancestor (parent is in forkchoice)
-	if !s.cfg.chain.InForkchoice(parentRoot) {
-		return true, errHeaderNotFinalizedDescendant
-	}
-
-	// [REJECT] Inclusion proof valid
-	if err := peerdas.VerifyPartialDataColumnHeaderInclusionProof(header); err != nil {
-		return true, errHeaderInvalidInclusionProof
-	}
-
-	// [REJECT] Valid proposer signature
-	parentState, err := s.cfg.stateGen.StateByRoot(ctx, parentRoot)
-	if err != nil {
-		return false, errors.Wrap(err, "get parent state")
-	}
-
-	proposerIdx := blockHeader.ProposerIndex
-	proposer, err := parentState.ValidatorAtIndex(proposerIdx)
-	if err != nil {
-		return false, errors.Wrap(err, "get proposer")
-	}
-
-	domain, err := signing.Domain(
-		parentState.Fork(),
-		slots.ToEpoch(headerSlot),
-		params.BeaconConfig().DomainBeaconProposer,
-		parentState.GenesisValidatorsRoot(),
-	)
-	if err != nil {
-		return false, errors.Wrap(err, "get domain")
-	}
-
-	if err := signing.VerifyBlockHeaderSigningRoot(
-		blockHeader,
-		proposer.PublicKey,
-		header.SignedBlockHeader.Signature,
-		domain,
-	); err != nil {
-		return true, errHeaderInvalidSignature
-	}
-
-	// [REJECT] Expected proposer for slot
-	expectedProposer, err := helpers.BeaconProposerIndexAtSlot(ctx, parentState, headerSlot)
-	if err != nil {
-		return false, errors.Wrap(err, "compute expected proposer")
-	}
-	if expectedProposer != proposerIdx {
-		return true, errHeaderUnexpectedProposer
-	}
-
-	return false, nil // Valid header
+	return verifier, false, nil
 }

--- a/beacon-chain/sync/validate_partial_header.go
+++ b/beacon-chain/sync/validate_partial_header.go
@@ -53,7 +53,7 @@ func (s *Service) validatePartialDataColumnHeader(ctx context.Context, col *bloc
 	}
 
 	if len(col.KzgCommitments) == 0 {
-		return nil, false, errHeaderEmptyCommitments
+		return nil, true, errHeaderEmptyCommitments
 	}
 
 	roDataColumn, err := blocks.NewRODataColumn(col.DataColumnSidecar)

--- a/beacon-chain/sync/validate_partial_header.go
+++ b/beacon-chain/sync/validate_partial_header.go
@@ -6,16 +6,18 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/pkg/errors"
 )
 
-var errNilPartialDataColumn = errors.New("nil partial data column")
 var errHeaderEmptyCommitments = errors.New("header has no kzg commitments")
+var errHeaderParentNotSeen = errors.New("header parent not seen")
+var errHeaderNil = errors.New("nil header")
 
 func (s *Service) partialVerifierFromTrustedColumn(ctx context.Context, col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier,
 	error) {
 	if col == nil || col.SignedBlockHeader == nil || col.SignedBlockHeader.Header == nil {
-		return nil, errNilPartialDataColumn
+		return nil, errHeaderNil
 	}
 
 	if len(col.KzgCommitments) == 0 {
@@ -48,10 +50,12 @@ func (s *Service) partialVerifierFromTrustedColumn(ctx context.Context, col *blo
 // validatePartialDataColumn validates only the header-applicable checks for a partial data column.
 func (s *Service) validatePartialDataColumnHeader(ctx context.Context, col *blocks.PartialDataColumn) (*verification.PartialColumnVerifier,
 	bool, error) {
+	// [IGNORE]
 	if col == nil || col.SignedBlockHeader == nil || col.SignedBlockHeader.Header == nil {
-		return nil, false, errNilPartialDataColumn
+		return nil, false, errHeaderNil
 	}
 
+	// [REJECT] kzg_commitments list is non-empty
 	if len(col.KzgCommitments) == 0 {
 		return nil, true, errHeaderEmptyCommitments
 	}
@@ -64,22 +68,32 @@ func (s *Service) validatePartialDataColumnHeader(ctx context.Context, col *bloc
 	dcv := s.newColumnsVerifier([]blocks.RODataColumn{roDataColumn}, verification.PartialColumnRequirements)
 	verifier := verification.NewPartialColumnVerifier(dcv, col)
 
+	// [IGNORE] Not from future slot (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
 	if err := verifier.NotFromFutureSlot(); err != nil {
 		return verifier, false, err
 	}
 
+	// [IGNORE] Slot above finalized
 	if err := verifier.SlotAboveFinalized(); err != nil {
 		return verifier, false, err
+	}
+
+	// [IGNORE] Parent has been seen
+	parentRoot := bytesutil.ToBytes32(col.SignedBlockHeader.Header.ParentRoot)
+	if !s.cfg.chain.HasBlock(ctx, parentRoot) {
+		return verifier, false, errHeaderParentNotSeen
 	}
 
 	if err := verifier.SidecarParentSeen(s.hasBadBlock); err != nil {
 		return verifier, false, err
 	}
 
+	// [REJECT] Parent passes validation (not a bad block)
 	if err := verifier.SidecarParentValid(s.hasBadBlock); err != nil {
 		return verifier, true, err
 	}
 
+	// [REJECT] Header slot > parent slot
 	if err := verifier.SidecarParentSlotLower(); err != nil {
 		if stderrors.Is(err, verification.ErrSidecarParentSlotUnavailable) {
 			return verifier, false, err
@@ -87,18 +101,22 @@ func (s *Service) validatePartialDataColumnHeader(ctx context.Context, col *bloc
 		return verifier, true, err
 	}
 
+	// [REJECT] Finalized checkpoint is ancestor (parent is in forkchoice)
 	if err := verifier.SidecarDescendsFromFinalized(); err != nil {
 		return verifier, true, err
 	}
 
+	// [REJECT] Inclusion proof valid
 	if err := verifier.SidecarInclusionProven(); err != nil {
 		return verifier, true, err
 	}
 
+	// [REJECT] Expected proposer for slot
 	if err := verifier.SidecarProposerExpected(ctx); err != nil {
 		return verifier, true, err
 	}
 
+	// [REJECT] Valid proposer signature
 	if err := verifier.ValidProposerSignature(ctx); err != nil {
 		return verifier, true, err
 	}

--- a/beacon-chain/sync/validate_partial_header_test.go
+++ b/beacon-chain/sync/validate_partial_header_test.go
@@ -1,0 +1,257 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/pkg/errors"
+)
+
+func TestService_PartialVerifierFromTrustedColumn(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		col          *blocks.PartialDataColumn
+		verifier     verification.MockDataColumnsVerifier
+		wantErr      error
+		expectResult bool
+		verify       func(t *testing.T, v *verification.PartialColumnVerifier)
+	}{
+		{
+			name:    "nil column",
+			col:     nil,
+			wantErr: errNilPartialDataColumn,
+		},
+		{
+			name:    "nil signed header",
+			col:     &blocks.PartialDataColumn{DataColumnSidecar: &ethpb.DataColumnSidecar{}},
+			wantErr: errNilPartialDataColumn,
+		},
+		{
+			name:    "empty commitments",
+			col:     buildPartialColumn(t, 0, nil),
+			wantErr: errHeaderEmptyCommitments,
+		},
+		{
+			name:         "marks included cells as verified",
+			col:          buildPartialColumn(t, 2, []uint64{0, 1}),
+			verifier:     verification.MockDataColumnsVerifier{},
+			expectResult: true,
+			verify: func(t *testing.T, v *verification.PartialColumnVerifier) {
+				require.NoError(t, v.SidecarKzgProofVerified())
+				_, ok, err := v.Complete()
+				require.NoError(t, err)
+				require.Equal(t, true, ok)
+			},
+		},
+		{
+			name: "propagates verifier field errors on completion",
+			col:  buildPartialColumn(t, 1, []uint64{0}),
+			verifier: verification.MockDataColumnsVerifier{
+				ErrValidFields: errors.New("invalid fields"),
+			},
+			expectResult: true,
+			verify: func(t *testing.T, v *verification.PartialColumnVerifier) {
+				_, _, err := v.Complete()
+				require.ErrorContains(t, "invalid fields", err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			service := &Service{
+				newColumnsVerifier: testNewColumnsVerifier(tc.verifier),
+			}
+			got, err := service.partialVerifierFromTrustedColumn(ctx, tc.col)
+			require.ErrorIs(t, tc.wantErr, err)
+			require.Equal(t, tc.expectResult, got != nil)
+			if tc.verify != nil {
+				tc.verify(t, got)
+			}
+		})
+	}
+}
+
+func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
+	ctx := context.Background()
+	genericErr := errors.New("generic error")
+	unavailableParentSlotErr := errors.Wrap(verification.ErrSidecarParentSlotUnavailable, "slot lookup failed")
+	invalidVerifierErr := errors.Wrap(verification.ErrInvalid, "invalid verification")
+
+	tests := []struct {
+		name         string
+		col          *blocks.PartialDataColumn
+		verifier     verification.MockDataColumnsVerifier
+		wantErr      error
+		wantReject   bool
+		expectResult bool
+	}{
+		{
+			name:       "nil column",
+			col:        nil,
+			wantErr:    errNilPartialDataColumn,
+			wantReject: false,
+		},
+		{
+			name:       "empty commitments is reject",
+			col:        buildPartialColumn(t, 0, nil),
+			wantErr:    errHeaderEmptyCommitments,
+			wantReject: true,
+		},
+		{
+			name:         "not from future slot is ignore",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrNotFromFutureSlot: genericErr},
+			wantErr:      genericErr,
+			wantReject:   false,
+			expectResult: true,
+		},
+		{
+			name:         "slot above finalized is ignore",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrSlotAboveFinalized: genericErr},
+			wantErr:      genericErr,
+			wantReject:   false,
+			expectResult: true,
+		},
+		{
+			name:         "parent seen is ignore",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentSeen: genericErr},
+			wantErr:      genericErr,
+			wantReject:   false,
+			expectResult: true,
+		},
+		{
+			name:         "parent valid is reject",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentValid: genericErr},
+			wantErr:      genericErr,
+			wantReject:   true,
+			expectResult: true,
+		},
+		{
+			name:         "parent slot unavailable is ignore",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentSlotLower: unavailableParentSlotErr},
+			wantErr:      unavailableParentSlotErr,
+			wantReject:   false,
+			expectResult: true,
+		},
+		{
+			name:         "parent slot lower invalid is reject",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentSlotLower: genericErr},
+			wantErr:      genericErr,
+			wantReject:   true,
+			expectResult: true,
+		},
+		{
+			name:         "proposer expected verification failure is reject",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrSidecarProposerExpected: invalidVerifierErr},
+			wantErr:      invalidVerifierErr,
+			wantReject:   true,
+			expectResult: true,
+		},
+		{
+			name:         "proposer expected non verification failure is ignore",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrSidecarProposerExpected: genericErr},
+			wantErr:      genericErr,
+			wantReject:   false,
+			expectResult: true,
+		},
+		{
+			name:         "invalid proposer signature is reject",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrValidProposerSignature: verification.ErrInvalidProposerSignature},
+			wantErr:      verification.ErrInvalidProposerSignature,
+			wantReject:   true,
+			expectResult: true,
+		},
+		{
+			name:         "signature infra failure is ignore",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{ErrValidProposerSignature: genericErr},
+			wantErr:      genericErr,
+			wantReject:   false,
+			expectResult: true,
+		},
+		{
+			name:         "nominal",
+			col:          buildPartialColumn(t, 1, nil),
+			verifier:     verification.MockDataColumnsVerifier{},
+			wantErr:      nil,
+			wantReject:   false,
+			expectResult: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			service := &Service{
+				newColumnsVerifier: testNewColumnsVerifier(tc.verifier),
+			}
+			got, reject, err := service.validatePartialDataColumnHeader(ctx, tc.col)
+			require.ErrorIs(t, tc.wantErr, err)
+			require.Equal(t, tc.wantReject, reject)
+			require.Equal(t, tc.expectResult, got != nil)
+		})
+	}
+}
+
+func testNewColumnsVerifier(v verification.MockDataColumnsVerifier) verification.NewDataColumnsVerifier {
+	return func(cols []blocks.RODataColumn, _ []verification.Requirement) verification.DataColumnsVerifier {
+		for _, col := range cols {
+			v.AppendRODataColumns(col)
+		}
+		return &v
+	}
+}
+
+func buildPartialColumn(t *testing.T, nCommitments int, included []uint64) *blocks.PartialDataColumn {
+	t.Helper()
+
+	commitments := make([][]byte, nCommitments)
+	for i := range nCommitments {
+		commitments[i] = make([]byte, fieldparams.KzgCommitmentSize)
+		commitments[i][0] = byte(i + 1)
+	}
+
+	inclusionProof := [][]byte{
+		make([]byte, 32),
+		make([]byte, 32),
+		make([]byte, 32),
+		make([]byte, 32),
+	}
+
+	col, err := blocks.NewPartialDataColumn(
+		&ethpb.SignedBeaconBlockHeader{
+			Header: &ethpb.BeaconBlockHeader{
+				ParentRoot: make([]byte, fieldparams.RootLength),
+				StateRoot:  make([]byte, fieldparams.RootLength),
+				BodyRoot:   make([]byte, fieldparams.RootLength),
+			},
+			Signature: make([]byte, fieldparams.BLSSignatureLength),
+		},
+		0,
+		commitments,
+		inclusionProof,
+	)
+	require.NoError(t, err)
+
+	for _, idx := range included {
+		extended := col.ExtendFromVerifiedCell(idx, []byte{byte(idx + 1)}, []byte{byte(idx + 2)})
+		require.Equal(t, true, extended)
+	}
+
+	return &col
+}

--- a/beacon-chain/sync/validate_partial_header_test.go
+++ b/beacon-chain/sync/validate_partial_header_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -26,12 +28,12 @@ func TestService_PartialVerifierFromTrustedColumn(t *testing.T) {
 		{
 			name:    "nil column",
 			col:     nil,
-			wantErr: errNilPartialDataColumn,
+			wantErr: errHeaderNil,
 		},
 		{
 			name:    "nil signed header",
 			col:     &blocks.PartialDataColumn{DataColumnSidecar: &ethpb.DataColumnSidecar{}},
-			wantErr: errNilPartialDataColumn,
+			wantErr: errHeaderNil,
 		},
 		{
 			name:    "empty commitments",
@@ -85,9 +87,27 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 	unavailableParentSlotErr := errors.Wrap(verification.ErrSidecarParentSlotUnavailable, "slot lookup failed")
 	invalidVerifierErr := errors.Wrap(verification.ErrInvalid, "invalid verification")
 
+	db := dbtest.SetupDB(t)
+
+	// chainWithParent returns a mock chain where HasBlock returns true for the zero parent root.
+	chainWithParent := func() *mock.ChainService {
+		return &mock.ChainService{
+			DB: db,
+			InitSyncBlockRoots: map[[32]byte]bool{
+				{}: true, // zero root matches buildPartialColumn's parent root
+			},
+		}
+	}
+
+	// chainWithoutParent returns a mock chain where HasBlock returns false.
+	chainWithoutParent := func() *mock.ChainService {
+		return &mock.ChainService{DB: db}
+	}
+
 	tests := []struct {
 		name         string
 		col          *blocks.PartialDataColumn
+		chain        *mock.ChainService
 		verifier     verification.MockDataColumnsVerifier
 		wantErr      error
 		wantReject   bool
@@ -96,7 +116,7 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 		{
 			name:       "nil column",
 			col:        nil,
-			wantErr:    errNilPartialDataColumn,
+			wantErr:    errHeaderNil,
 			wantReject: false,
 		},
 		{
@@ -122,8 +142,17 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 			expectResult: true,
 		},
 		{
+			name:         "parent not seen is ignore",
+			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithoutParent(),
+			wantErr:      errHeaderParentNotSeen,
+			wantReject:   false,
+			expectResult: true,
+		},
+		{
 			name:         "parent seen is ignore",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentSeen: genericErr},
 			wantErr:      genericErr,
 			wantReject:   false,
@@ -132,6 +161,7 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 		{
 			name:         "parent valid is reject",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentValid: genericErr},
 			wantErr:      genericErr,
 			wantReject:   true,
@@ -140,6 +170,7 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 		{
 			name:         "parent slot unavailable is ignore",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentSlotLower: unavailableParentSlotErr},
 			wantErr:      unavailableParentSlotErr,
 			wantReject:   false,
@@ -148,6 +179,7 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 		{
 			name:         "parent slot lower invalid is reject",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrSidecarParentSlotLower: genericErr},
 			wantErr:      genericErr,
 			wantReject:   true,
@@ -156,38 +188,43 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 		{
 			name:         "proposer expected verification failure is reject",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrSidecarProposerExpected: invalidVerifierErr},
 			wantErr:      invalidVerifierErr,
 			wantReject:   true,
 			expectResult: true,
 		},
 		{
-			name:         "proposer expected non verification failure is ignore",
+			name:         "proposer expected non verification failure is reject",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrSidecarProposerExpected: genericErr},
 			wantErr:      genericErr,
-			wantReject:   false,
+			wantReject:   true,
 			expectResult: true,
 		},
 		{
 			name:         "invalid proposer signature is reject",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrValidProposerSignature: verification.ErrInvalidProposerSignature},
 			wantErr:      verification.ErrInvalidProposerSignature,
 			wantReject:   true,
 			expectResult: true,
 		},
 		{
-			name:         "signature infra failure is ignore",
+			name:         "signature infra failure is reject",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{ErrValidProposerSignature: genericErr},
 			wantErr:      genericErr,
-			wantReject:   false,
+			wantReject:   true,
 			expectResult: true,
 		},
 		{
 			name:         "nominal",
 			col:          buildPartialColumn(t, 1, nil),
+			chain:        chainWithParent(),
 			verifier:     verification.MockDataColumnsVerifier{},
 			wantErr:      nil,
 			wantReject:   false,
@@ -199,6 +236,9 @@ func TestService_ValidatePartialDataColumnHeader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			service := &Service{
 				newColumnsVerifier: testNewColumnsVerifier(tc.verifier),
+			}
+			if tc.chain != nil {
+				service.cfg = &config{chain: tc.chain}
 			}
 			got, reject, err := service.validatePartialDataColumnHeader(ctx, tc.col)
 			require.ErrorIs(t, tc.wantErr, err)

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -90,10 +90,6 @@ func NewPartialColumnVerifier(dv DataColumnsVerifier, col *blocks.PartialDataCol
 }
 
 func (pv *PartialColumnVerifier) Complete() (blocks.VerifiedRODataColumn, bool, error) {
-	if pv == nil || pv.Column == nil {
-		return blocks.VerifiedRODataColumn{}, false, errors.New("partial column verifier is nil")
-	}
-
 	if !pv.Column.IsComplete() {
 		return blocks.VerifiedRODataColumn{}, false, nil
 	}
@@ -118,13 +114,6 @@ func (pv *PartialColumnVerifier) Complete() (blocks.VerifiedRODataColumn, bool, 
 }
 
 func (pv *PartialColumnVerifier) SidecarKzgProofVerified() error {
-	if pv == nil || pv.Column == nil {
-		return errors.Wrap(ErrSidecarKzgProofInvalid, "partial column verifier is nil")
-	}
-	if pv.verifiedCellByIndex == nil {
-		pv.verifiedCellByIndex = make(map[uint64]bool)
-	}
-
 	nCells := uint64(len(pv.Column.KzgCommitments))
 	for i := range nCells {
 		if !pv.verifiedCellByIndex[i] {
@@ -137,12 +126,6 @@ func (pv *PartialColumnVerifier) SidecarKzgProofVerified() error {
 }
 
 func (pv *PartialColumnVerifier) ExtendFromVerifiedCell(cellIndex uint64, cell, proof []byte) bool {
-	if pv == nil || pv.Column == nil {
-		return false
-	}
-	if pv.verifiedCellByIndex == nil {
-		pv.verifiedCellByIndex = make(map[uint64]bool)
-	}
 	extended := pv.Column.ExtendFromVerifiedCell(cellIndex, cell, proof)
 	if extended {
 		pv.verifiedCellByIndex[cellIndex] = true
@@ -151,12 +134,6 @@ func (pv *PartialColumnVerifier) ExtendFromVerifiedCell(cellIndex uint64, cell, 
 }
 
 func (pv *PartialColumnVerifier) MarkIncludedCellsVerified() {
-	if pv == nil || pv.Column == nil {
-		return
-	}
-	if pv.verifiedCellByIndex == nil {
-		pv.verifiedCellByIndex = make(map[uint64]bool)
-	}
 	for i := range pv.Column.Included.Len() {
 		if pv.Column.Included.BitAt(i) {
 			pv.verifiedCellByIndex[i] = true
@@ -452,7 +429,7 @@ func (dv *RODataColumnsVerifier) SidecarParentSeen(parentSeen func([fieldparams.
 		}
 
 		if !dv.fc.HasNode(parentRoot) {
-			return columnErrBuilder(errors.Wrapf(ErrSidecarParentNotSeen, "parent root: %#x", parentRoot))
+			return columnErrBuilder(errors.Wrapf(errSidecarParentNotSeen, "parent root: %#x", parentRoot))
 		}
 	}
 

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -40,6 +40,8 @@ var (
 		RequireSidecarProposerExpected,
 	}
 
+	PartialColumnRequirements = requirementList(GossipDataColumnSidecarRequirements).excluding(RequireCorrectSubnet)
+
 	// ByRangeRequestDataColumnSidecarRequirements defines the set of requirements that DataColumnSidecars received
 	// via the by range request must satisfy in order to upgrade an RODataColumn to a VerifiedRODataColumn.
 	// https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#datacolumnsidecarsbyrange-v1
@@ -72,6 +74,95 @@ type LazyHeadStateProvider struct {
 }
 
 var _ HeadStateProvider = &LazyHeadStateProvider{}
+
+type PartialColumnVerifier struct {
+	DataColumnsVerifier
+	Column              *blocks.PartialDataColumn
+	verifiedCellByIndex map[uint64]bool
+}
+
+func NewPartialColumnVerifier(dv DataColumnsVerifier, col *blocks.PartialDataColumn) *PartialColumnVerifier {
+	return &PartialColumnVerifier{
+		DataColumnsVerifier: dv,
+		Column:              col,
+		verifiedCellByIndex: make(map[uint64]bool),
+	}
+}
+
+func (pv *PartialColumnVerifier) Complete() (blocks.VerifiedRODataColumn, bool, error) {
+	if pv == nil || pv.Column == nil {
+		return blocks.VerifiedRODataColumn{}, false, errors.New("partial column verifier is nil")
+	}
+
+	if !pv.Column.IsComplete() {
+		return blocks.VerifiedRODataColumn{}, false, nil
+	}
+
+	// now that we have all the cells and proofs, the valid fields check should pass
+	if err := pv.ValidFields(); err != nil {
+		return blocks.VerifiedRODataColumn{}, false, err
+	}
+
+	if err := pv.SidecarKzgProofVerified(); err != nil {
+		return blocks.VerifiedRODataColumn{}, false, err
+	}
+
+	cols, err := pv.VerifiedRODataColumns()
+	if err != nil {
+		return blocks.VerifiedRODataColumn{}, false, err
+	}
+	if len(cols) != 1 {
+		return blocks.VerifiedRODataColumn{}, false, errors.New("unexpected number of verified data columns")
+	}
+	return cols[0], true, nil
+}
+
+func (pv *PartialColumnVerifier) SidecarKzgProofVerified() error {
+	if pv == nil || pv.Column == nil {
+		return errors.Wrap(ErrSidecarKzgProofInvalid, "partial column verifier is nil")
+	}
+	if pv.verifiedCellByIndex == nil {
+		pv.verifiedCellByIndex = make(map[uint64]bool)
+	}
+
+	nCells := uint64(len(pv.Column.KzgCommitments))
+	for i := range nCells {
+		if !pv.verifiedCellByIndex[i] {
+			return errors.Wrapf(ErrSidecarKzgProofInvalid, "missing verified cell at index %d", i)
+		}
+	}
+
+	pv.SatisfyRequirement(RequireSidecarKzgProofVerified)
+	return nil
+}
+
+func (pv *PartialColumnVerifier) ExtendFromVerifiedCell(cellIndex uint64, cell, proof []byte) bool {
+	if pv == nil || pv.Column == nil {
+		return false
+	}
+	if pv.verifiedCellByIndex == nil {
+		pv.verifiedCellByIndex = make(map[uint64]bool)
+	}
+	extended := pv.Column.ExtendFromVerifiedCell(cellIndex, cell, proof)
+	if extended {
+		pv.verifiedCellByIndex[cellIndex] = true
+	}
+	return extended
+}
+
+func (pv *PartialColumnVerifier) MarkIncludedCellsVerified() {
+	if pv == nil || pv.Column == nil {
+		return
+	}
+	if pv.verifiedCellByIndex == nil {
+		pv.verifiedCellByIndex = make(map[uint64]bool)
+	}
+	for i := range pv.Column.Included.Len() {
+		if pv.Column.Included.BitAt(i) {
+			pv.verifiedCellByIndex[i] = true
+		}
+	}
+}
 
 type (
 	RODataColumnsVerifier struct {
@@ -361,7 +452,7 @@ func (dv *RODataColumnsVerifier) SidecarParentSeen(parentSeen func([fieldparams.
 		}
 
 		if !dv.fc.HasNode(parentRoot) {
-			return columnErrBuilder(errors.Wrapf(errSidecarParentNotSeen, "parent root: %#x", parentRoot))
+			return columnErrBuilder(errors.Wrapf(ErrSidecarParentNotSeen, "parent root: %#x", parentRoot))
 		}
 	}
 
@@ -395,7 +486,7 @@ func (dv *RODataColumnsVerifier) SidecarParentSlotLower() (err error) {
 		// Compute the slot of the parent block.
 		parentSlot, err := dv.fc.Slot(dataColumn.ParentRoot())
 		if err != nil {
-			return columnErrBuilder(errors.Wrap(err, "slot"))
+			return columnErrBuilder(errors.Wrap(ErrSidecarParentSlotUnavailable, err.Error()))
 		}
 
 		// Check if the data column slot is after the parent slot.

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -75,6 +75,8 @@ type LazyHeadStateProvider struct {
 
 var _ HeadStateProvider = &LazyHeadStateProvider{}
 
+// PartialColumnVerifier is used to verify a partial data column before it can be used as a fully verified data column
+// Note: It is not thread safe and the caller is responsible for thread-safety
 type PartialColumnVerifier struct {
 	DataColumnsVerifier
 	Column              *blocks.PartialDataColumn

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -815,6 +815,193 @@ func TestDataColumnsSidecarKzgProofVerified(t *testing.T) {
 	}
 }
 
+func TestPartialColumnVerifierComplete(t *testing.T) {
+	validFieldsErr := errors.New("invalid fields")
+	testCases := []struct {
+		name           string
+		included       []uint64
+		markIncluded   bool
+		validFieldsErr error
+		verifiedCols   []blocks.RODataColumn
+		wantComplete   bool
+		wantErr        error
+	}{
+		{
+			name:         "incomplete column",
+			included:     []uint64{0},
+			wantComplete: false,
+		},
+		{
+			name:         "complete happy path",
+			included:     []uint64{0, 1},
+			markIncluded: true,
+			verifiedCols: []blocks.RODataColumn{
+				{},
+			},
+			wantComplete: true,
+		},
+		{
+			name:           "valid fields failure",
+			included:       []uint64{0, 1},
+			markIncluded:   true,
+			validFieldsErr: validFieldsErr,
+			wantComplete:   false,
+			wantErr:        validFieldsErr,
+		},
+		{
+			name:         "missing verified cell",
+			included:     []uint64{0, 1},
+			verifiedCols: []blocks.RODataColumn{{}},
+			wantComplete: false,
+			wantErr:      ErrSidecarKzgProofInvalid,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			verifier := &MockDataColumnsVerifier{
+				ErrValidFields: tc.validFieldsErr,
+			}
+			verifier.AppendRODataColumns(tc.verifiedCols...)
+
+			pv := NewPartialColumnVerifier(verifier, buildTestPartialColumnForVerifier(t, 2, tc.included))
+			if tc.markIncluded {
+				pv.MarkIncludedCellsVerified()
+			}
+
+			_, complete, err := pv.Complete()
+			require.Equal(t, tc.wantComplete, complete)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPartialColumnVerifierSidecarKzgProofVerified(t *testing.T) {
+	testCases := []struct {
+		name            string
+		verifiedIndices []uint64
+		wantErr         bool
+		errContains     string
+	}{
+		{
+			name:            "happy path",
+			verifiedIndices: []uint64{0, 1},
+			wantErr:         false,
+		},
+		{
+			name:            "missing verified cell",
+			verifiedIndices: []uint64{0},
+			wantErr:         true,
+			errContains:     "missing verified cell at index 1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := NewPartialColumnVerifier(&MockDataColumnsVerifier{}, buildTestPartialColumnForVerifier(t, 2, nil))
+			for _, index := range tc.verifiedIndices {
+				require.Equal(t, true, pv.ExtendFromVerifiedCell(index, []byte{byte(index + 1)}, []byte{byte(index + 2)}))
+			}
+
+			err := pv.SidecarKzgProofVerified()
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrSidecarKzgProofInvalid)
+				require.ErrorContains(t, tc.errContains, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPartialColumnVerifierExtendFromVerifiedCell(t *testing.T) {
+	testCases := []struct {
+		name            string
+		initialIncluded []uint64
+		cellIndex       uint64
+		cell            []byte
+		proof           []byte
+		wantExtended    bool
+		wantMarked      bool
+		wantCell        []byte
+		wantProof       []byte
+	}{
+		{
+			name:            "happy path",
+			initialIncluded: nil,
+			cellIndex:       1,
+			cell:            []byte{9},
+			proof:           []byte{8},
+			wantExtended:    true,
+			wantMarked:      true,
+			wantCell:        []byte{9},
+			wantProof:       []byte{8},
+		},
+		{
+			name:            "already included cell",
+			initialIncluded: []uint64{1},
+			cellIndex:       1,
+			cell:            []byte{9},
+			proof:           []byte{8},
+			wantExtended:    false,
+			wantMarked:      false,
+			wantCell:        []byte{2},
+			wantProof:       []byte{3},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := NewPartialColumnVerifier(&MockDataColumnsVerifier{}, buildTestPartialColumnForVerifier(t, 2, tc.initialIncluded))
+
+			extended := pv.ExtendFromVerifiedCell(tc.cellIndex, tc.cell, tc.proof)
+			require.Equal(t, tc.wantExtended, extended)
+			require.Equal(t, tc.wantMarked, pv.verifiedCellByIndex[tc.cellIndex])
+
+			require.Equal(t, true, reflect.DeepEqual(tc.wantCell, pv.Column.Column[tc.cellIndex]))
+			require.Equal(t, true, reflect.DeepEqual(tc.wantProof, pv.Column.KzgProofs[tc.cellIndex]))
+		})
+	}
+}
+
+func TestPartialColumnVerifierMarkIncludedCellsVerified(t *testing.T) {
+	testCases := []struct {
+		name         string
+		included     []uint64
+		wantVerified map[uint64]bool
+	}{
+		{
+			name:     "happy path",
+			included: []uint64{1, 3},
+			wantVerified: map[uint64]bool{
+				1: true,
+				3: true,
+			},
+		},
+		{
+			name:         "no included cells",
+			included:     nil,
+			wantVerified: map[uint64]bool{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := NewPartialColumnVerifier(&MockDataColumnsVerifier{}, buildTestPartialColumnForVerifier(t, 4, tc.included))
+			pv.MarkIncludedCellsVerified()
+
+			for i := range uint64(4) {
+				require.Equal(t, tc.wantVerified[i], pv.verifiedCellByIndex[i])
+			}
+		})
+	}
+}
+
 func TestDataColumnsSidecarProposerExpected(t *testing.T) {
 	const (
 		columnSlot = 1
@@ -905,6 +1092,45 @@ func generateTestDataColumnsWithProposer(t *testing.T, parent [fieldparams.RootL
 	require.NoError(t, err)
 
 	return roDataColumnSidecars
+}
+
+func buildTestPartialColumnForVerifier(t *testing.T, nCommitments int, included []uint64) *blocks.PartialDataColumn {
+	t.Helper()
+
+	commitments := make([][]byte, nCommitments)
+	for i := range nCommitments {
+		commitments[i] = make([]byte, fieldparams.KzgCommitmentSize)
+		commitments[i][0] = byte(i + 1)
+	}
+
+	inclusionProof := [][]byte{
+		make([]byte, fieldparams.RootLength),
+		make([]byte, fieldparams.RootLength),
+		make([]byte, fieldparams.RootLength),
+		make([]byte, fieldparams.RootLength),
+	}
+
+	col, err := blocks.NewPartialDataColumn(
+		&ethpb.SignedBeaconBlockHeader{
+			Header: &ethpb.BeaconBlockHeader{
+				ParentRoot: make([]byte, fieldparams.RootLength),
+				StateRoot:  make([]byte, fieldparams.RootLength),
+				BodyRoot:   make([]byte, fieldparams.RootLength),
+			},
+			Signature: make([]byte, fieldparams.BLSSignatureLength),
+		},
+		0,
+		commitments,
+		inclusionProof,
+	)
+	require.NoError(t, err)
+
+	for _, idx := range included {
+		extended := col.ExtendFromVerifiedCell(idx, []byte{byte(idx + 1)}, []byte{byte(idx + 2)})
+		require.Equal(t, true, extended)
+	}
+
+	return &col
 }
 
 func TestColumnRequirementSatisfaction(t *testing.T) {

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -818,13 +818,13 @@ func TestDataColumnsSidecarKzgProofVerified(t *testing.T) {
 func TestPartialColumnVerifierComplete(t *testing.T) {
 	validFieldsErr := errors.New("invalid fields")
 	testCases := []struct {
-		name           string
-		included       []uint64
-		markIncluded   bool
-		validFieldsErr error
-		verifiedCols   []blocks.RODataColumn
 		wantComplete   bool
+		markIncluded   bool
 		wantErr        error
+		validFieldsErr error
+		name           string
+		verifiedCols   []blocks.RODataColumn
+		included       []uint64
 	}{
 		{
 			name:         "incomplete column",

--- a/beacon-chain/verification/error.go
+++ b/beacon-chain/verification/error.go
@@ -40,11 +40,7 @@ var (
 
 	// errSidecarParentNotSeen means RequireSidecarParentSeen failed.
 	errSidecarParentNotSeen = errors.New("parent root has not been seen")
-	// ErrSidecarParentNotSeen is an exported marker used by callers that need to classify
-	// RequireSidecarParentSeen failures as IGNORE instead of REJECT.
-	ErrSidecarParentNotSeen = errSidecarParentNotSeen
-	// ErrSidecarParentSlotUnavailable is an exported marker used by callers that need to
-	// classify missing parent slot information as IGNORE instead of REJECT.
+	// ErrSidecarParentSlotUnavailable means that looking up a sidecar parent's slot failed.
 	ErrSidecarParentSlotUnavailable = errors.New("parent slot unavailable")
 
 	// errSidecarParentInvalid means RequireSidecarParentValid failed.

--- a/beacon-chain/verification/error.go
+++ b/beacon-chain/verification/error.go
@@ -40,6 +40,12 @@ var (
 
 	// errSidecarParentNotSeen means RequireSidecarParentSeen failed.
 	errSidecarParentNotSeen = errors.New("parent root has not been seen")
+	// ErrSidecarParentNotSeen is an exported marker used by callers that need to classify
+	// RequireSidecarParentSeen failures as IGNORE instead of REJECT.
+	ErrSidecarParentNotSeen = errSidecarParentNotSeen
+	// ErrSidecarParentSlotUnavailable is an exported marker used by callers that need to
+	// classify missing parent slot information as IGNORE instead of REJECT.
+	ErrSidecarParentSlotUnavailable = errors.New("parent slot unavailable")
 
 	// errSidecarParentInvalid means RequireSidecarParentValid failed.
 	errSidecarParentInvalid = errors.Join(ErrBlobInvalid, errors.New("parent block is not valid"))

--- a/consensus-types/blocks/partialdatacolumn.go
+++ b/consensus-types/blocks/partialdatacolumn.go
@@ -389,19 +389,7 @@ func (p *PartialDataColumn) ExtendFromVerifiedCells(cellIndices []uint64, cells 
 	return extended
 }
 
-// Complete returns a verified read-only column if all cells are now present in this column.
-func (p *PartialDataColumn) Complete() (VerifiedRODataColumn, bool) {
-	if uint64(len(p.KzgCommitments)) != p.Included.Count() {
-		return VerifiedRODataColumn{}, false
-	}
-
-	rodc, err := NewRODataColumn(p.DataColumnSidecar)
-	if err != nil {
-		// We shouldn't get an error, as we check the hash root when creating
-		// the partial column
-		log.WithError(err).Error("Failed to create RODataColumn")
-		return VerifiedRODataColumn{}, false
-	}
-
-	return NewVerifiedRODataColumn(rodc), true
+// IsComplete returns true if all cells are now present in this column.
+func (p *PartialDataColumn) IsComplete() bool {
+	return uint64(len(p.KzgCommitments)) == p.Included.Count()
 }

--- a/consensus-types/blocks/partialdatacolumn_test.go
+++ b/consensus-types/blocks/partialdatacolumn_test.go
@@ -1192,19 +1192,16 @@ func TestPartialDataColumn_Complete(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:   "complete but invalid signed header",
+			name:   "complete with invalid signed header is still complete",
 			p:      mustNewPartialColumnWithSigLen(t, 2, 0, 0, 1),
-			wantOK: false,
+			wantOK: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := tt.p.Complete()
+			ok := tt.p.IsComplete()
 			require.Equal(t, tt.wantOK, ok)
-			if tt.wantOK {
-				require.NotNil(t, got.DataColumnSidecar)
-			}
 		})
 	}
 }

--- a/consensus-types/blocks/partialdatacolumn_test.go
+++ b/consensus-types/blocks/partialdatacolumn_test.go
@@ -1191,11 +1191,6 @@ func TestPartialDataColumn_Complete(t *testing.T) {
 			p:      mustNewPartialColumn(t, 2, 0, 1),
 			wantOK: true,
 		},
-		{
-			name:   "complete with invalid signed header is still complete",
-			p:      mustNewPartialColumnWithSigLen(t, 2, 0, 0, 1),
-			wantOK: true,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one line below and remove others.
Feature


**What does this PR do? Why is it needed?**

This PR unifies the validation pipelines for full data columns and partial data columns so they both satisfy the same set of validation requirements once the partial data column is full. It also ensures that we can get a verified data column from a partial data column only from the verification package after all the validation requirements have been satisfied.

We account for the fact that partial data column headers and cells arrive separately and in incremental parts.
Also, cells that we read from the EL are trusted and do not need to be verified.



**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
