### PR TITLE
Remove next epoch lookahead from PTC duties

### DIFF
--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -1242,26 +1242,17 @@ func (s *Server) GetPTCDuties(w http.ResponseWriter, r *http.Request) {
 		requestedValIndices[i] = primitives.ValidatorIndex(valIx)
 	}
 
-	// Limit how far in the future we can query (current + 1 epoch).
+	// PTC assignments are not stable for the next epoch, so only allow current epoch.
 	cs := s.TimeFetcher.CurrentSlot()
 	currentEpoch := slots.ToEpoch(cs)
-	nextEpoch := currentEpoch + 1
-	if requestedEpoch > nextEpoch {
+	if requestedEpoch > currentEpoch {
 		httputil.HandleError(w,
-			fmt.Sprintf("Request epoch %d can not be greater than next epoch %d", requestedEpoch, nextEpoch),
+			fmt.Sprintf("Request epoch %d can not be greater than current epoch %d", requestedEpoch, currentEpoch),
 			http.StatusBadRequest)
 		return
 	}
 
-	// For next epoch requests, we use the current epoch's state since PTC
-	// assignments for next epoch can be computed from current epoch's state.
-	// This mirrors the spec's get_ptc_assignment which asserts epoch <= next_epoch
-	// and uses the current state to compute assignments.
-	epochForState := requestedEpoch
-	if requestedEpoch == nextEpoch {
-		epochForState = currentEpoch
-	}
-	st, err := s.Stater.StateByEpoch(ctx, epochForState)
+	st, err := s.Stater.StateByEpoch(ctx, requestedEpoch)
 	if err != nil {
 		shared.WriteStateFetchError(w, err)
 		return

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -3289,7 +3289,7 @@ func TestGetPTCDuties(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
 		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
-		assert.StringContains(t, "can not be greater than next epoch", e.Message)
+		assert.StringContains(t, "can not be greater than current epoch", e.Message)
 	})
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2.go
@@ -85,11 +85,8 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 	if rpcErr != nil {
 		return nil, status.Errorf(core.ErrorReasonToGRPC(rpcErr.Reason), "%v", rpcErr.Err)
 	}
+	// PTC assignments are not stable for the next epoch, so only compute for current epoch.
 	currentPTCDuties, rpcErr := vs.CoreService.PTCDuties(ctx, s, req.Epoch, requestIndices)
-	if rpcErr != nil {
-		return nil, status.Errorf(core.ErrorReasonToGRPC(rpcErr.Reason), "%v", rpcErr.Err)
-	}
-	nextPTCDuties, rpcErr := vs.CoreService.PTCDuties(ctx, s, req.Epoch+1, requestIndices)
 	if rpcErr != nil {
 		return nil, status.Errorf(core.ErrorReasonToGRPC(rpcErr.Reason), "%v", rpcErr.Err)
 	}
@@ -99,7 +96,6 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 	nextAttesterMap := buildAttesterMap(nextAttesterDuties)
 	proposerMap := buildProposerMap(proposerDuties)
 	currentPTCAssignments := buildPTCMap(currentPTCDuties)
-	nextPTCAssignments := buildPTCMap(nextPTCDuties)
 	validatorAssignments := make([]*ethpb.DutiesV2Response_Duty, 0, len(req.PublicKeys))
 	nextValidatorAssignments := make([]*ethpb.DutiesV2Response_Duty, 0, len(req.PublicKeys))
 
@@ -153,10 +149,6 @@ func (vs *Server) dutiesv2(ctx context.Context, req *ethpb.DutiesRequest) (*ethp
 			nextDuty.CommitteesAtSlot = ad.CommitteesAtSlot
 			nextDuty.ValidatorCommitteeIndex = ad.ValidatorCommitteeIndex
 		}
-		if ptcSlots, ok := nextPTCAssignments[info.index]; ok {
-			nextDuty.PtcSlots = ptcSlots
-		}
-
 		// Sync committee flags
 		if coreTime.HigherEqualThanAltairVersionAndEpoch(s, req.Epoch) {
 			inSync, err := helpers.IsCurrentPeriodSyncCommittee(s, info.index)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
@@ -745,23 +745,11 @@ func TestGetDutiesV2_PTC_OK(t *testing.T) {
 	res, err := vs.GetDutiesV2(t.Context(), req)
 	require.NoError(t, err)
 
-	// Next-epoch duties span slots [SlotsPerEpoch, 2*SlotsPerEpoch).
-	nextEpochStart := params.BeaconConfig().SlotsPerEpoch
-	nextEpochEnd := nextEpochStart * 2
-	nextPTCCount := 0
+	// PTC assignments are not stable for the next epoch, so only current epoch should be populated.
 	for _, d := range res.NextEpochDuties {
-		for _, ptcSlot := range d.PtcSlots {
-			nextPTCCount++
-			if ptcSlot < nextEpochStart {
-				t.Errorf("next-epoch PtcSlot %d below epoch start %d", ptcSlot, nextEpochStart)
-			}
-			if ptcSlot >= nextEpochEnd {
-				t.Errorf("next-epoch PtcSlot %d at or after epoch end %d", ptcSlot, nextEpochEnd)
-			}
+		if len(d.PtcSlots) > 0 {
+			t.Error("expected no next-epoch PTC assignments (not stable for next epoch)")
 		}
-	}
-	if nextPTCCount == 0 {
-		t.Error("expected next-epoch PTC assignments with GloasForkEpoch=0")
 	}
 
 	currentCount := 0

--- a/changelog/satushh_ptcduties-remove-next-epoch.md
+++ b/changelog/satushh_ptcduties-remove-next-epoch.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Removed next epoch lookahead from PTC duties


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

Implemented the spec change: https://github.com/ethereum/beacon-APIs/pull/586

(Removed next epoch lookahead from PTC duties)