### PR TITLE
Hdiff fixes

### DIFF
--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -123,6 +123,11 @@ func (s *Store) LegacyGenesisState(ctx context.Context) (state.BeaconState, erro
 func (s *Store) SaveState(ctx context.Context, st state.ReadOnlyBeaconState, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveState")
 	defer span.End()
+
+	if features.Get().EnableStateDiff && s.stateDiffCache != nil {
+		return s.saveStateByDiff(ctx, st)
+	}
+
 	ok, err := s.isStateValidatorMigrationOver()
 	if err != nil {
 		return err

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -1103,12 +1103,16 @@ func (s *Store) getStateUsingStateDiff(ctx context.Context, blockRoot [32]byte) 
 		return nil, ErrSlotBeforeOffset
 	}
 
+	if computeLevel(s.getOffset(), slot) == -1 {
+		return nil, ErrNotFoundState
+	}
+
 	st, err := s.stateByDiff(ctx, slot)
 	if err != nil {
 		return nil, err
 	}
 	if st == nil || st.IsNil() {
-		return nil, errors.Wrap(ErrNotFoundState, "state not found")
+		return nil, ErrNotFoundState
 	}
 
 	if blk == nil {

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -1153,5 +1153,33 @@ func (s *Store) hasStateUsingStateDiff(ctx context.Context, blockRoot [32]byte) 
 	}
 
 	stateLvl := computeLevel(s.getOffset(), slot)
-	return stateLvl != -1, nil
+	if stateLvl == -1 {
+		return false, nil
+	}
+
+	if !s.stateDiffCache.levelHasData(stateLvl) {
+		return false, nil
+	}
+
+	hasState := false
+	err = s.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(stateDiffBucket)
+		if bucket == nil {
+			return errors.New("state diff bucket not found")
+		}
+
+		if stateLvl == 0 {
+			hasState = bucket.Get(makeKeyForStateDiffTree(stateLvl, uint64(slot))) != nil
+			return nil
+		}
+
+		hasState = hasCompleteDiffAtLevelSlot(bucket, stateLvl, uint64(slot))
+
+		return nil
+	})
+
+	if err != nil {
+		return false, err
+	}
+	return hasState, nil
 }

--- a/beacon-chain/db/kv/state_diff_helpers.go
+++ b/beacon-chain/db/kv/state_diff_helpers.go
@@ -288,7 +288,7 @@ func (s *Store) initializeStateDiff(slot primitives.Slot, initialState state.Rea
 		return bucket.Put(exponentsKey, exponentsBytes)
 	})
 	if err != nil {
-		return pkgerrors.Wrap(err, "failed to set offset")
+		return pkgerrors.Wrap(err, "failed to set state diff metadata in db")
 	}
 
 	// Create the state diff cache (this will read the offset from the database).

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -1368,7 +1368,7 @@ func TestStore_CanSaveRetrieveStateUsingStateDiff(t *testing.T) {
 		require.NoError(t, err)
 
 		readSt, err := db.State(context.Background(), r)
-		require.ErrorContains(t, "slot not in tree", err)
+		require.ErrorContains(t, "state not found", err)
 		require.IsNil(t, readSt)
 
 	})
@@ -1647,7 +1647,7 @@ func TestStore_HasStateUsingStateDiff(t *testing.T) {
 		require.Equal(t, false, hasSt)
 	})
 
-	t.Run("slot in tree or not", func(t *testing.T) {
+	t.Run("Slot not in tree", func(t *testing.T) {
 		db := setupDB(t)
 		featCfg := &features.Flags{}
 		featCfg.EnableStateDiff = true
@@ -1658,27 +1658,13 @@ func TestStore_HasStateUsingStateDiff(t *testing.T) {
 		err := setOffsetInDB(db, 0)
 		require.NoError(t, err)
 
-		testCases := []struct {
-			slot     primitives.Slot
-			expected bool
-		}{
-			{slot: 1, expected: false},                                      // slot 1 not in tree
-			{slot: 32, expected: true},                                      // slot 32 in tree
-			{slot: 0, expected: true},                                       // slot 0 in tree
-			{slot: primitives.Slot(math.PowerOf2(21)), expected: true},      // slot in tree
-			{slot: primitives.Slot(math.PowerOf2(21) - 1), expected: false}, // slot not in tree
-			{slot: primitives.Slot(math.PowerOf2(22)), expected: true},      // slot in tree
-		}
+		r := bytesutil.ToBytes32([]byte{'A'})
+		ss := &ethpb.StateSummary{Slot: 1, Root: r[:]} // slot 1 not in tree
+		err = db.SaveStateSummary(context.Background(), ss)
+		require.NoError(t, err)
 
-		for _, tc := range testCases {
-			r := bytesutil.ToBytes32([]byte{'A'})
-			ss := &ethpb.StateSummary{Slot: tc.slot, Root: r[:]}
-			err = db.SaveStateSummary(t.Context(), ss)
-			require.NoError(t, err)
-
-			hasSt := db.HasState(t.Context(), r)
-			require.Equal(t, tc.expected, hasSt)
-		}
+		has := db.HasState(context.Background(), r)
+		require.Equal(t, false, has)
 
 	})
 
@@ -1710,14 +1696,62 @@ func TestStore_HasStateUsingStateDiff(t *testing.T) {
 		require.NoError(t, setOffsetInDB(db, 0))
 
 		blk := util.NewBeaconBlock()
-		blk.Block.Slot = 32
+		blk.Block.Slot = 0
 		signedBlk, err := blocks.NewSignedBeaconBlock(blk)
 		require.NoError(t, err)
 		require.NoError(t, db.SaveBlock(t.Context(), signedBlk))
 		r, err := signedBlk.Block().HashTreeRoot()
 		require.NoError(t, err)
 
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, st.SetSlot(0))
+		require.NoError(t, db.SaveState(t.Context(), st, r))
+
 		hasSt := db.HasState(t.Context(), r)
 		require.Equal(t, true, hasSt)
+	})
+
+	t.Run("state summary found", func(t *testing.T) {
+		db := setupDB(t)
+		featCfg := &features.Flags{}
+		featCfg.EnableStateDiff = true
+		reset := features.InitWithReset(featCfg)
+		defer reset()
+		setDefaultStateDiffExponents()
+
+		require.NoError(t, setOffsetInDB(db, 0))
+
+		r := bytesutil.ToBytes32([]byte{'A'})
+		ss := &ethpb.StateSummary{Slot: 0, Root: r[:]}
+		err := db.SaveStateSummary(context.Background(), ss)
+		require.NoError(t, err)
+
+		st, err := util.NewBeaconState()
+		require.NoError(t, err)
+		require.NoError(t, st.SetSlot(0))
+		require.NoError(t, db.SaveState(t.Context(), st, r))
+
+		hasSt := db.HasState(t.Context(), r)
+		require.Equal(t, true, hasSt)
+	})
+
+	t.Run("summary exists but no state", func(t *testing.T) {
+		db := setupDB(t)
+		featCfg := &features.Flags{}
+		featCfg.EnableStateDiff = true
+		reset := features.InitWithReset(featCfg)
+		defer reset()
+		setDefaultStateDiffExponents()
+
+		require.NoError(t, setOffsetInDB(db, 0))
+
+		r := bytesutil.ToBytes32([]byte{'A'})
+		ss := &ethpb.StateSummary{Slot: 0, Root: r[:]}
+		err := db.SaveStateSummary(context.Background(), ss)
+		require.NoError(t, err)
+
+		hasSt := db.HasState(t.Context(), r)
+		require.Equal(t, false, hasSt)
 	})
 }

--- a/beacon-chain/db/kv/wss.go
+++ b/beacon-chain/db/kv/wss.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/ssz/detect"
@@ -68,9 +69,16 @@ func (s *Store) SaveOrigin(ctx context.Context, serState, serBlock []byte) error
 		return errors.Wrap(err, "save block")
 	}
 
-	// save state
-	if err = s.SaveState(ctx, state, blockRoot); err != nil {
-		return errors.Wrap(err, "save state")
+	if features.Get().EnableStateDiff {
+		// initializeStateDiff will save the state, so we don't need to call SaveState here
+		if err := s.initializeStateDiff(state.Slot(), state); err != nil {
+			return errors.Wrap(err, "failed to initialize state diff")
+		}
+	} else {
+		// save state
+		if err = s.SaveState(ctx, state, blockRoot); err != nil {
+			return errors.Wrap(err, "save state")
+		}
 	}
 
 	if err = s.SaveStateSummary(ctx, &ethpb.StateSummary{
@@ -109,9 +117,6 @@ func (s *Store) SaveOrigin(ctx context.Context, serState, serBlock []byte) error
 
 	if err = s.SaveFinalizedCheckpoint(ctx, chkpt); err != nil {
 		return errors.Wrap(err, "save finalized checkpoint")
-	}
-	if err := s.initializeStateDiff(state.Slot(), state); err != nil {
-		return errors.Wrap(err, "failed to initialize state diff")
 	}
 	return nil
 }

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -226,7 +226,7 @@ func TestStateByRoot_FallsBackToReplayOnNotFoundStateFromDirectRead(t *testing.T
 	ib10, err := blt.NewSignedBeaconBlock(blk10)
 	require.NoError(t, err)
 
-	st10, err = executeStateTransitionStateGen(ctx, st10, ib10)
+	st10, err = executeStateTransitionStateGen(ctx, st10, ib10, nil)
 	require.NoError(t, err)
 	st10Root, err := st10.HashTreeRoot(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR addresses multiple issues in the hdiff code:

1. the function `hasStateUsingStateDiff()` that's called in `db.HasState()` was returning true for any slot that fell on the hdiff tree levels. This is wrong because those states might not actually be saved. This PR fixes that by actually looking in the db to check.
2. add the call to `saveStateByDiff()` in `db.SaveState()` to actually save the states in the hdiff tree. this was missed previously. the reason for the if guard `s.stateDiffCache != nil` over this call is that when syncing from genesis, the call to initialize state diff comes after the call of `SaveState()` to save the genesis state. which would cause a panic here. with this guard, that save goes to the legacy `stateBucket`. but the state will later get saved in the hdiff tree when `initializeStateDiff()` is called.
3. adds an early return to `getStateUsingStateDiff()` when `computeLevel(slot)` returns -1.
4. moves the call to `initializeStateDiff()` higher when doing checkpoint sync. specifically moves it before the call to `SaveState()`. otherwise there is a bug: state diff tries to save that state in the tree because it has offset 0 from the genesis call, then it would error out because the checkpoint slot doesn't have the necessary parents in the tree. (the offset isn't updated yet). this move makes it so the offset is updated before saving the state. the `SaveState()` call is also skipped after initializing state diff, because it's redundant. ~~**NOTE:** maybe if this pattern is good, we want to do the same in genesis.go to avoid writing to the legacy `stateBucket` entirely.~~ This is done in #16534 
5. other small fixes.