### PR TITLE
fix(sync): do not fail block processing on hot state DB cleanup error

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -153,7 +153,7 @@ func (s *Service) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySig
 
 	// Have we been finalizing? Should we start saving hot states to db?
 	if err := s.checkSaveHotStateDB(ctx); err != nil {
-		return errors.Wrap(err, "check save hot state db")
+		log.WithError(err).Error("Could not check save hot state DB")
 	}
 
 	// We apply the same heuristic to some of our more important caches.

--- a/changelog/fix_hot_state_db_check.md
+++ b/changelog/fix_hot_state_db_check.md
@@ -1,0 +1,2 @@
+### Fixed
+- Do not fail block processing when hot state DB cleanup encounters a finalized state.


### PR DESCRIPTION
During initial sync, `checkSaveHotStateDB` can fail when it tries to disable hot-state-saving mode and clean up previously saved states. If one of those states has since become the finalized checkpoint, `DeleteStates` returns `ErrDeleteJustifiedAndFinalized`, which is correct behavior from the DB layer, but should not kill block processing.
This was observed on epbs-devnet-0 at slot ~3742 where the error cascaded as:
```
Skip processing Gloas blocks error=receive Gloas block at slot 3742: check save hot state db: cannot delete finalized block or state
```
The fix downgrades the error to a log, matching the pattern already used by `prunePostBlockOperationPools` two lines above. In the long run, we should remove such scheme saving unfinalized states in DB when we dont finalize after some epochs this was a work around for medella incident