### PR TITLE
forkchoice: fix head change on every attestation tick pre gloas

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -500,7 +500,7 @@ func (f *ForkChoice) FullHead(ctx context.Context) ([32]byte, [32]byte, bool, er
 	}
 	n := f.store.headNode
 	pn := f.store.choosePayloadContent(n)
-	if pn.full {
+	if pn.full && slots.ToEpoch(n.slot) >= params.BeaconConfig().GloasForkEpoch {
 		return hr, pn.node.blockHash, true, nil
 	}
 	fullAncestor := f.store.fullParent(pn)

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -1456,3 +1456,33 @@ func TestFullHead_EmptyPayload(t *testing.T) {
 	assert.Equal(t, blockHashA, bh)
 	assert.Equal(t, false, full)
 }
+
+// TestFullHead_PreGloasBlock_ReturnsFalse verifies that FullHead returns full=false
+// for pre-Gloas (Fulu) blocks even though the fork choice store internally creates a
+// fullNodeByRoot entry with full=true for them (for EL optimistic validation tracking).
+// Without the epoch guard in FullHead, isNewHead would spuriously fire every ticker
+// tick because FullHead returned full=true while saveHead stored head.full=false.
+func TestFullHead_PreGloasBlock_ReturnsFalse(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GloasForkEpoch = 100 // Gloas activates far in the future; slot 1 is pre-Gloas
+	params.OverrideBeaconConfig(cfg)
+
+	f := setup(0, 0)
+	ctx := t.Context()
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	st, blk, err := prepareForkchoiceState(ctx, 1, rootA, zeroHash, blockHashA, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	driftGenesisTime(f, 1, 0)
+	require.NoError(t, f.NewSlot(ctx, 1))
+
+	hr, _, full, err := f.FullHead(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, rootA, hr)
+	assert.Equal(t, false, full, "pre-Gloas block must return full=false from FullHead")
+}

--- a/changelog/t_fix-gloas-fullhead-pre-gloas.md
+++ b/changelog/t_fix-gloas-fullhead-pre-gloas.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix spurious "Head changed due to attestations" log firing every tick for pre-Gloas (Fulu) blocks.


### PR DESCRIPTION
`store.go` creates a `fullNodeByRoot` entry with `full=true` for all fulu blocks because pre-Ggoas blocks embed their EL payload inline and need optimistic validation tracking. `FullHead` was surfacing this internal `full=true` to callers without distinguishing whether the node was actually post-gloas.

`UpdateHead` called `FullHead` which returned `full=true` for fulu blocks. Meanwhile `saveHead` always stored `s.head.full=false`for pre-gloas states. The mismatch caused `isNewHead` to fire on ticker interval.

I liked the option to fix in `FullHead`, it's a simple change. The con is `CanonicalNodeAtSlot` is a different path that also returns `pn.full` for pre-gloas, t's already call-site guarded by `GloasForkEpoch` so it's fine, but the internal inconsistency remains.

**Option 2** is Fix in `saveHead` for fulu
```go
if headState.Version() >= version.Gloas {
} else {
    full = true
}
```
This aligns `s.head.full` with what `FullHead` returns

**Option 3** is Fix in `isNewHead` (ignore full pre-gloas)
```go
    postGloas := slots.ToEpoch(s.CurrentSlot()) >= params.BeaconConfig().GloasForkEpoch
    fullChanged := postGloas && full != currentFull
    return r != currentHeadRoot || fullChanged || r == [32]byte{}
```

**Option 4** is Fix in `store.go` to not expose full=true pre gloas, which change `choosePayloadContent` to return the empty node for pre gloas. I haven't analyzed this one deeply to understand its downstream effect
```go
func (s *Store) choosePayloadContent(n *Node) *PayloadNode {
    fn := s.fullNodeByRoot[n.root]
    en := s.emptyNodeByRoot[n.root]
    if fn == nil {
        return en
    }
    if fn.full && slots.ToEpoch(n.slot) < params.BeaconConfig().GloasForkEpoch {
        return en
    }
    ...
```