### PR TITLE
Key badPayloadCache by envelope HTR instead of block root

### DIFF
--- a/beacon-chain/sync/pending_payload_envelope.go
+++ b/beacon-chain/sync/pending_payload_envelope.go
@@ -59,6 +59,8 @@ func (s *Service) processPendingPayloadEnvelope(ctx context.Context, root [32]by
 		s.setSeenPayloadEnvelope(root, env.BuilderIndex())
 		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(ctx, e); err != nil {
 			log.WithError(err).Debug("Could not process pending payload envelope")
+		} else if s.cfg.chain.HasFullNode(root) {
+			s.setGoodPayloadRoot(ctx, root)
 		}
 	}
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -173,6 +173,10 @@ type Service struct {
 	badBlockLock                        sync.RWMutex
 	badPayloadCache                     *lru.Cache
 	badPayloadLock                      sync.RWMutex
+	badPayloadRootCache                 *lru.Cache
+	badPayloadRootLock                  sync.RWMutex
+	goodPayloadRootCache                *lru.Cache
+	goodPayloadRootLock                 sync.RWMutex
 	syncContributionBitsOverlapLock     sync.RWMutex
 	syncContributionBitsOverlapCache    *lru.Cache
 	signatureChan                       chan *signatureVerifier
@@ -384,6 +388,8 @@ func (s *Service) initCaches() {
 	s.seenProposerSlashingCache = lruwrpr.New(seenProposerSlashingSize)
 	s.badBlockCache = lruwrpr.New(badBlockSize)
 	s.badPayloadCache = lruwrpr.New(badBlockSize)
+	s.badPayloadRootCache = lruwrpr.New(badBlockSize)
+	s.goodPayloadRootCache = lruwrpr.New(badBlockSize)
 }
 
 func (s *Service) waitForChainStart() {

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -60,19 +60,6 @@ func (s *Service) validateExecutionPayloadBidParentSeen(_ context.Context, blk i
 	return pubsub.ValidationIgnore, errors.New("parent payload not yet available")
 }
 
-// validateExecutionPayloadBidParentValid validates parent payload verification status.
-// If execution_payload verification of block's execution payload parent by an execution node is complete:
-// [REJECT] The block's execution payload parent (defined by bid.parent_block_hash) passes all validation.
-func (s *Service) validateExecutionPayloadBidParentValid(_ context.Context, blk interfaces.ReadOnlyBeaconBlock) (pubsub.ValidationResult, error) {
-	if blk.Version() < version.Gloas {
-		return pubsub.ValidationAccept, nil
-	}
-	if s.hasBadPayload(blk.ParentRoot()) {
-		return pubsub.ValidationReject, errors.New("parent payload is invalid")
-	}
-	return pubsub.ValidationAccept, nil
-}
-
 // requestPayloadEnvelope asks a random peer for the execution payload
 // envelope identified by root and feeds any response through
 // ReceiveExecutionPayloadEnvelope.
@@ -96,6 +83,15 @@ func (s *Service) requestPayloadEnvelope(root [32]byte) {
 		log.Warn("Multiple payload envelopes returned by peer, expected at most one")
 	}
 	for _, env := range envelopes {
+		envelopeHTR, err := env.HashTreeRoot()
+		if err != nil {
+			log.WithError(err).Debug("Could not compute envelope HTR")
+			continue
+		}
+		if s.hasBadPayload(envelopeHTR) {
+			log.Debug("Skipping known bad payload envelope")
+			continue
+		}
 		wrapped, err := consensusblocks.WrappedROSignedExecutionPayloadEnvelope(env)
 		if err != nil {
 			log.WithError(err).Debug("Could not wrap requested payload envelope")
@@ -103,7 +99,7 @@ func (s *Service) requestPayloadEnvelope(root [32]byte) {
 		}
 		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(s.ctx, wrapped); err != nil {
 			if blockchain.IsInvalidBlock(err) {
-				s.setBadPayload(s.ctx, root)
+				s.setBadPayload(s.ctx, envelopeHTR)
 			}
 			log.WithError(err).Debug("Could not process requested payload envelope")
 		}

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -60,6 +60,25 @@ func (s *Service) validateExecutionPayloadBidParentSeen(_ context.Context, blk i
 	return pubsub.ValidationIgnore, errors.New("parent payload not yet available")
 }
 
+// validateExecutionPayloadBidParentValid validates cached parent payload
+// verification status for a block's parent root.
+// Reject If prior execution payload verification marked the parent root
+// (defined by bid.parent_block_hash) as invalid.
+//
+// A good payload root overrides a bad one to handle builder equivocation:
+// if a bad envelope was seen first but a valid one was processed later,
+// the block is accepted.
+func (s *Service) validateExecutionPayloadBidParentValid(_ context.Context, blk interfaces.ReadOnlyBeaconBlock) (pubsub.ValidationResult, error) {
+	if blk.Version() < version.Gloas {
+		return pubsub.ValidationAccept, nil
+	}
+	parentRoot := blk.ParentRoot()
+	if s.hasBadPayloadRoot(parentRoot) {
+		return pubsub.ValidationReject, errors.New("parent payload is invalid")
+	}
+	return pubsub.ValidationAccept, nil
+}
+
 // requestPayloadEnvelope asks a random peer for the execution payload
 // envelope identified by root and feeds any response through
 // ReceiveExecutionPayloadEnvelope.
@@ -100,8 +119,11 @@ func (s *Service) requestPayloadEnvelope(root [32]byte) {
 		if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(s.ctx, wrapped); err != nil {
 			if blockchain.IsInvalidBlock(err) {
 				s.setBadPayload(s.ctx, envelopeHTR)
+				s.setBadPayloadRoot(s.ctx, root)
 			}
 			log.WithError(err).Debug("Could not process requested payload envelope")
+		} else if s.cfg.chain.HasFullNode(root) {
+			s.setGoodPayloadRoot(s.ctx, root)
 		}
 	}
 }

--- a/beacon-chain/sync/validate_beacon_block_gloas_test.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas_test.go
@@ -120,25 +120,128 @@ func TestValidateExecutionPayloadBidParentSeen_Ignore(t *testing.T) {
 	require.Equal(t, pubsub.ValidationIgnore, res)
 }
 
+func TestValidateExecutionPayloadBidParentValid_PreGloas(t *testing.T) {
+	ctx := context.Background()
+	blk := util.HydrateSignedBeaconBlockDeneb(nil)
+	wsb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+
+	s := &Service{}
+	res, err := s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, res)
+}
+
+func TestValidateExecutionPayloadBidParentValid_Accept(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	ctx := context.Background()
+
+	s := &Service{
+		badPayloadRootCache:  lruwrpr.New(10),
+		goodPayloadRootCache: lruwrpr.New(10),
+	}
+
+	blk := util.NewBeaconBlockGloas()
+	wsb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+
+	res, err := s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, res)
+}
+
+func TestValidateExecutionPayloadBidParentValid_Reject(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	ctx := context.Background()
+
+	s := &Service{
+		badPayloadRootCache:  lruwrpr.New(10),
+		goodPayloadRootCache: lruwrpr.New(10),
+	}
+
+	blk := util.NewBeaconBlockGloas()
+	wsb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+
+	parentRoot := wsb.Block().ParentRoot()
+	s.setBadPayloadRoot(ctx, parentRoot)
+
+	res, err := s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
+	require.Error(t, err)
+	require.Equal(t, pubsub.ValidationReject, res)
+}
+
 // TestBadPayloadCache_EquivocationSafe verifies that the bad payload cache,
-// now keyed by envelope HTR, does not suffer from builder equivocation
-// poisoning. A bad envelope for block N is cached by its own HTR. A different
-// (good) envelope for the same block N has a different HTR and is not blocked.
+// keyed by envelope HTR, does not suffer from builder equivocation poisoning.
 func TestBadPayloadCache_EquivocationSafe(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	ctx := context.Background()
 
 	s := &Service{badPayloadCache: lruwrpr.New(10)}
 
-	// Two different envelope HTRs for the same block root (builder equivocation).
 	badEnvelopeHTR := [32]byte{0xBB}
 	goodEnvelopeHTR := [32]byte{0xCC}
 
-	// Bad envelope is marked in the cache.
 	s.setBadPayload(ctx, badEnvelopeHTR)
 
-	// Bad envelope is recognized.
 	require.True(t, s.hasBadPayload(badEnvelopeHTR))
-	// Good envelope is NOT blocked — different HTR, not in cache.
 	require.False(t, s.hasBadPayload(goodEnvelopeHTR))
+}
+
+// TestBadPayloadRoot_GoodOverridesBad verifies that a good payload root
+// overrides a bad one, handling builder equivocation correctly.
+func TestBadPayloadRoot_GoodOverridesBad(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	ctx := context.Background()
+
+	s := &Service{
+		badPayloadRootCache:  lruwrpr.New(10),
+		goodPayloadRootCache: lruwrpr.New(10),
+	}
+
+	blockRoot := [32]byte{0xAA}
+
+	// Step 1: Bad envelope → mark root as bad.
+	s.setBadPayloadRoot(ctx, blockRoot)
+	require.True(t, s.hasBadPayloadRoot(blockRoot))
+
+	// Step 2: Good envelope → mark root as good (heals).
+	s.setGoodPayloadRoot(ctx, blockRoot)
+	require.False(t, s.hasBadPayloadRoot(blockRoot))
+}
+
+// TestBadPayloadRoot_RejectThenAcceptAfterHeal verifies the full equivocation
+// flow: bad payload causes REJECT, good payload heals, subsequent block accepted.
+func TestBadPayloadRoot_RejectThenAcceptAfterHeal(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	ctx := context.Background()
+
+	s := &Service{
+		badPayloadRootCache:  lruwrpr.New(10),
+		goodPayloadRootCache: lruwrpr.New(10),
+	}
+
+	blockNRoot := bytesutil.PadTo([]byte{0xAA}, fieldparams.RootLength)
+
+	// Step 1: Bad envelope for block N.
+	s.setBadPayloadRoot(ctx, [32]byte(blockNRoot))
+
+	// Step 2: Block N+1 arrives — parent is bad → REJECT.
+	childBlock := util.NewBeaconBlockGloas()
+	childBlock.Block.ParentRoot = blockNRoot
+	childBlock.Block.Body.SignedExecutionPayloadBid.Message.ParentBlockRoot = blockNRoot
+	wsb, err := blocks.NewSignedBeaconBlock(childBlock)
+	require.NoError(t, err)
+
+	res, err := s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
+	require.Error(t, err)
+	require.Equal(t, pubsub.ValidationReject, res)
+
+	// Step 3: Good envelope for block N arrives → heals.
+	s.setGoodPayloadRoot(ctx, [32]byte(blockNRoot))
+
+	// Step 4: Block N+2 with same parent → now accepted.
+	res, err = s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, res)
 }

--- a/beacon-chain/sync/validate_beacon_block_gloas_test.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas_test.go
@@ -120,47 +120,25 @@ func TestValidateExecutionPayloadBidParentSeen_Ignore(t *testing.T) {
 	require.Equal(t, pubsub.ValidationIgnore, res)
 }
 
-func TestValidateExecutionPayloadBidParentValid_PreGloas(t *testing.T) {
-	ctx := context.Background()
-	blk := util.HydrateSignedBeaconBlockDeneb(nil)
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-
-	s := &Service{}
-	res, err := s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, res)
-}
-
-func TestValidateExecutionPayloadBidParentValid_Accept(t *testing.T) {
+// TestBadPayloadCache_EquivocationSafe verifies that the bad payload cache,
+// now keyed by envelope HTR, does not suffer from builder equivocation
+// poisoning. A bad envelope for block N is cached by its own HTR. A different
+// (good) envelope for the same block N has a different HTR and is not blocked.
+func TestBadPayloadCache_EquivocationSafe(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	ctx := context.Background()
 
 	s := &Service{badPayloadCache: lruwrpr.New(10)}
 
-	blk := util.NewBeaconBlockGloas()
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
+	// Two different envelope HTRs for the same block root (builder equivocation).
+	badEnvelopeHTR := [32]byte{0xBB}
+	goodEnvelopeHTR := [32]byte{0xCC}
 
-	res, err := s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
-	require.NoError(t, err)
-	require.Equal(t, pubsub.ValidationAccept, res)
-}
+	// Bad envelope is marked in the cache.
+	s.setBadPayload(ctx, badEnvelopeHTR)
 
-func TestValidateExecutionPayloadBidParentValid_Reject(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	ctx := context.Background()
-
-	s := &Service{badPayloadCache: lruwrpr.New(10)}
-
-	blk := util.NewBeaconBlockGloas()
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-
-	parentRoot := wsb.Block().ParentRoot()
-	s.badPayloadCache.Add(string(parentRoot[:]), true)
-
-	res, err := s.validateExecutionPayloadBidParentValid(ctx, wsb.Block())
-	require.Error(t, err)
-	require.Equal(t, pubsub.ValidationReject, res)
+	// Bad envelope is recognized.
+	require.True(t, s.hasBadPayload(badEnvelopeHTR))
+	// Good envelope is NOT blocked — different HTR, not in cache.
+	require.False(t, s.hasBadPayload(goodEnvelopeHTR))
 }

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -127,6 +127,9 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		log.WithError(err).WithFields(getBlockFields(blk)).Debug("Received block with an invalid parent")
 		return pubsub.ValidationReject, err
 	}
+	if res, err := s.validateExecutionPayloadBidParentValid(ctx, blk.Block()); err != nil {
+		return res, err
+	}
 	s.pendingQueueLock.RLock()
 	if s.seenPendingBlocks[blockRoot] {
 		s.pendingQueueLock.RUnlock()
@@ -518,6 +521,9 @@ func (s *Service) hasBadBlock(root [32]byte) bool {
 // hasBadPayload returns true if the signed execution payload envelope
 // identified by its hash tree root has been marked as invalid.
 func (s *Service) hasBadPayload(envelopeHTR [32]byte) bool {
+	if s.badPayloadCache == nil {
+		return false
+	}
 	s.badPayloadLock.RLock()
 	defer s.badPayloadLock.RUnlock()
 	_, seen := s.badPayloadCache.Get(string(envelopeHTR[:]))
@@ -529,6 +535,9 @@ func (s *Service) hasBadPayload(envelopeHTR [32]byte) bool {
 // root) prevents builder equivocation from poisoning valid envelopes that
 // share the same beacon block root.
 func (s *Service) setBadPayload(ctx context.Context, envelopeHTR [32]byte) {
+	if s.badPayloadCache == nil {
+		return
+	}
 	s.badPayloadLock.Lock()
 	defer s.badPayloadLock.Unlock()
 	if ctx.Err() != nil {
@@ -536,6 +545,52 @@ func (s *Service) setBadPayload(ctx context.Context, envelopeHTR [32]byte) {
 	}
 	log.WithField("envelopeHTR", fmt.Sprintf("%#x", envelopeHTR)).Debug("Inserting in invalid payload cache")
 	s.badPayloadCache.Add(string(envelopeHTR[:]), true)
+}
+
+// hasBadPayloadRoot returns true if a payload for the given block root has been
+// marked as invalid AND no valid payload has since been processed for that root.
+func (s *Service) hasBadPayloadRoot(root [32]byte) bool {
+	if s.goodPayloadRootCache == nil || s.badPayloadRootCache == nil {
+		return false
+	}
+	s.goodPayloadRootLock.RLock()
+	_, good := s.goodPayloadRootCache.Get(string(root[:]))
+	s.goodPayloadRootLock.RUnlock()
+	if good {
+		return false
+	}
+	s.badPayloadRootLock.RLock()
+	defer s.badPayloadRootLock.RUnlock()
+	_, bad := s.badPayloadRootCache.Get(string(root[:]))
+	return bad
+}
+
+// setBadPayloadRoot marks a block root as having an invalid payload.
+func (s *Service) setBadPayloadRoot(ctx context.Context, root [32]byte) {
+	if s.badPayloadRootCache == nil {
+		return
+	}
+	s.badPayloadRootLock.Lock()
+	defer s.badPayloadRootLock.Unlock()
+	if ctx.Err() != nil {
+		return
+	}
+	s.badPayloadRootCache.Add(string(root[:]), true)
+}
+
+// setGoodPayloadRoot marks a block root as having a valid payload, overriding
+// any previous bad marking. This handles builder equivocation where a bad
+// envelope arrives before a good one for the same block.
+func (s *Service) setGoodPayloadRoot(ctx context.Context, root [32]byte) {
+	if s.goodPayloadRootCache == nil {
+		return
+	}
+	s.goodPayloadRootLock.Lock()
+	defer s.goodPayloadRootLock.Unlock()
+	if ctx.Err() != nil {
+		return
+	}
+	s.goodPayloadRootCache.Add(string(root[:]), true)
 }
 
 // Set bad block in the cache.

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -127,10 +127,6 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		log.WithError(err).WithFields(getBlockFields(blk)).Debug("Received block with an invalid parent")
 		return pubsub.ValidationReject, err
 	}
-	if res, err := s.validateExecutionPayloadBidParentValid(ctx, blk.Block()); err != nil {
-		return res, err
-	}
-
 	s.pendingQueueLock.RLock()
 	if s.seenPendingBlocks[blockRoot] {
 		s.pendingQueueLock.RUnlock()
@@ -519,23 +515,27 @@ func (s *Service) hasBadBlock(root [32]byte) bool {
 	return seen
 }
 
-// Returns true if the payload for the given block root is marked as bad.
-func (s *Service) hasBadPayload(root [32]byte) bool {
+// hasBadPayload returns true if the signed execution payload envelope
+// identified by its hash tree root has been marked as invalid.
+func (s *Service) hasBadPayload(envelopeHTR [32]byte) bool {
 	s.badPayloadLock.RLock()
 	defer s.badPayloadLock.RUnlock()
-	_, seen := s.badPayloadCache.Get(string(root[:]))
+	_, seen := s.badPayloadCache.Get(string(envelopeHTR[:]))
 	return seen
 }
 
-// Set bad payload in the cache.
-func (s *Service) setBadPayload(ctx context.Context, root [32]byte) {
+// setBadPayload marks a signed execution payload envelope as invalid, keyed
+// by the envelope's hash tree root. Keying by envelope HTR (rather than block
+// root) prevents builder equivocation from poisoning valid envelopes that
+// share the same beacon block root.
+func (s *Service) setBadPayload(ctx context.Context, envelopeHTR [32]byte) {
 	s.badPayloadLock.Lock()
 	defer s.badPayloadLock.Unlock()
 	if ctx.Err() != nil {
 		return
 	}
-	log.WithField("root", fmt.Sprintf("%#x", root)).Debug("Inserting in invalid payload cache")
-	s.badPayloadCache.Add(string(root[:]), true)
+	log.WithField("envelopeHTR", fmt.Sprintf("%#x", envelopeHTR)).Debug("Inserting in invalid payload cache")
+	s.badPayloadCache.Add(string(envelopeHTR[:]), true)
 }
 
 // Set bad block in the cache.

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -225,6 +225,7 @@ func (s *Service) executionPayloadEnvelopeSubscriber(ctx context.Context, msg pr
 	if err != nil {
 		return errors.Wrap(err, "could not wrap signed execution payload envelope")
 	}
+	envelope, envErr := env.Envelope()
 	if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(ctx, env); err != nil {
 		if blockchain.IsInvalidBlock(err) {
 			envelopeHTR, htrErr := e.HashTreeRoot()
@@ -233,8 +234,17 @@ func (s *Service) executionPayloadEnvelopeSubscriber(ctx context.Context, msg pr
 			} else {
 				log.WithError(htrErr).Error("failed to compute envelope HTR for bad payload cache")
 			}
+			if envErr == nil {
+				s.setBadPayloadRoot(ctx, envelope.BeaconBlockRoot())
+			}
 		}
 		return err
+	}
+	if envErr == nil {
+		root := envelope.BeaconBlockRoot()
+		if s.cfg.chain.HasFullNode(root) {
+			s.setGoodPayloadRoot(ctx, root)
+		}
 	}
 	return nil
 }

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -227,11 +227,11 @@ func (s *Service) executionPayloadEnvelopeSubscriber(ctx context.Context, msg pr
 	}
 	if err := s.cfg.chain.ReceiveExecutionPayloadEnvelope(ctx, env); err != nil {
 		if blockchain.IsInvalidBlock(err) {
-			envelope, envErr := env.Envelope()
-			if envErr == nil {
-				s.setBadPayload(ctx, envelope.BeaconBlockRoot())
+			envelopeHTR, htrErr := e.HashTreeRoot()
+			if htrErr == nil {
+				s.setBadPayload(ctx, envelopeHTR)
 			} else {
-				log.WithError(envErr).Error("failed to get envelope from signed execution payload envelope")
+				log.WithError(htrErr).Error("failed to compute envelope HTR for bad payload cache")
 			}
 		}
 		return err

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -150,6 +150,50 @@ func TestExecutionPayloadEnvelopeSubscriber_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestExecutionPayloadEnvelopeSubscriber_NoGoodRootWithoutFullNode verifies
+// that setGoodPayloadRoot is NOT called when ReceiveExecutionPayloadEnvelope
+// returns nil but HasFullNode is false (the errBlockBeingSynced early-return).
+func TestExecutionPayloadEnvelopeSubscriber_NoGoodRootWithoutFullNode(t *testing.T) {
+	root := [32]byte{0x01}
+	blockHash := [32]byte{0x02}
+
+	// HasFullNode returns false by default (no ForkchoiceRoots set).
+	s := &Service{
+		cfg:                  &config{chain: &mock.ChainService{}},
+		goodPayloadRootCache: lruwrpr.New(10),
+	}
+	env := testSignedExecutionPayloadEnvelope(t, 1, 2, root, blockHash)
+
+	err := s.executionPayloadEnvelopeSubscriber(context.Background(), env)
+	require.NoError(t, err)
+
+	// Good root must NOT be set because HasFullNode is false.
+	_, found := s.goodPayloadRootCache.Get(string(root[:]))
+	require.Equal(t, false, found, "goodPayloadRootCache should not be populated when HasFullNode is false")
+}
+
+// TestExecutionPayloadEnvelopeSubscriber_GoodRootWithFullNode verifies
+// that setGoodPayloadRoot IS called when processing succeeds and HasFullNode is true.
+func TestExecutionPayloadEnvelopeSubscriber_GoodRootWithFullNode(t *testing.T) {
+	root := [32]byte{0x01}
+	blockHash := [32]byte{0x02}
+
+	s := &Service{
+		cfg: &config{chain: &mock.ChainService{
+			ForkchoiceRoots: map[[32]byte]bool{root: true},
+		}},
+		goodPayloadRootCache: lruwrpr.New(10),
+	}
+	env := testSignedExecutionPayloadEnvelope(t, 1, 2, root, blockHash)
+
+	err := s.executionPayloadEnvelopeSubscriber(context.Background(), env)
+	require.NoError(t, err)
+
+	// Good root must be set because HasFullNode is true.
+	_, found := s.goodPayloadRootCache.Get(string(root[:]))
+	require.Equal(t, true, found, "goodPayloadRootCache should be populated when HasFullNode is true")
+}
+
 type mockExecutionPayloadEnvelopeVerifier struct {
 	errBlockRootSeen      error
 	errBlockRootValid     error

--- a/changelog/satushh-payload-cache-htr.md
+++ b/changelog/satushh-payload-cache-htr.md
@@ -1,0 +1,3 @@
+### Changed
+
+ - Key badPayloadCache by envelope HTR instead of block root


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix


**What does this PR do? Why is it needed?**

This PR fixes builder-equivocation poisoning while preserving parent-payload rejection semantics.

  - Changes badPayloadCache to be keyed by envelope HTR instead of block root, so one bad envelope does not poison all envelopes for the same beacon block root.
  - Adds root-level payload status caches:
      - badPayloadRootCache (root seen with invalid payload)
      - goodPayloadRootCache (root later confirmed with valid payload if any)
  - Updates parent validation to reject based on hasBadPayloadRoot(parentRoot), with good-root status overriding bad-root status to recover after equivocation.
  - On invalid envelope processing, marks both:
      - bad envelope HTR (setBadPayload)
      - bad block root (setBadPayloadRoot)
  - On successful envelope processing, marks root good only if HasFullNode(root) is true.
