### PR TITLE
Hdiff fixes 2

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -680,8 +680,8 @@ func (s *Store) SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveHeadBlockRoot")
 	defer span.End()
 	hasStateSummary := s.HasStateSummary(ctx, blockRoot)
+	hasStateInDB := s.HasState(ctx, blockRoot)
 	return s.db.Update(func(tx *bolt.Tx) error {
-		hasStateInDB := tx.Bucket(stateBucket).Get(blockRoot[:]) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			return errors.New("no state or state summary found with head block root")
 		}

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -681,11 +681,11 @@ func (s *Store) SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	defer span.End()
 	hasStateSummary := s.HasStateSummary(ctx, blockRoot)
 	hasStateInDB := s.HasState(ctx, blockRoot)
-	return s.db.Update(func(tx *bolt.Tx) error {
-		if !(hasStateInDB || hasStateSummary) {
-			return errors.New("no state or state summary found with head block root")
-		}
+	if !(hasStateInDB || hasStateSummary) {
+		return errors.New("no state or state summary found with head block root")
+	}
 
+	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(blocksBucket)
 		return bucket.Put(headBlockRootKey, blockRoot[:])
 	})

--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -70,9 +70,9 @@ func (s *Store) SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 		return err
 	}
 	hasStateSummary := s.HasStateSummary(ctx, bytesutil.ToBytes32(checkpoint.Root))
+	hasStateInDB := s.HasState(ctx, bytesutil.ToBytes32(checkpoint.Root))
 	err = s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.Warnf("Recovering state summary for finalized root: %#x", bytesutil.Trunc(checkpoint.Root))
 			if err := recoverStateSummary(ctx, tx, checkpoint.Root); err != nil {
@@ -99,9 +99,9 @@ func (s *Store) saveCheckpoint(ctx context.Context, key []byte, checkpoint *ethp
 		return err
 	}
 	hasStateSummary := s.HasStateSummary(ctx, bytesutil.ToBytes32(checkpoint.Root))
+	hasStateInDB := s.HasState(ctx, bytesutil.ToBytes32(checkpoint.Root))
 	err = s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.WithField("root", fmt.Sprintf("%#x", bytesutil.Trunc(checkpoint.Root))).Warn("Recovering state summary")
 			if err := recoverStateSummary(ctx, tx, checkpoint.Root); err != nil {

--- a/beacon-chain/db/kv/genesis.go
+++ b/beacon-chain/db/kv/genesis.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/blocks"
 	dbIface "github.com/OffchainLabs/prysm/v7/beacon-chain/db/iface"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/encoding/ssz/detect"
 	"github.com/OffchainLabs/prysm/v7/genesis"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
@@ -26,9 +27,17 @@ func (s *Store) SaveGenesisData(ctx context.Context, genesisState state.BeaconSt
 	if err := s.SaveBlock(ctx, wsb); err != nil {
 		return errors.Wrap(err, "could not save genesis block")
 	}
-	if err := s.SaveState(ctx, genesisState, genesisBlkRoot); err != nil {
-		return errors.Wrap(err, "could not save genesis state")
+
+	if features.Get().EnableStateDiff {
+		if err := s.initializeStateDiff(0, genesisState); err != nil {
+			return errors.Wrap(err, "failed to initialize state diff for genesis")
+		}
+	} else {
+		if err := s.SaveState(ctx, genesisState, genesisBlkRoot); err != nil {
+			return errors.Wrap(err, "could not save genesis state")
+		}
 	}
+
 	if err := s.SaveStateSummary(ctx, &ethpb.StateSummary{
 		Slot: 0,
 		Root: genesisBlkRoot[:],
@@ -43,9 +52,6 @@ func (s *Store) SaveGenesisData(ctx context.Context, genesisState state.BeaconSt
 		return errors.Wrap(err, "could not save genesis block root")
 	}
 
-	if err := s.initializeStateDiff(0, genesisState); err != nil {
-		return errors.Wrap(err, "failed to initialize state diff for genesis")
-	}
 	return nil
 }
 

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -226,7 +226,7 @@ func TestStateByRoot_FallsBackToReplayOnNotFoundStateFromDirectRead(t *testing.T
 	ib10, err := blt.NewSignedBeaconBlock(blk10)
 	require.NoError(t, err)
 
-	st10, err = executeStateTransitionStateGen(ctx, st10, ib10)
+	st10, err = executeStateTransitionStateGen(ctx, st10, ib10, nil)
 	require.NoError(t, err)
 	st10Root, err := st10.HashTreeRoot(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
In 3 places, in order to see if db has a state, we're directly reading from the `stateBucket` in a bolt tx. This would cause problems when using state diffs. 
So this PR moves those checks outside of the tx and calls the `HasState()` function which already accounts for everything.

due to a bug where these `HasState()` calls result in a panic because the `stateDiffCache` is not initialized before the calls, the call to initialize state diff was moved higher to ensure we have the cache before doing anything.