### PR TITLE
adding payload_attestation_message event

### DIFF
--- a/api/server/structs/block.go
+++ b/api/server/structs/block.go
@@ -540,6 +540,12 @@ type PayloadAttestation struct {
 	Signature       string                  `json:"signature"`
 }
 
+type PayloadAttestationMessage struct {
+	ValidatorIndex string                  `json:"validator_index"`
+	Data           *PayloadAttestationData `json:"data"`
+	Signature      string                  `json:"signature"`
+}
+
 type BeaconBlockBodyGloas struct {
 	RandaoReveal              string                        `json:"randao_reveal"`
 	Eth1Data                  *Eth1Data                     `json:"eth1_data"`

--- a/api/server/structs/conversions_block.go
+++ b/api/server/structs/conversions_block.go
@@ -2966,6 +2966,14 @@ func PayloadAttestationFromConsensus(pa *eth.PayloadAttestation) *PayloadAttesta
 	}
 }
 
+func PayloadAttestationMessageFromConsensus(m *eth.PayloadAttestationMessage) *PayloadAttestationMessage {
+	return &PayloadAttestationMessage{
+		ValidatorIndex: fmt.Sprintf("%d", m.ValidatorIndex),
+		Data:           PayloadAttestationDataFromConsensus(m.Data),
+		Signature:      hexutil.Encode(m.Signature),
+	}
+}
+
 func PayloadAttestationDataFromConsensus(d *eth.PayloadAttestationData) *PayloadAttestationData {
 	return &PayloadAttestationData{
 		BeaconBlockRoot:   hexutil.Encode(d.BeaconBlockRoot),

--- a/beacon-chain/core/feed/operation/events.go
+++ b/beacon-chain/core/feed/operation/events.go
@@ -46,6 +46,9 @@ const (
 
 	// DataColumnReceived is sent after a data column has been seen after gossip validation rules.
 	DataColumnReceived = 12
+
+	// PayloadAttestationMessageReceived is sent after a payload attestation message is received from gossip or rpc.
+	PayloadAttestationMessageReceived = 13
 )
 
 // UnAggregatedAttReceivedData is the data sent with UnaggregatedAttReceived events.
@@ -113,4 +116,9 @@ type DataColumnReceivedData struct {
 	Index          uint64
 	BlockRoot      [32]byte
 	KzgCommitments [][]byte
+}
+
+// PayloadAttestationMessageReceivedData is the data sent with PayloadAttestationMessageReceived events.
+type PayloadAttestationMessageReceivedData struct {
+	Message *ethpb.PayloadAttestationMessage
 }

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -79,6 +79,8 @@ const (
 	// ExecutionPayloadBidTopic represents a new execution payload bid event topic.
 	// This topic is currently not triggered but is recognized to avoid client subscription errors.
 	ExecutionPayloadBidTopic = "execution_payload_bid"
+	// PayloadAttestationMessageTopic represents a new payload attestation message event topic.
+	PayloadAttestationMessageTopic = "payload_attestation_message"
 )
 
 var (
@@ -113,6 +115,7 @@ var opsFeedEventTopics = map[feed.EventType]string{
 	operation.ProposerSlashingReceived:          ProposerSlashingTopic,
 	operation.BlockGossipReceived:               BlockGossipTopic,
 	operation.DataColumnReceived:                DataColumnTopic,
+	operation.PayloadAttestationMessageReceived: PayloadAttestationMessageTopic,
 }
 
 var stateFeedEventTopics = map[feed.EventType]string{
@@ -476,6 +479,8 @@ func topicForEvent(event *feed.Event) string {
 		return PayloadAttributesTopic
 	case *operation.DataColumnReceivedData:
 		return DataColumnTopic
+	case *operation.PayloadAttestationMessageReceivedData:
+		return PayloadAttestationMessageTopic
 	case *statefeed.PayloadProcessedData:
 		return ExecutionPayloadTopic
 	default:
@@ -649,6 +654,10 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 				ExecutionOptimistic: v.Optimistic,
 			}
 			return jsonMarshalReader(eventName, blk)
+		}, nil
+	case *operation.PayloadAttestationMessageReceivedData:
+		return func() io.Reader {
+			return jsonMarshalReader(eventName, structs.PayloadAttestationMessageFromConsensus(v.Message))
 		}, nil
 	case *statefeed.PayloadProcessedData:
 		return func() io.Reader {

--- a/beacon-chain/rpc/eth/events/events_test.go
+++ b/beacon-chain/rpc/eth/events/events_test.go
@@ -123,6 +123,7 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 		ProposerSlashingTopic,
 		BlockGossipTopic,
 		DataColumnTopic,
+		PayloadAttestationMessageTopic,
 	})
 	require.NoError(t, err)
 	ro, err := blocks.NewROBlob(util.HydrateBlobSidecar(&eth.BlobSidecar{}))
@@ -310,6 +311,21 @@ func operationEventsFixtures(t *testing.T) (*topicRequest, []*feed.Event) {
 				Index:          2,
 				BlockRoot:      [32]byte{'a'},
 				KzgCommitments: [][]byte{{'a'}, {'b'}, {'c'}},
+			},
+		},
+		{
+			Type: operation.PayloadAttestationMessageReceived,
+			Data: &operation.PayloadAttestationMessageReceivedData{
+				Message: &eth.PayloadAttestationMessage{
+					ValidatorIndex: 0,
+					Data: &eth.PayloadAttestationData{
+						BeaconBlockRoot:   make([]byte, fieldparams.RootLength),
+						Slot:              0,
+						PayloadPresent:    true,
+						BlobDataAvailable: true,
+					},
+					Signature: make([]byte, fieldparams.BLSSignatureLength),
+				},
 			},
 		},
 	}
@@ -729,7 +745,7 @@ func TestStuckReaderScenarios(t *testing.T) {
 
 func wedgedWriterTestCase(t *testing.T, queueDepth func([]*feed.Event) int) {
 	topics, events := operationEventsFixtures(t)
-	require.Equal(t, 12, len(events))
+	require.Equal(t, 13, len(events))
 
 	// set eventFeedDepth to a number lower than the events we intend to send to force the server to drop the reader.
 	stn := mockChain.NewEventFeedWrapper()

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation.go
@@ -3,6 +3,8 @@ package validator
 import (
 	"context"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -103,6 +105,13 @@ func (vs *Server) SubmitPayloadAttestation(
 	if err := vs.PayloadAttestationPool.InsertPayloadAttestation(msg, idx); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not insert payload attestation into pool: %v", err)
 	}
+
+	vs.OperationNotifier.OperationFeed().Send(&feed.Event{
+		Type: opfeed.PayloadAttestationMessageReceived,
+		Data: &opfeed.PayloadAttestationMessageReceivedData{
+			Message: msg,
+		},
+	})
 
 	log.WithField("slot", msg.Data.Slot).Debug("Submitted payload attestation message")
 	return &emptypb.Empty{}, nil

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation.go
@@ -3,8 +3,6 @@ package validator
 import (
 	"context"
 
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
-	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -105,13 +103,6 @@ func (vs *Server) SubmitPayloadAttestation(
 	if err := vs.PayloadAttestationPool.InsertPayloadAttestation(msg, idx); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not insert payload attestation into pool: %v", err)
 	}
-
-	vs.OperationNotifier.OperationFeed().Send(&feed.Event{
-		Type: opfeed.PayloadAttestationMessageReceived,
-		Data: &opfeed.PayloadAttestationMessageReceivedData{
-			Message: msg,
-		},
-	})
 
 	log.WithField("slot", msg.Data.Slot).Debug("Submitted payload attestation message")
 	return &emptypb.Empty{}, nil

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/payload_attestation_test.go
@@ -112,6 +112,7 @@ func TestSubmitPayloadAttestation_OK(t *testing.T) {
 		BlockReceiver:              receiver,
 		PayloadAttestationReceiver: receiver,
 		PayloadAttestationPool:     payloadattestation.NewPool(),
+		OperationNotifier:          chain.OperationNotifier(),
 	}
 
 	msg := &ethpb.PayloadAttestationMessage{

--- a/beacon-chain/sync/subscriber_payload_attestation.go
+++ b/beacon-chain/sync/subscriber_payload_attestation.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"context"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
+	opfeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/operation"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"google.golang.org/protobuf/proto"
@@ -16,6 +18,13 @@ func (s *Service) payloadAttestationSubscriber(ctx context.Context, msg proto.Me
 	if a == nil || a.Data == nil {
 		return errNilMessage
 	}
+
+	s.cfg.operationNotifier.OperationFeed().Send(&feed.Event{
+		Type: opfeed.PayloadAttestationMessageReceived,
+		Data: &opfeed.PayloadAttestationMessageReceivedData{
+			Message: a,
+		},
+	})
 
 	if err := s.payloadAttestationCache.Add(a.Data.Slot, a.ValidatorIndex); err != nil {
 		return err

--- a/beacon-chain/sync/subscriber_payload_attestation_test.go
+++ b/beacon-chain/sync/subscriber_payload_attestation_test.go
@@ -43,6 +43,7 @@ func TestPayloadAttestationSubscriber_NoPool(t *testing.T) {
 		cfg: &config{
 			chain:                  &mock.ChainService{State: st},
 			payloadAttestationPool: payloadattestation.NewPool(),
+			operationNotifier:      &mock.MockOperationNotifier{},
 		},
 	}
 	msg := &ethpb.PayloadAttestationMessage{
@@ -65,6 +66,7 @@ func TestPayloadAttestationSubscriber_HeadStateError(t *testing.T) {
 				HeadStateErr: headErr,
 			},
 			payloadAttestationPool: payloadattestation.NewPool(),
+			operationNotifier:      &mock.MockOperationNotifier{},
 		},
 	}
 	msg := &ethpb.PayloadAttestationMessage{
@@ -90,6 +92,7 @@ func TestPayloadAttestationSubscriber_ValidatorInPTC(t *testing.T) {
 		cfg: &config{
 			chain:                  &mock.ChainService{State: st},
 			payloadAttestationPool: pool,
+			operationNotifier:      &mock.MockOperationNotifier{},
 		},
 	}
 	msg := &ethpb.PayloadAttestationMessage{
@@ -126,6 +129,7 @@ func TestPayloadAttestationSubscriber_ValidatorNotInPTC(t *testing.T) {
 		cfg: &config{
 			chain:                  &mock.ChainService{State: st},
 			payloadAttestationPool: payloadattestation.NewPool(),
+			operationNotifier:      &mock.MockOperationNotifier{},
 		},
 	}
 	msg := &ethpb.PayloadAttestationMessage{

--- a/changelog/james-prysm_payload-attestation-event.md
+++ b/changelog/james-prysm_payload-attestation-event.md
@@ -1,0 +1,3 @@
+### Added
+
+- payload_attestation_message event triggered on grpc and gossip message recieved 

--- a/changelog/james-prysm_payload-attestation-event.md
+++ b/changelog/james-prysm_payload-attestation-event.md
@@ -1,3 +1,3 @@
 ### Added
 
-- payload_attestation_message event triggered on grpc and gossip message recieved 
+- payload_attestation_message event triggered on gossip message received.

--- a/changelog/james-prysm_payload-attestation-event.md
+++ b/changelog/james-prysm_payload-attestation-event.md
@@ -1,3 +1,3 @@
 ### Added
 
-- payload_attestation_message event triggered on gossip message received.
+- payload_attestation_message event triggered on grpc and gossip message received.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

adds payload_attestation_message event triggered via  grpc and gossip message received, introduced in https://github.com/ethereum/beacon-APIs/pull/552 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
