### PR TITLE
Beacon state: Replace `*ethpb.Validator` by `CompactValidator`

### DIFF
--- a/beacon-chain/core/blocks/exports_test.go
+++ b/beacon-chain/core/blocks/exports_test.go
@@ -2,4 +2,5 @@ package blocks
 
 var ProcessBLSToExecutionChange = processBLSToExecutionChange
 var ErrInvalidBLSPrefix = errInvalidBLSPrefix
+var ErrInvalidWithdrawalCredentials = errInvalidWithdrawalCredentials
 var VerifyBlobCommitmentCount = verifyBlobCommitmentCount

--- a/beacon-chain/core/blocks/withdrawals_test.go
+++ b/beacon-chain/core/blocks/withdrawals_test.go
@@ -147,7 +147,7 @@ func TestProcessBLSToExecutionChange(t *testing.T) {
 		_, err = blocks.ValidateBLSToExecutionChange(st, signed)
 		// The state should return an empty validator, even when the validator object in the registry is
 		// nil. This error should return when the withdrawal credentials are invalid or too short.
-		require.ErrorIs(t, err, blocks.ErrInvalidBLSPrefix)
+		require.ErrorIs(t, err, blocks.ErrInvalidWithdrawalCredentials)
 	})
 	t.Run("non-existent validator", func(t *testing.T) {
 		priv, err := bls.RandKey()

--- a/beacon-chain/core/electra/effective_balance_updates.go
+++ b/beacon-chain/core/electra/effective_balance_updates.go
@@ -39,9 +39,6 @@ func ProcessEffectiveBalanceUpdates(st state.BeaconState) error {
 
 	// Update effective balances with hysteresis.
 	validatorFunc := func(idx int, val state.ReadOnlyValidator) (newVal *ethpb.Validator, err error) {
-		if val.IsNil() {
-			return nil, fmt.Errorf("validator %d is nil in state", idx)
-		}
 		if idx >= len(bals) {
 			return nil, fmt.Errorf("validator index exceeds validator length in state %d >= %d", idx, len(st.Balances()))
 		}

--- a/beacon-chain/core/electra/validator_test.go
+++ b/beacon-chain/core/electra/validator_test.go
@@ -17,9 +17,6 @@ func TestSwitchToCompoundingValidator(t *testing.T) {
 	s, err := state_native.InitializeFromProtoElectra(&eth.BeaconStateElectra{
 		Validators: []*eth.Validator{
 			{
-				WithdrawalCredentials: []byte{}, // No withdrawal credentials
-			},
-			{
 				WithdrawalCredentials: []byte{0x01, 0xFF}, // Has withdrawal credentials
 			},
 			{
@@ -28,21 +25,18 @@ func TestSwitchToCompoundingValidator(t *testing.T) {
 		},
 		Balances: []uint64{
 			params.BeaconConfig().MinActivationBalance,
-			params.BeaconConfig().MinActivationBalance,
 			params.BeaconConfig().MinActivationBalance + 100_000, // Has excess balance
 		},
 	})
-	// Test that a validator with no withdrawal credentials cannot be switched to compounding.
 	require.NoError(t, err)
-	require.ErrorContains(t, "validator has no withdrawal credentials", electra.SwitchToCompoundingValidator(s, 0))
 
 	// Test that a validator with withdrawal credentials can be switched to compounding.
-	require.NoError(t, electra.SwitchToCompoundingValidator(s, 1))
-	v, err := s.ValidatorAtIndex(1)
+	require.NoError(t, electra.SwitchToCompoundingValidator(s, 0))
+	v, err := s.ValidatorAtIndex(0)
 	require.NoError(t, err)
 	require.Equal(t, true, bytes.HasPrefix(v.WithdrawalCredentials, []byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte}), "withdrawal credentials were not updated")
-	// val_1 Balance is not changed
-	b, err := s.BalanceAtIndex(1)
+	// val_0 Balance is not changed
+	b, err := s.BalanceAtIndex(0)
 	require.NoError(t, err)
 	require.Equal(t, params.BeaconConfig().MinActivationBalance, b, "balance was changed")
 	pbd, err := s.PendingDeposits()
@@ -50,8 +44,8 @@ func TestSwitchToCompoundingValidator(t *testing.T) {
 	require.Equal(t, 0, len(pbd), "pending balance deposits should be empty")
 
 	// Test that a validator with excess balance can be switched to compounding, excess balance is queued.
-	require.NoError(t, electra.SwitchToCompoundingValidator(s, 2))
-	b, err = s.BalanceAtIndex(2)
+	require.NoError(t, electra.SwitchToCompoundingValidator(s, 1))
+	b, err = s.BalanceAtIndex(1)
 	require.NoError(t, err)
 	require.Equal(t, params.BeaconConfig().MinActivationBalance, b, "balance was not changed")
 	pbd, err = s.PendingDeposits()

--- a/beacon-chain/core/transition/state-bellatrix.go
+++ b/beacon-chain/core/transition/state-bellatrix.go
@@ -120,7 +120,8 @@ func OptimizedGenesisBeaconStateBellatrix(genesisTime uint64, preState state.Bea
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}

--- a/beacon-chain/core/transition/state.go
+++ b/beacon-chain/core/transition/state.go
@@ -147,7 +147,8 @@ func OptimizedGenesisBeaconState(genesisTime uint64, preState state.BeaconState,
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}

--- a/beacon-chain/rpc/core/duties.go
+++ b/beacon-chain/rpc/core/duties.go
@@ -263,7 +263,7 @@ func findValidatorIndexInCommittee(committee []primitives.ValidatorIndex, valida
 // It returns Active for any active validator and Pending otherwise.
 func syncDutyStatus(st state.BeaconState, idx primitives.ValidatorIndex) validator.Status {
 	val, err := st.ValidatorAtIndexReadOnly(idx)
-	if err != nil || val.IsNil() {
+	if err != nil {
 		return validator.Pending
 	}
 	currentEpoch := coreTime.CurrentEpoch(st)

--- a/beacon-chain/rpc/eth/beacon/handlers_validators_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_validators_test.go
@@ -1188,10 +1188,16 @@ func TestGetValidatorBalances(t *testing.T) {
 func TestGetValidatorIdentities(t *testing.T) {
 	count := uint64(4)
 	genesisState, _ := util.DeterministicGenesisState(t, count)
-	st := genesisState.ToProtoUnsafe().(*eth.BeaconState)
 	for i := range count {
-		st.Validators[i].ActivationEpoch = primitives.Epoch(i)
+		val, err := genesisState.ValidatorAtIndex(primitives.ValidatorIndex(i))
+		require.NoError(t, err)
+
+		val.ActivationEpoch = primitives.Epoch(i)
+		err = genesisState.UpdateValidatorAtIndex(primitives.ValidatorIndex(i), val)
+		require.NoError(t, err)
 	}
+
+	st := genesisState.ToProtoUnsafe().(*eth.BeaconState)
 
 	t.Run("json", func(t *testing.T) {
 		t.Run("get all", func(t *testing.T) {
@@ -1219,9 +1225,9 @@ func TestGetValidatorIdentities(t *testing.T) {
 			require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
 			require.Equal(t, 4, len(resp.Data))
 			for i := range count {
-				assert.Equal(t, fmt.Sprintf("%d", i), resp.Data[i].Index)
-				assert.DeepEqual(t, hexutil.Encode(st.Validators[i].PublicKey), resp.Data[i].Pubkey)
-				assert.Equal(t, fmt.Sprintf("%d", st.Validators[i].ActivationEpoch), resp.Data[i].ActivationEpoch)
+				require.Equal(t, fmt.Sprintf("%d", i), resp.Data[i].Index)
+				require.DeepEqual(t, hexutil.Encode(st.Validators[i].PublicKey), resp.Data[i].Pubkey)
+				require.Equal(t, fmt.Sprintf("%d", st.Validators[i].ActivationEpoch), resp.Data[i].ActivationEpoch)
 			}
 		})
 		t.Run("get by index", func(t *testing.T) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/status.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/status.go
@@ -411,7 +411,7 @@ func statusForPubKey(headState state.ReadOnlyBeaconState, pubKey []byte) (ethpb.
 
 func assignmentStatus(beaconState state.ReadOnlyBeaconState, validatorIndex primitives.ValidatorIndex) ethpb.ValidatorStatus {
 	validator, err := beaconState.ValidatorAtIndexReadOnly(validatorIndex)
-	if err != nil || validator.IsNil() {
+	if err != nil {
 		return ethpb.ValidatorStatus_UNKNOWN_STATUS
 	}
 

--- a/beacon-chain/state/fieldtrie/field_trie_helpers.go
+++ b/beacon-chain/state/fieldtrie/field_trie_helpers.go
@@ -74,11 +74,11 @@ func fieldConverters(field types.FieldIndex, indices []uint64, elements any, con
 func convertRoots(indices []uint64, elements any, convertAll bool) ([][32]byte, error) {
 	switch castedType := elements.(type) {
 	case customtypes.BlockRoots:
-		return handle32ByteMVslice(multi_value_slice.BuildEmptyCompositeSlice[[32]byte](castedType), indices, convertAll)
+		return handle32ByteMVslice(multi_value_slice.BuildEmptyCompositeSlice(castedType), indices, convertAll)
 	case customtypes.StateRoots:
-		return handle32ByteMVslice(multi_value_slice.BuildEmptyCompositeSlice[[32]byte](castedType), indices, convertAll)
+		return handle32ByteMVslice(multi_value_slice.BuildEmptyCompositeSlice(castedType), indices, convertAll)
 	case customtypes.RandaoMixes:
-		return handle32ByteMVslice(multi_value_slice.BuildEmptyCompositeSlice[[32]byte](castedType), indices, convertAll)
+		return handle32ByteMVslice(multi_value_slice.BuildEmptyCompositeSlice(castedType), indices, convertAll)
 	case multi_value_slice.MultiValueSliceComposite[[32]byte]:
 		return handle32ByteMVslice(castedType, indices, convertAll)
 	default:
@@ -97,7 +97,7 @@ func convertEth1DataVotes(indices []uint64, elements any, convertAll bool) ([][3
 func convertValidators(indices []uint64, elements any, convertAll bool) ([][32]byte, error) {
 	switch casted := elements.(type) {
 	case []*ethpb.Validator:
-		return handleValidatorMVSlice(multi_value_slice.BuildEmptyCompositeSlice[*ethpb.Validator](casted), indices, convertAll)
+		return handleValidatorMVSlice(multi_value_slice.BuildEmptyCompositeSlice(casted), indices, convertAll)
 	case multi_value_slice.MultiValueSliceComposite[*ethpb.Validator]:
 		return handleValidatorMVSlice(casted, indices, convertAll)
 	default:
@@ -116,7 +116,7 @@ func convertAttestations(indices []uint64, elements any, convertAll bool) ([][32
 func convertBalances(indices []uint64, elements any, convertAll bool) ([][32]byte, error) {
 	switch casted := elements.(type) {
 	case []uint64:
-		return handleBalanceMVSlice(multi_value_slice.BuildEmptyCompositeSlice[uint64](casted), indices, convertAll)
+		return handleBalanceMVSlice(multi_value_slice.BuildEmptyCompositeSlice(casted), indices, convertAll)
 	case multi_value_slice.MultiValueSliceComposite[uint64]:
 		return handleBalanceMVSlice(casted, indices, convertAll)
 	default:

--- a/beacon-chain/state/fieldtrie/field_trie_helpers.go
+++ b/beacon-chain/state/fieldtrie/field_trie_helpers.go
@@ -96,12 +96,12 @@ func convertEth1DataVotes(indices []uint64, elements any, convertAll bool) ([][3
 
 func convertValidators(indices []uint64, elements any, convertAll bool) ([][32]byte, error) {
 	switch casted := elements.(type) {
-	case []*ethpb.Validator:
+	case []stateutil.CompactValidator:
 		return handleValidatorMVSlice(multi_value_slice.BuildEmptyCompositeSlice(casted), indices, convertAll)
-	case multi_value_slice.MultiValueSliceComposite[*ethpb.Validator]:
+	case multi_value_slice.MultiValueSliceComposite[stateutil.CompactValidator]:
 		return handleValidatorMVSlice(casted, indices, convertAll)
 	default:
-		return nil, errors.Errorf("Wanted type of %T but got %T", []*ethpb.Validator{}, elements)
+		return nil, errors.Errorf("Wanted type of CompactValidator but got %T", elements)
 	}
 }
 
@@ -160,20 +160,12 @@ func handle32ByteMVslice(mv multi_value_slice.MultiValueSliceComposite[[32]byte]
 }
 
 // handleValidatorMVSlice returns the validator indices in a slice of root format.
-func handleValidatorMVSlice(mv multi_value_slice.MultiValueSliceComposite[*ethpb.Validator], indices []uint64, convertAll bool) ([][32]byte, error) {
+func handleValidatorMVSlice(mv multi_value_slice.MultiValueSliceComposite[stateutil.CompactValidator], indices []uint64, convertAll bool) ([][32]byte, error) {
 	length := len(indices)
 	if convertAll {
 		return stateutil.OptimizedValidatorRoots(mv.Value(mv.State()))
 	}
 	roots := make([][32]byte, 0, length)
-	rootCreator := func(input *ethpb.Validator) error {
-		newRoot, err := stateutil.ValidatorRootWithHasher(input)
-		if err != nil {
-			return err
-		}
-		roots = append(roots, newRoot)
-		return nil
-	}
 	totalLen := mv.Len(mv.State())
 	if totalLen > 0 {
 		for _, idx := range indices {
@@ -184,10 +176,11 @@ func handleValidatorMVSlice(mv multi_value_slice.MultiValueSliceComposite[*ethpb
 			if err != nil {
 				return nil, err
 			}
-			err = rootCreator(val)
+			newRoot, err := val.Root()
 			if err != nil {
 				return nil, err
 			}
+			roots = append(roots, newRoot)
 		}
 	}
 	return roots, nil

--- a/beacon-chain/state/fieldtrie/field_trie_test.go
+++ b/beacon-chain/state/fieldtrie/field_trie_test.go
@@ -60,8 +60,9 @@ func TestFieldTrie_RecomputeTrie(t *testing.T) {
 func runRecomputeTrie(t *testing.T) {
 	newState, _ := util.DeterministicGenesisState(t, 32)
 
-	mvRoots := buildTestCompositeSlice[*ethpb.Validator](newState.Validators())
-	elements := mvslice.MultiValueSliceComposite[*ethpb.Validator]{
+	compactVals := stateutil.CompactValidatorsFromProto(newState.Validators())
+	mvRoots := buildTestCompositeSlice[stateutil.CompactValidator](compactVals)
+	elements := mvslice.MultiValueSliceComposite[stateutil.CompactValidator]{
 		Identifiable:    mockIdentifier{},
 		MultiValueSlice: mvRoots,
 	}
@@ -88,9 +89,10 @@ func runRecomputeTrie(t *testing.T) {
 	require.NoError(t, newState.UpdateValidatorAtIndex(primitives.ValidatorIndex(changedIdx[0]), changedVals[0]))
 	require.NoError(t, newState.UpdateValidatorAtIndex(primitives.ValidatorIndex(changedIdx[1]), changedVals[1]))
 
-	expectedRoot, err := stateutil.ValidatorRegistryRoot(newState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(newState.Validators())
+	expectedRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	require.NoError(t, err)
-	root, err := trie.RecomputeTrie(changedIdx, newState.Validators())
+	root, err := trie.RecomputeTrie(changedIdx, compactValidators)
 	require.NoError(t, err)
 	assert.Equal(t, expectedRoot, root)
 }

--- a/beacon-chain/state/fieldtrie/helpers_test.go
+++ b/beacon-chain/state/fieldtrie/helpers_test.go
@@ -36,13 +36,13 @@ func Test_handleEth1DataSlice_OutOfRange(t *testing.T) {
 func Test_handleValidatorSlice_OutOfRange(t *testing.T) {
 	vals := make([]*ethpb.Validator, 1)
 	indices := []uint64{3}
-	_, err := handleValidatorMVSlice(mvslice.BuildEmptyCompositeSlice[*ethpb.Validator](vals), indices, false)
+	_, err := handleValidatorMVSlice(mvslice.BuildEmptyCompositeSlice(vals), indices, false)
 	assert.ErrorContains(t, "index 3 greater than number of validators 1", err)
 }
 
 func TestBalancesSlice_CorrectRoots_All(t *testing.T) {
 	balances := []uint64{5, 2929, 34, 1291, 354305}
-	roots, err := handleBalanceMVSlice(mvslice.BuildEmptyCompositeSlice[uint64](balances), []uint64{}, true)
+	roots, err := handleBalanceMVSlice(mvslice.BuildEmptyCompositeSlice(balances), []uint64{}, true)
 	assert.NoError(t, err)
 
 	var root1 [32]byte
@@ -59,7 +59,7 @@ func TestBalancesSlice_CorrectRoots_All(t *testing.T) {
 
 func TestBalancesSlice_CorrectRoots_Some(t *testing.T) {
 	balances := []uint64{5, 2929, 34, 1291, 354305}
-	roots, err := handleBalanceMVSlice(mvslice.BuildEmptyCompositeSlice[uint64](balances), []uint64{2, 3}, false)
+	roots, err := handleBalanceMVSlice(mvslice.BuildEmptyCompositeSlice(balances), []uint64{2, 3}, false)
 	assert.NoError(t, err)
 
 	var root1 [32]byte

--- a/beacon-chain/state/fieldtrie/helpers_test.go
+++ b/beacon-chain/state/fieldtrie/helpers_test.go
@@ -34,7 +34,7 @@ func Test_handleEth1DataSlice_OutOfRange(t *testing.T) {
 }
 
 func Test_handleValidatorSlice_OutOfRange(t *testing.T) {
-	vals := make([]*ethpb.Validator, 1)
+	vals := make([]stateutil.CompactValidator, 1)
 	indices := []uint64{3}
 	_, err := handleValidatorMVSlice(mvslice.BuildEmptyCompositeSlice(vals), indices, false)
 	assert.ErrorContains(t, "index 3 greater than number of validators 1", err)
@@ -241,7 +241,7 @@ func TestFieldTrie_NativeState_fieldConvertersNative(t *testing.T) {
 			args: &args{
 				field:   types.FieldIndex(11),
 				indices: []uint64{},
-				elements: []*ethpb.Validator{
+				elements: []stateutil.CompactValidator{
 					{
 						ActivationEpoch: 1,
 					},
@@ -259,7 +259,7 @@ func TestFieldTrie_NativeState_fieldConvertersNative(t *testing.T) {
 				convertAll: true,
 			},
 			wantHex: nil,
-			errMsg:  fmt.Sprintf("Wanted type of %T", []*ethpb.Validator{}),
+			errMsg:  "Wanted type of CompactValidator",
 		},
 		{
 			name: "Attestations",

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -127,7 +127,6 @@ type ReadOnlyValidator interface {
 	GetWithdrawalCredentials() []byte
 	Copy() *ethpb.Validator
 	Slashed() bool
-	IsNil() bool
 	HasETH1WithdrawalCredentials() bool
 	HasCompoundingWithdrawalCredentials() bool
 	HasExecutionWithdrawalCredentials() bool

--- a/beacon-chain/state/state-native/beacon_state.go
+++ b/beacon-chain/state/state-native/beacon_state.go
@@ -166,7 +166,7 @@ func (b *BeaconState) MarshalJSON() ([]byte, error) {
 		Eth1Data:                            b.eth1Data,
 		Eth1DataVotes:                       b.eth1DataVotes,
 		Eth1DepositIndex:                    b.eth1DepositIndex,
-		Validators:                          vals,
+		Validators:                          stateutil.CompactValidatorsToProto(vals),
 		Balances:                            balances,
 		RandaoMixes:                         mixes,
 		Slashings:                           b.slashings,

--- a/beacon-chain/state/state-native/getters_state.go
+++ b/beacon-chain/state/state-native/getters_state.go
@@ -2,6 +2,7 @@ package state_native
 
 import (
 	customtypes "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/custom-types"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stateutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
@@ -29,7 +30,7 @@ func (b *BeaconState) ToProtoUnsafe() any {
 		inactivityScores = b.inactivityScoresMultiValue.Value(b)
 	}
 	if b.validatorsMultiValue != nil {
-		vals = b.validatorsMultiValue.Value(b)
+		vals = stateutil.CompactValidatorsToProto(b.validatorsMultiValue.Value(b))
 	}
 
 	switch b.version {

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -2,10 +2,10 @@ package state_native
 
 import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stateutil"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
-	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
@@ -28,21 +28,11 @@ func (b *BeaconState) ValidatorsReadOnly() []state.ReadOnlyValidator {
 }
 
 func (b *BeaconState) validatorsVal() []*ethpb.Validator {
-	var v []*ethpb.Validator
 	if b.validatorsMultiValue == nil {
 		return nil
 	}
-	v = b.validatorsMultiValue.Value(b)
-
-	res := make([]*ethpb.Validator, len(v))
-	for i := range res {
-		val := v[i]
-		if val == nil {
-			continue
-		}
-		res[i] = ethpb.CopyValidator(val)
-	}
-	return res
+	v := b.validatorsMultiValue.Value(b)
+	return stateutil.CompactValidatorsToProto(v)
 }
 
 func (b *BeaconState) validatorsReadOnlyVal() []state.ReadOnlyValidator {
@@ -52,18 +42,18 @@ func (b *BeaconState) validatorsReadOnlyVal() []state.ReadOnlyValidator {
 	v := b.validatorsMultiValue.Value(b)
 
 	res := make([]state.ReadOnlyValidator, len(v))
-	var err error
 	for i := range res {
-		val := v[i]
-		if val == nil {
-			continue
-		}
-		res[i], err = NewValidator(val)
-		if err != nil {
-			continue
-		}
+		res[i] = NewValidatorFromCompact(v[i])
 	}
 	return res
+}
+
+// validatorsCompactVal returns the raw compact validator slice for internal use (hashing).
+func (b *BeaconState) validatorsCompactVal() []stateutil.CompactValidator {
+	if b.validatorsMultiValue == nil {
+		return nil
+	}
+	return b.validatorsMultiValue.Value(b)
 }
 
 func (b *BeaconState) validatorsLen() int {
@@ -108,7 +98,7 @@ func (b *BeaconState) validatorAtIndex(idx primitives.ValidatorIndex) (*ethpb.Va
 	if err != nil {
 		return nil, err
 	}
-	return ethpb.CopyValidator(v), nil
+	return v.ToProto(), nil
 }
 
 // ValidatorAtIndexReadOnly is the validator at the provided index. This method
@@ -128,7 +118,7 @@ func (b *BeaconState) validatorAtIndexReadOnly(idx primitives.ValidatorIndex) (s
 	if err != nil {
 		return nil, err
 	}
-	return NewValidator(v)
+	return NewValidatorFromCompact(v), nil
 }
 
 // ValidatorIndexByPubkey returns a given validator by its 48-byte public key.
@@ -164,10 +154,7 @@ func (b *BeaconState) PubkeyAtIndex(idx primitives.ValidatorIndex) [fieldparams.
 		return [fieldparams.BLSPubkeyLength]byte{}
 	}
 
-	if v == nil {
-		return [fieldparams.BLSPubkeyLength]byte{}
-	}
-	return bytesutil.ToBytes48(v.PublicKey)
+	return v.PublicKey
 }
 
 // AggregateKeyFromIndices builds an aggregated public key from the provided
@@ -182,10 +169,7 @@ func (b *BeaconState) AggregateKeyFromIndices(idxs []uint64) (bls.PublicKey, err
 		if err != nil {
 			return nil, err
 		}
-		if v == nil {
-			return nil, ErrNilWrappedValidator
-		}
-		pubKeys[i] = v.PublicKey
+		pubKeys[i] = v.PublicKey[:]
 	}
 	return bls.AggregatePublicKeys(pubKeys)
 }
@@ -202,7 +186,7 @@ func (b *BeaconState) PublicKeys() ([][fieldparams.BLSPubkeyLength]byte, error) 
 		if err != nil {
 			return nil, err
 		}
-		copy(res[i][:], val.PublicKey)
+		res[i] = val.PublicKey
 	}
 	return res, nil
 }
@@ -231,10 +215,7 @@ func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val state.ReadOnlyV
 		if err != nil {
 			return err
 		}
-		rov, err := NewValidator(v)
-		if err != nil {
-			return err
-		}
+		rov := NewValidatorFromCompact(v)
 		if err = f(i, rov); err != nil {
 			return err
 		}

--- a/beacon-chain/state/state-native/hasher.go
+++ b/beacon-chain/state/state-native/hasher.go
@@ -122,7 +122,7 @@ func ComputeFieldRootsWithHasher(ctx context.Context, state *BeaconState) ([][]b
 	fieldRoots[types.Eth1DepositIndex.RealPosition()] = eth1DepositBuf[:]
 
 	// Validators slice root.
-	validatorsRoot, err := stateutil.ValidatorRegistryRoot(state.validatorsVal())
+	validatorsRoot, err := stateutil.ValidatorRegistryRoot(state.validatorsCompactVal())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compute validator registry merkleization")
 	}

--- a/beacon-chain/state/state-native/multi_value_slices.go
+++ b/beacon-chain/state/state-native/multi_value_slices.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native/types"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stateutil"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	multi_value_slice "github.com/OffchainLabs/prysm/v7/container/multi-value-slice"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -111,13 +112,15 @@ func NewMultiValueInactivityScores(scores []uint64) *MultiValueInactivityScores 
 	return mv
 }
 
-// MultiValueValidators is a multi-value slice of validator references.
-type MultiValueValidators = multi_value_slice.Slice[*ethpb.Validator]
+// MultiValueValidators is a multi-value slice of compact validators.
+type MultiValueValidators = multi_value_slice.Slice[stateutil.CompactValidator]
 
 // NewMultiValueValidators creates a new slice whose shared items will be populated with input values.
+// It converts the protobuf validators to compact representation internally.
 func NewMultiValueValidators(vals []*ethpb.Validator) *MultiValueValidators {
+	compactVals := stateutil.CompactValidatorsFromProto(vals)
 	mv := &MultiValueValidators{}
-	mv.Init(vals)
+	mv.Init(compactVals)
 	multiValueCountGauge.WithLabelValues(types.Validators.String()).Inc()
 	runtime.SetFinalizer(mv, validatorsFinalizer)
 	return mv

--- a/beacon-chain/state/state-native/readonly_validator.go
+++ b/beacon-chain/state/state-native/readonly_validator.go
@@ -2,6 +2,7 @@ package state_native
 
 import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state/stateutil"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -17,20 +18,27 @@ var (
 // readOnlyValidator returns a wrapper that only allows fields from a validator
 // to be read, and prevents any modification of internal validator fields.
 type readOnlyValidator struct {
-	validator *ethpb.Validator
+	validator stateutil.CompactValidator
 }
 
 var _ = state.ReadOnlyValidator(readOnlyValidator{})
 
-// NewValidator initializes the read only wrapper for validator.
+// NewValidator initializes the read only wrapper for validator from a proto.
 func NewValidator(v *ethpb.Validator) (state.ReadOnlyValidator, error) {
 	if v == nil {
 		return nil, ErrNilWrappedValidator
 	}
 	rov := readOnlyValidator{
-		validator: v,
+		validator: stateutil.CompactValidatorFromProto(v),
 	}
 	return rov, nil
+}
+
+// NewValidatorFromCompact initializes the read only wrapper from a CompactValidator.
+func NewValidatorFromCompact(cv stateutil.CompactValidator) state.ReadOnlyValidator {
+	return readOnlyValidator{
+		validator: cv,
+	}
 }
 
 // EffectiveBalance returns the effective balance of the
@@ -66,16 +74,14 @@ func (v readOnlyValidator) ExitEpoch() primitives.Epoch {
 // PublicKey returns the public key of the
 // read only validator.
 func (v readOnlyValidator) PublicKey() [fieldparams.BLSPubkeyLength]byte {
-	var pubkey [fieldparams.BLSPubkeyLength]byte
-	copy(pubkey[:], v.validator.PublicKey)
-	return pubkey
+	return v.validator.PublicKey
 }
 
 // WithdrawalCredentials returns the withdrawal credentials of the
 // read only validator.
 func (v readOnlyValidator) GetWithdrawalCredentials() []byte {
-	creds := make([]byte, len(v.validator.WithdrawalCredentials))
-	copy(creds, v.validator.WithdrawalCredentials)
+	creds := make([]byte, 32)
+	copy(creds, v.validator.WithdrawalCredentials[:])
 	return creds
 }
 
@@ -84,24 +90,13 @@ func (v readOnlyValidator) Slashed() bool {
 	return v.validator.Slashed
 }
 
-// IsNil returns true if the validator is nil.
-func (v readOnlyValidator) IsNil() bool {
-	return v.validator == nil
-}
-
 // HasETH1WithdrawalCredentials returns true if the validator has an ETH1 withdrawal credentials.
 func (v readOnlyValidator) HasETH1WithdrawalCredentials() bool {
-	if v.IsNil() {
-		return false
-	}
 	return v.validator.WithdrawalCredentials[0] == params.BeaconConfig().ETH1AddressWithdrawalPrefixByte
 }
 
 // HasCompoundingWithdrawalCredentials returns true if the validator has a compounding withdrawal credentials.
 func (v readOnlyValidator) HasCompoundingWithdrawalCredentials() bool {
-	if v.IsNil() {
-		return false
-	}
 	return v.validator.WithdrawalCredentials[0] == params.BeaconConfig().CompoundingWithdrawalPrefixByte
 }
 
@@ -112,16 +107,5 @@ func (v readOnlyValidator) HasExecutionWithdrawalCredentials() bool {
 
 // Copy returns a new validator from the read only validator
 func (v readOnlyValidator) Copy() *ethpb.Validator {
-	pubKey := v.PublicKey()
-	withdrawalCreds := v.GetWithdrawalCredentials()
-	return &ethpb.Validator{
-		PublicKey:                  pubKey[:],
-		WithdrawalCredentials:      withdrawalCreds,
-		EffectiveBalance:           v.EffectiveBalance(),
-		Slashed:                    v.Slashed(),
-		ActivationEligibilityEpoch: v.ActivationEligibilityEpoch(),
-		ActivationEpoch:            v.ActivationEpoch(),
-		ExitEpoch:                  v.ExitEpoch(),
-		WithdrawableEpoch:          v.WithdrawableEpoch(),
-	}
+	return v.validator.ToProto()
 }

--- a/beacon-chain/state/state-native/readonly_validator_test.go
+++ b/beacon-chain/state/state-native/readonly_validator_test.go
@@ -60,10 +60,10 @@ func TestReadOnlyValidator_PublicKey(t *testing.T) {
 }
 
 func TestReadOnlyValidator_WithdrawalCredentials(t *testing.T) {
-	creds := []byte{0xFA, 0xCC}
-	v, err := statenative.NewValidator(&ethpb.Validator{WithdrawalCredentials: creds})
+	creds := [32]byte{0xFA, 0xCC}
+	v, err := statenative.NewValidator(&ethpb.Validator{WithdrawalCredentials: creds[:]})
 	require.NoError(t, err)
-	assert.DeepEqual(t, creds, v.GetWithdrawalCredentials())
+	assert.DeepEqual(t, creds[:], v.GetWithdrawalCredentials())
 }
 
 func TestReadOnlyValidator_Slashed(t *testing.T) {

--- a/beacon-chain/state/state-native/setters_validator.go
+++ b/beacon-chain/state/state-native/setters_validator.go
@@ -38,17 +38,15 @@ func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val state.ReadOnlyVa
 		if err != nil {
 			return err
 		}
-		ro, err := NewValidator(v)
-		if err != nil {
-			return err
-		}
+		ro := NewValidatorFromCompact(v)
 		newVal, err := f(i, ro)
 		if err != nil {
 			return err
 		}
 		if newVal != nil {
 			changedVals = append(changedVals, uint64(i))
-			if err = b.validatorsMultiValue.UpdateAt(b, uint64(i), newVal); err != nil {
+			compactValidator := stateutil.CompactValidatorFromProto(newVal)
+			if err := b.validatorsMultiValue.UpdateAt(b, uint64(i), compactValidator); err != nil {
 				return errors.Wrapf(err, "could not update validator at index %d", i)
 			}
 		}
@@ -67,7 +65,8 @@ func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val state.ReadOnlyVa
 // UpdateValidatorAtIndex for the beacon state. Updates the validator
 // at a specific index to a new value.
 func (b *BeaconState) UpdateValidatorAtIndex(idx primitives.ValidatorIndex, val *ethpb.Validator) error {
-	if err := b.validatorsMultiValue.UpdateAt(b, uint64(idx), val); err != nil {
+	compactValidator := stateutil.CompactValidatorFromProto(val)
+	if err := b.validatorsMultiValue.UpdateAt(b, uint64(idx), compactValidator); err != nil {
 		return errors.Wrap(err, "could not update validator")
 	}
 
@@ -151,7 +150,8 @@ func (b *BeaconState) UpdateSlashingsAtIndex(idx, val uint64) error {
 // AppendValidator for the beacon state. Appends the new value
 // to the end of list.
 func (b *BeaconState) AppendValidator(val *ethpb.Validator) error {
-	b.validatorsMultiValue.Append(b, val)
+	compactValidator := stateutil.CompactValidatorFromProto(val)
+	b.validatorsMultiValue.Append(b, compactValidator)
 	valIdx := primitives.ValidatorIndex(b.validatorsMultiValue.Len(b) - 1)
 
 	b.lock.Lock()

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -1578,7 +1578,7 @@ func (b *BeaconState) stateRootsRootSelector(field types.FieldIndex) ([32]byte, 
 
 func (b *BeaconState) validatorsRootSelector(field types.FieldIndex) ([32]byte, error) {
 	if b.rebuildTrie[field] {
-		err := b.resetFieldTrie(field, mvslice.MultiValueSliceComposite[*ethpb.Validator]{
+		err := b.resetFieldTrie(field, mvslice.MultiValueSliceComposite[stateutil.CompactValidator]{
 			Identifiable:    b,
 			MultiValueSlice: b.validatorsMultiValue,
 		}, fieldparams.ValidatorRegistryLimit)
@@ -1589,7 +1589,7 @@ func (b *BeaconState) validatorsRootSelector(field types.FieldIndex) ([32]byte, 
 		delete(b.rebuildTrie, field)
 		return b.stateFieldLeaves[field].TrieRoot()
 	}
-	return b.recomputeFieldTrie(field, mvslice.MultiValueSliceComposite[*ethpb.Validator]{
+	return b.recomputeFieldTrie(field, mvslice.MultiValueSliceComposite[stateutil.CompactValidator]{
 		Identifiable:    b,
 		MultiValueSlice: b.validatorsMultiValue,
 	})

--- a/beacon-chain/state/stateutil/BUILD.bazel
+++ b/beacon-chain/state/stateutil/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "builder_pending_payments_root.go",
         "builder_pending_withdrawals_root.go",
         "builders_root.go",
+        "compact_validator.go",
         "eth1_root.go",
         "execution_payload_availability_root.go",
         "field_root_attestation.go",
@@ -53,6 +54,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "benchmark_test.go",
+        "compact_validator_test.go",
         "field_root_test.go",
         "field_root_validator_test.go",
         "proposer_lookahead_root_test.go",

--- a/beacon-chain/state/stateutil/compact_validator.go
+++ b/beacon-chain/state/stateutil/compact_validator.go
@@ -1,0 +1,142 @@
+package stateutil
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+)
+
+// CompactValidator is a fixed-size, pointer-free representation of a validator.
+// It stores the same data as *ethpb.Validator but in a flat 128-byte struct
+// with zero heap pointers.
+// (The used size is 121 bytes, but the struct is padded to 128 bytes for alignment.)
+type CompactValidator struct {
+	PublicKey                  [fieldparams.BLSPubkeyLength]byte // 48 bytes
+	WithdrawalCredentials      [32]byte                          // 32 bytes
+	EffectiveBalance           uint64                            // 8 bytes
+	Slashed                    bool                              // 1 byte
+	ActivationEligibilityEpoch primitives.Epoch                  // 8 bytes
+	ActivationEpoch            primitives.Epoch                  // 8 bytes
+	ExitEpoch                  primitives.Epoch                  // 8 bytes
+	WithdrawableEpoch          primitives.Epoch                  // 8 bytes
+}
+
+// CompactValidatorsFromProto converts a slice of protobuf Validators to CompactValidators.
+func CompactValidatorsFromProto(validators []*ethpb.Validator) []CompactValidator {
+	compactValidators := make([]CompactValidator, len(validators))
+	for i, validators := range validators {
+		if validators != nil {
+			compactValidators[i] = CompactValidatorFromProto(validators)
+		}
+	}
+
+	return compactValidators
+}
+
+// CompactValidatorsToProto converts a slice of CompactValidators to protobuf Validators.
+func CompactValidatorsToProto(compactValidators []CompactValidator) []*ethpb.Validator {
+	validators := make([]*ethpb.Validator, len(compactValidators))
+	for i := range compactValidators {
+		validators[i] = compactValidators[i].ToProto()
+	}
+
+	return validators
+}
+
+// CompactValidatorFromProto converts a protobuf Validator to a CompactValidator.
+func CompactValidatorFromProto(v *ethpb.Validator) CompactValidator {
+	var publicKey [fieldparams.BLSPubkeyLength]byte
+	copy(publicKey[:], v.PublicKey)
+
+	var withdrawalCredentials [32]byte
+	copy(withdrawalCredentials[:], v.WithdrawalCredentials)
+
+	return CompactValidator{
+		PublicKey:                  publicKey,
+		WithdrawalCredentials:      withdrawalCredentials,
+		EffectiveBalance:           v.EffectiveBalance,
+		ActivationEligibilityEpoch: v.ActivationEligibilityEpoch,
+		ActivationEpoch:            v.ActivationEpoch,
+		ExitEpoch:                  v.ExitEpoch,
+		WithdrawableEpoch:          v.WithdrawableEpoch,
+		Slashed:                    v.Slashed,
+	}
+}
+
+// ToProto converts a CompactValidator back to a protobuf Validator.
+func (cv *CompactValidator) ToProto() *ethpb.Validator {
+	publicKey := make([]byte, fieldparams.BLSPubkeyLength)
+	copy(publicKey, cv.PublicKey[:])
+
+	withdrawalCredentials := make([]byte, 32)
+	copy(withdrawalCredentials, cv.WithdrawalCredentials[:])
+
+	return &ethpb.Validator{
+		PublicKey:                  publicKey,
+		WithdrawalCredentials:      withdrawalCredentials,
+		EffectiveBalance:           cv.EffectiveBalance,
+		ActivationEligibilityEpoch: cv.ActivationEligibilityEpoch,
+		ActivationEpoch:            cv.ActivationEpoch,
+		ExitEpoch:                  cv.ExitEpoch,
+		WithdrawableEpoch:          cv.WithdrawableEpoch,
+		Slashed:                    cv.Slashed,
+	}
+}
+
+// Root computes the hash tree root of a CompactValidator.
+func (cv *CompactValidator) Root() ([32]byte, error) {
+	fieldRoots, err := cv.fieldRoots()
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("fieldRoots: %w", err)
+	}
+
+	return ssz.BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+}
+
+// fieldRoots computes the field roots of a CompactValidator
+// for hash tree root computation.
+func (cv *CompactValidator) fieldRoots() ([][32]byte, error) {
+	// Public key root (merkleize 48-byte pubkey).
+	pubKeyRoot, err := merkleizePubkey(cv.PublicKey[:])
+	if err != nil {
+		return nil, err
+	}
+
+	// Withdrawal credentials (already 32 bytes).
+	withdrawCreds := cv.WithdrawalCredentials
+
+	// Effective balance.
+	var effectiveBalanceBuf [32]byte
+	binary.LittleEndian.PutUint64(effectiveBalanceBuf[:8], cv.EffectiveBalance)
+
+	// Slashed.
+	var slashBuf [32]byte
+	if cv.Slashed {
+		slashBuf[0] = 1
+	}
+
+	// Activation eligibility epoch.
+	var activationEligibilityBuf [32]byte
+	binary.LittleEndian.PutUint64(activationEligibilityBuf[:8], uint64(cv.ActivationEligibilityEpoch))
+
+	// Activation epoch.
+	var activationBuf [32]byte
+	binary.LittleEndian.PutUint64(activationBuf[:8], uint64(cv.ActivationEpoch))
+
+	// Exit epoch.
+	var exitBuf [32]byte
+	binary.LittleEndian.PutUint64(exitBuf[:8], uint64(cv.ExitEpoch))
+
+	// Withdrawable epoch.
+	var withdrawalBuf [32]byte
+	binary.LittleEndian.PutUint64(withdrawalBuf[:8], uint64(cv.WithdrawableEpoch))
+
+	return [][32]byte{
+		pubKeyRoot, withdrawCreds, effectiveBalanceBuf, slashBuf,
+		activationEligibilityBuf, activationBuf, exitBuf, withdrawalBuf,
+	}, nil
+}

--- a/beacon-chain/state/stateutil/compact_validator.go
+++ b/beacon-chain/state/stateutil/compact_validator.go
@@ -28,9 +28,9 @@ type CompactValidator struct {
 // CompactValidatorsFromProto converts a slice of protobuf Validators to CompactValidators.
 func CompactValidatorsFromProto(validators []*ethpb.Validator) []CompactValidator {
 	compactValidators := make([]CompactValidator, len(validators))
-	for i, validators := range validators {
-		if validators != nil {
-			compactValidators[i] = CompactValidatorFromProto(validators)
+	for i, validator := range validators {
+		if validator != nil {
+			compactValidators[i] = CompactValidatorFromProto(validator)
 		}
 	}
 

--- a/beacon-chain/state/stateutil/compact_validator_test.go
+++ b/beacon-chain/state/stateutil/compact_validator_test.go
@@ -1,0 +1,71 @@
+package stateutil
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+)
+
+func validator(slashed bool) *ethpb.Validator {
+	return &ethpb.Validator{
+		PublicKey:                  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48},
+		WithdrawalCredentials:      []byte{0xaa, 0xbb, 0xcc, 0xdd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff},
+		EffectiveBalance:           32000000000,
+		Slashed:                    slashed,
+		ActivationEligibilityEpoch: 10,
+		ActivationEpoch:            20,
+		ExitEpoch:                  primitives.Epoch(30),
+		WithdrawableEpoch:          primitives.Epoch(40),
+	}
+}
+
+func TestCompactValidator(t *testing.T) {
+	t.Run("ProtoRoundTrip", func(t *testing.T) {
+		for _, slashed := range []bool{true, false} {
+			validatorStart := validator(slashed)
+			compactValidator := CompactValidatorFromProto(validatorStart)
+			validatorEnd := compactValidator.ToProto()
+
+			assert.DeepEqual(t, validatorStart.PublicKey, validatorEnd.PublicKey)
+			assert.DeepEqual(t, validatorStart.WithdrawalCredentials, validatorEnd.WithdrawalCredentials)
+			assert.Equal(t, validatorStart.EffectiveBalance, validatorEnd.EffectiveBalance)
+			assert.Equal(t, validatorStart.Slashed, validatorEnd.Slashed)
+			assert.Equal(t, validatorStart.ActivationEligibilityEpoch, validatorEnd.ActivationEligibilityEpoch)
+			assert.Equal(t, validatorStart.ActivationEpoch, validatorEnd.ActivationEpoch)
+			assert.Equal(t, validatorStart.ExitEpoch, validatorEnd.ExitEpoch)
+			assert.Equal(t, validatorStart.WithdrawableEpoch, validatorEnd.WithdrawableEpoch)
+		}
+	})
+
+	t.Run("RootMatchesProto", func(t *testing.T) {
+		validator := validator(true)
+
+		protoRoot, err := ValidatorRootWithHasher(validator)
+		require.NoError(t, err)
+
+		compactValidator := CompactValidatorFromProto(validator)
+		compactRoot, err := compactValidator.Root()
+		require.NoError(t, err)
+
+		assert.Equal(t, protoRoot, compactRoot)
+	})
+
+	t.Run("FieldRootsMatchProto", func(t *testing.T) {
+		v := validator(true)
+
+		protoFieldRoots, err := ValidatorFieldRoots(v)
+		require.NoError(t, err)
+
+		compactValidator := CompactValidatorFromProto(v)
+		compactFieldRoots, err := compactValidator.fieldRoots()
+		require.NoError(t, err)
+
+		require.Equal(t, len(protoFieldRoots), len(compactFieldRoots))
+		for i := range protoFieldRoots {
+			assert.Equal(t, protoFieldRoots[i], compactFieldRoots[i], "field root mismatch at index %d", i)
+		}
+	})
+}

--- a/beacon-chain/state/stateutil/field_root_validator.go
+++ b/beacon-chain/state/stateutil/field_root_validator.go
@@ -9,7 +9,6 @@ import (
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/crypto/hash/htr"
 	"github.com/OffchainLabs/prysm/v7/encoding/ssz"
-	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -26,13 +25,13 @@ const (
 )
 
 // ValidatorRegistryRoot computes the HashTreeRoot Merkleization of
-// a list of validator structs according to the Ethereum
+// a list of compact validator structs according to the Ethereum
 // Simple Serialize specification.
-func ValidatorRegistryRoot(vals []*ethpb.Validator) ([32]byte, error) {
+func ValidatorRegistryRoot(vals []CompactValidator) ([32]byte, error) {
 	return validatorRegistryRoot(vals)
 }
 
-func validatorRegistryRoot(validators []*ethpb.Validator) ([32]byte, error) {
+func validatorRegistryRoot(validators []CompactValidator) ([32]byte, error) {
 	roots, err := OptimizedValidatorRoots(validators)
 	if err != nil {
 		return [32]byte{}, err
@@ -54,10 +53,10 @@ func validatorRegistryRoot(validators []*ethpb.Validator) ([32]byte, error) {
 	return res, nil
 }
 
-func hashValidatorHelper(validators []*ethpb.Validator, roots [][32]byte, j int, groupSize int, wg *sync.WaitGroup) {
+func hashValidatorHelper(validators []CompactValidator, roots [][32]byte, j int, groupSize int, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for i := range groupSize {
-		fRoots, err := ValidatorFieldRoots(validators[j*groupSize+i])
+		fRoots, err := validators[j*groupSize+i].fieldRoots()
 		if err != nil {
 			logrus.WithError(err).Error("Could not get validator field roots")
 			return
@@ -69,8 +68,8 @@ func hashValidatorHelper(validators []*ethpb.Validator, roots [][32]byte, j int,
 }
 
 // OptimizedValidatorRoots uses an optimized routine with gohashtree in order to
-// derive a list of validator roots from a list of validator objects.
-func OptimizedValidatorRoots(validators []*ethpb.Validator) ([][32]byte, error) {
+// derive a list of validator roots from a list of compact validator objects.
+func OptimizedValidatorRoots(validators []CompactValidator) ([][32]byte, error) {
 	// Exit early if no validators are provided.
 	if len(validators) == 0 {
 		return [][32]byte{}, nil
@@ -85,7 +84,7 @@ func OptimizedValidatorRoots(validators []*ethpb.Validator) ([][32]byte, error) 
 		go hashValidatorHelper(validators, roots, j, groupSize, &wg)
 	}
 	for i := (n - 1) * groupSize; i < len(validators); i++ {
-		fRoots, err := ValidatorFieldRoots(validators[i])
+		fRoots, err := validators[i].fieldRoots()
 		if err != nil {
 			return [][32]byte{}, errors.Wrap(err, "could not compute validators merkleization")
 		}

--- a/beacon-chain/state/stateutil/field_root_validator_test.go
+++ b/beacon-chain/state/stateutil/field_root_validator_test.go
@@ -29,15 +29,16 @@ func TestValidatorConstants(t *testing.T) {
 	assert.Equal(t, validatorFieldRoots, numOfValFields)
 	assert.Equal(t, uint64(validatorFieldRoots), mathutil.PowerOf2(validatorTreeDepth))
 
-	_, err := ValidatorRegistryRoot([]*ethpb.Validator{v})
+	cv := CompactValidatorFromProto(v)
+	_, err := ValidatorRegistryRoot([]CompactValidator{cv})
 	assert.NoError(t, err)
 }
 
 func TestHashValidatorHelper(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	v := &ethpb.Validator{}
-	valList := make([]*ethpb.Validator, 10*validatorFieldRoots)
+	v := CompactValidator{}
+	valList := make([]CompactValidator, 10*validatorFieldRoots)
 	for i := range valList {
 		valList[i] = v
 	}
@@ -46,7 +47,7 @@ func TestHashValidatorHelper(t *testing.T) {
 	for i := range 4 * validatorFieldRoots {
 		require.Equal(t, [32]byte{}, roots[i])
 	}
-	emptyValRoots, err := ValidatorFieldRoots(v)
+	emptyValRoots, err := v.fieldRoots()
 	require.NoError(t, err)
 	for i := 4; i < 6; i++ {
 		for j := range validatorFieldRoots {

--- a/beacon-chain/state/stateutil/trie_helpers.go
+++ b/beacon-chain/state/stateutil/trie_helpers.go
@@ -154,7 +154,7 @@ func recomputeRootFromLayer(idx int, layers [][]*[32]byte, chunks []*[32]byte,
 		neighborIdx := currentIndex ^ 1
 
 		var neighbor [32]byte
-		if layers[i] != nil && len(layers[i]) != 0 && neighborIdx < len(layers[i]) {
+		if len(layers[i]) != 0 && neighborIdx < len(layers[i]) {
 			neighbor = *layers[i][neighborIdx]
 		}
 		if isLeft {

--- a/beacon-chain/state/stateutil/trie_helpers_test.go
+++ b/beacon-chain/state/stateutil/trie_helpers_test.go
@@ -60,7 +60,8 @@ func BenchmarkReturnTrieLayer_VectorizedAlgorithm(b *testing.B) {
 
 func TestReturnTrieLayerVariable_OK(t *testing.T) {
 	newState, _ := util.DeterministicGenesisState(t, 32)
-	root, err := stateutil.ValidatorRegistryRoot(newState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(newState.Validators())
+	root, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	require.NoError(t, err)
 	validators := newState.Validators()
 	roots := make([][32]byte, 0, len(validators))
@@ -85,7 +86,8 @@ func TestReturnTrieLayerVariable_OK(t *testing.T) {
 
 func BenchmarkReturnTrieLayerVariable_NormalAlgorithm(b *testing.B) {
 	newState, _ := util.DeterministicGenesisState(b, 16000)
-	root, err := stateutil.ValidatorRegistryRoot(newState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(newState.Validators())
+	root, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	require.NoError(b, err)
 	validators := newState.Validators()
 	roots := make([][32]byte, 0, len(validators))
@@ -107,7 +109,8 @@ func BenchmarkReturnTrieLayerVariable_NormalAlgorithm(b *testing.B) {
 func BenchmarkReturnTrieLayerVariable_VectorizedAlgorithm(b *testing.B) {
 
 	newState, _ := util.DeterministicGenesisState(b, 16000)
-	root, err := stateutil.ValidatorRegistryRoot(newState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(newState.Validators())
+	root, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	require.NoError(b, err)
 	validators := newState.Validators()
 	roots := make([][32]byte, 0, len(validators))
@@ -171,7 +174,8 @@ func TestRecomputeFromLayer_VariableSizedArray(t *testing.T) {
 	require.NoError(t, newState.UpdateValidatorAtIndex(primitives.ValidatorIndex(changedIdx[0]), changedVals[0]))
 	require.NoError(t, newState.UpdateValidatorAtIndex(primitives.ValidatorIndex(changedIdx[1]), changedVals[1]))
 
-	expectedRoot, err := stateutil.ValidatorRegistryRoot(newState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(newState.Validators())
+	expectedRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	require.NoError(t, err)
 	roots = make([][32]byte, 0, len(changedVals))
 	for _, val := range changedVals {

--- a/beacon-chain/state/stateutil/unrealized_justification_test.go
+++ b/beacon-chain/state/stateutil/unrealized_justification_test.go
@@ -5,18 +5,17 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	multi_value_slice "github.com/OffchainLabs/prysm/v7/container/multi-value-slice"
-	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 )
 
 func TestState_UnrealizedCheckpointBalances(t *testing.T) {
-	validators := make([]*ethpb.Validator, params.BeaconConfig().MinGenesisActiveValidatorCount)
+	validators := make([]CompactValidator, params.BeaconConfig().MinGenesisActiveValidatorCount)
 	targetFlag := params.BeaconConfig().TimelyTargetFlagIndex
 	expectedActive := params.BeaconConfig().MinGenesisActiveValidatorCount * params.BeaconConfig().MaxEffectiveBalance
 
 	balances := make([]uint64, params.BeaconConfig().MinGenesisActiveValidatorCount)
 	for i := range validators {
-		validators[i] = &ethpb.Validator{
+		validators[i] = CompactValidator{
 			ExitEpoch:        params.BeaconConfig().FarFutureEpoch,
 			EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
 		}
@@ -95,20 +94,20 @@ func TestState_UnrealizedCheckpointBalances(t *testing.T) {
 }
 
 func TestState_MVSlice_UnrealizedCheckpointBalances(t *testing.T) {
-	validators := make([]*ethpb.Validator, params.BeaconConfig().MinGenesisActiveValidatorCount)
+	validators := make([]CompactValidator, params.BeaconConfig().MinGenesisActiveValidatorCount)
 	targetFlag := params.BeaconConfig().TimelyTargetFlagIndex
 	expectedActive := params.BeaconConfig().MinGenesisActiveValidatorCount * params.BeaconConfig().MaxEffectiveBalance
 
 	balances := make([]uint64, params.BeaconConfig().MinGenesisActiveValidatorCount)
 	for i := range validators {
-		validators[i] = &ethpb.Validator{
+		validators[i] = CompactValidator{
 			ExitEpoch:        params.BeaconConfig().FarFutureEpoch,
 			EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
 		}
 		balances[i] = params.BeaconConfig().MaxEffectiveBalance
 	}
 
-	mv := &multi_value_slice.Slice[*ethpb.Validator]{}
+	mv := &multi_value_slice.Slice[CompactValidator]{}
 	mv.Init(validators)
 
 	cp := make([]byte, len(validators))
@@ -154,6 +153,7 @@ func TestState_MVSlice_UnrealizedCheckpointBalances(t *testing.T) {
 
 	t.Run("votes in both epochs, decreased balance in first validator", func(tt *testing.T) {
 		validators[0].EffectiveBalance = params.BeaconConfig().MaxEffectiveBalance - params.BeaconConfig().MinDepositAmount
+		_ = mv.UpdateAt(&testObject{id: 0}, 0, validators[0])
 		copy(cp, []byte{0xFF, 0xFF, 0x00, 0x00, 0xFF ^ (1 << targetFlag), 0})
 		copy(pp, []byte{0xFF ^ (1 << targetFlag), 0xFF ^ (1 << targetFlag), 0xFF ^ (1 << targetFlag), 0x00, 0xFF, 0xFF})
 		active, previous, current, err := UnrealizedCheckpointBalances(cp, pp, NewValMultiValueSliceReader(mv, &testObject{id: 0}), 1)
@@ -166,6 +166,7 @@ func TestState_MVSlice_UnrealizedCheckpointBalances(t *testing.T) {
 
 	t.Run("slash a validator", func(tt *testing.T) {
 		validators[1].Slashed = true
+		_ = mv.UpdateAt(&testObject{id: 0}, 1, validators[1])
 		active, previous, current, err := UnrealizedCheckpointBalances(cp, pp, NewValMultiValueSliceReader(mv, &testObject{id: 0}), 1)
 		require.NoError(tt, err)
 		require.Equal(tt, expectedActive, active)
@@ -174,6 +175,7 @@ func TestState_MVSlice_UnrealizedCheckpointBalances(t *testing.T) {
 	})
 	t.Run("Exit a validator", func(tt *testing.T) {
 		validators[4].ExitEpoch = 1
+		_ = mv.UpdateAt(&testObject{id: 0}, 4, validators[4])
 		active, previous, current, err := UnrealizedCheckpointBalances(cp, pp, NewValMultiValueSliceReader(mv, &testObject{id: 0}), 2)
 		require.NoError(tt, err)
 		expectedActive -= params.BeaconConfig().MaxEffectiveBalance

--- a/beacon-chain/state/stateutil/validator_reader.go
+++ b/beacon-chain/state/stateutil/validator_reader.go
@@ -2,22 +2,21 @@ package stateutil
 
 import (
 	multi_value_slice "github.com/OffchainLabs/prysm/v7/container/multi-value-slice"
-	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 )
 
 // ValReader specifies an interface through which we can access the validator registry.
 type ValReader interface {
 	Len() int
-	At(i int) (*ethpb.Validator, error)
+	At(i int) (CompactValidator, error)
 }
 
 // ValSliceReader describes a struct that conforms to the ValReader interface
 type ValSliceReader struct {
-	Validators []*ethpb.Validator
+	Validators []CompactValidator
 }
 
 // NewValSliceReader constructs a ValSliceReader object.
-func NewValSliceReader(vals []*ethpb.Validator) ValSliceReader {
+func NewValSliceReader(vals []CompactValidator) ValSliceReader {
 	return ValSliceReader{Validators: vals}
 }
 
@@ -27,7 +26,7 @@ func (v ValSliceReader) Len() int {
 }
 
 // At returns the validator at the provided index.
-func (v ValSliceReader) At(i int) (*ethpb.Validator, error) {
+func (v ValSliceReader) At(i int) (CompactValidator, error) {
 	return v.Validators[i], nil
 }
 
@@ -35,12 +34,12 @@ func (v ValSliceReader) At(i int) (*ethpb.Validator, error) {
 // This struct is specifically designed for accessing validator data from a
 // multivalue slice.
 type ValMultiValueSliceReader struct {
-	ValMVSlice *multi_value_slice.Slice[*ethpb.Validator]
+	ValMVSlice *multi_value_slice.Slice[CompactValidator]
 	Identifier multi_value_slice.Identifiable
 }
 
 // NewValMultiValueSliceReader constructs a new val reader object.
-func NewValMultiValueSliceReader(valSlice *multi_value_slice.Slice[*ethpb.Validator],
+func NewValMultiValueSliceReader(valSlice *multi_value_slice.Slice[CompactValidator],
 	identifier multi_value_slice.Identifiable) ValMultiValueSliceReader {
 	return ValMultiValueSliceReader{
 		ValMVSlice: valSlice,
@@ -54,6 +53,6 @@ func (v ValMultiValueSliceReader) Len() int {
 }
 
 // At returns the validator at the provided index.
-func (v ValMultiValueSliceReader) At(i int) (*ethpb.Validator, error) {
+func (v ValMultiValueSliceReader) At(i int) (CompactValidator, error) {
 	return v.ValMVSlice.At(v.Identifier, uint64(i))
 }

--- a/changelog/manu_compact_validator.md
+++ b/changelog/manu_compact_validator.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Replace `multi_value_slice.Slice[*ethpb.Validator]` by `multi_value_slice.Slice[stateutil.CompactValidator]` to reduce memory usage.

--- a/encoding/ssz/query/proof_collector_test.go
+++ b/encoding/ssz/query/proof_collector_test.go
@@ -399,9 +399,11 @@ func BenchmarkOptimizedValidatorRoots(b *testing.B) {
 		validators[i] = makeTestValidator(i)
 	}
 
+	compactValidators := stateutil.CompactValidatorsFromProto(validators)
+
 	b.ResetTimer()
 	for b.Loop() {
-		_, err := stateutil.OptimizedValidatorRoots(validators)
+		_, err := stateutil.OptimizedValidatorRoots(compactValidators)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/runtime/interop/premine-state.go
+++ b/runtime/interop/premine-state.go
@@ -330,7 +330,8 @@ func (s *PremineGenesisConfig) populate(g state.BeaconState) error {
 }
 
 func (s *PremineGenesisConfig) setGenesisValidatorsRoot(g state.BeaconState) error {
-	vroot, err := stateutil.ValidatorRegistryRoot(g.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(g.Validators())
+	vroot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return err
 	}

--- a/testing/spectest/shared/altair/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/altair/ssz_static/ssz_static.go
@@ -21,7 +21,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	switch object.(type) {
 	case *ethpb.BeaconStateAltair:
 		htrs = append(htrs, func(s any) ([32]byte, error) {
-			beaconState, err := state_native.InitializeFromProtoAltair(s.(*ethpb.BeaconStateAltair))
+			beaconState, err := state_native.InitializeFromProtoUnsafeAltair(s.(*ethpb.BeaconStateAltair))
 			require.NoError(t, err)
 			return beaconState.HashTreeRoot(context.Background())
 		})

--- a/testing/spectest/shared/bellatrix/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/bellatrix/ssz_static/ssz_static.go
@@ -22,7 +22,7 @@ func customHtr(t *testing.T, htrs []common.HTR, object any) []common.HTR {
 	switch object.(type) {
 	case *ethpb.BeaconStateBellatrix:
 		htrs = append(htrs, func(s any) ([32]byte, error) {
-			beaconState, err := state_native.InitializeFromProtoBellatrix(s.(*ethpb.BeaconStateBellatrix))
+			beaconState, err := state_native.InitializeFromProtoUnsafeBellatrix(s.(*ethpb.BeaconStateBellatrix))
 			require.NoError(t, err)
 			return beaconState.HashTreeRoot(context.Background())
 		})

--- a/testing/util/altair.go
+++ b/testing/util/altair.go
@@ -112,7 +112,8 @@ func buildGenesisBeaconState(genesisTime uint64, preState state.BeaconState, eth
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}

--- a/testing/util/bellatrix_state.go
+++ b/testing/util/bellatrix_state.go
@@ -118,7 +118,8 @@ func buildGenesisBeaconStateBellatrix(genesisTime time.Time, preState state.Beac
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}

--- a/testing/util/capella_state.go
+++ b/testing/util/capella_state.go
@@ -116,7 +116,8 @@ func buildGenesisBeaconStateCapella(genesisTime uint64, preState state.BeaconSta
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}

--- a/testing/util/deneb_state.go
+++ b/testing/util/deneb_state.go
@@ -116,7 +116,8 @@ func buildGenesisBeaconStateDeneb(genesisTime uint64, preState state.BeaconState
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}

--- a/testing/util/electra_state.go
+++ b/testing/util/electra_state.go
@@ -145,7 +145,8 @@ func buildGenesisBeaconStateElectra(genesisTime uint64, preState state.BeaconSta
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}

--- a/testing/util/fulu_state.go
+++ b/testing/util/fulu_state.go
@@ -140,7 +140,8 @@ func buildGenesisBeaconStateFulu(genesisTime uint64, preState state.BeaconState,
 
 	slashings := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
-	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(preState.Validators())
+	compactValidators := stateutil.CompactValidatorsFromProto(preState.Validators())
+	genesisValidatorsRoot, err := stateutil.ValidatorRegistryRoot(compactValidators)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not hash tree root genesis validators %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
Optimisation (@nisdas)

**What does this PR do? Why is it needed?**
The beacon state contains the list of all validators that have been at least once deposited on the network.

| Network  | Active       | Total                | Ratio      |
|----------|-----------|---------------|---------|
| Hoodi      | 1,224,855 | **1,294,521**  | 94.1%   |
| Mainnet  | 948,883   | **2,229,313** | 43.56% |

Currently, the validators are stored in the beacon state like this:
```go
type BeaconState struct {
...
	validatorsMultiValue                *MultiValueValidators
...
}

type MultiValueValidators = multi_value_slice.Slice[*ethpb.Validator]

type Validator struct {
	state                      protoimpl.MessageState                                            `protogen:"open.v1"`
	PublicKey                  []byte                                                            `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty" spec-name:"pubkey" ssz-size:"48"`
	WithdrawalCredentials      []byte                                                            `protobuf:"bytes,2,opt,name=withdrawal_credentials,json=withdrawalCredentials,proto3" json:"withdrawal_credentials,omitempty" ssz-size:"32"`
	EffectiveBalance           uint64                                                            `protobuf:"varint,3,opt,name=effective_balance,json=effectiveBalance,proto3" json:"effective_balance,omitempty"`
	Slashed                    bool                                                              `protobuf:"varint,4,opt,name=slashed,proto3" json:"slashed,omitempty"`
	ActivationEligibilityEpoch github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch `protobuf:"varint,5,opt,name=activation_eligibility_epoch,json=activationEligibilityEpoch,proto3" json:"activation_eligibility_epoch,omitempty" cast-type:"github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"`
	ActivationEpoch            github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch `protobuf:"varint,6,opt,name=activation_epoch,json=activationEpoch,proto3" json:"activation_epoch,omitempty" cast-type:"github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"`
	ExitEpoch                  github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch `protobuf:"varint,7,opt,name=exit_epoch,json=exitEpoch,proto3" json:"exit_epoch,omitempty" cast-type:"github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"`
	WithdrawableEpoch          github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch `protobuf:"varint,8,opt,name=withdrawable_epoch,json=withdrawableEpoch,proto3" json:"withdrawable_epoch,omitempty" cast-type:"github.com/OffchainLabs/prysm/v7/consensus-types/primitives.Epoch"`
	unknownFields              protoimpl.UnknownFields
	sizeCache                  protoimpl.SizeCache
}
```

Some fields, used only by protobuf (`state`, `unknownFields`, `sizeCache`) are not used by the beacon node.
Some other fields, stored as slices (`PublicKey`, `WithdrawalCredentials`) need extra memory (`ptr+len+cap`) while they could be stored as arrays because their sizes are fixed and known in advance.

We define a new custom type called `CompactValidator`, which is a fixed-size, pointer-free representation of a validator:

```go
type CompactValidator struct {
	PublicKey                  [fieldparams.BLSPubkeyLength]byte // 48 bytes
	WithdrawalCredentials      [32]byte                          // 32 bytes
	EffectiveBalance           uint64                            // 8 bytes
	Slashed                    bool                              // 1 byte
	ActivationEligibilityEpoch primitives.Epoch                  // 8 bytes
	ActivationEpoch            primitives.Epoch                  // 8 bytes
	ExitEpoch                  primitives.Epoch                  // 8 bytes
	WithdrawableEpoch          primitives.Epoch                  // 8 bytes
}
```

Here is the comparison, per validator, between storing a `*ethpb.Validator` and a `CompactValidator`.

  | Component                                | `*ethpb.Validator` | `CompactValidator` | Wasted  |
  |------------------------------------------|--------------------|--------------------|---------|
  | Pointer to struct                        | 8 B                | 0 B                | 8 B     |
  | `state` (protoimpl.MessageState)         | 8 B                | 0 B                | 8 B     |
  | `PublicKey` slice header (ptr+len+cap)   | 24 B               | 0 B                | 24 B    |
  | `PublicKey` backing array (heap)         | 48 B               | 48 B (inline)      | 0 B     |
  | `PublicKey` malloc overhead              | ~16 B              | 0 B                | ~16 B   |
  | `WithdrawalCredentials` slice header     | 24 B               | 0 B                | 24 B    |
  | `WithdrawalCredentials` backing array    | 32 B               | 32 B (inline)      | 0 B     |
  | `WithdrawalCredentials` malloc overhead  | ~16 B              | 0 B                | ~16 B   |
  | `EffectiveBalance` (uint64)              | 8 B                | 8 B                | 0 B     |
  | `Slashed` (bool + padding)              | 8 B                | 8 B                | 0 B     |
  | `ActivationEligibilityEpoch`            | 8 B                | 8 B                | 0 B     |
  | `ActivationEpoch`                        | 8 B                | 8 B                | 0 B     |
  | `ExitEpoch`                              | 8 B                | 8 B                | 0 B     |
  | `WithdrawableEpoch`                      | 8 B                | 8 B                | 0 B     |
  | `unknownFields` ([]byte header)          | 24 B               | 0 B                | 24 B    |
  | `sizeCache` (int32 + padding)            | 8 B                | 0 B                | 8 B     |
  | Struct malloc overhead                   | ~16 B              | 0 B                | ~16 B   |
  | **Total**                                | **~264 B**         | **128 B**          | **~136 B (52%)** |

We waste `~136 B` per validator.
With a total of `2,229,313` validators (mainnet), it represents `~290 MB`.
Storing `CompactValidator` instead of `*ethpb.Validator` also reduces the garbage collection pressure.

The following graph represents, for a Hoodi supernode (200 validators managed):
1. The heap memory usage (`go_memstats_alloc_bytes`) without this PR (`ref`) and with this PR (`current`)
2. `1.`, but averaged over the latest four hours.
3. The diff of the graphs in `2`. (The bigger, the better)

> [!NOTE]
>  The improvement is, after stabilisation, **~300MB-450MB**, representing **~8%-11%**.
>
> <img width="1028" height="917" alt="image" src="https://github.com/user-attachments/assets/9179d9b1-bc50-4248-9f47-82a7646d58ab" />
>
> For some reasons, the gain is higher than initialy expected.

**For the reviewers:**
This PR should be reviewed commit by commit:
Commits 1 and 2 are independent and unrelated to this PR
Commit 3 is an oversight of:
- https://github.com/OffchainLabs/prysm/pull/16420

Commit 4 implements the `CompactValidator`
Commit 5 uses the `CompactValidator`. The key change is:
```go
// MultiValueValidators is a multi-value slice of compact validators.
type MultiValueValidators = multi_value_slice.Slice[stateutil.CompactValidator]
```

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
