### PR TITLE
rpc: allow execution payload envelope lookup by block ID

### DIFF
--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "handlers_equivocation_test.go",
+        "handlers_gloas_test.go",
         "handlers_pool_test.go",
         "handlers_state_test.go",
         "handlers_test.go",
@@ -91,6 +92,7 @@ go_test(
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
+        "//beacon-chain/execution/testing:go_default_library",
         "//beacon-chain/forkchoice/doubly-linked-tree:go_default_library",
         "//beacon-chain/operations/attestations:go_default_library",
         "//beacon-chain/operations/blstoexec:go_default_library",
@@ -117,6 +119,7 @@ go_test(
         "//encoding/bytesutil:go_default_library",
         "//encoding/ssz:go_default_library",
         "//network/httputil:go_default_library",
+        "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//runtime/version:go_default_library",
         "//testing/assert:go_default_library",

--- a/beacon-chain/rpc/eth/beacon/handlers_gloas.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_gloas.go
@@ -6,7 +6,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/api"
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db"
-	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/eth/shared"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
@@ -20,12 +20,17 @@ func (s *Server) GetExecutionPayloadEnvelope(w http.ResponseWriter, r *http.Requ
 	ctx, span := trace.StartSpan(r.Context(), "beacon.GetExecutionPayloadEnvelope")
 	defer span.End()
 
-	rootBytes, err := bytesutil.DecodeHexWithLength(r.PathValue("block_root"), 32)
-	if err != nil {
-		httputil.HandleError(w, "Could not decode block root: "+err.Error(), http.StatusBadRequest)
+	blockID := r.PathValue("block_root")
+	if blockID == "" {
+		httputil.HandleError(w, "block_root is required in URL params", http.StatusBadRequest)
 		return
 	}
-	root := [32]byte(rootBytes)
+
+	root, err := s.Blocker.BlockRoot(ctx, []byte(blockID))
+	if !shared.WriteBlockRootFetchError(w, err) {
+		return
+	}
+
 	blinded, err := s.BeaconDB.ExecutionPayloadEnvelope(ctx, root)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {

--- a/beacon-chain/rpc/eth/beacon/handlers_gloas_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_gloas_test.go
@@ -1,0 +1,107 @@
+package beacon
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chainMock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	dbTest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
+	executiontesting "github.com/OffchainLabs/prysm/v7/beacon-chain/execution/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/lookup"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/testutil"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func TestGetExecutionPayloadEnvelope_AcceptsSlotID(t *testing.T) {
+	ctx := t.Context()
+	beaconDB := dbTest.SetupDB(t)
+
+	root := bytesutil.ToBytes32(bytesutil.PadTo([]byte("beacon-root"), 32))
+	blockHash := bytesutil.ToBytes32(bytesutil.PadTo([]byte("block-hash"), 32))
+
+	env := &ethpb.SignedExecutionPayloadEnvelope{
+		Message: &ethpb.ExecutionPayloadEnvelope{
+			Payload: &enginev1.ExecutionPayloadDeneb{
+				ParentHash:    bytesutil.PadTo([]byte("parent"), 32),
+				FeeRecipient:  bytesutil.PadTo([]byte("fee"), 20),
+				StateRoot:     bytesutil.PadTo([]byte("state"), 32),
+				ReceiptsRoot:  bytesutil.PadTo([]byte("receipts"), 32),
+				LogsBloom:     make([]byte, 256),
+				PrevRandao:    bytesutil.PadTo([]byte("randao"), 32),
+				BaseFeePerGas: bytesutil.PadTo([]byte{1}, 32),
+				BlockHash:     blockHash[:],
+				Transactions:  [][]byte{},
+				Withdrawals:   []*enginev1.Withdrawal{},
+			},
+			ExecutionRequests: &enginev1.ExecutionRequests{},
+			BuilderIndex:      primitives.BuilderIndex(42),
+			BeaconBlockRoot:   root[:],
+			Slot:              primitives.Slot(177),
+			StateRoot:         bytesutil.PadTo([]byte("envelope-state"), 32),
+		},
+		Signature: bytesutil.PadTo([]byte("sig"), 96),
+	}
+	require.NoError(t, beaconDB.SaveExecutionPayloadEnvelope(ctx, env))
+
+	reconstructor := &executiontesting.EngineClient{
+		ExecutionPayloadByBlockHash: map[[32]byte]*enginev1.ExecutionPayload{
+			blockHash: &enginev1.ExecutionPayload{
+				ParentHash:    bytesutil.PadTo([]byte("parent"), 32),
+				FeeRecipient:  bytesutil.PadTo([]byte("fee"), 20),
+				StateRoot:     bytesutil.PadTo([]byte("state"), 32),
+				ReceiptsRoot:  bytesutil.PadTo([]byte("receipts"), 32),
+				LogsBloom:     make([]byte, 256),
+				PrevRandao:    bytesutil.PadTo([]byte("randao"), 32),
+				BaseFeePerGas: bytesutil.PadTo([]byte{1}, 32),
+				BlockHash:     blockHash[:],
+				Transactions:  [][]byte{},
+			},
+		},
+	}
+
+	chain := &chainMock.ChainService{
+		FinalizedRoots:  map[[32]byte]bool{},
+		OptimisticRoots: map[[32]byte]bool{},
+	}
+	s := &Server{
+		BeaconDB:               beaconDB,
+		Blocker:                &testutil.MockBlocker{RootToReturn: root},
+		ExecutionReconstructor: reconstructor,
+		OptimisticModeFetcher:  chain,
+		FinalizationFetcher:    chain,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/execution_payload_envelope/{block_root}", nil)
+	req.SetPathValue("block_root", "177")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.GetExecutionPayloadEnvelope(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, version.String(version.Gloas), w.Header().Get("Eth-Consensus-Version"))
+}
+
+func TestGetExecutionPayloadEnvelope_BlockNotFound(t *testing.T) {
+	s := &Server{
+		Blocker: &testutil.MockBlocker{
+			ErrorToReturn: lookup.NewBlockNotFoundError("missing block"),
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/eth/v1/beacon/execution_payload_envelope/{block_root}", nil)
+	req.SetPathValue("block_root", "not-a-root")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.GetExecutionPayloadEnvelope(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, true, bytes.Contains(w.Body.Bytes(), []byte("Block not found")))
+}

--- a/changelog/tt_execution-payload-envelope-block-id.md
+++ b/changelog/tt_execution-payload-envelope-block-id.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Allow `GET /eth/v1/beacon/execution_payload_envelope/{block_root}` to resolve standard beacon block IDs such as slots and `head`, instead of requiring only a hex block root.


### PR DESCRIPTION
fixes #[16494](https://github.com/OffchainLabs/prysm/issues/16494)