### PR TITLE
Remove non-standard `validator_count` beacon API, leave it as Prysm-specific

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -1109,16 +1109,6 @@ func (s *Service) prysmBeaconEndpoints(
 			methods: []string{http.MethodGet},
 		},
 		{
-			template: "/eth/v1/beacon/states/{state_id}/validator_count",
-			name:     namespace + ".GetValidatorCount",
-			middleware: []middleware.Middleware{
-				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
-				middleware.AcceptEncodingHeaderHandler(),
-			},
-			handler: server.GetValidatorCount,
-			methods: []string{http.MethodGet},
-		},
-		{
 			template: "/prysm/v1/beacon/states/{state_id}/validator_count",
 			name:     namespace + ".GetValidatorCount",
 			middleware: []middleware.Middleware{

--- a/beacon-chain/rpc/endpoints_test.go
+++ b/beacon-chain/rpc/endpoints_test.go
@@ -114,7 +114,6 @@ func Test_endpoints(t *testing.T) {
 
 	prysmBeaconRoutes := map[string][]string{
 		"/prysm/v1/beacon/weak_subjectivity":                 {http.MethodGet},
-		"/eth/v1/beacon/states/{state_id}/validator_count":   {http.MethodGet},
 		"/prysm/v1/beacon/states/{state_id}/validator_count": {http.MethodGet},
 		"/prysm/v1/beacon/chain_head":                        {http.MethodGet},
 		"/prysm/v1/beacon/blobs":                             {http.MethodPost},

--- a/beacon-chain/rpc/prysm/beacon/validator_count.go
+++ b/beacon-chain/rpc/prysm/beacon/validator_count.go
@@ -20,7 +20,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 )
 
-// GetValidatorCount is a HTTP handler that serves the GET /eth/v1/beacon/states/{state_id}/validator_count endpoint.
+// GetValidatorCount is a HTTP handler that serves the GET /prysm/v1/beacon/states/{state_id}/validator_count endpoint.
 // It returns the total validator count according to the given statuses provided as a query parameter.
 //
 // The state ID is expected to be a valid Beacon Chain state identifier.
@@ -30,7 +30,7 @@ import (
 //
 // Example usage:
 //
-//	GET /eth/v1/beacon/states/12345/validator_count?status=active&status=pending
+//	GET /prysm/v1/beacon/states/12345/validator_count?status=active&status=pending
 //
 // The above request will return a JSON response like:
 //

--- a/beacon-chain/rpc/prysm/beacon/validator_count_test.go
+++ b/beacon-chain/rpc/prysm/beacon/validator_count_test.go
@@ -85,13 +85,13 @@ func TestGetValidatorCountInvalidRequest(t *testing.T) {
 			}
 
 			testRouter := http.NewServeMux()
-			testRouter.HandleFunc("/eth/v1/beacon/states/{state_id}/validator_count", server.GetValidatorCount)
+			testRouter.HandleFunc("/prysm/v1/beacon/states/{state_id}/validator_count", server.GetValidatorCount)
 			s := httptest.NewServer(testRouter)
 			defer s.Close()
 
 			queryParams := neturl.Values{}
 			queryParams.Add("status", test.status)
-			resp, err := http.Get(s.URL + fmt.Sprintf("/eth/v1/beacon/states/%s/validator_count?%s",
+			resp, err := http.Get(s.URL + fmt.Sprintf("/prysm/v1/beacon/states/%s/validator_count?%s",
 				test.stateID, queryParams.Encode()))
 			require.NoError(t, err)
 			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
@@ -465,7 +465,7 @@ func TestGetValidatorCount(t *testing.T) {
 			}
 
 			testRouter := http.NewServeMux()
-			testRouter.HandleFunc("/eth/v1/beacon/states/{state_id}/validator_count", server.GetValidatorCount)
+			testRouter.HandleFunc("/prysm/v1/beacon/states/{state_id}/validator_count", server.GetValidatorCount)
 			s := httptest.NewServer(testRouter)
 			defer s.Close()
 
@@ -473,7 +473,7 @@ func TestGetValidatorCount(t *testing.T) {
 			for _, status := range test.statuses {
 				queryParams.Add("status", status)
 			}
-			resp, err := http.Get(s.URL + fmt.Sprintf("/eth/v1/beacon/states/%s/validator_count?%s",
+			resp, err := http.Get(s.URL + fmt.Sprintf("/prysm/v1/beacon/states/%s/validator_count?%s",
 				test.stateID, queryParams.Encode()))
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/changelog/syjn99_chore-nonstandard-validator-count.md
+++ b/changelog/syjn99_chore-nonstandard-validator-count.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Remove support for `/eth/v1/beacon/states/{state_id}/validator_count` which is a non-standard Beacon API.

--- a/validator/client/beacon-api/prysm_beacon_chain_client.go
+++ b/validator/client/beacon-api/prysm_beacon_chain_client.go
@@ -47,7 +47,7 @@ func (c prysmChainClient) ValidatorCount(ctx context.Context, stateID string, st
 		queryParams.Add("status", status.String())
 	}
 
-	queryUrl := apiutil.BuildURL(fmt.Sprintf("/eth/v1/beacon/states/%s/validator_count", stateID), queryParams)
+	queryUrl := apiutil.BuildURL(fmt.Sprintf("/prysm/v1/beacon/states/%s/validator_count", stateID), queryParams)
 
 	var validatorCountResponse structs.GetValidatorCountResponse
 	if err = c.handler.Get(ctx, queryUrl, &validatorCountResponse); err != nil {

--- a/validator/client/beacon-api/prysm_beacon_chain_client_test.go
+++ b/validator/client/beacon-api/prysm_beacon_chain_client_test.go
@@ -134,7 +134,7 @@ func TestGetValidatorCount(t *testing.T) {
 			var validatorCountResponse structs.GetValidatorCountResponse
 			handler.EXPECT().Get(
 				gomock.Any(),
-				"/eth/v1/beacon/states/head/validator_count?status=active",
+				"/prysm/v1/beacon/states/head/validator_count?status=active",
 				&validatorCountResponse,
 			).Return(
 				test.validatorCountEndpointError,

--- a/validator/client/beacon-api/status_test.go
+++ b/validator/client/beacon-api/status_test.go
@@ -335,7 +335,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 	var validatorCountResponse structs.GetValidatorCountResponse
 	handler.EXPECT().Get(
 		gomock.Any(),
-		"/eth/v1/beacon/states/head/validator_count?",
+		"/prysm/v1/beacon/states/head/validator_count?",
 		&validatorCountResponse,
 	).Return(
 		nil,


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

- `/eth/v1/beacon/states/{state_id}/validator_count`

This API isn't a standard, seems like the [initial context](https://github.com/OffchainLabs/prysm/pull/12752#pullrequestreview-1587273903) was lost while refactoring API modules (e.g., https://github.com/OffchainLabs/prysm/pull/13588). This PR shouldn't bring any functional changes as we already have an identical endpoint starts with `/prysm`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
