### PR TITLE
operations/payloadattestation: add PTC attestation pool

### DIFF
--- a/beacon-chain/operations/payloadattestation/BUILD.bazel
+++ b/beacon-chain/operations/payloadattestation/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pool.go"],
+    importpath = "github.com/OffchainLabs/prysm/v7/beacon-chain/operations/payloadattestation",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config/fieldparams:go_default_library",
+        "//consensus-types/primitives:go_default_library",
+        "//crypto/bls:go_default_library",
+        "//encoding/bytesutil:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["pool_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//consensus-types/primitives:go_default_library",
+        "//crypto/bls:go_default_library",
+        "//crypto/hash:go_default_library",
+        "//encoding/bytesutil:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
+        "//testing/assert:go_default_library",
+        "//testing/require:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+    ],
+)

--- a/beacon-chain/operations/payloadattestation/BUILD.bazel
+++ b/beacon-chain/operations/payloadattestation/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     srcs = ["pool_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//config/fieldparams:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//crypto/bls:go_default_library",
         "//crypto/hash:go_default_library",

--- a/beacon-chain/operations/payloadattestation/pool.go
+++ b/beacon-chain/operations/payloadattestation/pool.go
@@ -1,0 +1,184 @@
+package payloadattestation
+
+import (
+	"sync"
+
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/crypto/bls"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/pkg/errors"
+)
+
+var errNilPayloadAttestationMessage = errors.New("nil payload attestation message")
+
+type payloadAttestationDataKey struct {
+	beaconBlockRoot   [32]byte
+	slot              primitives.Slot
+	payloadPresent    bool
+	blobDataAvailable bool
+}
+
+// PoolManager manages pending, aggregated payload attestations keyed by
+// payload-attestation data.
+type PoolManager interface {
+	// PendingPayloadAttestations consumes and returns pending attestations for
+	// the requested slot. It also prunes stale entries with slot lower than the
+	// requested slot.
+	PendingPayloadAttestations(slot primitives.Slot) []*ethpb.PayloadAttestation
+	// InsertPayloadAttestation inserts or aggregates a payload attestation
+	// message into the pool. The idx parameter is the PTC committee index
+	// of the validator (position in the bitvector).
+	InsertPayloadAttestation(msg *ethpb.PayloadAttestationMessage, idx uint64) error
+	// Seen returns true if the PTC committee index has already been seen
+	// for the given PayloadAttestationData.
+	Seen(data *ethpb.PayloadAttestationData, idx uint64) bool
+}
+
+// Pool is an in-memory implementation of PoolManager.
+// Entries are keyed by payload-attestation data fields and store an aggregated
+// PayloadAttestation value.
+type Pool struct {
+	lock    sync.RWMutex
+	pending map[payloadAttestationDataKey]*ethpb.PayloadAttestation
+}
+
+// NewPool returns an initialized pool.
+func NewPool() *Pool {
+	return &Pool{
+		pending: make(map[payloadAttestationDataKey]*ethpb.PayloadAttestation),
+	}
+}
+
+// PendingPayloadAttestations consumes and returns payload attestations for the
+// requested slot, and prunes older slots.
+func (p *Pool) PendingPayloadAttestations(slot primitives.Slot) []*ethpb.PayloadAttestation {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	result := make([]*ethpb.PayloadAttestation, 0, len(p.pending))
+	for key, att := range p.pending {
+		if att == nil || att.Data == nil {
+			delete(p.pending, key)
+			continue
+		}
+		switch {
+		case att.Data.Slot < slot:
+			delete(p.pending, key)
+		case att.Data.Slot == slot:
+			result = append(result, att)
+			delete(p.pending, key)
+		default:
+			continue
+		}
+	}
+	return result
+}
+
+// InsertPayloadAttestation inserts a payload attestation message into the pool.
+// If an attestation with matching data already exists, it aggregates the BLS
+// signature and sets the aggregation bit for idx.
+// idx is the validator's position in the PTC committee bitfield.
+func (p *Pool) InsertPayloadAttestation(msg *ethpb.PayloadAttestationMessage, idx uint64) error {
+	if msg == nil || msg.Data == nil {
+		return errNilPayloadAttestationMessage
+	}
+
+	key, err := dataKey(msg.Data)
+	if err != nil {
+		return errors.Wrap(err, "could not compute data key")
+	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	existing, ok := p.pending[key]
+	if !ok {
+		p.pending[key] = messageToPayloadAttestation(msg, idx)
+		return nil
+	}
+
+	if existing.AggregationBits.BitAt(idx) {
+		return nil
+	}
+
+	sig, err := aggregateSigFromMessage(existing, msg)
+	if err != nil {
+		return errors.Wrap(err, "could not aggregate signatures")
+	}
+	existing.Signature = sig
+	existing.AggregationBits.SetBitAt(idx, true)
+	return nil
+}
+
+// Seen reports whether idx has already been observed for the given
+// PayloadAttestationData.
+func (p *Pool) Seen(data *ethpb.PayloadAttestationData, idx uint64) bool {
+	if data == nil {
+		return false
+	}
+
+	key, err := dataKey(data)
+	if err != nil {
+		return false
+	}
+
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	existing, ok := p.pending[key]
+	if !ok {
+		return false
+	}
+	return existing.AggregationBits.BitAt(idx)
+}
+
+// messageToPayloadAttestation creates an aggregated PayloadAttestation with a
+// single bit set at idx from msg.
+func messageToPayloadAttestation(msg *ethpb.PayloadAttestationMessage, idx uint64) *ethpb.PayloadAttestation {
+	bits := ethpb.NewPayloadAttestationAggregationBits()
+	bits.SetBitAt(idx, true)
+	data := &ethpb.PayloadAttestationData{
+		BeaconBlockRoot:   bytesutil.SafeCopyBytes(msg.Data.BeaconBlockRoot),
+		Slot:              msg.Data.Slot,
+		PayloadPresent:    msg.Data.PayloadPresent,
+		BlobDataAvailable: msg.Data.BlobDataAvailable,
+	}
+	return &ethpb.PayloadAttestation{
+		AggregationBits: bits,
+		Data:            data,
+		Signature:       bytesutil.SafeCopyBytes(msg.Signature),
+	}
+}
+
+// aggregateSigFromMessage aggregates the existing signature with the new
+// message signature.
+func aggregateSigFromMessage(aggregated *ethpb.PayloadAttestation, message *ethpb.PayloadAttestationMessage) ([]byte, error) {
+	aggSig, err := bls.SignatureFromBytesNoValidation(aggregated.Signature)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := bls.SignatureFromBytesNoValidation(message.Signature)
+	if err != nil {
+		return nil, err
+	}
+	return bls.AggregateSignatures([]bls.Signature{aggSig, sig}).Marshal(), nil
+}
+
+// dataKey derives the map key directly from PayloadAttestationData fields.
+// BeaconBlockRoot must be 32 bytes.
+func dataKey(data *ethpb.PayloadAttestationData) (payloadAttestationDataKey, error) {
+	if data == nil {
+		return payloadAttestationDataKey{}, errNilPayloadAttestationMessage
+	}
+	if len(data.BeaconBlockRoot) != fieldparams.RootLength {
+		return payloadAttestationDataKey{}, errors.Errorf("invalid beacon block root length: %d", len(data.BeaconBlockRoot))
+	}
+	return payloadAttestationDataKey{
+		beaconBlockRoot:   bytesutil.ToBytes32(data.BeaconBlockRoot),
+		slot:              data.Slot,
+		payloadPresent:    data.PayloadPresent,
+		blobDataAvailable: data.BlobDataAvailable,
+	}, nil
+}

--- a/beacon-chain/operations/payloadattestation/pool.go
+++ b/beacon-chain/operations/payloadattestation/pool.go
@@ -24,8 +24,7 @@ type payloadAttestationDataKey struct {
 // payload-attestation data.
 type PoolManager interface {
 	// PendingPayloadAttestations consumes and returns pending attestations for
-	// the requested slot. It also prunes stale entries with slot lower than the
-	// requested slot.
+	// the requested slot.
 	PendingPayloadAttestations(slot primitives.Slot) []*ethpb.PayloadAttestation
 	// InsertPayloadAttestation inserts or aggregates a payload attestation
 	// message into the pool. The idx parameter is the PTC committee index
@@ -52,7 +51,7 @@ func NewPool() *Pool {
 }
 
 // PendingPayloadAttestations consumes and returns payload attestations for the
-// requested slot, and prunes older slots.
+// requested slot.
 func (p *Pool) PendingPayloadAttestations(slot primitives.Slot) []*ethpb.PayloadAttestation {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -63,14 +62,9 @@ func (p *Pool) PendingPayloadAttestations(slot primitives.Slot) []*ethpb.Payload
 			delete(p.pending, key)
 			continue
 		}
-		switch {
-		case att.Data.Slot < slot:
-			delete(p.pending, key)
-		case att.Data.Slot == slot:
+		if att.Data.Slot == slot {
 			result = append(result, att)
 			delete(p.pending, key)
-		default:
-			continue
 		}
 	}
 	return result
@@ -79,10 +73,14 @@ func (p *Pool) PendingPayloadAttestations(slot primitives.Slot) []*ethpb.Payload
 // InsertPayloadAttestation inserts a payload attestation message into the pool.
 // If an attestation with matching data already exists, it aggregates the BLS
 // signature and sets the aggregation bit for idx.
-// idx is the validator's position in the PTC committee bitfield.
+// idx is the validator's position in the PTC committee bitfield. It also prunes
+// stale entries with slot lower than msg.Data.Slot.
 func (p *Pool) InsertPayloadAttestation(msg *ethpb.PayloadAttestationMessage, idx uint64) error {
 	if msg == nil || msg.Data == nil {
 		return errNilPayloadAttestationMessage
+	}
+	if idx >= uint64(fieldparams.PTCSize) {
+		return errors.Errorf("invalid payload attestation committee index: %d", idx)
 	}
 
 	key, err := dataKey(msg.Data)
@@ -92,6 +90,8 @@ func (p *Pool) InsertPayloadAttestation(msg *ethpb.PayloadAttestationMessage, id
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
+	p.pruneOlderSlotsLocked(msg.Data.Slot)
 
 	existing, ok := p.pending[key]
 	if !ok {
@@ -110,6 +110,14 @@ func (p *Pool) InsertPayloadAttestation(msg *ethpb.PayloadAttestationMessage, id
 	existing.Signature = sig
 	existing.AggregationBits.SetBitAt(idx, true)
 	return nil
+}
+
+func (p *Pool) pruneOlderSlotsLocked(slot primitives.Slot) {
+	for key, att := range p.pending {
+		if att == nil || att.Data == nil || att.Data.Slot < slot {
+			delete(p.pending, key)
+		}
+	}
 }
 
 // Seen reports whether idx has already been observed for the given

--- a/beacon-chain/operations/payloadattestation/pool_test.go
+++ b/beacon-chain/operations/payloadattestation/pool_test.go
@@ -1,0 +1,354 @@
+package payloadattestation
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/crypto/bls"
+	"github.com/OffchainLabs/prysm/v7/crypto/hash"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	benchmarkPayloadAttestationDataHashSink   [32]byte
+	benchmarkPayloadAttestationDataStructSink payloadAttestationDataKey
+)
+
+func TestPool_PendingPayloadAttestations(t *testing.T) {
+	t.Run("empty pool", func(t *testing.T) {
+		pool := NewPool()
+		atts := pool.PendingPayloadAttestations(primitives.Slot(0))
+		assert.Equal(t, 0, len(atts))
+		assert.Equal(t, 0, pendingCount(pool))
+	})
+
+	t.Run("returns requested slot and prunes lower slots", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		msg1 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		msg2 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 1,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              2,
+				PayloadPresent:    false,
+				BlobDataAvailable: true,
+			},
+			Signature: sig,
+		}
+		require.NoError(t, pool.InsertPayloadAttestation(msg1, 0))
+		require.NoError(t, pool.InsertPayloadAttestation(msg2, 1))
+		atts := pool.PendingPayloadAttestations(primitives.Slot(2))
+		assert.Equal(t, 1, len(atts))
+		assert.Equal(t, primitives.Slot(2), atts[0].Data.Slot)
+		assert.Equal(t, 0, pendingCount(pool))
+	})
+
+	t.Run("slot filtering keeps future entries", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		msg1 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		msg2 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 1,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              2,
+				PayloadPresent:    false,
+				BlobDataAvailable: true,
+			},
+			Signature: sig,
+		}
+		require.NoError(t, pool.InsertPayloadAttestation(msg1, 0))
+		require.NoError(t, pool.InsertPayloadAttestation(msg2, 1))
+
+		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
+		assert.Equal(t, 1, len(atts))
+		assert.Equal(t, primitives.Slot(1), atts[0].Data.Slot)
+		assert.Equal(t, 1, pendingCount(pool))
+
+		atts = pool.PendingPayloadAttestations(primitives.Slot(2))
+		assert.Equal(t, 1, len(atts))
+		assert.Equal(t, primitives.Slot(2), atts[0].Data.Slot)
+		assert.Equal(t, 0, pendingCount(pool))
+
+		atts = pool.PendingPayloadAttestations(primitives.Slot(99))
+		assert.Equal(t, 0, len(atts))
+		assert.Equal(t, 0, pendingCount(pool))
+	})
+
+	t.Run("future slot request prunes all lower slots", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		msg1 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   bytesutil.PadTo([]byte("r1"), 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		msg2 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 1,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   bytesutil.PadTo([]byte("r2"), 32),
+				Slot:              2,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		require.NoError(t, pool.InsertPayloadAttestation(msg1, 0))
+		require.NoError(t, pool.InsertPayloadAttestation(msg2, 1))
+
+		atts := pool.PendingPayloadAttestations(primitives.Slot(10))
+		assert.Equal(t, 0, len(atts))
+		assert.Equal(t, 0, pendingCount(pool))
+	})
+}
+
+func TestPool_InsertPayloadAttestation(t *testing.T) {
+	t.Run("nil message", func(t *testing.T) {
+		pool := NewPool()
+		err := pool.InsertPayloadAttestation(nil, 0)
+		require.ErrorContains(t, "nil payload attestation message", err)
+	})
+
+	t.Run("nil data", func(t *testing.T) {
+		pool := NewPool()
+		err := pool.InsertPayloadAttestation(&ethpb.PayloadAttestationMessage{}, 0)
+		require.ErrorContains(t, "nil payload attestation message", err)
+	})
+
+	t.Run("invalid beacon block root length", func(t *testing.T) {
+		pool := NewPool()
+		msg := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   []byte{0x01, 0x02}, // invalid length
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: bls.NewAggregateSignature().Marshal(),
+		}
+		err := pool.InsertPayloadAttestation(msg, 0)
+		require.ErrorContains(t, "invalid beacon block root length", err)
+		assert.Equal(t, 0, pendingCount(pool))
+	})
+
+	t.Run("insert creates new entry with correct aggregation bit", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		idx := uint64(5)
+		msg := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		require.NoError(t, pool.InsertPayloadAttestation(msg, idx))
+		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
+		require.Equal(t, 1, len(atts))
+		assert.Equal(t, true, atts[0].AggregationBits.BitAt(idx))
+		assert.Equal(t, false, atts[0].AggregationBits.BitAt(idx+1))
+	})
+
+	t.Run("duplicate index is no-op", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		idx := uint64(3)
+		msg := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		require.NoError(t, pool.InsertPayloadAttestation(msg, idx))
+		key, err := dataKey(msg.Data)
+		require.NoError(t, err)
+		firstSig := bytesutil.SafeCopyBytes(pool.pending[key].Signature)
+
+		require.NoError(t, pool.InsertPayloadAttestation(msg, idx))
+		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
+		require.Equal(t, 1, len(atts))
+		assert.DeepEqual(t, firstSig, atts[0].Signature)
+	})
+
+	t.Run("aggregates different indices", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		root := make([]byte, 32)
+		root[0] = 'r'
+		data := &ethpb.PayloadAttestationData{
+			BeaconBlockRoot:   root,
+			Slot:              1,
+			PayloadPresent:    true,
+			BlobDataAvailable: false,
+		}
+		msg1 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data:           data,
+			Signature:      sig,
+		}
+		msg2 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 1,
+			Data:           data,
+			Signature:      sig,
+		}
+
+		require.NoError(t, pool.InsertPayloadAttestation(msg1, 5))
+		require.NoError(t, pool.InsertPayloadAttestation(msg2, 7))
+
+		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
+		require.Equal(t, 1, len(atts))
+		assert.Equal(t, true, atts[0].AggregationBits.BitAt(5))
+		assert.Equal(t, true, atts[0].AggregationBits.BitAt(7))
+		assert.Equal(t, false, atts[0].AggregationBits.BitAt(6))
+	})
+
+	t.Run("different data creates separate entries", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		msg1 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		msg2 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 1,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              1,
+				PayloadPresent:    false, // different
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		require.NoError(t, pool.InsertPayloadAttestation(msg1, 0))
+		require.NoError(t, pool.InsertPayloadAttestation(msg2, 1))
+		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
+		assert.Equal(t, 2, len(atts))
+	})
+}
+
+func TestPool_Seen(t *testing.T) {
+	pool := NewPool()
+	sig := bls.NewAggregateSignature().Marshal()
+	data := &ethpb.PayloadAttestationData{
+		BeaconBlockRoot:   make([]byte, 32),
+		Slot:              1,
+		PayloadPresent:    true,
+		BlobDataAvailable: false,
+	}
+
+	assert.Equal(t, false, pool.Seen(data, 5))
+
+	msg := &ethpb.PayloadAttestationMessage{
+		ValidatorIndex: 0,
+		Data:           data,
+		Signature:      sig,
+	}
+	require.NoError(t, pool.InsertPayloadAttestation(msg, 5))
+
+	assert.Equal(t, true, pool.Seen(data, 5))
+	assert.Equal(t, false, pool.Seen(data, 6))
+	assert.Equal(t, false, pool.Seen(nil, 5))
+
+	assert.Equal(t, false, pool.Seen(&ethpb.PayloadAttestationData{
+		BeaconBlockRoot: []byte{0x01}, // invalid
+		Slot:            1,
+	}, 5))
+}
+
+func pendingCount(pool *Pool) int {
+	pool.lock.RLock()
+	defer pool.lock.RUnlock()
+	return len(pool.pending)
+}
+
+func BenchmarkPayloadAttestationDataKeyStrategies(b *testing.B) {
+	data := &ethpb.PayloadAttestationData{
+		BeaconBlockRoot:   bytesutil.PadTo([]byte("benchmark-root"), 32),
+		Slot:              primitives.Slot(12345),
+		PayloadPresent:    true,
+		BlobDataAvailable: true,
+	}
+
+	b.Run("protoMarshal", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			key, err := dataKeyProtoMarshal(data)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkPayloadAttestationDataHashSink = key
+		}
+	})
+
+	b.Run("ssz", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			key, err := data.HashTreeRoot()
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkPayloadAttestationDataHashSink = key
+		}
+	})
+
+	b.Run("struct", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			key, err := dataKey(data)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkPayloadAttestationDataStructSink = key
+		}
+	})
+}
+
+func dataKeyProtoMarshal(data *ethpb.PayloadAttestationData) ([32]byte, error) {
+	enc, err := proto.Marshal(data)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return hash.Hash(enc), nil
+}

--- a/beacon-chain/operations/payloadattestation/pool_test.go
+++ b/beacon-chain/operations/payloadattestation/pool_test.go
@@ -3,6 +3,7 @@ package payloadattestation
 import (
 	"testing"
 
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
 	"github.com/OffchainLabs/prysm/v7/crypto/hash"
@@ -26,7 +27,7 @@ func TestPool_PendingPayloadAttestations(t *testing.T) {
 		assert.Equal(t, 0, pendingCount(pool))
 	})
 
-	t.Run("returns requested slot and prunes lower slots", func(t *testing.T) {
+	t.Run("returns requested slot", func(t *testing.T) {
 		pool := NewPool()
 		sig := bls.NewAggregateSignature().Marshal()
 		msg1 := &ethpb.PayloadAttestationMessage{
@@ -60,16 +61,6 @@ func TestPool_PendingPayloadAttestations(t *testing.T) {
 	t.Run("slot filtering keeps future entries", func(t *testing.T) {
 		pool := NewPool()
 		sig := bls.NewAggregateSignature().Marshal()
-		msg1 := &ethpb.PayloadAttestationMessage{
-			ValidatorIndex: 0,
-			Data: &ethpb.PayloadAttestationData{
-				BeaconBlockRoot:   make([]byte, 32),
-				Slot:              1,
-				PayloadPresent:    true,
-				BlobDataAvailable: false,
-			},
-			Signature: sig,
-		}
 		msg2 := &ethpb.PayloadAttestationMessage{
 			ValidatorIndex: 1,
 			Data: &ethpb.PayloadAttestationData{
@@ -80,12 +71,10 @@ func TestPool_PendingPayloadAttestations(t *testing.T) {
 			},
 			Signature: sig,
 		}
-		require.NoError(t, pool.InsertPayloadAttestation(msg1, 0))
 		require.NoError(t, pool.InsertPayloadAttestation(msg2, 1))
 
 		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
-		assert.Equal(t, 1, len(atts))
-		assert.Equal(t, primitives.Slot(1), atts[0].Data.Slot)
+		assert.Equal(t, 0, len(atts))
 		assert.Equal(t, 1, pendingCount(pool))
 
 		atts = pool.PendingPayloadAttestations(primitives.Slot(2))
@@ -98,7 +87,7 @@ func TestPool_PendingPayloadAttestations(t *testing.T) {
 		assert.Equal(t, 0, pendingCount(pool))
 	})
 
-	t.Run("future slot request prunes all lower slots", func(t *testing.T) {
+	t.Run("future slot request does not prune", func(t *testing.T) {
 		pool := NewPool()
 		sig := bls.NewAggregateSignature().Marshal()
 		msg1 := &ethpb.PayloadAttestationMessage{
@@ -126,7 +115,7 @@ func TestPool_PendingPayloadAttestations(t *testing.T) {
 
 		atts := pool.PendingPayloadAttestations(primitives.Slot(10))
 		assert.Equal(t, 0, len(atts))
-		assert.Equal(t, 0, pendingCount(pool))
+		assert.Equal(t, 1, pendingCount(pool))
 	})
 }
 
@@ -179,6 +168,24 @@ func TestPool_InsertPayloadAttestation(t *testing.T) {
 		require.Equal(t, 1, len(atts))
 		assert.Equal(t, true, atts[0].AggregationBits.BitAt(idx))
 		assert.Equal(t, false, atts[0].AggregationBits.BitAt(idx+1))
+	})
+
+	t.Run("out-of-range index returns error and does not insert", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		msg := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   make([]byte, 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		err := pool.InsertPayloadAttestation(msg, uint64(fieldparams.PTCSize))
+		require.ErrorContains(t, "invalid payload attestation committee index", err)
+		assert.Equal(t, 0, pendingCount(pool))
 	})
 
 	t.Run("duplicate index is no-op", func(t *testing.T) {
@@ -265,6 +272,40 @@ func TestPool_InsertPayloadAttestation(t *testing.T) {
 		require.NoError(t, pool.InsertPayloadAttestation(msg2, 1))
 		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
 		assert.Equal(t, 2, len(atts))
+	})
+
+	t.Run("inserting newer slot prunes older slots", func(t *testing.T) {
+		pool := NewPool()
+		sig := bls.NewAggregateSignature().Marshal()
+		msg1 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 0,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   bytesutil.PadTo([]byte("older"), 32),
+				Slot:              1,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+		msg2 := &ethpb.PayloadAttestationMessage{
+			ValidatorIndex: 1,
+			Data: &ethpb.PayloadAttestationData{
+				BeaconBlockRoot:   bytesutil.PadTo([]byte("newer"), 32),
+				Slot:              2,
+				PayloadPresent:    true,
+				BlobDataAvailable: false,
+			},
+			Signature: sig,
+		}
+
+		require.NoError(t, pool.InsertPayloadAttestation(msg1, 0))
+		require.NoError(t, pool.InsertPayloadAttestation(msg2, 1))
+		assert.Equal(t, 1, pendingCount(pool))
+
+		atts := pool.PendingPayloadAttestations(primitives.Slot(1))
+		assert.Equal(t, 0, len(atts))
+		atts = pool.PendingPayloadAttestations(primitives.Slot(2))
+		assert.Equal(t, 1, len(atts))
 	})
 }
 

--- a/changelog/tt_payload-attestation-pool.md
+++ b/changelog/tt_payload-attestation-pool.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add payload timeliness committee (PTC) attestation pool

--- a/proto/prysm/v1alpha1/BUILD.bazel
+++ b/proto/prysm/v1alpha1/BUILD.bazel
@@ -379,6 +379,8 @@ go_library(
         "log.go",
         "sync_committee_mainnet.go",
         "sync_committee_minimal.go",  # keep
+        "payload_attestation_mainnet.go",
+        "payload_attestation_minimal.go",  # keep
         "validator.go",
         ":ssz_generated_altair",  # keep
         ":ssz_generated_bellatrix",  # keep

--- a/proto/prysm/v1alpha1/payload_attestation_mainnet.go
+++ b/proto/prysm/v1alpha1/payload_attestation_mainnet.go
@@ -1,0 +1,9 @@
+//go:build !minimal
+
+package eth
+
+import "github.com/OffchainLabs/go-bitfield"
+
+func NewPayloadAttestationAggregationBits() bitfield.Bitvector512 {
+	return bitfield.NewBitvector512()
+}

--- a/proto/prysm/v1alpha1/payload_attestation_minimal.go
+++ b/proto/prysm/v1alpha1/payload_attestation_minimal.go
@@ -1,0 +1,9 @@
+//go:build minimal
+
+package eth
+
+import "github.com/OffchainLabs/go-bitfield"
+
+func NewPayloadAttestationAggregationBits() bitfield.Bitvector2 {
+	return bitfield.NewBitvector2()
+}


### PR DESCRIPTION
Introduces the `payloadattestation` pool package, a thread-safe store for aggregating `PayloadAttestationMessage`s from PTC members before they are included in blocks by the `slot N+1` proposer.

PTC validators broadcast `PayloadAttestationMessage`s during slot N attesting whether the execution payload arrived on time (`PayloadPresent`) and whether blob data is available (`BlobDataAvailable`). The slot N+1 proposer collects these and includes aggregated `PayloadAttestation`s in the block body.

The pool:
- Keys entries by struct — one entry per distinct `(block_root, slot, payload_present, blob_data_available)` tuple
- Aggregates BLS signatures and bit vectors as messages arrive
- Exposes `PendingPayloadAttestations(slot)` for proposer block construction. Slot and lower are automatically pruned
