### PR TITLE
Add `Close()` call for resources (http response, file descriptor) in e2e package

### DIFF
--- a/changelog/syjn99_e2e-resource-leaks.md
+++ b/changelog/syjn99_e2e-resource-leaks.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix unclosed HTTP response bodies and file descriptors in E2E test infrastructure

--- a/testing/endtoend/components/web3remotesigner.go
+++ b/testing/endtoend/components/web3remotesigner.go
@@ -148,10 +148,12 @@ func (w *Web3RemoteSigner) monitorStart() {
 			panic(err)
 		}
 		res, err := client.Do(req)
-		_ = err
-		if res != nil && res.StatusCode == http.StatusOK {
-			close(w.started)
-			return
+		if err == nil && res != nil {
+			_ = res.Body.Close()
+			if res.StatusCode == http.StatusOK {
+				close(w.started)
+				return
+			}
 		}
 		time.Sleep(time.Second)
 	}
@@ -181,6 +183,7 @@ func (w *Web3RemoteSigner) PublicKeys(ctx context.Context) ([]bls.PublicKey, err
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("returned status code %d", res.StatusCode)
 	}

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -164,6 +164,7 @@ func (r *testRunner) waitForChainStart() {
 	time.Sleep(time.Duration(params.BeaconConfig().GenesisDelay) * time.Second)
 	beaconLogFile, err := os.Open(path.Join(e2e.TestParams.LogPath, fmt.Sprintf(e2e.BeaconNodeLogFileName, 0)))
 	require.NoError(r.t, err)
+	defer func() { _ = beaconLogFile.Close() }()
 
 	r.t.Run("chain started", func(t *testing.T) {
 		require.NoError(t, helpers.WaitForTextInFile(beaconLogFile, "Chain started in sync service"), "Chain did not start")
@@ -397,6 +398,7 @@ func (r *testRunner) testBeaconChainSync(ctx context.Context, g *errgroup.Group,
 
 	syncLogFile, err := os.Open(path.Join(e2e.TestParams.LogPath, fmt.Sprintf(e2e.BeaconNodeLogFileName, index)))
 	require.NoError(t, err)
+	defer func() { _ = syncLogFile.Close() }()
 	defer helpers.LogErrorOutput(t, syncLogFile, "beacon chain node", index)
 	t.Run("sync completed", func(t *testing.T) {
 		assert.NoError(t, helpers.WaitForTextInFile(syncLogFile, "Synced up to"), "Failed to sync")
@@ -447,6 +449,7 @@ func (r *testRunner) testDoppelGangerProtection(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to open log file: %w", err)
 	}
+	defer func() { _ = logFile.Close() }()
 	r.t.Run("doppelganger found", func(t *testing.T) {
 		assert.NoError(t, helpers.WaitForTextInFile(logFile, "Duplicate instances exists in the network for validator keys"), "Failed to carry out doppelganger check correctly")
 	})

--- a/testing/endtoend/evaluators/beaconapi/util.go
+++ b/testing/endtoend/evaluators/beaconapi/util.go
@@ -45,6 +45,7 @@ func doJSONGETRequest(template, requestPath string, beaconNodeIdx int, resp any,
 	if err != nil {
 		return errors.Wrap(err, "request failed")
 	}
+	defer closeBody(httpResp.Body)
 
 	var body any
 	if httpResp.StatusCode != http.StatusOK {
@@ -53,7 +54,6 @@ func doJSONGETRequest(template, requestPath string, beaconNodeIdx int, resp any,
 				return errors.Wrap(err, "failed to decode response body")
 			}
 		} else {
-			defer closeBody(httpResp.Body)
 			body, err = io.ReadAll(httpResp.Body)
 			if err != nil {
 				return errors.Wrap(err, "failed to read response body")
@@ -94,6 +94,7 @@ func doSSZGETRequest(template, requestPath string, beaconNodeIdx int, bnType ...
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}
+	defer closeBody(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		var body any
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
@@ -101,7 +102,6 @@ func doSSZGETRequest(template, requestPath string, beaconNodeIdx int, bnType ...
 		}
 		return nil, fmt.Errorf(msgRequestFailed, bnType[0], resp.StatusCode, body)
 	}
-	defer closeBody(resp.Body)
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
@@ -138,6 +138,7 @@ func doJSONPOSTRequest(template, requestPath string, beaconNodeIdx int, postObj,
 	if err != nil {
 		return errors.Wrap(err, "request failed")
 	}
+	defer closeBody(httpResp.Body)
 
 	var body any
 	if httpResp.StatusCode != http.StatusOK {
@@ -146,7 +147,6 @@ func doJSONPOSTRequest(template, requestPath string, beaconNodeIdx int, postObj,
 				return errors.Wrap(err, "failed to decode response body")
 			}
 		} else {
-			defer closeBody(httpResp.Body)
 			body, err = io.ReadAll(httpResp.Body)
 			if err != nil {
 				return errors.Wrap(err, "failed to read response body")
@@ -192,6 +192,7 @@ func doSSZPOSTRequest(template, requestPath string, beaconNodeIdx int, postObj a
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}
+	defer closeBody(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		var body any
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
@@ -199,7 +200,6 @@ func doSSZPOSTRequest(template, requestPath string, beaconNodeIdx int, postObj a
 		}
 		return nil, fmt.Errorf(msgRequestFailed, bnType[0], resp.StatusCode, body)
 	}
-	defer closeBody(resp.Body)
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")

--- a/testing/endtoend/evaluators/beaconapi/verify.go
+++ b/testing/endtoend/evaluators/beaconapi/verify.go
@@ -219,6 +219,7 @@ func postEvaluation(nodeIdx int, requests map[string]endpoint, epoch primitives.
 	if err != nil {
 		return errors.Wrap(err, "could not perform a health check")
 	}
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("health check response's status code is %d", resp.StatusCode)
 	}

--- a/testing/endtoend/evaluators/execution_engine.go
+++ b/testing/endtoend/evaluators/execution_engine.go
@@ -33,6 +33,7 @@ func optimisticSyncEnabled(_ *types.EvaluationContext, conns ...*grpc.ClientConn
 		if err != nil {
 			return err
 		}
+		defer func() { _ = httpResp.Body.Close() }()
 		if httpResp.StatusCode != http.StatusOK {
 			e := httputil.DefaultJsonError{}
 			if err = json.NewDecoder(httpResp.Body).Decode(&e); err != nil {
@@ -59,6 +60,7 @@ func optimisticSyncEnabled(_ *types.EvaluationContext, conns ...*grpc.ClientConn
 			if err != nil {
 				return err
 			}
+			defer func() { _ = httpResp.Body.Close() }()
 			if httpResp.StatusCode == http.StatusNotFound {
 				// Continue in the event of non-existent blocks.
 				continue

--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -155,6 +155,7 @@ func validatorsParticipating(_ *types.EvaluationContext, conns ...*grpc.ClientCo
 		if err != nil {
 			return err
 		}
+		defer func() { _ = httpResp.Body.Close() }()
 		if httpResp.StatusCode != http.StatusOK {
 			e := httputil.DefaultJsonError{}
 			if err = json.NewDecoder(httpResp.Body).Decode(&e); err != nil {

--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -211,12 +211,14 @@ func LogOutput(t *testing.T) {
 			t.Fatal(err)
 		}
 		LogErrorOutput(t, beaconLogFile, "beacon chain node", i)
+		_ = beaconLogFile.Close()
 
 		validatorLogFile, err := os.Open(path.Join(e2e.TestParams.LogPath, fmt.Sprintf(e2e.ValidatorLogFileName, i)))
 		if err != nil {
 			t.Fatal(err)
 		}
 		LogErrorOutput(t, validatorLogFile, "validator client", i)
+		_ = validatorLogFile.Close()
 	}
 
 	t.Logf("Ending time: %s\n", time.Now().String())
@@ -277,10 +279,10 @@ func writeURLRespAtPath(url, fp string) error {
 	}
 
 	file, err := os.Create(filepath.Clean(fp))
-
 	if err != nil {
 		return err
 	}
+	defer func() { _ = file.Close() }()
 	if _, err = file.Write(body); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Some resources in e2e package didn't get closed after usage.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
