### PR TITLE
Use read only validator accessor in `IsPayloadTimelyCommittee`

### DIFF
--- a/beacon-chain/core/gloas/payload_attestation.go
+++ b/beacon-chain/core/gloas/payload_attestation.go
@@ -275,12 +275,12 @@ func acceptByBalance(st state.ReadOnlyBeaconState, idx primitives.ValidatorIndex
 	offset := (round % 16) * 2
 	randomValue := uint64(binary.LittleEndian.Uint16(random[offset : offset+2])) // 16-bit draw per spec
 
-	val, err := st.ValidatorAtIndex(idx)
+	val, err := st.ValidatorAtIndexReadOnly(idx)
 	if err != nil {
 		return false, errors.Wrapf(err, "validator %d", idx)
 	}
 
-	return val.EffectiveBalance*fieldparams.MaxRandomValueElectra >= maxBalance*randomValue, nil
+	return val.EffectiveBalance()*fieldparams.MaxRandomValueElectra >= maxBalance*randomValue, nil
 }
 
 // validIndexedPayloadAttestation verifies the signature of an indexed payload attestation.

--- a/beacon-chain/core/gloas/payload_attestation_test.go
+++ b/beacon-chain/core/gloas/payload_attestation_test.go
@@ -211,7 +211,8 @@ func TestProcessPayloadAttestations_IndexedVerificationError(t *testing.T) {
 		errIndex:    0,
 	}
 	err := gloas.ProcessPayloadAttestations(t.Context(), errState, body)
-	require.ErrorContains(t, "failed to verify indexed form", err)
+	require.ErrorContains(t, "failed to convert to indexed form", err)
+	require.ErrorContains(t, "failed to sample beacon committee 0", err)
 	require.ErrorContains(t, "validator 0", err)
 }
 

--- a/changelog/tt_read-only-validator-accessor.md
+++ b/changelog/tt_read-only-validator-accessor.md
@@ -1,0 +1,2 @@
+### Fixed
+- Use read-only validator accessor in IsPayloadTimelyCommittee


### PR DESCRIPTION
This PR replaces `ValidatorAtIndex` with `ValidatorAtIndexReadOnly` in `IsPayloadTimelyCommittee` to avoid copying the entire validator on each call

CPU and heap profiling of ePBS devnet nodes shows `PayloadCommittee` → `CopyValidator` as the single largest hotspot, consuming ~18-20% of CPU time across all servers. `IsPayloadTimelyCommittee` calls `ValidatorAtIndex` in a loop over candidate committee members, and each call deep-copies the full validator struct (~1 KB) only to read `EffectiveBalance`

`ValidatorAtIndexReadOnly` returns a read-only reference to the underlying validator, eliminating the copy. The only field accessed is `EffectiveBalance()`, which is available on the read-only interface