### PR TITLE
Fix file descriptor leaks in `CopyFile`

### DIFF
--- a/changelog/syjn99_fix-copy-file-descriptor-leak.md
+++ b/changelog/syjn99_fix-copy-file-descriptor-leak.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix file descriptor leaks in `CopyFile`: close both source and destination files with deferred close.

--- a/io/file/fileutil.go
+++ b/io/file/fileutil.go
@@ -249,7 +249,7 @@ func ReadFileAsBytes(filename string) ([]byte, error) {
 }
 
 // CopyFile copy a file from source to destination path.
-func CopyFile(src, dst string) error {
+func CopyFile(src, dst string) (err error) {
 	exists, err := Exists(src, Regular)
 	if err != nil {
 		return errors.Wrapf(err, "could not check if file exists at path %s", src)
@@ -262,10 +262,20 @@ func CopyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, params.BeaconIoConfig().ReadWritePermissions) // #nosec G304
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if closeErr := dstFile.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 	_, err = io.Copy(dstFile, f)
 	return err
 }


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Close file descriptors for both source/destination files in `CopyFile` function.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
