### PR TITLE
Update gossipsub partial messages API usage

### DIFF
--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -47,14 +47,11 @@ func extractColumnIndexFromTopic(topic string) (uint64, error) {
 type HeaderValidator func(header *ethpb.PartialDataColumnHeader) (reject bool, err error)
 type HeaderHandler func(header *ethpb.PartialDataColumnHeader, groupID string)
 type ColumnValidator func(cells []blocks.CellProofBundle) error
-type partialColumnPubSub interface {
-	PeerFeedback(topic string, peer peer.ID, kind pubsub.PeerFeedbackKind) error
-	PublishPartialMessage(topic string, partialMessage partialmessages.Message, opts partialmessages.PublishOptions) error
-}
 
 type PartialColumnBroadcaster struct {
-	ps   partialColumnPubSub
-	stop chan struct{}
+	peerFeedback      func(topic string, peer peer.ID, kind pubsub.PeerFeedbackKind) error
+	publishPartialCol func(topic string, groupID []byte, col *blocks.PartialDataColumn) error
+	stop              chan struct{}
 
 	validateHeader HeaderValidator
 	validateColumn ColumnValidator
@@ -87,7 +84,7 @@ const (
 	requestKindPublish requestKind = iota
 	requestKindSubscribe
 	requestKindUnsubscribe
-	requestKindGossipForPeer
+	requestKindGossip
 	requestKindHandleIncomingRPC
 	requestKindCellsValidated
 )
@@ -100,7 +97,7 @@ type request struct {
 	incomingRPC    rpcWithFrom
 	sub            subscribe
 	publish        publish
-	gossipForPeer  gossipForPeer
+	gossip         gossip
 }
 
 type publish struct {
@@ -137,19 +134,10 @@ type cellsValidated struct {
 	cells          []blocks.CellProofBundle
 }
 
-type gossipForPeer struct {
-	topic             string
-	groupID           string
-	remote            peer.ID
-	peerState         partialmessages.PeerState
-	gossipForPeerResp chan gossipForPeerResponse
-}
-
-type gossipForPeerResponse struct {
-	nextPeerState       partialmessages.PeerState
-	encodedMsg          []byte
-	partsMetadataToSend partialmessages.PartsMetadata
-	err                 error
+// gossip is used when we are republishing our PartialDataColumn to gossip peers.
+type gossip struct {
+	topic   string
+	groupID []byte
 }
 
 func NewBroadcaster() *PartialColumnBroadcaster {
@@ -171,34 +159,28 @@ func NewBroadcaster() *PartialColumnBroadcaster {
 // AppendPubSubOpts adds the necessary pubsub options to enable partial messages.
 func (p *PartialColumnBroadcaster) AppendPubSubOpts(opts []pubsub.Option) []pubsub.Option {
 	opts = append(opts,
-		pubsub.WithPartialMessagesExtension(&partialmessages.PartialMessagesExtension{
+		pubsub.WithPartialMessagesExtension(&partialmessages.PartialMessagesExtension[blocks.PartialDataColumnPeerState]{
 			Logger: slog.Default().With("package", "beacon-chain/p2p/partialdatacolumnbroadcaster"),
-			GossipForPeer: func(topic string, groupID string, remote peer.ID, peerState partialmessages.PeerState) (partialmessages.PeerState, []byte, partialmessages.PartsMetadata, error) {
-				respCh := make(chan gossipForPeerResponse, 1)
-				p.incomingReq <- request{
-					kind: requestKindGossipForPeer,
-					gossipForPeer: gossipForPeer{
-						topic:             topic,
-						groupID:           groupID,
-						remote:            remote,
-						peerState:         peerState,
-						gossipForPeerResp: respCh,
-					},
-				}
+			OnEmitGossip: func(topic string, groupID []byte, gossipPeers []peer.ID, peerStates map[peer.ID]blocks.PartialDataColumnPeerState) {
 				select {
-				case resp := <-respCh:
-					return resp.nextPeerState, resp.encodedMsg, resp.partsMetadataToSend, resp.err
-				case <-p.stop:
-					return peerState, nil, nil, errors.New("broadcaster stopped")
+				case p.incomingReq <- request{
+					kind: requestKindPublish,
+					gossip: gossip{
+						topic:   topic,
+						groupID: groupID,
+					},
+				}:
+				default:
+					// Drop gossip emission if we have too many pending requests
 				}
 			},
-			OnIncomingRPC: func(from peer.ID, peerState partialmessages.PeerState, rpc *pubsub_pb.PartialMessagesExtension) (partialmessages.PeerState, error) {
+			OnIncomingRPC: func(from peer.ID, peerStates map[peer.ID]blocks.PartialDataColumnPeerState, rpc *pubsub_pb.PartialMessagesExtension) error {
 				if rpc == nil {
-					return peerState, errors.New("rpc is nil")
+					return nil
 				}
-				nextPeerState, message, err := updatePeerStateFromIncomingRPC(peerState, rpc)
+				nextPeerState, message, err := updatePeerStateFromIncomingRPC(peerStates[from], rpc)
 				if err != nil {
-					return peerState, err
+					return err
 				}
 				select {
 				case p.incomingReq <- request{
@@ -207,13 +189,18 @@ func (p *PartialColumnBroadcaster) AppendPubSubOpts(opts []pubsub.Option) []pubs
 				}:
 				default:
 					log.WithField("rpc", rpc).Warn("Dropping incoming partial RPC")
-					return nextPeerState, errors.New("incomingReq channel is full, dropping RPC")
+					return errors.New("incomingReq channel is full, dropping RPC")
 				}
-				return nextPeerState, nil
+
+				peerStates[from] = nextPeerState
+				return nil
 			},
 		}),
 		func(ps *pubsub.PubSub) error {
-			p.ps = ps
+			p.peerFeedback = ps.PeerFeedback
+			p.publishPartialCol = func(topic string, groupID []byte, col *blocks.PartialDataColumn) error {
+				return pubsub.PublishPartial(ps, topic, groupID, col.PublishActions)
+			}
 			return nil
 		},
 	)
@@ -284,14 +271,8 @@ func (p *PartialColumnBroadcaster) loop() {
 				req.response <- p.subscribe(req.sub.t)
 			case requestKindUnsubscribe:
 				req.response <- p.unsubscribe(req.unsub.topic)
-			case requestKindGossipForPeer:
-				nextPeerState, encodedMsg, partsMetadataToSend, err := p.handleGossipForPeer(req.gossipForPeer)
-				req.gossipForPeer.gossipForPeerResp <- gossipForPeerResponse{
-					nextPeerState:       nextPeerState,
-					encodedMsg:          encodedMsg,
-					partsMetadataToSend: partsMetadataToSend,
-					err:                 err,
-				}
+			case requestKindGossip:
+				p.gossip(req.gossip.topic, req.gossip.groupID)
 			case requestKindHandleIncomingRPC:
 				err := p.handleIncomingRPC(req.incomingRPC)
 				if err != nil {
@@ -321,31 +302,14 @@ func (p *PartialColumnBroadcaster) getDataColumn(topic string, group []byte) *bl
 	return msg
 }
 
-func (p *PartialColumnBroadcaster) handleGossipForPeer(req gossipForPeer) (partialmessages.PeerState, []byte, partialmessages.PartsMetadata, error) {
-	topicStore, ok := p.partialMsgStore[req.topic]
-	if !ok {
-		return req.peerState, nil, nil, errors.New("not tracking topic for group")
-	}
-	partialColumn, ok := topicStore[req.groupID]
-	if !ok || partialColumn == nil {
-		return req.peerState, nil, nil, errors.New("not tracking topic for group")
-	}
-	// we're not requesting a message here as this will be used to emit gossip. So, we pass requested message as false.
-	return partialColumn.ForPeer(req.remote, false, req.peerState)
-}
-
-func parsePartsMetadataFromPeerState(state any, expectedLength uint64) (*ethpb.PartialDataColumnPartsMetadata, error) {
+func parsePartsMetadataFromPeerState(state *ethpb.PartialDataColumnPartsMetadata, expectedLength uint64) (*ethpb.PartialDataColumnPartsMetadata, error) {
 	if state == nil {
 		return blocks.NewPartsMetaWithNoAvailableAndNoRequests(expectedLength), nil
 	}
-	meta, ok := state.(*ethpb.PartialDataColumnPartsMetadata)
-	if !ok {
-		return nil, errors.New("state is not *PartialDataColumnPartsMetadata")
-	}
-	return meta, nil
+	return state, nil
 }
 
-func updatePeerStateFromIncomingRPC(peerState partialmessages.PeerState, rpc *pubsub_pb.PartialMessagesExtension) (partialmessages.PeerState,
+func updatePeerStateFromIncomingRPC(peerState blocks.PartialDataColumnPeerState, rpc *pubsub_pb.PartialMessagesExtension) (blocks.PartialDataColumnPeerState,
 	*ethpb.PartialDataColumnSidecar, error) {
 	peerState = blocks.ClonePeerState(peerState)
 	hasIncomingPartsMetadata := len(rpc.PartsMetadata) > 0
@@ -360,16 +324,15 @@ func updatePeerStateFromIncomingRPC(peerState partialmessages.PeerState, rpc *pu
 			return peerState, nil, errors.New("incoming parts metadata has 0 length availability")
 		}
 
-		if peerState.RecvdState == nil {
-			peerState.RecvdState = &incomingMeta
+		if peerState.Recvd == nil {
+			peerState.Recvd = &incomingMeta
 		} else {
-			existingMeta, ok := peerState.RecvdState.(*ethpb.PartialDataColumnPartsMetadata)
-			if !ok {
-				return peerState, nil, errors.New("recvdState is not *PartialDataColumnPartsMetadata")
+			if peerState.Recvd.Requests.Len() != incomingMeta.Requests.Len() {
+				return peerState, nil, errors.New("failed to merge available cells into recvdState parts metadata. requests length mismatch")
 			}
-			existingMeta.Requests = incomingMeta.Requests
+			peerState.Recvd.Requests = incomingMeta.Requests
 			var err error
-			peerState.RecvdState, err = blocks.MergeAvailableIntoPartsMetadata(existingMeta, incomingMeta.Available)
+			peerState.Recvd.Available, err = peerState.Recvd.Available.Or(incomingMeta.Available)
 			if err != nil {
 				return peerState, nil, errors.Wrap(err, "failed to merge available cells into recvdState parts metadata")
 			}
@@ -397,7 +360,7 @@ func updatePeerStateFromIncomingRPC(peerState partialmessages.PeerState, rpc *pu
 
 	// only update RecvdState using the incoming partial message if the peer did not send us their parts metadata
 	if !hasIncomingPartsMetadata {
-		recievedMeta, err := parsePartsMetadataFromPeerState(peerState.RecvdState, nKzgCommitments)
+		recievedMeta, err := parsePartsMetadataFromPeerState(peerState.Recvd, nKzgCommitments)
 		if err != nil {
 			return peerState, nil, errors.Wrap(err, "received")
 		}
@@ -405,10 +368,10 @@ func updatePeerStateFromIncomingRPC(peerState partialmessages.PeerState, rpc *pu
 		if err != nil {
 			return peerState, nil, err
 		}
-		peerState.RecvdState = recvdState
+		peerState.Recvd = recvdState
 	}
 
-	sentMeta, err := parsePartsMetadataFromPeerState(peerState.SentState, nKzgCommitments)
+	sentMeta, err := parsePartsMetadataFromPeerState(peerState.Sent, nKzgCommitments)
 	if err != nil {
 		return peerState, nil, errors.Wrap(err, "sent")
 	}
@@ -417,13 +380,13 @@ func updatePeerStateFromIncomingRPC(peerState partialmessages.PeerState, rpc *pu
 	if err != nil {
 		return peerState, nil, err
 	}
-	peerState.SentState = sentState
+	peerState.Sent = sentState
 
 	return peerState, &message, nil
 }
 
 func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) error {
-	if p.ps == nil {
+	if p.peerFeedback == nil || p.publishPartialCol == nil {
 		return errors.New("pubsub not initialized")
 	}
 
@@ -453,7 +416,7 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 				log.WithError(err).WithField("reject", reject).Debug("Header validation failed")
 				if reject {
 					// REJECT case: penalize the peer
-					_ = p.ps.PeerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
+					_ = p.peerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
 				}
 				// Both REJECT and IGNORE: don't process further
 				return nil
@@ -546,10 +509,10 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 				err := p.validateColumn(cellsToVerify)
 				if err != nil {
 					logger.WithError(err).Error("Failed to validate cells")
-					_ = p.ps.PeerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
+					_ = p.peerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackInvalidMessage)
 					return
 				}
-				_ = p.ps.PeerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackUsefulMessage)
+				_ = p.peerFeedback(topicID, rpcWithFrom.from, pubsub.PeerFeedbackUsefulMessage)
 				p.incomingReq <- request{
 					kind: requestKindCellsValidated,
 					cellsValidated: &cellsValidated{
@@ -582,7 +545,7 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpcWithFrom rpcWithFrom) er
 	}
 
 	if shouldRepublish {
-		err := p.ps.PublishPartialMessage(topicID, ourDataColumn, partialmessages.PublishOptions{})
+		err := p.publishPartialCol(topicID, ourDataColumn.GroupID(), ourDataColumn)
 		if err != nil {
 			return err
 		}
@@ -622,7 +585,7 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 			return nil
 		}
 
-		err := p.ps.PublishPartialMessage(cells.topic, ourDataColumn, partialmessages.PublishOptions{})
+		err := p.publishPartialCol(cells.topic, ourDataColumn.GroupID(), ourDataColumn)
 		if err != nil {
 			return err
 		}
@@ -638,7 +601,7 @@ func (p *PartialColumnBroadcaster) Stop() {
 
 // Publish publishes the partial column.
 func (p *PartialColumnBroadcaster) Publish(topic string, c blocks.PartialDataColumn, getBlobsCalled bool) (bool, error) {
-	if p.ps == nil {
+	if p.peerFeedback == nil || p.publishPartialCol == nil {
 		return false, errors.New("pubsub not initialized")
 	}
 	respCh := make(chan publishResponse, 1)
@@ -653,6 +616,28 @@ func (p *PartialColumnBroadcaster) Publish(topic string, c blocks.PartialDataCol
 	}
 	resp := <-respCh
 	return resp.columnCompleted, resp.err
+}
+
+func (p *PartialColumnBroadcaster) gossip(topic string, groupID []byte) {
+	topicStore, ok := p.partialMsgStore[topic]
+	if !ok {
+		return
+	}
+	existing := topicStore[string(groupID)]
+	if existing == nil {
+		return
+	}
+	if existing.Included.Count() == 0 {
+		// Nothing useful here
+		return
+	}
+	if !p.getBlobsCalled[string(groupID)] {
+		return
+	}
+	err := p.publishPartialCol(topic, existing.GroupID(), existing)
+	if err != nil {
+		log.WithFields(logrus.Fields{"err": err}).Warn("Failed to publish gossip")
+	}
 }
 
 func (p *PartialColumnBroadcaster) publish(topic string, c blocks.PartialDataColumn, getBlobsCalled bool) (bool, error) {
@@ -692,7 +677,7 @@ func (p *PartialColumnBroadcaster) publish(topic string, c blocks.PartialDataCol
 
 	p.groupTTL[string(groupIDBytes)] = TTLInSlots
 
-	err := p.ps.PublishPartialMessage(topic, existing, partialmessages.PublishOptions{})
+	err := p.publishPartialCol(topic, existing.GroupID(), existing)
 	if err == nil {
 		p.getBlobsCalled[string(groupIDBytes)] = getBlobsCalled
 	}

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	libp2p "github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p-pubsub/partialmessages"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -117,7 +116,7 @@ func (m *mockPubSub) assertPartialColumnsPublished(t *testing.T, topic string, e
 	}
 }
 
-func (m *mockPubSub) PeerFeedback(topic string, id peer.ID, kind pubsub.PeerFeedbackKind) error {
+func (m *mockPubSub) peerFeedback(topic string, id peer.ID, kind pubsub.PeerFeedbackKind) error {
 	m.peerFeedbackCalls = append(m.peerFeedbackCalls, peerFeedbackCall{
 		peerID: id,
 		topic:  topic,
@@ -126,26 +125,18 @@ func (m *mockPubSub) PeerFeedback(topic string, id peer.ID, kind pubsub.PeerFeed
 	return m.peerFeedbackErr
 }
 
-func (m *mockPubSub) PublishPartialMessage(
-	topic string,
-	message partialmessages.Message,
-	_ partialmessages.PublishOptions,
-) error {
-	column, ok := message.(*blocks.PartialDataColumn)
-	if !ok {
-		return errors.New("partial message is not *blocks.PartialDataColumn")
-	}
-	m.publishedPartialColumns = append(m.publishedPartialColumns, publishedColumn{column, topic})
+func (m *mockPubSub) publishPartialCol(topic string, groupID []byte, col *blocks.PartialDataColumn) error {
+	m.publishedPartialColumns = append(m.publishedPartialColumns, publishedColumn{col, topic})
 	retErr := m.publishPartialMessageErr
 	return retErr
 }
 
-var _ partialColumnPubSub = (*mockPubSub)(nil)
-
-func newBroadcasterHarness(t *testing.T, ps partialColumnPubSub) *broadcasterHarness {
+func newBroadcasterHarness(t *testing.T, ps *mockPubSub) *broadcasterHarness {
 	t.Helper()
 	broadcaster := NewBroadcaster()
-	broadcaster.ps = ps
+	broadcaster.peerFeedback = ps.peerFeedback
+	broadcaster.publishPartialCol = ps.publishPartialCol
+
 	return &broadcasterHarness{
 		t:           t,
 		broadcaster: broadcaster,
@@ -269,18 +260,16 @@ func mustMarshalSidecar(t *testing.T, cellsPresent bitfield.Bitlist) []byte {
 	return b
 }
 
-func assertPeerStatePartsMetadata(t *testing.T, got any, want *ethpb.PartialDataColumnPartsMetadata) {
+func assertPeerStatePartsMetadata(t *testing.T, got, want *ethpb.PartialDataColumnPartsMetadata) {
 	t.Helper()
 	if want == nil {
-		require.Equal(t, nil, got)
+		require.Equal(t, want, got)
 		return
 	}
 
 	require.NotNil(t, got)
-	meta, ok := got.(*ethpb.PartialDataColumnPartsMetadata)
-	require.Equal(t, true, ok)
-	require.DeepEqual(t, want.Available, meta.Available)
-	require.DeepEqual(t, want.Requests, meta.Requests)
+	require.DeepEqual(t, want.Available, got.Available)
+	require.DeepEqual(t, want.Requests, got.Requests)
 }
 
 func assertBitlistEqual(t *testing.T, got, want bitfield.Bitlist) {
@@ -423,7 +412,7 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 	tests := []struct {
 		wantErrContains      string
 		name                 string
-		inputPeerState       func() partialmessages.PeerState
+		inputPeerState       func() blocks.PartialDataColumnPeerState
 		inputRPC             func(t *testing.T) *pubsub_pb.PartialMessagesExtension
 		expectedRecvdState   func() *ethpb.PartialDataColumnPartsMetadata
 		expectedSentState    func() *ethpb.PartialDataColumnPartsMetadata
@@ -432,8 +421,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 	}{
 		{
 			name: "incoming parts metadata only initializes recvd state",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{}
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
 				return &pubsub_pb.PartialMessagesExtension{
@@ -446,10 +435,10 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "incoming parts metadata merges with existing recvd state available and overwrites requests and does not update sent state",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{
-					RecvdState: testPartsMetadata(4, []uint64{0}, []uint64{0}),
-					SentState:  testPartsMetadata(4, []uint64{3}, []uint64{1}),
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{
+					Recvd: testPartsMetadata(4, []uint64{0}, []uint64{0}),
+					Sent:  testPartsMetadata(4, []uint64{3}, []uint64{1}),
 				}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
@@ -466,8 +455,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "partial message  updates recvd and sent states when existing peer state is empty",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{}
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
 				return &pubsub_pb.PartialMessagesExtension{
@@ -485,9 +474,9 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "incoming parts metadata with message skips recvd update from message and updates sent",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{
-					SentState: testPartsMetadata(4, []uint64{0, 1}, nil),
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{
+					Sent: testPartsMetadata(4, []uint64{0, 1}, nil),
 				}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
@@ -507,8 +496,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "message with empty cells bitmap bytes returns decode error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{}
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
 				return &pubsub_pb.PartialMessagesExtension{
@@ -519,8 +508,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "invalid incoming parts metadata bytes return error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{}
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{}
 			},
 			inputRPC: func(_ *testing.T) *pubsub_pb.PartialMessagesExtension {
 				return &pubsub_pb.PartialMessagesExtension{
@@ -531,8 +520,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "incoming parts metadata with zero-length availability returns error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{}
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
 				return &pubsub_pb.PartialMessagesExtension{
@@ -542,22 +531,10 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 			wantErrContains: "incoming parts metadata has 0 length availability",
 		},
 		{
-			name: "incoming parts metadata with non-metadata recvd state returns error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{RecvdState: "not-metadata"}
-			},
-			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
-				return &pubsub_pb.PartialMessagesExtension{
-					PartsMetadata: mustMarshalPartsMetadata(t, testPartsMetadata(3, []uint64{1}, []uint64{2})),
-				}
-			},
-			wantErrContains: "recvdState is not *PartialDataColumnPartsMetadata",
-		},
-		{
 			name: "incoming parts metadata merge length mismatch returns wrapped error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{
-					RecvdState: testPartsMetadataCustom(3, []uint64{0}, 3, []uint64{0}),
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{
+					Recvd: testPartsMetadataCustom(3, []uint64{0}, 3, []uint64{0}),
 				}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
@@ -569,8 +546,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "invalid partial message bytes return error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{}
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{}
 			},
 			inputRPC: func(_ *testing.T) *pubsub_pb.PartialMessagesExtension {
 				return &pubsub_pb.PartialMessagesExtension{
@@ -581,8 +558,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 		},
 		{
 			name: "partial message with non-empty bitmap bytes but zero logical length returns error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{}
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
 				return &pubsub_pb.PartialMessagesExtension{
@@ -592,24 +569,10 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 			wantErrContains: "length of cells present bitmap is 0",
 		},
 		{
-			name: "partial message with non-metadata sent state returns wrapped error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{
-					SentState: 123,
-				}
-			},
-			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
-				return &pubsub_pb.PartialMessagesExtension{
-					PartialMessage: mustMarshalSidecar(t, testBitlist(3, 1)),
-				}
-			},
-			wantErrContains: "sent: state is not *PartialDataColumnPartsMetadata",
-		},
-		{
 			name: "partial message sent merge length mismatch returns error",
-			inputPeerState: func() partialmessages.PeerState {
-				return partialmessages.PeerState{
-					SentState: testPartsMetadataCustom(3, []uint64{0}, 4, []uint64{0}),
+			inputPeerState: func() blocks.PartialDataColumnPeerState {
+				return blocks.PartialDataColumnPeerState{
+					Sent: testPartsMetadataCustom(3, []uint64{0}, 4, []uint64{0}),
 				}
 			},
 			inputRPC: func(t *testing.T) *pubsub_pb.PartialMessagesExtension {
@@ -629,8 +592,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 			nextPeerState, msg, err := updatePeerStateFromIncomingRPC(peerState, tt.inputRPC(t))
 
 			// updatePeerStateFromIncomingRPC must not mutate the input peerState.
-			require.DeepEqual(t, originalPeerState.RecvdState, peerState.RecvdState)
-			require.DeepEqual(t, originalPeerState.SentState, peerState.SentState)
+			require.DeepEqual(t, originalPeerState.Recvd, peerState.Recvd)
+			require.DeepEqual(t, originalPeerState.Sent, peerState.Sent)
 
 			if tt.wantErrContains != "" {
 				require.ErrorContains(t, tt.wantErrContains, err)
@@ -653,8 +616,8 @@ func TestUpdatePeerStateFromIncomingRPC(t *testing.T) {
 			if tt.expectedSentState != nil {
 				wantSent = tt.expectedSentState()
 			}
-			assertPeerStatePartsMetadata(t, nextPeerState.RecvdState, wantRecvd)
-			assertPeerStatePartsMetadata(t, nextPeerState.SentState, wantSent)
+			assertPeerStatePartsMetadata(t, nextPeerState.Recvd, wantRecvd)
+			assertPeerStatePartsMetadata(t, nextPeerState.Sent, wantSent)
 		})
 	}
 }
@@ -693,7 +656,7 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 			name:                "pubsub not initialized returns error",
 			expectedErrContains: "pubsub not initialized",
 			setup: func(t *testing.T, b *PartialColumnBroadcaster) testSetup {
-				b.ps = nil
+				b.publishPartialCol = nil
 				group := []byte("missing-group")
 				return testSetup{
 					inputRPC: buildIncomingRPC(validTopic, group, nil, nil),

--- a/consensus-types/blocks/partialdatacolumn.go
+++ b/consensus-types/blocks/partialdatacolumn.go
@@ -3,6 +3,7 @@ package blocks
 import (
 	"bytes"
 	"errors"
+	"iter"
 	"slices"
 
 	"github.com/OffchainLabs/go-bitfield"
@@ -12,7 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-var _ partialmessages.Message = (*PartialDataColumn)(nil)
+var _ partialmessages.PublishActionsFn[PartialDataColumnPeerState] = (*PartialDataColumn)(nil).PublishActions
 
 // CellProofBundle contains a cell, its proof, and the corresponding
 // commitment/index information.
@@ -21,6 +22,11 @@ type CellProofBundle struct {
 	Commitment  []byte
 	Cell        []byte
 	Proof       []byte
+}
+
+type PartialDataColumnPeerState struct {
+	Sent  *ethpb.PartialDataColumnPartsMetadata
+	Recvd *ethpb.PartialDataColumnPartsMetadata
 }
 
 // PartialDataColumn is a partially populated DataColumnSidecar used for
@@ -109,21 +115,20 @@ func marshalPartsMetadata(meta *ethpb.PartialDataColumnPartsMetadata) (partialme
 // ClonePeerState creates a deep copy of the given PeerState. It clones the
 // RecvdState and SentState fields if they are of type *PartialDataColumnPartsMetadata,
 // ensuring that modifications to the returned state do not affect the original.
-func ClonePeerState(peerState partialmessages.PeerState) partialmessages.PeerState {
+func ClonePeerState(peerState PartialDataColumnPeerState) PartialDataColumnPeerState {
 	clonePartsMetadataF := func(meta *ethpb.PartialDataColumnPartsMetadata) *ethpb.PartialDataColumnPartsMetadata {
+		if meta == nil {
+			return nil
+		}
 		return &ethpb.PartialDataColumnPartsMetadata{
 			Available: slices.Clone(meta.Available),
 			Requests:  slices.Clone(meta.Requests),
 		}
 	}
 
-	nextPeerState := peerState
-	if recvdMeta, ok := nextPeerState.RecvdState.(*ethpb.PartialDataColumnPartsMetadata); ok {
-		nextPeerState.RecvdState = clonePartsMetadataF(recvdMeta)
-	}
-	if sentMeta, ok := nextPeerState.SentState.(*ethpb.PartialDataColumnPartsMetadata); ok {
-		nextPeerState.SentState = clonePartsMetadataF(sentMeta)
-	}
+	var nextPeerState PartialDataColumnPeerState
+	nextPeerState.Sent = clonePartsMetadataF(peerState.Sent)
+	nextPeerState.Recvd = clonePartsMetadataF(peerState.Recvd)
 	return nextPeerState
 }
 
@@ -222,59 +227,61 @@ func MergeAvailableIntoPartsMetadata(base *ethpb.PartialDataColumnPartsMetadata,
 	return base, nil
 }
 
-// ForPeer implements partialmessages.Message.
-func (p *PartialDataColumn) ForPeer(remote peer.ID, requestedMessage bool, peerState partialmessages.PeerState) (partialmessages.PeerState, []byte,
-	partialmessages.PartsMetadata, error) {
+func (p *PartialDataColumn) PublishActions(peerStates map[peer.ID]PartialDataColumnPeerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, partialmessages.PublishAction] {
+	return func(yield func(peer.ID, partialmessages.PublishAction) bool) {
+		for peer, peerState := range peerStates {
+			nextState, action := p.forPeer(peer, peerRequestsPartial(peer), peerState)
+			if action.Err == nil {
+				// Only update state if there was no error.
+				peerStates[peer] = nextState
+			}
+			if !yield(peer, action) {
+				return
+			}
+		}
+	}
+}
+
+// forPeer returns the next peer state and the publish action for this peer
+func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerState PartialDataColumnPeerState) (PartialDataColumnPeerState, partialmessages.PublishAction) {
 	peerState = ClonePeerState(peerState)
 
 	// Eager push header - we don't know what the peer has and message has been requested.
 	// Set RecvdState so subsequent calls skip the eager push path.
-	if requestedMessage && peerState.RecvdState == nil {
+	if requestedMessage && peerState.Recvd == nil {
 		encoded, err := p.eagerPushBytes()
 		if err != nil {
-			return peerState, nil, nil, err
+			return peerState, partialmessages.PublishAction{Err: err}
 		}
-		peerState.RecvdState = NewPartsMetaWithNoAvailableAndNoRequests(p.NKzgCommitments())
+		peerState.Recvd = NewPartsMetaWithNoAvailableAndNoRequests(p.NKzgCommitments())
 		myPartsMeta, err := marshalPartsMetadata(p.newPartsMetadata())
 		if err != nil {
-			return peerState, nil, nil, err
+			return peerState, partialmessages.PublishAction{Err: err}
 		}
-		return peerState, encoded, myPartsMeta, nil
+		return peerState, partialmessages.PublishAction{
+			EncodedPartialMessage: encoded,
+			EncodedPartsMetadata:  myPartsMeta,
+		}
 	}
 
 	var cellsSent bitfield.Bitlist
-	var sentMeta *ethpb.PartialDataColumnPartsMetadata
-	var recvdMeta *ethpb.PartialDataColumnPartsMetadata
+	sentMeta := peerState.Sent
+	recvdMeta := peerState.Recvd
 	var encodedMsg []byte
-	if peerState.SentState != nil {
-		var ok bool
-		sentMeta, ok = peerState.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-		// should never happen but checking this for safety
-		if !ok {
-			return peerState, nil, nil, errors.New("SentState is not *PartialDataColumnPartsMetadata")
-		}
-	}
-	if peerState.RecvdState != nil {
-		var ok bool
-		recvdMeta, ok = peerState.RecvdState.(*ethpb.PartialDataColumnPartsMetadata)
-		if !ok {
-			return peerState, nil, nil, errors.New("RecvdState is not *PartialDataColumnPartsMetadata")
-		}
-	}
 
 	//  Normal - message requested and we have RecvdState.
 	if requestedMessage && recvdMeta != nil {
 		var err error
 		encodedMsg, cellsSent, err = p.cellsToSendForPeer(recvdMeta)
 		if err != nil {
-			return peerState, nil, nil, err
+			return peerState, partialmessages.PublishAction{Err: err}
 		}
 		if cellsSent != nil && cellsSent.Count() != 0 {
 			newRecvd, err := MergeAvailableIntoPartsMetadata(recvdMeta, cellsSent)
 			if err != nil {
-				return peerState, nil, nil, err
+				return peerState, partialmessages.PublishAction{Err: err}
 			}
-			peerState.RecvdState = newRecvd
+			peerState.Recvd = newRecvd
 		}
 	}
 
@@ -289,7 +296,7 @@ func (p *PartialDataColumn) ForPeer(remote peer.ID, requestedMessage bool, peerS
 		} else {
 			contains, err := sentMeta.Available.Contains(myPartsMeta.Available)
 			if err != nil {
-				return peerState, nil, nil, err
+				return peerState, partialmessages.PublishAction{Err: err}
 			}
 			shouldSendPartsMetadata = !contains
 		}
@@ -299,21 +306,24 @@ func (p *PartialDataColumn) ForPeer(remote peer.ID, requestedMessage bool, peerS
 		var err error
 		partsMetadataToSend, err = marshalPartsMetadata(myPartsMeta)
 		if err != nil {
-			return peerState, nil, nil, err
+			return peerState, partialmessages.PublishAction{Err: err}
 		}
 		if sentMeta == nil {
-			peerState.SentState = myPartsMeta
+			peerState.Sent = myPartsMeta
 		} else {
 			sentMeta, err = MergeAvailableIntoPartsMetadata(sentMeta, myPartsMeta.Available)
 			if err != nil {
-				return peerState, nil, nil, err
+				return peerState, partialmessages.PublishAction{Err: err}
 			}
 			sentMeta.Requests = myPartsMeta.Requests
-			peerState.SentState = sentMeta
+			peerState.Sent = sentMeta
 		}
 	}
 
-	return peerState, encodedMsg, partsMetadataToSend, nil
+	return peerState, partialmessages.PublishAction{
+		EncodedPartialMessage: encodedMsg,
+		EncodedPartsMetadata:  partsMetadataToSend,
+	}
 }
 
 // CellsToVerifyFromPartialMessage returns cells from the partial message that need to be verified.

--- a/consensus-types/blocks/partialdatacolumn_test.go
+++ b/consensus-types/blocks/partialdatacolumn_test.go
@@ -528,19 +528,16 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			name: "eager push first time for peer",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
-				initial := partialmessages.PeerState{}
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), true, initial)
-				require.NoError(t, err)
-				require.NotNil(t, encoded)
-				require.NotNil(t, meta)
-				require.NotNil(t, next.RecvdState)
-				require.IsNil(t, next.SentState)
-				// RecvdState should be no-available, no-requests metadata.
-				recvdMeta, ok := next.RecvdState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.Equal(t, uint64(0), bitfield.Bitlist(recvdMeta.Available).Count())
-				require.Equal(t, uint64(0), bitfield.Bitlist(recvdMeta.Requests).Count())
-				decoded := mustDecodeSidecar(t, encoded)
+				var initial PartialDataColumnPeerState
+				nextState, action := p.forPeer(peer.ID("peer-a"), true, initial)
+				require.NoError(t, action.Err)
+				require.NotNil(t, action.EncodedPartialMessage)
+				require.NotNil(t, action.EncodedPartsMetadata)
+				require.NotNil(t, nextState.Recvd)
+				require.IsNil(t, nextState.Sent)
+				require.Equal(t, uint64(0), bitfield.Bitlist(nextState.Recvd.Available).Count())
+				require.Equal(t, uint64(0), bitfield.Bitlist(nextState.Recvd.Requests).Count())
+				decoded := mustDecodeSidecar(t, action.EncodedPartialMessage)
 				require.Equal(t, 1, len(decoded.Header))
 				require.Equal(t, 0, len(decoded.PartialColumn))
 			},
@@ -549,57 +546,39 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			name: "eager push not repeated when peerState preserved",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
-				state, _, _, err := p.ForPeer(peer.ID("peer-a"), true, partialmessages.PeerState{})
-				require.NoError(t, err)
-				require.NotNil(t, state.RecvdState)
+				state, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{})
+				require.NoError(t, action.Err)
+				require.NotNil(t, state.Recvd)
 				// Second call with the returned state should not send eager push again.
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), true, state)
-				require.NoError(t, err)
-				require.IsNil(t, encoded) // no cells to send (peer has no requests)
-				require.NotNil(t, meta)   // partsMetadata is sent since SentState differs
-				require.NotNil(t, next.RecvdState)
+				next, action := p.forPeer(peer.ID("peer-a"), true, state)
+				require.NoError(t, action.Err)
+				require.IsNil(t, action.EncodedPartialMessage) // no cells to send (peer has no requests)
+				require.NotNil(t, action.EncodedPartsMetadata) // partsMetadata is sent since SentState differs
+				require.NotNil(t, next.Recvd)
 			},
 		},
 		{
 			name: "requested false sends only parts metadata",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0)
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{})
-				require.NoError(t, err)
-				require.IsNil(t, encoded)
-				require.NotNil(t, meta)
-				require.NotNil(t, next.SentState)
-				_, ok := next.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-			},
-		},
-		{
-			name: "invalid SentState type",
-			run: func(t *testing.T) {
-				p := mustNewPartialColumn(t, 3, 0)
-				_, _, _, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{SentState: "bad"})
-				require.ErrorContains(t, "SentState is not *PartialDataColumnPartsMetadata", err)
-			},
-		},
-		{
-			name: "invalid RecvdState type",
-			run: func(t *testing.T) {
-				p := mustNewPartialColumn(t, 3, 0)
-				_, _, _, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{RecvdState: "bad"})
-				require.ErrorContains(t, "RecvdState is not *PartialDataColumnPartsMetadata", err)
+				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{})
+				require.NoError(t, action.Err)
+				require.IsNil(t, action.EncodedPartialMessage)
+				require.NotNil(t, action.EncodedPartsMetadata)
+				require.NotNil(t, next.Sent)
 			},
 		},
 		{
 			name: "recvdState with mismatched length",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0)
-				_, _, _, err := p.ForPeer(peer.ID("peer-a"), true, partialmessages.PeerState{
-					RecvdState: &ethpb.PartialDataColumnPartsMetadata{
+				_, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+					Recvd: &ethpb.PartialDataColumnPartsMetadata{
 						Available: testBitlist(2),
 						Requests:  testBitlist(2, 0, 1),
 					},
 				})
-				require.ErrorContains(t, "peer metadata bitmap length mismatch", err)
+				require.ErrorContains(t, "peer metadata bitmap length mismatch", action.Err)
 			},
 		},
 		{
@@ -609,37 +588,33 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				initialMeta := testPeerMeta(4, nil, allSet(4))
 				initialAvailable := slices.Clone(initialMeta.Available)
 				initialRequests := slices.Clone(initialMeta.Requests)
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), true, partialmessages.PeerState{
-					RecvdState: initialMeta,
+				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+					Recvd: initialMeta,
 				})
-				require.NoError(t, err)
-				require.NotNil(t, encoded)
-				require.NotNil(t, meta)
+				require.NoError(t, action.Err)
+				require.NotNil(t, action.EncodedPartialMessage)
+				require.NotNil(t, action.EncodedPartsMetadata)
 				require.DeepEqual(t, initialAvailable, initialMeta.Available)
 				require.DeepEqual(t, initialRequests, initialMeta.Requests)
 
 				// Verify wire-format partsMetadata
-				sentMetaWire, parseSentErr := ParsePartsMetadata(meta, 4)
+				sentMetaWire, parseSentErr := ParsePartsMetadata(action.EncodedPartsMetadata, 4)
 				require.NoError(t, parseSentErr)
 				require.Equal(t, uint64(2), bitfield.Bitlist(sentMetaWire.Available).Count())
 				require.Equal(t, true, bitfield.Bitlist(sentMetaWire.Available).BitAt(0))
 				require.Equal(t, true, bitfield.Bitlist(sentMetaWire.Available).BitAt(2))
 				require.Equal(t, uint64(4), bitfield.Bitlist(sentMetaWire.Requests).Count())
 
-				// Verify SentState stored as proto matches wire metadata
-				sentState, ok := next.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.DeepEqual(t, sentMetaWire.Available, sentState.Available)
-				require.DeepEqual(t, sentMetaWire.Requests, sentState.Requests)
+				// Verify Sent stored as proto matches wire metadata
+				require.DeepEqual(t, sentMetaWire.Available, next.Sent.Available)
+				require.DeepEqual(t, sentMetaWire.Requests, next.Sent.Requests)
 
-				msg := mustDecodeSidecar(t, encoded)
+				msg := mustDecodeSidecar(t, action.EncodedPartialMessage)
 				require.Equal(t, 2, len(msg.PartialColumn))
 				require.Equal(t, true, bitfield.Bitlist(msg.CellsPresentBitmap).BitAt(0))
 				require.Equal(t, true, bitfield.Bitlist(msg.CellsPresentBitmap).BitAt(2))
-				recvdOut, ok := next.RecvdState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.Equal(t, true, bitfield.Bitlist(recvdOut.Available).BitAt(0))
-				require.Equal(t, true, bitfield.Bitlist(recvdOut.Available).BitAt(2))
+				require.Equal(t, true, bitfield.Bitlist(next.Recvd.Available).BitAt(0))
+				require.Equal(t, true, bitfield.Bitlist(next.Recvd.Available).BitAt(2))
 			},
 		},
 		{
@@ -650,31 +625,27 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(3, 1),
 					Requests:  testBitlist(3, allSet(3)...),
 				}
-				next, encoded, _, err := p.ForPeer(peer.ID("peer-a"), true, partialmessages.PeerState{
-					RecvdState: recvd,
+				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+					Recvd: recvd,
 				})
-				require.NoError(t, err)
-				require.IsNil(t, encoded)
-				nextRecvd, ok := next.RecvdState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.DeepEqual(t, recvd.Available, nextRecvd.Available)
-				require.DeepEqual(t, recvd.Requests, nextRecvd.Requests)
+				require.NoError(t, action.Err)
+				require.IsNil(t, action.EncodedPartialMessage)
+				require.DeepEqual(t, recvd.Available, next.Recvd.Available)
+				require.DeepEqual(t, recvd.Requests, next.Recvd.Requests)
 			},
 		},
 		{
 			name: "requested true nil SentState peer requests nothing",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0, 1, 2)
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), true, partialmessages.PeerState{
-					RecvdState: testPeerMeta(3, nil, nil), // no requests
+				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+					Recvd: testPeerMeta(3, nil, nil), // no requests
 				})
-				require.NoError(t, err)
-				require.IsNil(t, encoded) // no cells requested
-				require.NotNil(t, meta)   // partsMetadata sent because SentState was nil
-				// SentState should now reflect our availability.
-				sentState, ok := next.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.Equal(t, uint64(3), bitfield.Bitlist(sentState.Available).Count())
+				require.NoError(t, action.Err)
+				require.IsNil(t, action.EncodedPartialMessage) // no cells requested
+				require.NotNil(t, action.EncodedPartsMetadata) // partsMetadata sent because Sent was nil
+				// Sent should now reflect our availability.
+				require.Equal(t, uint64(3), bitfield.Bitlist(next.Sent.Available).Count())
 			},
 		},
 		{
@@ -682,25 +653,23 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			run: func(t *testing.T) {
 				// We have cells 0, 1, 2. Peer has none but only requests 0 and 2.
 				p := mustNewPartialColumn(t, 3, 0, 1, 2)
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), true, partialmessages.PeerState{
-					RecvdState: testPeerMeta(3, nil, []uint64{0, 2}),
+				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+					Recvd: testPeerMeta(3, nil, []uint64{0, 2}),
 				})
-				require.NoError(t, err)
-				require.NotNil(t, encoded)
-				require.NotNil(t, meta)
+				require.NoError(t, action.Err)
+				require.NotNil(t, action.EncodedPartialMessage)
+				require.NotNil(t, action.EncodedPartsMetadata)
 
-				msg := mustDecodeSidecar(t, encoded)
+				msg := mustDecodeSidecar(t, action.EncodedPartialMessage)
 				require.Equal(t, 2, len(msg.PartialColumn))
 				require.Equal(t, true, bitfield.Bitlist(msg.CellsPresentBitmap).BitAt(0))
 				require.Equal(t, false, bitfield.Bitlist(msg.CellsPresentBitmap).BitAt(1))
 				require.Equal(t, true, bitfield.Bitlist(msg.CellsPresentBitmap).BitAt(2))
 
-				// RecvdState should reflect the cells we sent.
-				recvdOut, ok := next.RecvdState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.Equal(t, true, bitfield.Bitlist(recvdOut.Available).BitAt(0))
-				require.Equal(t, false, bitfield.Bitlist(recvdOut.Available).BitAt(1))
-				require.Equal(t, true, bitfield.Bitlist(recvdOut.Available).BitAt(2))
+				// Recvd should reflect the cells we sent.
+				require.Equal(t, true, bitfield.Bitlist(next.Recvd.Available).BitAt(0))
+				require.Equal(t, false, bitfield.Bitlist(next.Recvd.Available).BitAt(1))
+				require.Equal(t, true, bitfield.Bitlist(next.Recvd.Available).BitAt(2))
 			},
 		},
 		{
@@ -708,173 +677,159 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 1)
 				myMeta := p.newPartsMetadata()
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{
-					SentState: myMeta,
+				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+					Sent: myMeta,
 				})
-				require.NoError(t, err)
-				require.IsNil(t, encoded)
-				require.IsNil(t, meta)
-				nextSent, ok := next.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.DeepEqual(t, myMeta.Available, nextSent.Available)
-				require.DeepEqual(t, myMeta.Requests, nextSent.Requests)
+				require.NoError(t, action.Err)
+				require.IsNil(t, action.EncodedPartialMessage)
+				require.IsNil(t, action.EncodedPartsMetadata)
+				require.DeepEqual(t, myMeta.Available, next.Sent.Available)
+				require.DeepEqual(t, myMeta.Requests, next.Sent.Requests)
 			},
 		},
 		{
 			name: "sentMeta available superset of ours suppresses resend",
 			run: func(t *testing.T) {
-				// We have cell 0. SentState already has cells 0 and 1
+				// We have cell 0. Sent already has cells 0 and 1
 				// (superset of our available). Requests match. No resend needed.
 				p := mustNewPartialColumn(t, 3, 0)
 				sentMeta := &ethpb.PartialDataColumnPartsMetadata{
 					Available: testBitlist(3, 0, 1),
 					Requests:  testBitlist(3, allSet(3)...), // all requested, same as newPartsMetadata
 				}
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{
-					SentState: sentMeta,
+				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+					Sent: sentMeta,
 				})
-				require.NoError(t, err)
-				require.IsNil(t, encoded)
-				require.IsNil(t, meta) // no resend because sentMeta.Available contains ours
-				nextSent, ok := next.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				// SentState unchanged because we didn't resend.
-				require.DeepEqual(t, sentMeta.Available, nextSent.Available)
+				require.NoError(t, action.Err)
+				require.IsNil(t, action.EncodedPartialMessage)
+				require.IsNil(t, action.EncodedPartsMetadata) // no resend because sentMeta.Available contains ours
+				// Sent unchanged because we didn't resend.
+				require.DeepEqual(t, sentMeta.Available, next.Sent.Available)
 			},
 		},
 		{
 			name: "sentMeta available subset triggers resend with merged available",
 			run: func(t *testing.T) {
-				// We have cells 0, 2. SentState only has cell 0.
+				// We have cells 0, 2. Sent only has cell 0.
 				// Our available has cell 2 which isn't in sentMeta, so we resend.
 				p := mustNewPartialColumn(t, 3, 0, 2)
 				sentMeta := &ethpb.PartialDataColumnPartsMetadata{
 					Available: testBitlist(3, 0),
 					Requests:  testBitlist(3, allSet(3)...),
 				}
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{
-					SentState: sentMeta,
+				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+					Sent: sentMeta,
 				})
-				require.NoError(t, err)
-				require.IsNil(t, encoded) // not requested, no cells
-				require.NotNil(t, meta)   // metadata resent because available changed
-				nextSent, ok := next.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				// SentState should be merged: old {0} | new {0,2} = {0,2}
-				require.Equal(t, true, bitfield.Bitlist(nextSent.Available).BitAt(0))
-				require.Equal(t, false, bitfield.Bitlist(nextSent.Available).BitAt(1))
-				require.Equal(t, true, bitfield.Bitlist(nextSent.Available).BitAt(2))
+				require.NoError(t, action.Err)
+				require.IsNil(t, action.EncodedPartialMessage) // not requested, no cells
+				require.NotNil(t, action.EncodedPartsMetadata) // metadata resent because available changed
+				// Sent should be merged: old {0} | new {0,2} = {0,2}
+				require.Equal(t, true, bitfield.Bitlist(next.Sent.Available).BitAt(0))
+				require.Equal(t, false, bitfield.Bitlist(next.Sent.Available).BitAt(1))
+				require.Equal(t, true, bitfield.Bitlist(next.Sent.Available).BitAt(2))
 			},
 		},
 		{
 			name: "sentMeta available merge is cumulative across calls",
 			run: func(t *testing.T) {
-				// First call: we have cell 0 only, SentState is nil.
+				// First call: we have cell 0 only, Sent is nil.
 				p := mustNewPartialColumn(t, 3, 0)
-				state1, _, meta1, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{})
-				require.NoError(t, err)
-				require.NotNil(t, meta1)
-				sent1, ok := state1.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
-				require.Equal(t, true, bitfield.Bitlist(sent1.Available).BitAt(0))
-				require.Equal(t, false, bitfield.Bitlist(sent1.Available).BitAt(1))
+				state1, action1 := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{})
+				require.NoError(t, action1.Err)
+				require.NotNil(t, action1.EncodedPartsMetadata)
+				require.Equal(t, true, bitfield.Bitlist(state1.Sent.Available).BitAt(0))
+				require.Equal(t, false, bitfield.Bitlist(state1.Sent.Available).BitAt(1))
 
 				// Acquire cell 1 between calls.
 				p.ExtendFromVerifiedCell(1, []byte{0xAA}, []byte{0xBB})
 
-				// Second call: SentState has {0}, we now have {0,1}. Should trigger resend.
-				state2, _, meta2, err := p.ForPeer(peer.ID("peer-a"), false, state1)
-				require.NoError(t, err)
-				require.NotNil(t, meta2)
-				sent2, ok := state2.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
+				// Second call: Sent has {0}, we now have {0,1}. Should trigger resend.
+				state2, action2 := p.forPeer(peer.ID("peer-a"), false, state1)
+				require.NoError(t, action2.Err)
+				require.NotNil(t, action2.EncodedPartsMetadata)
 				// Merged: {0} | {0,1} = {0,1}
-				require.Equal(t, true, bitfield.Bitlist(sent2.Available).BitAt(0))
-				require.Equal(t, true, bitfield.Bitlist(sent2.Available).BitAt(1))
-				require.Equal(t, false, bitfield.Bitlist(sent2.Available).BitAt(2))
+				require.Equal(t, true, bitfield.Bitlist(state2.Sent.Available).BitAt(0))
+				require.Equal(t, true, bitfield.Bitlist(state2.Sent.Available).BitAt(1))
+				require.Equal(t, false, bitfield.Bitlist(state2.Sent.Available).BitAt(2))
 
-				// Third call: SentState has {0,1}, we still have {0,1}. No resend.
-				_, _, meta3, err := p.ForPeer(peer.ID("peer-a"), false, state2)
-				require.NoError(t, err)
-				require.IsNil(t, meta3)
+				// Third call: Sent has {0,1}, we still have {0,1}. No resend.
+				_, action3 := p.forPeer(peer.ID("peer-a"), false, state2)
+				require.NoError(t, action3.Err)
+				require.IsNil(t, action3.EncodedPartsMetadata)
 			},
 		},
 		{
 			name: "sentMeta requests mismatch triggers resend then converges",
 			run: func(t *testing.T) {
 				// We have cell 0. Our newPartsMetadata requests all 3 cells.
-				// SentState has matching available {0} but requests only {0,1} (not all 3).
+				// Sent has matching available {0} but requests only {0,1} (not all 3).
 				p := mustNewPartialColumn(t, 3, 0)
 				sentMeta := &ethpb.PartialDataColumnPartsMetadata{
 					Available: testBitlist(3, 0),
 					Requests:  testBitlist(3, 0, 1), // mismatch: we request all 3
 				}
-				state1, _, meta1, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{
-					SentState: sentMeta,
+				state1, action1 := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+					Sent: sentMeta,
 				})
-				require.NoError(t, err)
-				require.NotNil(t, meta1) // resent because Requests differ
-				sent1, ok := state1.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
+				require.NoError(t, action1.Err)
+				require.NotNil(t, action1.EncodedPartsMetadata) // resent because Requests differ
 				// Requests should now match our current requests (all 3).
 				for i := range uint64(3) {
-					require.Equal(t, true, bitfield.Bitlist(sent1.Requests).BitAt(i))
+					require.Equal(t, true, bitfield.Bitlist(state1.Sent.Requests).BitAt(i))
 				}
 				// Available should be merged: old {0} | new {0} = {0}
-				require.Equal(t, true, bitfield.Bitlist(sent1.Available).BitAt(0))
-				require.Equal(t, false, bitfield.Bitlist(sent1.Available).BitAt(1))
+				require.Equal(t, true, bitfield.Bitlist(state1.Sent.Available).BitAt(0))
+				require.Equal(t, false, bitfield.Bitlist(state1.Sent.Available).BitAt(1))
 
-				// Second call with corrected SentState should converge (no resend).
-				_, _, meta2, err := p.ForPeer(peer.ID("peer-a"), false, state1)
-				require.NoError(t, err)
-				require.IsNil(t, meta2) // converged, no resend
+				// Second call with corrected Sent should converge (no resend).
+				_, action2 := p.forPeer(peer.ID("peer-a"), false, state1)
+				require.NoError(t, action2.Err)
+				require.IsNil(t, action2.EncodedPartsMetadata) // converged, no resend
 			},
 		},
 		{
 			name: "sentMeta with mismatched available length returns error",
 			run: func(t *testing.T) {
-				// SentState.Available has length 2, but our column has 3 commitments.
+				// Sent.Available has length 2, but our column has 3 commitments.
 				// Contains() should error on length mismatch.
 				p := mustNewPartialColumn(t, 3, 0)
 				sentMeta := &ethpb.PartialDataColumnPartsMetadata{
 					Available: testBitlist(2, 0),
 					Requests:  testBitlist(3, allSet(3)...), // Requests match length so we reach Contains check
 				}
-				_, _, _, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{
-					SentState: sentMeta,
+				_, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+					Sent: sentMeta,
 				})
-				require.ErrorContains(t, "different lengths", err)
+				require.ErrorContains(t, "different lengths", action.Err)
 			},
 		},
 		{
 			name: "requested true with existing sentMeta merges available on resend",
 			run: func(t *testing.T) {
-				// We have cells 0,1,2. SentState has available {0} and all requests.
+				// We have cells 0,1,2. Sent has available {0} and all requests.
 				// recvdMeta peer has nothing and requests everything.
 				// This tests that both cell sending and metadata resending work together,
-				// and that SentState merges correctly when cells are also being sent.
+				// and that Sent merges correctly when cells are also being sent.
 				p := mustNewPartialColumn(t, 3, 0, 1, 2)
 				sentMeta := &ethpb.PartialDataColumnPartsMetadata{
 					Available: testBitlist(3, 0),
 					Requests:  testBitlist(3, allSet(3)...),
 				}
 				recvdMeta := testPeerMeta(3, nil, allSet(3))
-				next, encoded, meta, err := p.ForPeer(peer.ID("peer-a"), true, partialmessages.PeerState{
-					SentState:  sentMeta,
-					RecvdState: recvdMeta,
+				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+					Sent:  sentMeta,
+					Recvd: recvdMeta,
 				})
-				require.NoError(t, err)
-				require.NotNil(t, encoded) // cells sent to peer
-				require.NotNil(t, meta)    // metadata resent because available changed
+				require.NoError(t, action.Err)
+				require.NotNil(t, action.EncodedPartialMessage) // cells sent to peer
+				require.NotNil(t, action.EncodedPartsMetadata)  // metadata resent because available changed
 
-				msg := mustDecodeSidecar(t, encoded)
+				msg := mustDecodeSidecar(t, action.EncodedPartialMessage)
 				require.Equal(t, 3, len(msg.PartialColumn))
 
-				nextSent, ok := next.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, ok)
 				// Merged available: {0} | {0,1,2} = {0,1,2}
 				for i := range uint64(3) {
-					require.Equal(t, true, bitfield.Bitlist(nextSent.Available).BitAt(i))
+					require.Equal(t, true, bitfield.Bitlist(next.Sent.Available).BitAt(i))
 				}
 			},
 		},
@@ -888,11 +843,11 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(4, 0, 1), // same as ours
 					Requests:  testBitlist(4, 0, 1), // only 2 requests
 				}
-				_, _, meta, err := p.ForPeer(peer.ID("peer-a"), false, partialmessages.PeerState{
-					SentState: sentMeta,
+				_, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+					Sent: sentMeta,
 				})
-				require.NoError(t, err)
-				require.NotNil(t, meta) // resent because Requests differ (we request all 4)
+				require.NoError(t, action.Err)
+				require.NotNil(t, action.EncodedPartsMetadata) // resent because Requests differ (we request all 4)
 			},
 		},
 	}
@@ -1116,29 +1071,29 @@ func TestPartialDataColumn_ExtendFromVerifiedCells(t *testing.T) {
 func TestClonePeerState(t *testing.T) {
 	tests := []struct {
 		name  string
-		input partialmessages.PeerState
+		input PartialDataColumnPeerState
 	}{
 		{
 			name:  "both nil",
-			input: partialmessages.PeerState{},
+			input: PartialDataColumnPeerState{},
 		},
 		{
-			name: "nil RecvdState",
-			input: partialmessages.PeerState{
-				SentState: testPeerMeta(4, []uint64{1}, allSet(4)),
+			name: "nil Recvd",
+			input: PartialDataColumnPeerState{
+				Sent: testPeerMeta(4, []uint64{1}, allSet(4)),
 			},
 		},
 		{
-			name: "nil SentState",
-			input: partialmessages.PeerState{
-				RecvdState: testPeerMeta(4, []uint64{0, 2}, allSet(4)),
+			name: "nil Sent",
+			input: PartialDataColumnPeerState{
+				Recvd: testPeerMeta(4, []uint64{0, 2}, allSet(4)),
 			},
 		},
 		{
 			name: "both set",
-			input: partialmessages.PeerState{
-				RecvdState: testPeerMeta(4, []uint64{0}, allSet(4)),
-				SentState:  testPeerMeta(4, []uint64{1, 3}, allSet(4)),
+			input: PartialDataColumnPeerState{
+				Recvd: testPeerMeta(4, []uint64{0}, allSet(4)),
+				Sent:  testPeerMeta(4, []uint64{1, 3}, allSet(4)),
 			},
 		},
 	}
@@ -1156,20 +1111,16 @@ func TestClonePeerState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cloned := ClonePeerState(tt.input)
 
-			if origRecvd, ok := tt.input.RecvdState.(*ethpb.PartialDataColumnPartsMetadata); ok {
-				clonedRecvd, cloneOk := cloned.RecvdState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, cloneOk)
-				assertMetaCloned(t, origRecvd, clonedRecvd)
+			if tt.input.Recvd != nil {
+				assertMetaCloned(t, tt.input.Recvd, cloned.Recvd)
 			} else {
-				require.IsNil(t, cloned.RecvdState)
+				require.IsNil(t, cloned.Recvd)
 			}
 
-			if origSent, ok := tt.input.SentState.(*ethpb.PartialDataColumnPartsMetadata); ok {
-				clonedSent, cloneOk := cloned.SentState.(*ethpb.PartialDataColumnPartsMetadata)
-				require.Equal(t, true, cloneOk)
-				assertMetaCloned(t, origSent, clonedSent)
+			if tt.input.Sent != nil {
+				assertMetaCloned(t, tt.input.Sent, cloned.Sent)
 			} else {
-				require.IsNil(t, cloned.SentState)
+				require.IsNil(t, cloned.Sent)
 			}
 		})
 	}

--- a/deps.bzl
+++ b/deps.bzl
@@ -1929,8 +1929,8 @@ def prysm_deps():
         name = "com_github_libp2p_go_libp2p_pubsub",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/libp2p/go-libp2p-pubsub",
-        sum = "h1:rv9cHqvl7YV38hl637gTwPOfeWO8FjO5XScpJ5cKm1U=",
-        version = "v0.15.1-0.20260213050207-d8f500417dc9",
+        sum = "h1:Fy44dIDY1aBEJVIvXdT5A1VUU0tKEo95sSicWFlZIfU=",
+        version = "v0.15.1-0.20260304214010-30edef80aae7",
     )
     go_repository(
         name = "com_github_libp2p_go_libp2p_testing",

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/libp2p/go-libp2p v0.44.0
 	github.com/libp2p/go-libp2p-mplex v0.11.0
-	github.com/libp2p/go-libp2p-pubsub v0.15.1-0.20260213050207-d8f500417dc9
+	github.com/libp2p/go-libp2p-pubsub v0.15.1-0.20260304214010-30edef80aae7
 	github.com/libp2p/go-mplex v0.7.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl9
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
 github.com/libp2p/go-libp2p-mplex v0.11.0 h1:0vwpLXRSfkTzshEjETIEgJaVxXvg+orbxYoIb3Ty5qM=
 github.com/libp2p/go-libp2p-mplex v0.11.0/go.mod h1:QrsdNY3lzjpdo9V1goJfPb0O65Nms0sUR8CDAO18f6k=
-github.com/libp2p/go-libp2p-pubsub v0.15.1-0.20260213050207-d8f500417dc9 h1:rv9cHqvl7YV38hl637gTwPOfeWO8FjO5XScpJ5cKm1U=
-github.com/libp2p/go-libp2p-pubsub v0.15.1-0.20260213050207-d8f500417dc9/go.mod h1:lr4oE8bFgQaifRcoc2uWhWWiK6tPdOEKpUuR408GFN4=
+github.com/libp2p/go-libp2p-pubsub v0.15.1-0.20260304214010-30edef80aae7 h1:Fy44dIDY1aBEJVIvXdT5A1VUU0tKEo95sSicWFlZIfU=
+github.com/libp2p/go-libp2p-pubsub v0.15.1-0.20260304214010-30edef80aae7/go.mod h1:lr4oE8bFgQaifRcoc2uWhWWiK6tPdOEKpUuR408GFN4=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-mplex v0.7.0 h1:BDhFZdlk5tbr0oyFq/xv/NPGfjbnrsDam1EvutpBDbY=


### PR DESCRIPTION
@aarshkshah1992 

This updates usages of the gossipsub partial message api. The biggest change is:

1. Gossipsub now uses generics for the PeerState, so no more type assertions everywhere.
2. We simplified the interface to a single function `PublishActionsFn`
3. Gossiping partial message state has changed. The library tells the application it should gossip, and the application calls PublishPartial to do the actual gossip.

This is just the minimal change. There are likely more simplifications that can be made with the direct type.

There may also be a faster way of implementing the PublishActionsFn as well. Something like tracking the "generation" of your current partial column state and checking if the peerState has been evaluated for the current generation. Then you can skip peers with just one check.