### PR TITLE
Deduplicate `getVerifyingState` calls in data column verification using `singleflight`.

### DIFF
--- a/beacon-chain/verification/blob_test.go
+++ b/beacon-chain/verification/blob_test.go
@@ -624,11 +624,15 @@ var _ signatureCache = &mockSignatureCache{}
 type sbrfunc func(context.Context, [32]byte) (state.BeaconState, error)
 
 type mockStateByRooter struct {
-	sbr           sbrfunc
-	calledForRoot map[[32]byte]bool
+	sbr              sbrfunc
+	calledForRoot    map[[32]byte]bool
+	cachedNoCopyFunc func(root [32]byte) state.ReadOnlyBeaconState
 }
 
-func (sbr *mockStateByRooter) StateByRootIfCachedNoCopy(_ [32]byte) state.ReadOnlyBeaconState {
+func (sbr *mockStateByRooter) StateByRootIfCachedNoCopy(root [32]byte) state.ReadOnlyBeaconState {
+	if sbr.cachedNoCopyFunc != nil {
+		return sbr.cachedNoCopyFunc(root)
+	}
 	return nil
 }
 

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -3,6 +3,7 @@ package verification
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"time"
@@ -326,24 +327,46 @@ func (dv *RODataColumnsVerifier) getVerifyingState(ctx context.Context, dataColu
 		}
 	}
 
-	logrus.WithFields(logrus.Fields{
-		"slot":       dataColumnSlot,
-		"parentRoot": fmt.Sprintf("%#x", parentRoot),
-		"headRoot":   fmt.Sprintf("%#x", headRoot),
-	}).Debug("Replying state for data column verification")
-	targetRoot, err := dv.fc.TargetRootForEpoch(parentRoot, dataColumnEpoch)
+	// Deduplicate the expensive state replay across concurrent data columns for the same block.
+	var slotBytes [8]byte
+	binary.BigEndian.PutUint64(slotBytes[:], uint64(dataColumnSlot))
+	key := "vs:" + string(parentRoot[:]) + string(slotBytes[:])
+
+	v, err, _ := dv.sg.Do(key, func() (any, error) {
+		logrus.WithFields(logrus.Fields{
+			"slot":       dataColumnSlot,
+			"parentRoot": fmt.Sprintf("%#x", parentRoot),
+			"headRoot":   fmt.Sprintf("%#x", headRoot),
+			"index":      dataColumn.Index,
+		}).Debug("Replying state for data column verification")
+
+		targetRoot, err := dv.fc.TargetRootForEpoch(parentRoot, dataColumnEpoch)
+		if err != nil {
+			return nil, fmt.Errorf("target root for epoch: %w", err)
+		}
+
+		targetState, err := dv.sr.StateByRoot(ctx, targetRoot)
+		if err != nil {
+			return nil, fmt.Errorf("state by root: %w", err)
+		}
+
+		targetEpoch := slots.ToEpoch(targetState.Slot())
+		if targetEpoch == dataColumnEpoch || targetEpoch == dataColumnEpoch-1 {
+			return targetState, nil
+		}
+
+		st, err := dv.sr.StateByRoot(ctx, parentRoot)
+		if err != nil {
+			return nil, fmt.Errorf("state by root: %w", err)
+		}
+
+		return st, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	targetState, err := dv.sr.StateByRoot(ctx, targetRoot)
-	if err != nil {
-		return nil, err
-	}
-	targetEpoch := slots.ToEpoch(targetState.Slot())
-	if targetEpoch == dataColumnEpoch || targetEpoch == dataColumnEpoch-1 {
-		return targetState, nil
-	}
-	return transition.ProcessSlotsUsingNextSlotCache(ctx, targetState, parentRoot[:], dataColumnSlot)
+
+	return v.(state.ReadOnlyBeaconState), nil
 }
 
 func (dv *RODataColumnsVerifier) SidecarParentSeen(parentSeen func([fieldparams.RootLength]byte) bool) (err error) {

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -15,6 +15,7 @@ import (
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/runtime/logging"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
@@ -327,6 +328,16 @@ func (dv *RODataColumnsVerifier) getVerifyingState(ctx context.Context, dataColu
 		}
 	}
 
+	// Check caches before entering the expensive singleflight state replay.
+	cachedState, err := dv.cachedVerifyingState(parentRoot, dataColumnEpoch)
+	if err != nil {
+		return nil, fmt.Errorf("cached verifying state: %w", err)
+	}
+
+	if cachedState != nil {
+		return cachedState, nil
+	}
+
 	// Deduplicate the expensive state replay across concurrent data columns for the same block.
 	var slotBytes [8]byte
 	binary.BigEndian.PutUint64(slotBytes[:], uint64(dataColumnSlot))
@@ -367,6 +378,28 @@ func (dv *RODataColumnsVerifier) getVerifyingState(ctx context.Context, dataColu
 	}
 
 	return v.(state.ReadOnlyBeaconState), nil
+}
+
+// cachedVerifyingState attempts to find a suitable verifying state from caches,
+// avoiding the expensive StateByRoot disk lookup and singleflight contention.
+func (dv *RODataColumnsVerifier) cachedVerifyingState(parentRoot [fieldparams.RootLength]byte, dataColumnEpoch primitives.Epoch) (state.ReadOnlyBeaconState, error) {
+	targetRoot, err := dv.fc.TargetRootForEpoch(parentRoot, dataColumnEpoch)
+	if err != nil {
+		return nil, fmt.Errorf("target root for epoch: %w", err)
+	}
+
+	if state := dv.sr.StateByRootIfCachedNoCopy(targetRoot); state != nil {
+		targetEpoch := slots.ToEpoch(state.Slot())
+		if targetEpoch == dataColumnEpoch || targetEpoch == dataColumnEpoch-1 {
+			return state, nil
+		}
+	}
+
+	if state := dv.sr.StateByRootIfCachedNoCopy(parentRoot); state != nil {
+		return state, nil
+	}
+
+	return nil, nil
 }
 
 func (dv *RODataColumnsVerifier) SidecarParentSeen(parentSeen func([fieldparams.RootLength]byte) bool) (err error) {

--- a/beacon-chain/verification/data_column_test.go
+++ b/beacon-chain/verification/data_column_test.go
@@ -1059,6 +1059,91 @@ func TestGetVerifyingStateEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, true, headStateCalled, "HeadState should be called when head is far ahead")
 	})
+
+	t.Run("different dependent roots - cache hit on target root avoids StateByRoot", func(t *testing.T) {
+		signatureCache := &mockSignatureCache{
+			svcb: func(signatureData signatureData) (bool, error) {
+				return false, nil
+			},
+			vscb: func(signatureData signatureData, _ validatorAtIndexer) (err error) {
+				return nil
+			},
+		}
+
+		stateByRooter := &mockStateByRooter{
+			sbr: sbrErrorIfCalled(t), // StateByRoot should NOT be called
+			cachedNoCopyFunc: func(root [32]byte) state.ReadOnlyBeaconState {
+				return fuluState // Cache hit for any root
+			},
+		}
+
+		initializer := Initializer{
+			shared: &sharedResources{
+				sc: signatureCache,
+				sr: stateByRooter,
+				hsp: &mockHeadStateProvider{
+					headRoot: []byte{0xff},
+					headSlot: columnSlot,
+				},
+				fc: &mockForkchoicer{
+					DependentRootForEpochCB: func(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+						return root, nil // Different roots for parent vs head
+					},
+					TargetRootForEpochCB: fcReturnsTargetRoot([fieldparams.RootLength]byte{}),
+				},
+			},
+		}
+
+		verifier := initializer.NewDataColumnsVerifier(columns, GossipDataColumnSidecarRequirements)
+		err := verifier.ValidProposerSignature(t.Context())
+		require.NoError(t, err)
+	})
+
+	t.Run("different dependent roots - cache hit on parent root avoids StateByRoot", func(t *testing.T) {
+		signatureCache := &mockSignatureCache{
+			svcb: func(signatureData signatureData) (bool, error) {
+				return false, nil
+			},
+			vscb: func(signatureData signatureData, _ validatorAtIndexer) (err error) {
+				return nil
+			},
+		}
+
+		// Only return a cache hit for the parent root, not the target root.
+		// Also set the target state to a far-away epoch so it doesn't match the epoch check.
+		farState, _ := util.DeterministicGenesisStateFulu(t, numValidators)
+		stateByRooter := &mockStateByRooter{
+			sbr: sbrErrorIfCalled(t),
+			cachedNoCopyFunc: func(root [32]byte) state.ReadOnlyBeaconState {
+				if root == parentRoot {
+					return fuluState // Cache hit only for parent root
+				}
+				// Target root returns a state in epoch 0 (won't match epoch 3 or 2)
+				return farState
+			},
+		}
+
+		initializer := Initializer{
+			shared: &sharedResources{
+				sc: signatureCache,
+				sr: stateByRooter,
+				hsp: &mockHeadStateProvider{
+					headRoot: []byte{0xff},
+					headSlot: columnSlot,
+				},
+				fc: &mockForkchoicer{
+					DependentRootForEpochCB: func(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
+						return root, nil
+					},
+					TargetRootForEpochCB: fcReturnsTargetRoot([fieldparams.RootLength]byte{0xaa}),
+				},
+			},
+		}
+
+		verifier := initializer.NewDataColumnsVerifier(columns, GossipDataColumnSidecarRequirements)
+		err := verifier.ValidProposerSignature(t.Context())
+		require.NoError(t, err)
+	})
 }
 
 // headStateCallTracker wraps mockHeadStateProvider to track HeadState calls.

--- a/changelog/manu-dc-verifying-state.md
+++ b/changelog/manu-dc-verifying-state.md
@@ -1,0 +1,4 @@
+### Changed
+
+- `getVerifyingState`: Optimize state replay for concurrent data column verification using singleflight deduplication.
+- `getVerifyingState`: Check state caches before entering the expensive singleflight state replay.


### PR DESCRIPTION
**What type of PR is this?**
(Partial) Bug fix

- https://github.com/OffchainLabs/prysm/issues/16549

**What does this PR do? Why is it needed?**
When receiving multiple data column sidecars via gossip, it is possible that a lot of state replaying run concurrently at the same time. This consumes a lot of CPU and memory for nothing.
This PR prevents multiple concurrent state replaying targeting the same state.

> [!TIP]
> Please read commit by commit, with the "hide whitespace" feature activated
> <img width="291" height="330" alt="image" src="https://github.com/user-attachments/assets/854a5370-1fe3-4253-b361-87c766cadda7" />


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
