### PR TITLE
fix(sync): preserve the full signed execution payload envelope

### DIFF
--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -128,6 +128,7 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 		return pubsub.ValidationReject, err
 	}
 	s.setSeenPayloadEnvelope(root, env.BuilderIndex())
+	msg.ValidatorData = signedEnvelope
 	return pubsub.ValidationAccept, nil
 }
 

--- a/changelog/tt_validator-data-signed-envelope.md
+++ b/changelog/tt_validator-data-signed-envelope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Preserve the full signed execution payload envelope in pubsub validation by setting `msg.ValidatorData = signedEnvelope` after successful validation. This makes the validated envelope available to downstream handlers without re-decoding.

--- a/changelog/tt_validator-data-signed-envelope.md
+++ b/changelog/tt_validator-data-signed-envelope.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Preserve the full signed execution payload envelope in pubsub validation by setting `msg.ValidatorData = signedEnvelope` after successful validation. This makes the validated envelope available to downstream handlers without re-decoding.
+- Preserve the full signed execution payload envelope in pubsub validation by setting `msg.ValidatorData = signedEnvelope` after successful validation.


### PR DESCRIPTION
fix(sync): preserve the full signed execution payload envelope in pubsub validations