### PR TITLE
Reduce log noise by returning `nil` error when ignoring already-seen data column sidecars during gossip validation

### DIFF
--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -206,7 +206,7 @@ func (s *Service) validateDataColumnFulu(
 	// [IGNORE] The sidecar is the first sidecar for the tuple `(block_header.slot, block_header.proposer_index, sidecar.index)`
 	// with valid header signature, sidecar inclusion proof, and kzg proof.
 	if s.hasSeenDataColumnIndex(roDataColumn.Slot(), roDataColumn.ProposerIndex(), roDataColumn.DataColumnSidecar.Index) {
-		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.New("data column sidecar already seen"))
+		return blocks.VerifiedRODataColumn{}, ignoreValidation(nil)
 	}
 
 	// [REJECT] The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).

--- a/beacon-chain/sync/validate_data_column_test.go
+++ b/beacon-chain/sync/validate_data_column_test.go
@@ -214,7 +214,7 @@ func TestValidateDataColumn(t *testing.T) {
 		service, message := serviceAndMessage(t, testNewDataColumnSidecarsVerifier(verification.MockDataColumnsVerifier{}), dataColumnSidecarMsg)
 		service.setSeenDataColumnIndex(0, 0, 0)
 		result, err := service.validateDataColumn(ctx, "aDummyPID", message)
-		require.ErrorContains(t, "data column sidecar already seen", err)
+		require.NoError(t, err)
 		require.Equal(t, pubsub.ValidationIgnore, result)
 	})
 }

--- a/changelog/manu-dc-ignore-nil-err.md
+++ b/changelog/manu-dc-ignore-nil-err.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Return nil error when ignoring already-seen data column sidecars during gossip validation to reduce log noise.


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
Starting at:
- https://github.com/OffchainLabs/prysm/pull/16515

For a super node, the
> data column sidecar already seen

log takes almost **50%** of the whole debug log volume.

The reason is, previously, if a given data column sidecar was already seen, the message was ignored with the corresponding `err == nil`.
Starting at this PR, the message is still ignored but `err != nil`.
The direct consequence is the corresponding error is printed on the console.

This present pull request sets back to `nil` the corresponding error.
The rationale is receiving multiple times the same sidecar from different peers is an expected and normal behavior.
==> We don't need to consider this event as an error.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
