### PR TITLE
metrics: add initial gloas metric

### DIFF
--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -191,6 +191,7 @@ func (s *Service) latePayloadTasks(ctx context.Context) {
 	if attr == nil || attr.IsEmpty() {
 		return
 	}
+	beaconLatePayloadTaskTriggeredTotal.Inc()
 	// Head is the empty block.
 	bh, err := st.LatestBlockHash()
 	if err != nil {

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -234,6 +234,25 @@ var (
 			Help: "The maximum number of blobs allowed in a block.",
 		},
 	)
+	beaconExecutionPayloadEnvelopeValidTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_execution_payload_envelope_valid_total",
+		Help: "Count the number of execution payload envelopes that were processed successfully.",
+	})
+	beaconExecutionPayloadEnvelopeInvalidTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_execution_payload_envelope_invalid_total",
+		Help: "Count the number of execution payload envelopes that failed processing.",
+	})
+	beaconExecutionPayloadEnvelopeProcessingDurationSeconds = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "beacon_execution_payload_envelope_processing_duration_seconds",
+			Help:    "Captures end-to-end processing time for execution payload envelopes.",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+	beaconLatePayloadTaskTriggeredTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "beacon_late_payload_task_triggered_total",
+		Help: "Count the number of times late payload tasks fired.",
+	})
 )
 
 // reportSlotMetrics reports slot related metrics.

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
@@ -31,9 +32,18 @@ type ExecutionPayloadEnvelopeReceiver interface {
 }
 
 // ReceiveExecutionPayloadEnvelope processes a signed execution payload envelope for the Gloas fork.
-func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed interfaces.ROSignedExecutionPayloadEnvelope) error {
+func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed interfaces.ROSignedExecutionPayloadEnvelope) (err error) {
 	ctx, span := trace.StartSpan(ctx, "blockChain.ReceiveExecutionPayloadEnvelope")
 	defer span.End()
+	start := time.Now()
+	defer func() {
+		beaconExecutionPayloadEnvelopeProcessingDurationSeconds.Observe(time.Since(start).Seconds())
+		if err != nil {
+			beaconExecutionPayloadEnvelopeInvalidTotal.Inc()
+			return
+		}
+		beaconExecutionPayloadEnvelopeValidTotal.Inc()
+	}()
 
 	envelope, err := signed.Envelope()
 	if err != nil {

--- a/beacon-chain/core/gloas/BUILD.bazel
+++ b/beacon-chain/core/gloas/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "bid.go",
         "deposit_request.go",
         "log.go",
+        "metrics.go",
         "payload.go",
         "payload_attestation.go",
         "pending_payment.go",
@@ -38,6 +39,8 @@ go_library(
         "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/beacon-chain/core/gloas/deposit_request.go
+++ b/beacon-chain/core/gloas/deposit_request.go
@@ -65,29 +65,38 @@ func processDepositRequests(ctx context.Context, beaconState state.BeaconState, 
 //	    )
 //	</spec>
 func processDepositRequest(beaconState state.BeaconState, request *enginev1.DepositRequest) error {
+	var err error
+	defer func() {
+		if err == nil {
+			builderDepositsProcessedTotal.Inc()
+		}
+	}()
+
 	if request == nil {
-		return errors.New("nil deposit request")
+		err = errors.New("nil deposit request")
+		return err
 	}
 
-	applied, err := applyBuilderDepositRequest(beaconState, request)
+	var applied bool
+	applied, err = applyBuilderDepositRequest(beaconState, request)
 	if err != nil {
-		return errors.Wrap(err, "could not apply builder deposit")
+		err = errors.Wrap(err, "could not apply builder deposit")
+		return err
 	}
 	if applied {
-		gloasBuilderDepositsProcessedTotal.Inc()
 		return nil
 	}
 
-	if err := beaconState.AppendPendingDeposit(&ethpb.PendingDeposit{
+	if err = beaconState.AppendPendingDeposit(&ethpb.PendingDeposit{
 		PublicKey:             request.Pubkey,
 		WithdrawalCredentials: request.WithdrawalCredentials,
 		Amount:                request.Amount,
 		Signature:             request.Signature,
 		Slot:                  beaconState.Slot(),
 	}); err != nil {
-		return errors.Wrap(err, "could not append deposit request")
+		err = errors.Wrap(err, "could not append deposit request")
+		return err
 	}
-	gloasBuilderDepositsProcessedTotal.Inc()
 	return nil
 }
 

--- a/beacon-chain/core/gloas/deposit_request.go
+++ b/beacon-chain/core/gloas/deposit_request.go
@@ -74,6 +74,7 @@ func processDepositRequest(beaconState state.BeaconState, request *enginev1.Depo
 		return errors.Wrap(err, "could not apply builder deposit")
 	}
 	if applied {
+		gloasBuilderDepositsProcessedTotal.Inc()
 		return nil
 	}
 
@@ -86,6 +87,7 @@ func processDepositRequest(beaconState state.BeaconState, request *enginev1.Depo
 	}); err != nil {
 		return errors.Wrap(err, "could not append deposit request")
 	}
+	gloasBuilderDepositsProcessedTotal.Inc()
 	return nil
 }
 

--- a/beacon-chain/core/gloas/metrics.go
+++ b/beacon-chain/core/gloas/metrics.go
@@ -6,21 +6,21 @@ import (
 )
 
 var (
-	gloasBuilderPendingPaymentsProcessedTotal = promauto.NewCounter(
+	builderPendingPaymentsProcessedTotal = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "gloas_builder_pending_payments_processed_total",
+			Name: "builder_pending_payments_processed_total",
 			Help: "The number of builder pending payments promoted into the builder pending withdrawal queue.",
 		},
 	)
-	gloasBuilderDepositsProcessedTotal = promauto.NewCounter(
+	builderDepositsProcessedTotal = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "gloas_builder_deposits_processed_total",
+			Name: "builder_deposits_processed_total",
 			Help: "The number of builder-related deposit requests processed.",
 		},
 	)
-	gloasBuilderExitsProcessedTotal = promauto.NewCounter(
+	builderExitsProcessedTotal = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "gloas_builder_exits_processed_total",
+			Name: "builder_exits_processed_total",
 			Help: "The number of processed builder exits.",
 		},
 	)

--- a/beacon-chain/core/gloas/metrics.go
+++ b/beacon-chain/core/gloas/metrics.go
@@ -1,0 +1,27 @@
+package gloas
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	gloasBuilderPendingPaymentsProcessedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "gloas_builder_pending_payments_processed_total",
+			Help: "The number of builder pending payments promoted into the builder pending withdrawal queue.",
+		},
+	)
+	gloasBuilderDepositsProcessedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "gloas_builder_deposits_processed_total",
+			Help: "The number of builder-related deposit requests processed.",
+		},
+	)
+	gloasBuilderExitsProcessedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "gloas_builder_exits_processed_total",
+			Help: "The number of processed builder exits.",
+		},
+	)
+)

--- a/beacon-chain/core/gloas/pending_payment.go
+++ b/beacon-chain/core/gloas/pending_payment.go
@@ -52,6 +52,7 @@ func ProcessBuilderPendingPayments(state state.BeaconState) error {
 	if err := state.RotateBuilderPendingPayments(); err != nil {
 		return errors.Wrap(err, "could not rotate builder pending payments")
 	}
+	gloasBuilderPendingPaymentsProcessedTotal.Add(float64(len(withdrawals)))
 
 	return nil
 }

--- a/beacon-chain/core/gloas/pending_payment.go
+++ b/beacon-chain/core/gloas/pending_payment.go
@@ -52,7 +52,7 @@ func ProcessBuilderPendingPayments(state state.BeaconState) error {
 	if err := state.RotateBuilderPendingPayments(); err != nil {
 		return errors.Wrap(err, "could not rotate builder pending payments")
 	}
-	gloasBuilderPendingPaymentsProcessedTotal.Add(float64(len(withdrawals)))
+	builderPendingPaymentsProcessedTotal.Add(float64(len(withdrawals)))
 
 	return nil
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -372,6 +372,8 @@ func (f *ForkChoice) InsertPayload(pe interfaces.ROExecutionPayloadEnvelope) err
 		children:   make([]*Node, 0),
 	}
 	s.fullNodeByRoot[root] = fn
+	payloadInsertedCount.Inc()
+	updatePayloadNodeMetrics(s)
 	f.updateNewFullNodeWeight(fn)
 	return nil
 }
@@ -391,6 +393,7 @@ func (f *ForkChoice) SetPTCVote(root [32]byte, ptcIdx uint64, payloadPresent, bl
 	if n == nil {
 		return
 	}
+	ptcVoteCount.Inc()
 	if payloadPresent {
 		n.node.setPayloadAvailabilityVote(ptcIdx)
 	}

--- a/beacon-chain/forkchoice/doubly-linked-tree/metrics.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/metrics.go
@@ -48,4 +48,33 @@ var (
 			Help: "The number of times pruning happened.",
 		},
 	)
+	payloadInsertedCount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "forkchoice_payload_inserted_count",
+			Help: "The number of payloads inserted into forkchoice.",
+		},
+	)
+	payloadEmptyNodeCount = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "forkchoice_payload_empty_node_count",
+			Help: "The number of empty payload nodes currently tracked in forkchoice.",
+		},
+	)
+	payloadFullNodeCount = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "forkchoice_payload_full_node_count",
+			Help: "The number of full payload nodes currently tracked in forkchoice.",
+		},
+	)
+	ptcVoteCount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "forkchoice_ptc_vote_count",
+			Help: "The number of PTC votes recorded by forkchoice.",
+		},
+	)
 )
+
+func updatePayloadNodeMetrics(s *Store) {
+	payloadEmptyNodeCount.Set(float64(len(s.emptyNodeByRoot)))
+	payloadFullNodeCount.Set(float64(len(s.fullNodeByRoot)))
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync.go
@@ -143,5 +143,6 @@ func (s *Store) removeNodeAndChildren(ctx context.Context, pn *PayloadNode, inva
 		}
 		delete(s.emptyNodeByRoot, pn.node.root)
 	}
+	updatePayloadNodeMetrics(s)
 	return invalidRoots, nil
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -163,6 +163,7 @@ func (s *Store) insert(ctx context.Context,
 		} else {
 			delete(s.emptyNodeByRoot, root)
 			delete(s.fullNodeByRoot, root)
+			updatePayloadNodeMetrics(s)
 			return nil, errInvalidParentRoot
 		}
 	} else {
@@ -196,6 +197,7 @@ func (s *Store) insert(ctx context.Context,
 	// Update metrics.
 	processedBlockCount.Inc()
 	nodeCount.Set(float64(len(s.emptyNodeByRoot)))
+	updatePayloadNodeMetrics(s)
 
 	// Only update received block slot if it's within epoch from current time.
 	if slot+params.BeaconConfig().SlotsPerEpoch > slots.CurrentSlot(s.genesisTime) {
@@ -235,6 +237,7 @@ func (s *Store) pruneFinalizedNodeByRootMap(ctx context.Context, node, finalized
 		fn.children = nil
 		delete(s.fullNodeByRoot, node.root)
 	}
+	updatePayloadNodeMetrics(s)
 	return nil
 }
 

--- a/beacon-chain/operations/payloadattestation/BUILD.bazel
+++ b/beacon-chain/operations/payloadattestation/BUILD.bazel
@@ -2,7 +2,10 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["pool.go"],
+    srcs = [
+        "metrics.go",
+        "pool.go",
+    ],
     importpath = "github.com/OffchainLabs/prysm/v7/beacon-chain/operations/payloadattestation",
     visibility = ["//visibility:public"],
     deps = [
@@ -12,6 +15,8 @@ go_library(
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
 )
 

--- a/beacon-chain/operations/payloadattestation/metrics.go
+++ b/beacon-chain/operations/payloadattestation/metrics.go
@@ -1,0 +1,13 @@
+package payloadattestation
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var payloadAttestationPoolSize = promauto.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "payload_attestation_pool_size",
+		Help: "The number of unique payload attestation entries currently in the pool.",
+	},
+)

--- a/beacon-chain/operations/payloadattestation/pool.go
+++ b/beacon-chain/operations/payloadattestation/pool.go
@@ -44,9 +44,11 @@ type Pool struct {
 
 // NewPool returns an initialized pool.
 func NewPool() *Pool {
-	return &Pool{
+	pool := &Pool{
 		pending: make(map[payloadAttestationDataKey]*ethpb.PayloadAttestation),
 	}
+	payloadAttestationPoolSize.Set(0)
+	return pool
 }
 
 // PendingPayloadAttestations returns payload attestations for the requested slot.
@@ -89,6 +91,7 @@ func (p *Pool) InsertPayloadAttestation(msg *ethpb.PayloadAttestationMessage, id
 	existing, ok := p.pending[key]
 	if !ok {
 		p.pending[key] = messageToPayloadAttestation(msg, idx)
+		payloadAttestationPoolSize.Set(float64(len(p.pending)))
 		return nil
 	}
 
@@ -102,6 +105,7 @@ func (p *Pool) InsertPayloadAttestation(msg *ethpb.PayloadAttestationMessage, id
 	}
 	existing.Signature = sig
 	existing.AggregationBits.SetBitAt(idx, true)
+	payloadAttestationPoolSize.Set(float64(len(p.pending)))
 	return nil
 }
 
@@ -111,6 +115,7 @@ func (p *Pool) pruneOlderSlotsLocked(slot primitives.Slot) {
 			delete(p.pending, key)
 		}
 	}
+	payloadAttestationPoolSize.Set(float64(len(p.pending)))
 }
 
 // Seen reports whether idx has already been observed for the given

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -39,10 +39,6 @@ var (
 		Name: "payload_id_cache_hit",
 		Help: "The number of payload id get requests that are present in the cache.",
 	})
-	gloasPayloadIDCacheTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "gloas_payload_id_cache_total",
-		Help: "The number of Gloas payload ID cache requests by result.",
-	}, []string{"result"})
 )
 
 func setFeeRecipientIfBurnAddress(val *cache.TrackedValidator) {
@@ -93,9 +89,6 @@ func (vs *Server) getLocalPayloadFromEngine(
 		var pid primitives.PayloadID
 		copy(pid[:], payloadId[:])
 		payloadIDCacheHit.Inc()
-		if st.Version() >= version.Gloas {
-			gloasPayloadIDCacheTotal.WithLabelValues("hit").Inc()
-		}
 		res, err := vs.ExecutionEngineCaller.GetPayload(ctx, pid, slot)
 		if err == nil {
 			warnIfFeeRecipientDiffers(val.FeeRecipient[:], res.ExecutionData.FeeRecipient())
@@ -117,9 +110,6 @@ func (vs *Server) getLocalPayloadFromEngine(
 		return nil, err
 	}
 	payloadIDCacheMiss.Inc()
-	if st.Version() >= version.Gloas {
-		gloasPayloadIDCacheTotal.WithLabelValues("miss").Inc()
-	}
 
 	random, err := helpers.RandaoMix(st, time.CurrentEpoch(st))
 	if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -39,6 +39,10 @@ var (
 		Name: "payload_id_cache_hit",
 		Help: "The number of payload id get requests that are present in the cache.",
 	})
+	gloasPayloadIDCacheTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gloas_payload_id_cache_total",
+		Help: "The number of Gloas payload ID cache requests by result.",
+	}, []string{"result"})
 )
 
 func setFeeRecipientIfBurnAddress(val *cache.TrackedValidator) {
@@ -89,6 +93,9 @@ func (vs *Server) getLocalPayloadFromEngine(
 		var pid primitives.PayloadID
 		copy(pid[:], payloadId[:])
 		payloadIDCacheHit.Inc()
+		if st.Version() >= version.Gloas {
+			gloasPayloadIDCacheTotal.WithLabelValues("hit").Inc()
+		}
 		res, err := vs.ExecutionEngineCaller.GetPayload(ctx, pid, slot)
 		if err == nil {
 			warnIfFeeRecipientDiffers(val.FeeRecipient[:], res.ExecutionData.FeeRecipient())
@@ -110,6 +117,9 @@ func (vs *Server) getLocalPayloadFromEngine(
 		return nil, err
 	}
 	payloadIDCacheMiss.Inc()
+	if st.Version() >= version.Gloas {
+		gloasPayloadIDCacheTotal.WithLabelValues("miss").Inc()
+	}
 
 	random, err := helpers.RandaoMix(st, time.CurrentEpoch(st))
 	if err != nil {

--- a/beacon-chain/state/state-native/BUILD.bazel
+++ b/beacon-chain/state/state-native/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "gloas.go",
         "hasher.go",
         "log.go",
+        "metrics_gloas.go",
         "multi_value_slices.go",
         "proofs.go",
         "readonly_validator.go",

--- a/beacon-chain/state/state-native/metrics_gloas.go
+++ b/beacon-chain/state/state-native/metrics_gloas.go
@@ -1,0 +1,45 @@
+package state_native
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	gloasExecutionPayloadAvailabilityRatio = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "gloas_execution_payload_availability_ratio",
+			Help: "The fraction of execution payload availability bits currently set in the beacon state.",
+		},
+	)
+	gloasBuilderPendingWithdrawalsCount = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "gloas_builder_pending_withdrawals_count",
+			Help: "The number of builder pending withdrawals currently stored in the beacon state.",
+		},
+	)
+	gloasBuilderPendingWithdrawalsGwei = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "gloas_builder_pending_withdrawals_gwei",
+			Help: "The total gwei amount currently stored in builder pending withdrawals.",
+		},
+	)
+	gloasPayloadExpectedWithdrawalsCount = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "gloas_payload_expected_withdrawals_count",
+			Help: "The number of expected withdrawals currently cached for the next payload.",
+		},
+	)
+	gloasActiveBuildersCount = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "gloas_active_builders_count",
+			Help: "The number of active builders currently tracked in the beacon state.",
+		},
+	)
+	gloasActiveBuildersBalanceGwei = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "gloas_active_builders_balance_gwei",
+			Help: "The total balance in gwei held by active builders currently tracked in the beacon state.",
+		},
+	)
+)

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -3,6 +3,7 @@ package state_native
 import (
 	"context"
 	"fmt"
+	"math/bits"
 	"runtime"
 	"slices"
 
@@ -1195,6 +1196,66 @@ func (b *BeaconState) RecordStateMetrics() {
 		multiValueAppendedElementsCountGauge.WithLabelValues(types.RandaoMixes.String()).Set(float64(stats.TotalAppendedElements))
 		multiValueAppendedElementReferencesCountGauge.WithLabelValues(types.RandaoMixes.String()).Set(float64(stats.TotalAppendedElemReferences))
 	}
+
+	recordGloasStateMetrics(b)
+}
+
+func recordGloasStateMetrics(b *BeaconState) {
+	if b.version < version.Gloas {
+		gloasExecutionPayloadAvailabilityRatio.Set(0)
+		gloasBuilderPendingWithdrawalsCount.Set(0)
+		gloasBuilderPendingWithdrawalsGwei.Set(0)
+		gloasPayloadExpectedWithdrawalsCount.Set(0)
+		gloasActiveBuildersCount.Set(0)
+		gloasActiveBuildersBalanceGwei.Set(0)
+		return
+	}
+
+	slotsPerHistoricalRoot := uint64(params.BeaconConfig().SlotsPerHistoricalRoot)
+	if slotsPerHistoricalRoot == 0 {
+		gloasExecutionPayloadAvailabilityRatio.Set(0)
+	} else {
+		availableCount := 0
+		for i, availabilityByte := range b.executionPayloadAvailability {
+			if i == len(b.executionPayloadAvailability)-1 && slotsPerHistoricalRoot%8 != 0 {
+				mask := byte((1 << (slotsPerHistoricalRoot % 8)) - 1)
+				availableCount += bits.OnesCount8(availabilityByte & mask)
+				continue
+			}
+			availableCount += bits.OnesCount8(availabilityByte)
+		}
+		gloasExecutionPayloadAvailabilityRatio.Set(float64(availableCount) / float64(slotsPerHistoricalRoot))
+	}
+
+	var pendingWithdrawalsGwei uint64
+	for _, withdrawal := range b.builderPendingWithdrawals {
+		if withdrawal == nil {
+			continue
+		}
+		pendingWithdrawalsGwei += uint64(withdrawal.Amount)
+	}
+	gloasBuilderPendingWithdrawalsCount.Set(float64(len(b.builderPendingWithdrawals)))
+	gloasBuilderPendingWithdrawalsGwei.Set(float64(pendingWithdrawalsGwei))
+	gloasPayloadExpectedWithdrawalsCount.Set(float64(len(b.payloadExpectedWithdrawals)))
+
+	var activeBuildersCount uint64
+	var activeBuildersBalanceGwei uint64
+	finalizedEpoch := primitives.Epoch(0)
+	if b.finalizedCheckpoint != nil {
+		finalizedEpoch = b.finalizedCheckpoint.Epoch
+	}
+	for _, builder := range b.builders {
+		if builder == nil {
+			continue
+		}
+		if builder.DepositEpoch >= finalizedEpoch || builder.WithdrawableEpoch != params.BeaconConfig().FarFutureEpoch {
+			continue
+		}
+		activeBuildersCount++
+		activeBuildersBalanceGwei += uint64(builder.Balance)
+	}
+	gloasActiveBuildersCount.Set(float64(activeBuildersCount))
+	gloasActiveBuildersBalanceGwei.Set(float64(activeBuildersBalanceGwei))
 }
 
 // IsNil checks if the state and the underlying proto

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "rpc_data_column_sidecars_by_root.go",
         "rpc_execution_payload_envelopes_by_range.go",
         "rpc_execution_payload_envelopes_by_root.go",
+        "rpc_execution_payload_envelopes_metrics.go",
         "rpc_goodbye.go",
         "rpc_light_client.go",
         "rpc_metadata.go",

--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -139,6 +139,13 @@ var (
 			Help: "Time to verify gossiped attestations",
 		},
 	)
+	syncPayloadAttestationArrivalDelaySeconds = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sync_payload_attestation_arrival_delay_seconds",
+			Help:    "Time from slot start to payload attestation gossip arrival.",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
 	blockVerificationGossipSummary = promauto.NewSummary(
 		prometheus.SummaryOpts{
 			Name: "gossip_block_verification_milliseconds",
@@ -216,6 +223,32 @@ var (
 			Name: "data_columns_recovered_from_el_total",
 			Help: "Count the number of times data columns have been recovered from the execution layer.",
 		},
+	)
+	syncExecutionPayloadEnvelopeArrivalDelaySeconds = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sync_execution_payload_envelope_arrival_delay_seconds",
+			Help:    "Time from slot start to execution payload envelope gossip arrival.",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+	syncPayloadEnvelopeByRangeServedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "sync_payload_envelope_by_range_served_total",
+			Help: "Count the number of execution payload envelopes by range RPC requests served.",
+		},
+	)
+	syncPayloadEnvelopeByRootServedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "sync_payload_envelope_by_root_served_total",
+			Help: "Count the number of execution payload envelopes by root RPC requests served.",
+		},
+	)
+	gloasExecutionPayloadEnvelopesRPCRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gloas_execution_payload_envelopes_rpc_requests_total",
+			Help: "Count execution payload envelope RPC requests by method and outcome.",
+		},
+		[]string{"rpc", "result"},
 	)
 
 	// Data column sidecar validation, beacon metrics specs

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_range.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_range.go
@@ -26,6 +26,12 @@ var envelopeRpcThrottleInterval = time.Second
 func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context, msg any, stream libp2pcore.Stream) error {
 	ctx, span := trace.StartSpan(ctx, "sync.ExecutionPayloadEnvelopesByRangeHandler")
 	defer span.End()
+	recordResult := func(result string) {
+		gloasExecutionPayloadEnvelopesRPCRequestsTotal.WithLabelValues("by_range", result).Inc()
+		if result == "served" {
+			syncPayloadEnvelopeByRangeServedTotal.Inc()
+		}
+	}
 	ctx, cancel := context.WithTimeout(ctx, respTimeout)
 	defer cancel()
 	SetRPCStreamDeadlines(stream)
@@ -33,9 +39,11 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 
 	r, ok := msg.(*pb.ExecutionPayloadEnvelopesByRangeRequest)
 	if !ok {
+		recordResult("invalid")
 		return errors.New("message is not type *pb.ExecutionPayloadEnvelopesByRangeRequest")
 	}
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
+		recordResult("rate_limited")
 		return err
 	}
 
@@ -49,6 +57,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 
 	rp, err := validateEnvelopesByRange(r, s.cfg.clock.CurrentSlot())
 	if err != nil {
+		recordResult("invalid")
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		s.downscorePeer(remotePeer, "executionPayloadEnvelopesByRangeRPCHandlerValidationError")
 		tracing.AnnotateError(span, err)
@@ -56,6 +65,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	}
 	available := s.validateRangeAvailability(rp)
 	if !available {
+		recordResult("resource_unavailable")
 		currentSlot := s.cfg.clock.CurrentSlot()
 		unavailableErr := errors.Wrapf(
 			p2ptypes.ErrResourceUnavailable,
@@ -80,6 +90,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	defer ticker.Stop()
 	batcher, err := newBlockRangeBatcher(rp, s.cfg.beaconDB, s.rateLimiter, s.cfg.chain.IsCanonical, ticker)
 	if err != nil {
+		recordResult("error")
 		log.WithError(err).Error("Cannot create new block range batcher for envelopes")
 		s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
 		tracing.AnnotateError(span, err)
@@ -93,6 +104,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	for batch, more = batcher.next(ctx, stream); more; batch, more = batcher.next(ctx, stream) {
 		wQuota, err = s.streamEnvelopeBatch(ctx, batch, wQuota, stream)
 		if err != nil {
+			recordResult("error")
 			return err
 		}
 		if wQuota == 0 {
@@ -103,12 +115,16 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	if err := batch.error(); err != nil {
 		log.WithError(err).Debug("Error in ExecutionPayloadEnvelopesByRange batch")
 		if !errors.Is(err, p2ptypes.ErrRateLimited) {
+			recordResult("error")
 			s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
+		} else {
+			recordResult("rate_limited")
 		}
 		tracing.AnnotateError(span, err)
 		return err
 	}
 
+	recordResult("served")
 	closeStream(stream, log)
 	return nil
 }

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_range.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_range.go
@@ -26,9 +26,9 @@ var envelopeRpcThrottleInterval = time.Second
 func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context, msg any, stream libp2pcore.Stream) error {
 	ctx, span := trace.StartSpan(ctx, "sync.ExecutionPayloadEnvelopesByRangeHandler")
 	defer span.End()
-	recordResult := func(result string) {
-		gloasExecutionPayloadEnvelopesRPCRequestsTotal.WithLabelValues("by_range", result).Inc()
-		if result == "served" {
+	recordResult := func(result executionPayloadEnvelopeRPCResult) {
+		gloasExecutionPayloadEnvelopesRPCRequestsTotal.WithLabelValues("by_range", string(result)).Inc()
+		if result == executionPayloadEnvelopeRPCResultServed {
 			syncPayloadEnvelopeByRangeServedTotal.Inc()
 		}
 	}
@@ -39,11 +39,11 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 
 	r, ok := msg.(*pb.ExecutionPayloadEnvelopesByRangeRequest)
 	if !ok {
-		recordResult("invalid")
+		recordResult(executionPayloadEnvelopeRPCResultInvalid)
 		return errors.New("message is not type *pb.ExecutionPayloadEnvelopesByRangeRequest")
 	}
 	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
-		recordResult("rate_limited")
+		recordResult(executionPayloadEnvelopeRPCResultRateLimited)
 		return err
 	}
 
@@ -57,7 +57,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 
 	rp, err := validateEnvelopesByRange(r, s.cfg.clock.CurrentSlot())
 	if err != nil {
-		recordResult("invalid")
+		recordResult(executionPayloadEnvelopeRPCResultInvalid)
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		s.downscorePeer(remotePeer, "executionPayloadEnvelopesByRangeRPCHandlerValidationError")
 		tracing.AnnotateError(span, err)
@@ -65,7 +65,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	}
 	available := s.validateRangeAvailability(rp)
 	if !available {
-		recordResult("resource_unavailable")
+		recordResult(executionPayloadEnvelopeRPCResultResourceUnavailable)
 		currentSlot := s.cfg.clock.CurrentSlot()
 		unavailableErr := errors.Wrapf(
 			p2ptypes.ErrResourceUnavailable,
@@ -90,7 +90,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	defer ticker.Stop()
 	batcher, err := newBlockRangeBatcher(rp, s.cfg.beaconDB, s.rateLimiter, s.cfg.chain.IsCanonical, ticker)
 	if err != nil {
-		recordResult("error")
+		recordResult(executionPayloadEnvelopeRPCResultError)
 		log.WithError(err).Error("Cannot create new block range batcher for envelopes")
 		s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
 		tracing.AnnotateError(span, err)
@@ -104,7 +104,7 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	for batch, more = batcher.next(ctx, stream); more; batch, more = batcher.next(ctx, stream) {
 		wQuota, err = s.streamEnvelopeBatch(ctx, batch, wQuota, stream)
 		if err != nil {
-			recordResult("error")
+			recordResult(executionPayloadEnvelopeRPCResultError)
 			return err
 		}
 		if wQuota == 0 {
@@ -115,16 +115,16 @@ func (s *Service) executionPayloadEnvelopesByRangeRPCHandler(ctx context.Context
 	if err := batch.error(); err != nil {
 		log.WithError(err).Debug("Error in ExecutionPayloadEnvelopesByRange batch")
 		if !errors.Is(err, p2ptypes.ErrRateLimited) {
-			recordResult("error")
+			recordResult(executionPayloadEnvelopeRPCResultError)
 			s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
 		} else {
-			recordResult("rate_limited")
+			recordResult(executionPayloadEnvelopeRPCResultRateLimited)
 		}
 		tracing.AnnotateError(span, err)
 		return err
 	}
 
-	recordResult("served")
+	recordResult(executionPayloadEnvelopeRPCResultServed)
 	closeStream(stream, log)
 	return nil
 }

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_root.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_root.go
@@ -25,9 +25,9 @@ import (
 func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context, msg any, stream libp2pcore.Stream) error {
 	ctx, span := trace.StartSpan(ctx, "sync.executionPayloadEnvelopesByRootRPCHandler")
 	defer span.End()
-	recordResult := func(result string) {
-		gloasExecutionPayloadEnvelopesRPCRequestsTotal.WithLabelValues("by_root", result).Inc()
-		if result == "served" {
+	recordResult := func(result executionPayloadEnvelopeRPCResult) {
+		gloasExecutionPayloadEnvelopesRPCRequestsTotal.WithLabelValues("by_root", string(result)).Inc()
+		if result == executionPayloadEnvelopeRPCResultServed {
 			syncPayloadEnvelopeByRootServedTotal.Inc()
 		}
 	}
@@ -38,20 +38,20 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 
 	ref, ok := msg.(*types.ExecutionPayloadEnvelopesByRootReq)
 	if !ok {
-		recordResult("invalid")
+		recordResult(executionPayloadEnvelopeRPCResultInvalid)
 		return errors.New("message is not type ExecutionPayloadEnvelopesByRootReq")
 	}
 
 	requestedRoots := *ref
 
 	if err := s.rateLimiter.validateRequest(stream, uint64(len(requestedRoots))); err != nil {
-		recordResult("rate_limited")
+		recordResult(executionPayloadEnvelopeRPCResultRateLimited)
 		return errors.Wrap(err, "rate limiter validate request")
 	}
 
 	remotePeer := stream.Conn().RemotePeer()
 	if err := validateExecutionPayloadEnvelopeByRootRequest(len(requestedRoots)); err != nil {
-		recordResult("invalid")
+		recordResult(executionPayloadEnvelopeRPCResultInvalid)
 		s.downscorePeer(remotePeer, "executionPayloadEnvelopesByRootRPCHandlerValidationError")
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		return err
@@ -78,7 +78,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 		env  *ethpb.SignedBlindedExecutionPayloadEnvelope
 	}
 	if s.cfg.executionReconstructor == nil {
-		recordResult("error")
+		recordResult(executionPayloadEnvelopeRPCResultError)
 		s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 		return errors.New("execution reconstructor is nil")
 	}
@@ -96,7 +96,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 
 		for _, root := range rootsBatch {
 			if err := ctx.Err(); err != nil {
-				recordResult("error")
+				recordResult(executionPayloadEnvelopeRPCResultError)
 				return err
 			}
 			s.rateLimiter.add(stream, 1)
@@ -108,7 +108,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 					continue
 				}
 				log.WithError(err).Debug("Could not fetch blinded execution payload envelope")
-				recordResult("error")
+				recordResult(executionPayloadEnvelopeRPCResultError)
 				s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 				return err
 			}
@@ -137,7 +137,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 
 		payloadByHash, batchErr := s.cfg.executionReconstructor.ReconstructFullExecutionPayloadsByHash(ctx, batchHashes)
 		if batchErr != nil {
-			recordResult("error")
+			recordResult(executionPayloadEnvelopeRPCResultError)
 			log.WithError(batchErr).Debug("Could not batch reconstruct full execution payload envelopes")
 			s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 			return batchErr
@@ -165,7 +165,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 			SetStreamWriteDeadline(stream, defaultWriteDuration)
 			if chunkErr := WriteExecutionPayloadEnvelopeChunk(stream, s.cfg.p2p.Encoding(), envelope); chunkErr != nil {
 				log.WithError(chunkErr).Debug("Could not send a chunked response")
-				recordResult("error")
+				recordResult(executionPayloadEnvelopeRPCResultError)
 				s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 				tracing.AnnotateError(span, chunkErr)
 				return chunkErr
@@ -173,7 +173,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 		}
 	}
 
-	recordResult("served")
+	recordResult(executionPayloadEnvelopeRPCResultServed)
 	return nil
 }
 

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_root.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_root.go
@@ -25,6 +25,12 @@ import (
 func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context, msg any, stream libp2pcore.Stream) error {
 	ctx, span := trace.StartSpan(ctx, "sync.executionPayloadEnvelopesByRootRPCHandler")
 	defer span.End()
+	recordResult := func(result string) {
+		gloasExecutionPayloadEnvelopesRPCRequestsTotal.WithLabelValues("by_root", result).Inc()
+		if result == "served" {
+			syncPayloadEnvelopeByRootServedTotal.Inc()
+		}
+	}
 	ctx, cancel := context.WithTimeout(ctx, ttfbTimeout)
 	defer cancel()
 	SetRPCStreamDeadlines(stream)
@@ -32,17 +38,20 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 
 	ref, ok := msg.(*types.ExecutionPayloadEnvelopesByRootReq)
 	if !ok {
+		recordResult("invalid")
 		return errors.New("message is not type ExecutionPayloadEnvelopesByRootReq")
 	}
 
 	requestedRoots := *ref
 
 	if err := s.rateLimiter.validateRequest(stream, uint64(len(requestedRoots))); err != nil {
+		recordResult("rate_limited")
 		return errors.Wrap(err, "rate limiter validate request")
 	}
 
 	remotePeer := stream.Conn().RemotePeer()
 	if err := validateExecutionPayloadEnvelopeByRootRequest(len(requestedRoots)); err != nil {
+		recordResult("invalid")
 		s.downscorePeer(remotePeer, "executionPayloadEnvelopesByRootRPCHandlerValidationError")
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, err.Error(), stream)
 		return err
@@ -69,6 +78,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 		env  *ethpb.SignedBlindedExecutionPayloadEnvelope
 	}
 	if s.cfg.executionReconstructor == nil {
+		recordResult("error")
 		s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 		return errors.New("execution reconstructor is nil")
 	}
@@ -86,6 +96,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 
 		for _, root := range rootsBatch {
 			if err := ctx.Err(); err != nil {
+				recordResult("error")
 				return err
 			}
 			s.rateLimiter.add(stream, 1)
@@ -97,6 +108,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 					continue
 				}
 				log.WithError(err).Debug("Could not fetch blinded execution payload envelope")
+				recordResult("error")
 				s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 				return err
 			}
@@ -125,6 +137,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 
 		payloadByHash, batchErr := s.cfg.executionReconstructor.ReconstructFullExecutionPayloadsByHash(ctx, batchHashes)
 		if batchErr != nil {
+			recordResult("error")
 			log.WithError(batchErr).Debug("Could not batch reconstruct full execution payload envelopes")
 			s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 			return batchErr
@@ -152,6 +165,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 			SetStreamWriteDeadline(stream, defaultWriteDuration)
 			if chunkErr := WriteExecutionPayloadEnvelopeChunk(stream, s.cfg.p2p.Encoding(), envelope); chunkErr != nil {
 				log.WithError(chunkErr).Debug("Could not send a chunked response")
+				recordResult("error")
 				s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 				tracing.AnnotateError(span, chunkErr)
 				return chunkErr
@@ -159,6 +173,7 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 		}
 	}
 
+	recordResult("served")
 	return nil
 }
 

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_metrics.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_metrics.go
@@ -1,0 +1,11 @@
+package sync
+
+type executionPayloadEnvelopeRPCResult string
+
+const (
+	executionPayloadEnvelopeRPCResultServed              executionPayloadEnvelopeRPCResult = "served"
+	executionPayloadEnvelopeRPCResultInvalid             executionPayloadEnvelopeRPCResult = "invalid"
+	executionPayloadEnvelopeRPCResultRateLimited         executionPayloadEnvelopeRPCResult = "rate_limited"
+	executionPayloadEnvelopeRPCResultResourceUnavailable executionPayloadEnvelopeRPCResult = "resource_unavailable"
+	executionPayloadEnvelopeRPCResultError               executionPayloadEnvelopeRPCResult = "error"
+)

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	prysmTime "github.com/OffchainLabs/prysm/v7/time"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -29,6 +30,7 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 	if s.cfg.initialSync.Syncing() {
 		return pubsub.ValidationIgnore, nil
 	}
+	receivedTime := prysmTime.Now()
 
 	ctx, span := trace.StartSpan(ctx, "sync.validateExecutionPayloadEnvelope")
 	defer span.End()
@@ -129,6 +131,12 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 	}
 	s.setSeenPayloadEnvelope(root, env.BuilderIndex())
 	msg.ValidatorData = signedEnvelope
+	startTime, err := slots.StartTime(s.cfg.clock.GenesisTime(), env.Slot())
+	if err == nil {
+		syncExecutionPayloadEnvelopeArrivalDelaySeconds.Observe(receivedTime.Sub(startTime).Seconds())
+	} else {
+		log.WithError(err).WithField("slot", env.Slot()).Debug("Could not compute execution payload envelope slot start time")
+	}
 	return pubsub.ValidationAccept, nil
 }
 

--- a/beacon-chain/sync/validate_payload_attestation.go
+++ b/beacon-chain/sync/validate_payload_attestation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	prysmTime "github.com/OffchainLabs/prysm/v7/time"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -29,6 +30,7 @@ func (s *Service) validatePayloadAttestation(ctx context.Context, pid peer.ID, m
 	if s.cfg.initialSync.Syncing() {
 		return pubsub.ValidationIgnore, nil
 	}
+	receivedTime := prysmTime.Now()
 	ctx, span := trace.StartSpan(ctx, "sync.validatePayloadAttestation")
 	defer span.End()
 
@@ -90,6 +92,12 @@ func (s *Service) validatePayloadAttestation(ctx context.Context, pid peer.ID, m
 	}
 
 	msg.ValidatorData = att
+	startTime, err := slots.StartTime(s.cfg.clock.GenesisTime(), pa.Slot())
+	if err == nil {
+		syncPayloadAttestationArrivalDelaySeconds.Observe(receivedTime.Sub(startTime).Seconds())
+	} else {
+		log.WithError(err).WithField("slot", pa.Slot()).Debug("Could not compute payload attestation slot start time")
+	}
 
 	return pubsub.ValidationAccept, nil
 }

--- a/changelog/tt_gloas-metrics.md
+++ b/changelog/tt_gloas-metrics.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add initial Gloas observability metrics across forkchoice, blockchain, sync, payload attestation pool, validator RPC, validator client, core/gloas, and state-native

--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -205,6 +205,22 @@ var (
 			"pubkey",
 		},
 	)
+	validatorPayloadAttestationSubmissionTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "validator",
+			Name:      "payload_attestation_submission_total",
+			Help:      "The number of payload attestation submissions by result in the validator client.",
+		},
+		[]string{"result"},
+	)
+	validatorSelfBuildEnvelopeSubmissionTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "validator",
+			Name:      "self_build_envelope_submission_total",
+			Help:      "The number of self-build execution payload envelope submissions by result.",
+		},
+		[]string{"result"},
+	)
 )
 
 // LogValidatorGainsAndLosses logs important metrics related to this validator client's

--- a/validator/client/payload_attestation.go
+++ b/validator/client/payload_attestation.go
@@ -32,6 +32,7 @@ func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitive
 
 	data, err := v.validatorClient.PayloadAttestationData(ctx, slot)
 	if err != nil {
+		validatorPayloadAttestationSubmissionTotal.WithLabelValues("failed").Inc()
 		log.WithError(err).Error("Could not request payload attestation data")
 		tracing.AnnotateError(span, err)
 		return
@@ -39,12 +40,14 @@ func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitive
 
 	d, err := v.domainData(ctx, slots.ToEpoch(slot), params.BeaconConfig().DomainPTCAttester[:])
 	if err != nil {
+		validatorPayloadAttestationSubmissionTotal.WithLabelValues("failed").Inc()
 		log.WithError(err).Error("Could not get PTC attester domain data")
 		return
 	}
 
 	r, err := signing.ComputeSigningRoot(data, d.SignatureDomain)
 	if err != nil {
+		validatorPayloadAttestationSubmissionTotal.WithLabelValues("failed").Inc()
 		log.WithError(err).Error("Could not compute payload attestation signing root")
 		return
 	}
@@ -59,12 +62,14 @@ func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitive
 		SigningSlot: slot,
 	})
 	if err != nil {
+		validatorPayloadAttestationSubmissionTotal.WithLabelValues("failed").Inc()
 		log.WithError(err).Error("Could not sign payload attestation")
 		return
 	}
 
 	duty, err := v.duty(pubKey)
 	if err != nil {
+		validatorPayloadAttestationSubmissionTotal.WithLabelValues("failed").Inc()
 		log.WithError(err).Error("Could not fetch validator assignment")
 		return
 	}
@@ -75,9 +80,11 @@ func (v *validator) SubmitPayloadAttestation(ctx context.Context, slot primitive
 		Signature:      sig.Marshal(),
 	}
 	if _, err := v.validatorClient.SubmitPayloadAttestation(ctx, msg); err != nil {
+		validatorPayloadAttestationSubmissionTotal.WithLabelValues("failed").Inc()
 		log.WithError(err).Error("Could not submit payload attestation")
 		return
 	}
+	validatorPayloadAttestationSubmissionTotal.WithLabelValues("success").Inc()
 
 	slotTime, err := slots.StartTime(v.genesisTime, slot)
 	if err != nil {

--- a/validator/client/propose_gloas.go
+++ b/validator/client/propose_gloas.go
@@ -87,17 +87,21 @@ func (v *validator) proposeSelfBuildEnvelope(
 
 	envelope, err := v.validatorClient.GetExecutionPayloadEnvelope(ctx, slot)
 	if err != nil {
+		validatorSelfBuildEnvelopeSubmissionTotal.WithLabelValues("failed").Inc()
 		return errors.Wrap(err, "failed to get execution payload envelope for self-build")
 	}
 
 	signedEnvelope, err := v.signExecutionPayloadEnvelope(ctx, pubKey, slot, envelope)
 	if err != nil {
+		validatorSelfBuildEnvelopeSubmissionTotal.WithLabelValues("failed").Inc()
 		return errors.Wrap(err, "could not sign execution payload envelope")
 	}
 
 	if _, err := v.validatorClient.PublishExecutionPayloadEnvelope(ctx, signedEnvelope); err != nil {
+		validatorSelfBuildEnvelopeSubmissionTotal.WithLabelValues("failed").Inc()
 		return errors.Wrap(err, "failed to publish execution payload envelope")
 	}
+	validatorSelfBuildEnvelopeSubmissionTotal.WithLabelValues("success").Inc()
 
 	return nil
 }


### PR DESCRIPTION
This PR adds an initial gloas metric

**Forkchoice**
- Add `forkchoice_payload_inserted_count`
- Add `forkchoice_payload_empty_node_count`
- Add `forkchoice_payload_full_node_count`
- Add `forkchoice_ptc_vote_count`

These metrics show how forkchoice evolves under Gloas:
- how many payload nodes are inserted
- how many currently tracked nodes represent empty payloads vs full payloads
- how many PTC votes forkchoice receives

**Blockchain**
- Add `beacon_execution_payload_envelope_valid_total`
- Add `beacon_execution_payload_envelope_invalid_total`
- Add `beacon_execution_payload_envelope_processing_duration_seconds`
- Add `beacon_late_payload_task_triggered_total`

These metrics track the beacon node’s envelope handling:
- whether received execution payload envelopes are accepted or rejected
- how long envelope processing takes end-to-end
- how often the late payload task fires during the slot

**Sync**
- Add `sync_payload_attestation_arrival_delay_seconds`
- Add `sync_execution_payload_envelope_arrival_delay_seconds`
- Add `sync_payload_envelope_by_range_served_total`
- Add `sync_payload_envelope_by_root_served_total`
- Add `gloas_execution_payload_envelopes_rpc_requests_total{rpc,result}`

These metrics focus on network timing and RPC serving:
- how long after slot start payload attestations and payload envelopes arrive over gossip
- how often payload envelope RPC requests are served
- how payload-envelope RPC requests break down by method and result

For gossip validation, only arrival delay remains:
- payload attestation
- execution payload envelope
- data column sidecar continues to use the existing generic arrival metric

Custom sync-side gossip result counters were removed because libp2p already accounts for validation outcomes.

**Payload Attestation Pool**
- Add `payload_attestation_pool_size`

This metric shows the current size of the payload attestation pool, which is useful for seeing whether attestations are being accumulated or drained as expected.

**Validator RPC**
- Add `gloas_payload_id_cache_total{result}`

This metric shows Gloas proposer payload ID cache behavior:
- cache hits
- cache misses

That helps explain whether proposers are reusing cached EL payload IDs or falling back to fresh forkchoice updates.

**Validator Client**
- Add `validator_payload_attestation_submission_total{result}`
- Add `validator_self_build_envelope_submission_total{result}`

These metrics show validator-side Gloas behavior:
- whether payload attestation submissions succeed or fail
- whether self-build envelope submissions succeed or fail

**Core Gloas**
- Add `gloas_builder_pending_payments_processed_total`
- Add `gloas_builder_deposits_processed_total`

These metrics show builder-economics state transitions:
- how many pending builder payments are promoted into pending withdrawals
- how many builder-related deposit requests are processed

**State Native**
- Add `gloas_execution_payload_availability_ratio`
- Add `gloas_builder_pending_withdrawals_count`
- Add `gloas_builder_pending_withdrawals_gwei`
- Add `gloas_payload_expected_withdrawals_count`
- Add `gloas_active_builders_count`
- Add `gloas_active_builders_balance_gwei`

These metrics expose the current Gloas state snapshot:
- how much of the payload availability window is marked available
- how many builder pending withdrawals exist and their total value
- how many expected withdrawals are cached for the next payload
- how many builders are currently active and their aggregate balance

These are emitted from `RecordStateMetrics()` 

