### PR TITLE
 Fix forkchoice safe/finalized hash for reorged payloads

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -563,17 +563,17 @@ func (f *ForkChoice) CachedHeadRoot() [32]byte {
 
 // FinalizedPayloadBlockHash returns the hash of the payload at the finalized checkpoint
 func (f *ForkChoice) FinalizedPayloadBlockHash() [32]byte {
-	return f.store.latestHashForRoot(f.FinalizedCheckpoint().Root)
+	return f.store.latestCanonicalHashForRoot(f.FinalizedCheckpoint().Root)
 }
 
 // JustifiedPayloadBlockHash returns the hash of the payload at the justified checkpoint
 func (f *ForkChoice) JustifiedPayloadBlockHash() [32]byte {
-	return f.store.latestHashForRoot(f.JustifiedCheckpoint().Root)
+	return f.store.latestCanonicalHashForRoot(f.JustifiedCheckpoint().Root)
 }
 
 // UnrealizedJustifiedPayloadBlockHash returns the hash of the payload at the unrealized justified checkpoint
 func (f *ForkChoice) UnrealizedJustifiedPayloadBlockHash() [32]byte {
-	return f.store.latestHashForRoot(f.store.unrealizedJustifiedCheckpoint.Root)
+	return f.store.latestCanonicalHashForRoot(f.store.unrealizedJustifiedCheckpoint.Root)
 }
 
 // ForkChoiceDump returns a full dump of forkchoice.

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -563,17 +563,17 @@ func (f *ForkChoice) CachedHeadRoot() [32]byte {
 
 // FinalizedPayloadBlockHash returns the hash of the payload at the finalized checkpoint
 func (f *ForkChoice) FinalizedPayloadBlockHash() [32]byte {
-	return f.store.latestCanonicalHashForRoot(f.FinalizedCheckpoint().Root)
+	return f.store.latestParentHashForRoot(f.FinalizedCheckpoint().Root)
 }
 
 // JustifiedPayloadBlockHash returns the hash of the payload at the justified checkpoint
 func (f *ForkChoice) JustifiedPayloadBlockHash() [32]byte {
-	return f.store.latestCanonicalHashForRoot(f.JustifiedCheckpoint().Root)
+	return f.store.latestParentHashForRoot(f.JustifiedCheckpoint().Root)
 }
 
 // UnrealizedJustifiedPayloadBlockHash returns the hash of the payload at the unrealized justified checkpoint
 func (f *ForkChoice) UnrealizedJustifiedPayloadBlockHash() [32]byte {
-	return f.store.latestCanonicalHashForRoot(f.store.unrealizedJustifiedCheckpoint.Root)
+	return f.store.latestParentHashForRoot(f.store.unrealizedJustifiedCheckpoint.Root)
 }
 
 // ForkChoiceDump returns a full dump of forkchoice.

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -563,17 +563,17 @@ func (f *ForkChoice) CachedHeadRoot() [32]byte {
 
 // FinalizedPayloadBlockHash returns the hash of the payload at the finalized checkpoint
 func (f *ForkChoice) FinalizedPayloadBlockHash() [32]byte {
-	return f.store.latestParentHashForRoot(f.FinalizedCheckpoint().Root)
+	return f.store.checkpointPayloadHashForRoot(f.FinalizedCheckpoint().Root)
 }
 
 // JustifiedPayloadBlockHash returns the hash of the payload at the justified checkpoint
 func (f *ForkChoice) JustifiedPayloadBlockHash() [32]byte {
-	return f.store.latestParentHashForRoot(f.JustifiedCheckpoint().Root)
+	return f.store.checkpointPayloadHashForRoot(f.JustifiedCheckpoint().Root)
 }
 
 // UnrealizedJustifiedPayloadBlockHash returns the hash of the payload at the unrealized justified checkpoint
 func (f *ForkChoice) UnrealizedJustifiedPayloadBlockHash() [32]byte {
-	return f.store.latestParentHashForRoot(f.store.unrealizedJustifiedCheckpoint.Root)
+	return f.store.checkpointPayloadHashForRoot(f.store.unrealizedJustifiedCheckpoint.Root)
 }
 
 // ForkChoiceDump returns a full dump of forkchoice.

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -714,6 +714,11 @@ func TestForkchoice_UpdateJustifiedBalances(t *testing.T) {
 }
 
 func TestForkChoice_UnrealizedJustifiedPayloadBlockHash(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GloasForkEpoch = 100
+	params.OverrideBeaconConfig(cfg)
+
 	ctx := t.Context()
 	f := setup(0, 0)
 
@@ -722,22 +727,41 @@ func TestForkChoice_UnrealizedJustifiedPayloadBlockHash(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 
-	// A checkpoint finalizes a beacon root, not a payload. The only provably
-	// finalized EL hash is the parent hash — the EL block the checkpoint's
-	// beacon block built on. For 'a' at slot 0, the parent is genesis (zeroes).
+	// Pre-Gloas there is no empty/full ambiguity, so the checkpoint payload hash
+	// is the block's own payload hash.
 	f.store.unrealizedJustifiedCheckpoint.Root = [32]byte{'a'}
 	got := f.UnrealizedJustifiedPayloadBlockHash()
-	require.Equal(t, [32]byte{}, got)
+	require.Equal(t, [32]byte{'A'}, got)
 
 	// Insert block 'b' at slot 1 with blockHash 'B', parent is 'a'.
 	st, roblock, err = prepareForkchoiceState(ctx, 1, [32]byte{'b'}, [32]byte{'a'}, [32]byte{'B'}, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 
-	// For 'b', the parent hash is 'A' (block 'a's full node hash).
+	// Pre-Gloas the checkpoint payload hash is still the block's own payload hash.
 	f.store.unrealizedJustifiedCheckpoint.Root = [32]byte{'b'}
 	got = f.UnrealizedJustifiedPayloadBlockHash()
-	require.Equal(t, [32]byte{'A'}, got)
+	require.Equal(t, [32]byte{'B'}, got)
+}
+
+func TestForkChoice_FinalizedAndJustifiedPayloadBlockHash_PreGloas(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GloasForkEpoch = 100
+	params.OverrideBeaconConfig(cfg)
+
+	ctx := t.Context()
+	f := setup(0, 0)
+
+	st, roblock, err := prepareForkchoiceState(ctx, 1, [32]byte{'a'}, params.BeaconConfig().ZeroHash, [32]byte{'A'}, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	f.store.finalizedCheckpoint.Root = [32]byte{'a'}
+	f.store.justifiedCheckpoint.Root = [32]byte{'a'}
+
+	require.Equal(t, [32]byte{'A'}, f.FinalizedPayloadBlockHash())
+	require.Equal(t, [32]byte{'A'}, f.JustifiedPayloadBlockHash())
 }
 
 func TestForkChoiceIsViableForCheckpoint(t *testing.T) {

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -717,12 +717,26 @@ func TestForkChoice_UnrealizedJustifiedPayloadBlockHash(t *testing.T) {
 	ctx := t.Context()
 	f := setup(0, 0)
 
+	// Insert block 'a' at slot 0 with blockHash 'A', parent is genesis.
 	st, roblock, err := prepareForkchoiceState(ctx, 0, [32]byte{'a'}, params.BeaconConfig().ZeroHash, [32]byte{'A'}, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, st, roblock))
 
+	// A checkpoint finalizes a beacon root, not a payload. The only provably
+	// finalized EL hash is the parent hash — the EL block the checkpoint's
+	// beacon block built on. For 'a' at slot 0, the parent is genesis (zeroes).
 	f.store.unrealizedJustifiedCheckpoint.Root = [32]byte{'a'}
 	got := f.UnrealizedJustifiedPayloadBlockHash()
+	require.Equal(t, [32]byte{}, got)
+
+	// Insert block 'b' at slot 1 with blockHash 'B', parent is 'a'.
+	st, roblock, err = prepareForkchoiceState(ctx, 1, [32]byte{'b'}, [32]byte{'a'}, [32]byte{'B'}, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, roblock))
+
+	// For 'b', the parent hash is 'A' (block 'a's full node hash).
+	f.store.unrealizedJustifiedCheckpoint.Root = [32]byte{'b'}
+	got = f.UnrealizedJustifiedPayloadBlockHash()
 	require.Equal(t, [32]byte{'A'}, got)
 }
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -163,17 +163,18 @@ func (s *Store) parentHash(pn *PayloadNode) [32]byte {
 	return fullParent.node.blockHash
 }
 
-// latestHashForRoot returns the latest payload hash for the given block root.
-func (s *Store) latestHashForRoot(root [32]byte) [32]byte {
-	// try to get the full node first
-	fn := s.fullNodeByRoot[root]
-	if fn != nil {
-		return fn.node.blockHash
-	}
+// latestCanonicalHashForRoot returns the latest canonical payload hash for the given block root.
+// It uses choosePayloadContent to determine whether the full or empty payload node
+// is canonical. If the full node is canonical, it returns its block hash. Otherwise,
+// it returns the parent hash.
+func (s *Store) latestCanonicalHashForRoot(root [32]byte) [32]byte {
 	en := s.emptyNodeByRoot[root]
 	if en == nil {
-		// This should not happen
 		return [32]byte{}
+	}
+	pn := s.choosePayloadContent(en.node)
+	if pn.full {
+		return pn.node.blockHash
 	}
 	return s.parentHash(en)
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -163,18 +163,14 @@ func (s *Store) parentHash(pn *PayloadNode) [32]byte {
 	return fullParent.node.blockHash
 }
 
-// latestCanonicalHashForRoot returns the latest canonical payload hash for the given block root.
-// It uses choosePayloadContent to determine whether the full or empty payload node
-// is canonical. If the full node is canonical, it returns its block hash. Otherwise,
-// it returns the parent hash.
-func (s *Store) latestCanonicalHashForRoot(root [32]byte) [32]byte {
+// latestParentHashForRoot returns the parent payload hash for the given block root.
+// In ePBS, a checkpoint finalizes a beacon block root, not a payload. The child block
+// that would confirm full vs empty status is not itself finalized. Therefore we return
+// the parent hash.
+func (s *Store) latestParentHashForRoot(root [32]byte) [32]byte {
 	en := s.emptyNodeByRoot[root]
 	if en == nil {
 		return [32]byte{}
-	}
-	pn := s.choosePayloadContent(en.node)
-	if pn.full {
-		return pn.node.blockHash
 	}
 	return s.parentHash(en)
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -163,14 +163,18 @@ func (s *Store) parentHash(pn *PayloadNode) [32]byte {
 	return fullParent.node.blockHash
 }
 
-// latestParentHashForRoot returns the parent payload hash for the given block root.
-// In ePBS, a checkpoint finalizes a beacon block root, not a payload. The child block
-// that would confirm full vs empty status is not itself finalized. Therefore we return
-// the parent hash.
-func (s *Store) latestParentHashForRoot(root [32]byte) [32]byte {
+// checkpointPayloadHashForRoot returns the payload hash associated with a checkpoint root.
+// Before Gloas, there is no empty/full ambiguity, so the checkpoint payload hash is the
+// block's own payload hash. In Gloas, a checkpoint finalizes a beacon block root, not a
+// payload, and the child block that disambiguates full vs empty is not itself finalized,
+// so we return the latest known parent payload hash instead.
+func (s *Store) checkpointPayloadHashForRoot(root [32]byte) [32]byte {
 	en := s.emptyNodeByRoot[root]
 	if en == nil {
 		return [32]byte{}
+	}
+	if slots.ToEpoch(en.node.slot) < params.BeaconConfig().GloasForkEpoch {
+		return en.node.blockHash
 	}
 	return s.parentHash(en)
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas_test.go
@@ -1596,3 +1596,78 @@ func TestUpdateBalances_SlotChangeMovesBalance(t *testing.T) {
 	// slot 101 == C.node.slot(101) → pending=true → Node.balance
 	assert.Equal(t, validatorBalance, emptyC.node.balance, "C should have the validator's balance")
 }
+
+func TestLatestCanonicalHashForRoot_SameParentReorg(t *testing.T) {
+	f := setupGloas(t, 1, 1)
+	ctx := t.Context()
+	s := f.store
+	zeroHash := params.BeaconConfig().ZeroHash
+
+	balances := make([]uint64, 64)
+	for i := range balances {
+		balances[i] = 10
+	}
+	f.justifiedBalances = balances
+	s.committeeWeight = uint64(len(balances)*10) / uint64(params.BeaconConfig().SlotsPerEpoch)
+
+	// Slot A at epoch boundary (slot 32). Bid blockHashA, parentHash = genesis (zeroHash).
+	slotA := primitives.Slot(32)
+	rootA := indexToHash(1)
+	blockHashA := indexToHash(100)
+	driftGenesisTime(f, slotA, 0)
+	st, blk, err := prepareGloasForkchoiceState(ctx, slotA, rootA, zeroHash, blockHashA, zeroHash, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+	// Insert payload for A.
+	pe, err := prepareGloasForkchoicePayload(rootA)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	// Slot B at slot 33. Bid blockHashB, parentHash = zeroHash (same EL parent as A!).
+	// This means B builds on A's EMPTY node, not A's full node.
+	slotB := primitives.Slot(33)
+	rootB := indexToHash(2)
+	blockHashB := indexToHash(200)
+	driftGenesisTime(f, slotB, 0)
+	st, blk, err = prepareGloasForkchoiceState(ctx, slotB, rootB, rootA, blockHashB, zeroHash, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+	// Insert payload for B.
+	pe, err = prepareGloasForkchoicePayload(rootB)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertPayload(pe))
+
+	// Slot C at slot 34, building on B's full node.
+	slotC := primitives.Slot(34)
+	rootC := indexToHash(3)
+	blockHashC := indexToHash(300)
+	driftGenesisTime(f, slotC, 0)
+	st, blk, err = prepareGloasForkchoiceState(ctx, slotC, rootC, rootB, blockHashC, blockHashB, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, f.InsertNode(ctx, st, blk))
+
+	// Verify B builds on A's empty node.
+	nodeB := s.emptyNodeByRoot[rootB]
+	require.NotNil(t, nodeB)
+	emptyA := s.emptyNodeByRoot[rootA]
+	require.NotNil(t, emptyA)
+	require.Equal(t, emptyA, nodeB.node.parent, "B should build on A's empty node")
+
+	// Give the empty path weight so choosePayloadContent picks empty for A.
+	// B is a child of emptyA, so emptyA gets weight while fullA stays at 0.
+	emptyA.weight = 100
+	fullA := s.fullNodeByRoot[rootA]
+	require.NotNil(t, fullA)
+	fullA.weight = 0
+
+	// Verify choosePayloadContent picks empty for A.
+	pn := s.choosePayloadContent(emptyA.node)
+	require.Equal(t, false, pn.full, "canonical choice for A should be empty")
+
+	// latestCanonicalHashForRoot(rootA) should return the parent hash
+	// (genesis = zeroHash), NOT blockHashA.
+	f.store.unrealizedJustifiedCheckpoint.Root = rootA
+	got := f.UnrealizedJustifiedPayloadBlockHash()
+	require.NotEqual(t, blockHashA, got, "should NOT return A's reorged-out payload hash")
+	require.Equal(t, zeroHash, got, "should return the common EL ancestor hash (genesis)")
+}

--- a/changelog/terence_fix-forkchoice-safe-hash.md
+++ b/changelog/terence_fix-forkchoice-safe-hash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix forkchoice safe/finalized hash to use canonical payload status instead of blindly preferring the full node.


### PR DESCRIPTION
  In ePBS, a checkpoint finalizes a beacon block root, not a payload. We should be using parent payload hash for the given block root as a checkpoint finalizes a beacon block root, not a payload

  This was observed repeatedly on the ePBS devnet (prysm-geth-3)

  **Timeline (episode 3, block 92173):**
  - `16:46:23` — Slot 101472 (epoch 3171, slotInEpoch=0) synced, blockHash=`0x0bd75d`, parentHash=`0xf53040`. Geth imports as EL block 92173.
  - `16:46:35` — Slot 101473 (slotInEpoch=1) synced, blockHash=`0x800117`, parentHash=`0xf53040` (same parent). Geth reorgs: drops `0x0bd75d`, canonical is now `0x800117`.
  - `16:50:59` — CL justified checkpoint advances. `latestHashForRoot` returns `0x0bd75d` (the reorged-out hash) as `safeBlockHash`.
  - `16:50:59+` — Every `forkchoiceUpdated` fails: `"Invalid forkchoice state: safe block not in canonical chain"`. Node cannot propose blocks.

  **Fix:** Rename `latestHashForRoot` → `latestParentHashForRoot` and always return
  the parent hash
