### PR TITLE
feat: `on_execution_payload` fork choice test support

### DIFF
--- a/changelog/brech1_gloas-fork-choice-tests.md
+++ b/changelog/brech1_gloas-fork-choice-tests.md
@@ -1,0 +1,3 @@
+### Ignored
+
+- Add `on_execution_payload` fork choice spec test support for Gloas.

--- a/testing/spectest/shared/common/forkchoice/BUILD.bazel
+++ b/testing/spectest/shared/common/forkchoice/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//beacon-chain/state/state-native:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//beacon-chain/verification:go_default_library",
+        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
@@ -131,6 +132,24 @@ func (bb *Builder) AttesterSlashing(s *ethpb.AttesterSlashing) {
 	bb.service.InsertSlashingsToForkChoiceStore(context.TODO(), slashings)
 }
 
+// ExecutionPayloadEnvelope receives a valid signed execution payload envelope and notifies forkchoice.
+func (bb *Builder) ExecutionPayloadEnvelope(t testing.TB, envelope *ethpb.SignedExecutionPayloadEnvelope) {
+	signed, err := blocks.WrappedROSignedExecutionPayloadEnvelope(envelope)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	require.NoError(t, bb.service.ReceiveExecutionPayloadEnvelope(ctx, signed))
+}
+
+// InvalidExecutionPayloadEnvelope receives an invalid execution payload envelope and notifies forkchoice.
+func (bb *Builder) InvalidExecutionPayloadEnvelope(t testing.TB, envelope *ethpb.SignedExecutionPayloadEnvelope) {
+	signed, err := blocks.WrappedROSignedExecutionPayloadEnvelope(envelope)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	require.Equal(t, true, bb.service.ReceiveExecutionPayloadEnvelope(ctx, signed) != nil)
+}
+
 // Check evaluates the fork choice results and compares them to the expected values.
 func (bb *Builder) Check(t testing.TB, c *Check) {
 	if c == nil {
@@ -170,6 +189,17 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 		want := fmt.Sprintf("%#x", common.FromHex(*c.GetProposerHead))
 		got := fmt.Sprintf("%#x", bb.service.GetProposerHead())
 		require.Equal(t, want, got)
+	}
+	if c.HeadPayloadStatus != nil {
+		r, err := bb.service.HeadRoot(ctx)
+		require.NoError(t, err)
+		root := bytesutil.ToBytes32(r)
+		hasFull := bb.service.HasFullNode(root)
+		if *c.HeadPayloadStatus == 1 {
+			require.Equal(t, true, hasFull)
+		} else {
+			require.Equal(t, false, hasFull)
+		}
 	}
 	/* TODO: We need to mock the entire proposer system to be able to test this.
 	if c.ShouldOverrideFCU != nil {

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -41,8 +42,14 @@ func init() {
 
 // Run executes "forkchoice"  and "sync" test.
 func Run(t *testing.T, config string, fork int) {
+	if fork >= version.Gloas {
+		resetFn := features.InitWithReset(&features.Flags{
+			EnableStartOptimistic: true,
+		})
+		defer resetFn()
+	}
 	runTest(t, config, fork, "fork_choice")
-	if fork >= version.Bellatrix {
+	if fork >= version.Bellatrix && fork < version.Gloas {
 		runTest(t, config, fork, "sync")
 	}
 }
@@ -114,6 +121,9 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 				case version.Fulu:
 					beaconState = unmarshalFuluState(t, preBeaconStateSSZ)
 					beaconBlock = unmarshalFuluBlock(t, blockSSZ)
+				case version.Gloas:
+					beaconState = unmarshalGloasState(t, preBeaconStateSSZ)
+					beaconBlock = unmarshalGloasBlock(t, blockSSZ)
 				default:
 					t.Fatalf("unknown fork version: %v", fork)
 				}
@@ -156,6 +166,8 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 							beaconBlock = unmarshalSignedElectraBlock(t, blockSSZ)
 						case version.Fulu:
 							beaconBlock = unmarshalSignedFuluBlock(t, blockSSZ)
+						case version.Gloas:
+							beaconBlock = unmarshalSignedGloasBlock(t, blockSSZ)
 						default:
 							t.Fatalf("unknown fork version: %v", fork)
 						}
@@ -205,6 +217,19 @@ func runTest(t *testing.T, config string, fork int, basePath string) { // nolint
 						pb := &ethpb.PowBlock{}
 						require.NoError(t, pb.UnmarshalSSZ(p), "Failed to unmarshal")
 						builder.PoWBlock(pb)
+					}
+					if step.ExecutionPayload != nil {
+						envelopeFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), fmt.Sprint(*step.ExecutionPayload, ".ssz_snappy"))
+						require.NoError(t, err)
+						envelopeSSZ, err := snappy.Decode(nil /* dst */, envelopeFile)
+						require.NoError(t, err)
+						signedEnvelope := &ethpb.SignedExecutionPayloadEnvelope{}
+						require.NoError(t, signedEnvelope.UnmarshalSSZ(envelopeSSZ), "Failed to unmarshal")
+						if step.Valid != nil && !*step.Valid {
+							builder.InvalidExecutionPayloadEnvelope(t, signedEnvelope)
+						} else {
+							builder.ExecutionPayloadEnvelope(t, signedEnvelope)
+						}
 					}
 					builder.Check(t, step.Check)
 				}
@@ -666,6 +691,34 @@ func unmarshalFuluBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
 
 func unmarshalSignedFuluBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
 	base := &ethpb.SignedBeaconBlockFulu{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(base)
+	require.NoError(t, err)
+	return blk
+}
+
+// ----------------------------------------------------------------------------
+// Gloas
+// ----------------------------------------------------------------------------
+
+func unmarshalGloasState(t *testing.T, raw []byte) state.BeaconState {
+	base := &ethpb.BeaconStateGloas{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	st, err := state_native.InitializeFromProtoUnsafeGloas(base)
+	require.NoError(t, err)
+	return st
+}
+
+func unmarshalGloasBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+	base := &ethpb.BeaconBlockGloas{}
+	require.NoError(t, base.UnmarshalSSZ(raw))
+	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
+	require.NoError(t, err)
+	return blk
+}
+
+func unmarshalSignedGloasBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+	base := &ethpb.SignedBeaconBlockGloas{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(base)
 	require.NoError(t, err)

--- a/testing/spectest/shared/common/forkchoice/service.go
+++ b/testing/spectest/shared/common/forkchoice/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	pb "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -91,6 +92,17 @@ func startChainService(t testing.TB,
 	// force start kzg context here until Deneb fork epoch is decided
 	require.NoError(t, kzg.Start())
 	require.NoError(t, service.StartFromSavedState(st))
+	// gloas anchor blocks are full per spec
+	if block.Block().Version() >= version.Gloas {
+		// TODO: process anchor envelope from test vectors when available
+		env := &ethpb.ExecutionPayloadEnvelope{
+			BeaconBlockRoot: r[:],
+			Payload:         &pb.ExecutionPayloadDeneb{},
+		}
+		roEnv, err := blocks.WrappedROExecutionPayloadEnvelope(env)
+		require.NoError(t, err)
+		require.NoError(t, fc.InsertPayload(roEnv))
+	}
 	return service, sg, fc
 }
 

--- a/testing/spectest/shared/common/forkchoice/type.go
+++ b/testing/spectest/shared/common/forkchoice/type.go
@@ -12,6 +12,7 @@ type Step struct {
 	PowBlock         *string         `json:"pow_block"`
 	Check            *Check          `json:"checks"`
 	DataColumns      []*string       `json:"columns"`
+	ExecutionPayload *string         `json:"execution_payload"`
 }
 
 type Check struct {
@@ -24,6 +25,7 @@ type Check struct {
 	FinalizedCheckPoint     *EpochRoot      `json:"finalized_checkpoint"`
 	GetProposerHead         *string         `json:"get_proposer_head"`
 	ShouldOverrideFCU       *ShouldOverride `json:"should_override_forkchoice_update"`
+	HeadPayloadStatus       *int            `json:"head_payload_status"`
 }
 
 type SlotRoot struct {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Add test harness support for the `on_execution_payload` fork choice step type and `head_payload_status` check for Gloas.

- Handle `ExecutionPayloadEnvelope` step in fork choice test runner
- Insert payload envelope for Gloas anchor blocks
- Gate `on_execution_payload` handler to Gloas and later forks
- Enable `StartOptimistic` for Gloas fork choice tests

To enable:

- Update `consensus_spec_version` to `v1.7.0-alpha.3`: 

https://github.com/OffchainLabs/prysm/blob/36052ed1bb4e0e5494eab651e4601c8e0e560290/WORKSPACE#L276

- Register test files after: 
 
https://github.com/OffchainLabs/prysm/blob/36052ed1bb4e0e5494eab651e4601c8e0e560290/testing/spectest/mainnet/BUILD.bazel#L181 

https://github.com/OffchainLabs/prysm/blob/36052ed1bb4e0e5494eab651e4601c8e0e560290/testing/spectest/minimal/BUILD.bazel#L187           

**Other notes for review**

Let me know if this is useful, as it is right now it's just handlers code. I used this to check:

- https://github.com/ethereum/consensus-specs/pull/4940

Otherwise, I can close and leave the committed changes on my fork for future implementers.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected.
