### PR TITLE
fix: add missing ePBS values to /eth/v1/config/spec

### DIFF
--- a/beacon-chain/rpc/eth/config/BUILD.bazel
+++ b/beacon-chain/rpc/eth/config/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//api/server/structs:go_default_library",
+        "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//testing/assert:go_default_library",

--- a/beacon-chain/rpc/eth/config/handlers.go
+++ b/beacon-chain/rpc/eth/config/handlers.go
@@ -191,6 +191,12 @@ func prepareConfigSpec() (map[string]any, error) {
 	data["KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH"] = convertValueForJSON(reflect.ValueOf(uint64(4)), "KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH")
 	// UPDATE_TIMEOUT is derived from SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD
 	data["UPDATE_TIMEOUT"] = convertValueForJSON(reflect.ValueOf(uint64(config.SlotsPerEpoch)*uint64(config.EpochsPerSyncCommitteePeriod)), "UPDATE_TIMEOUT")
+	// Add Gloas preset values. These are compile-time constants from fieldparams,
+	// not runtime configs, but are required by the /eth/v1/config/spec API.
+	data["PTC_SIZE"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.PTCSize)), "PTC_SIZE")
+	data["MAX_PAYLOAD_ATTESTATIONS"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.MaxPayloadAttestations)), "MAX_PAYLOAD_ATTESTATIONS")
+	data["BUILDER_REGISTRY_LIMIT"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.BuilderRegistryLimit)), "BUILDER_REGISTRY_LIMIT")
+	data["BUILDER_PENDING_WITHDRAWALS_LIMIT"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.BuilderPendingWithdrawalsLimit)), "BUILDER_PENDING_WITHDRAWALS_LIMIT")
 
 	return data, nil
 }

--- a/beacon-chain/rpc/eth/config/handlers.go
+++ b/beacon-chain/rpc/eth/config/handlers.go
@@ -191,8 +191,7 @@ func prepareConfigSpec() (map[string]any, error) {
 	data["KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH"] = convertValueForJSON(reflect.ValueOf(uint64(4)), "KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH")
 	// UPDATE_TIMEOUT is derived from SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD
 	data["UPDATE_TIMEOUT"] = convertValueForJSON(reflect.ValueOf(uint64(config.SlotsPerEpoch)*uint64(config.EpochsPerSyncCommitteePeriod)), "UPDATE_TIMEOUT")
-	// Add Gloas preset values. These are compile-time constants from fieldparams,
-	// not runtime configs, but are required by the /eth/v1/config/spec API.
+	// Add Gloas config values from fieldparams required by the /eth/v1/config/spec API.
 	data["PTC_SIZE"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.PTCSize)), "PTC_SIZE")
 	data["MAX_PAYLOAD_ATTESTATIONS"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.MaxPayloadAttestations)), "MAX_PAYLOAD_ATTESTATIONS")
 	data["BUILDER_REGISTRY_LIMIT"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.BuilderRegistryLimit)), "BUILDER_REGISTRY_LIMIT")

--- a/beacon-chain/rpc/eth/config/handlers_test.go
+++ b/beacon-chain/rpc/eth/config/handlers_test.go
@@ -231,7 +231,7 @@ func TestGetSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
 	data, ok := resp.Data.(map[string]any)
 	require.Equal(t, true, ok)
-	assert.Equal(t, 197, len(data))
+	assert.Equal(t, 202, len(data))
 	for k, v := range data {
 		t.Run(k, func(t *testing.T) {
 			switch k {

--- a/beacon-chain/rpc/eth/config/handlers_test.go
+++ b/beacon-chain/rpc/eth/config/handlers_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -211,6 +213,9 @@ func TestGetSpec(t *testing.T) {
 	var dptc [4]byte
 	copy(dptc[:], []byte{'0', '0', '0', '8'})
 	config.DomainPTCAttester = dptc
+	var dpp [4]byte
+	copy(dpp[:], []byte{'0', '0', '0', '9'})
+	config.DomainProposerPreferences = dpp
 	var dam [4]byte
 	copy(dam[:], []byte{'1', '0', '0', '0'})
 	config.DomainApplicationMask = dam
@@ -438,6 +443,8 @@ func TestGetSpec(t *testing.T) {
 				assert.Equal(t, "0x30303037", v)
 			case "DOMAIN_PTC_ATTESTER":
 				assert.Equal(t, "0x30303038", v)
+			case "DOMAIN_PROPOSER_PREFERENCES":
+				assert.Equal(t, "0x30303039", v)
 			case "DOMAIN_APPLICATION_MASK":
 				assert.Equal(t, "0x31303030", v)
 			case "DOMAIN_SYNC_COMMITTEE":
@@ -646,6 +653,14 @@ func TestGetSpec(t *testing.T) {
 				assert.Equal(t, "128", v) // From fieldparams.NumberOfColumns
 			case "UPDATE_TIMEOUT":
 				assert.Equal(t, "1782", v) // SlotsPerEpoch (27) * EpochsPerSyncCommitteePeriod (66)
+			case "PTC_SIZE":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.PTCSize), 10), v)
+			case "MAX_PAYLOAD_ATTESTATIONS":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.MaxPayloadAttestations), 10), v)
+			case "BUILDER_REGISTRY_LIMIT":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.BuilderRegistryLimit), 10), v)
+			case "BUILDER_PENDING_WITHDRAWALS_LIMIT":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.BuilderPendingWithdrawalsLimit), 10), v)
 			default:
 				t.Errorf("Incorrect key: %s", k)
 			}

--- a/changelog/barnabasbusa_fix-epbs-config-spec.md
+++ b/changelog/barnabasbusa_fix-epbs-config-spec.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed missing ePBS values from `/eth/v1/config/spec`: `PTC_SIZE`, `MAX_PAYLOAD_ATTESTATIONS`, `BUILDER_REGISTRY_LIMIT`, and `BUILDER_PENDING_WITHDRAWALS_LIMIT`.
+- Fixed missing `DOMAIN_PROPOSER_PREFERENCES` (0x0d000000) domain type from `/eth/v1/config/spec`.

--- a/changelog/barnabasbusa_fix-epbs-config-spec.md
+++ b/changelog/barnabasbusa_fix-epbs-config-spec.md
@@ -1,4 +1,4 @@
-### Fixed
+### Added
 
-- Fixed missing ePBS values from `/eth/v1/config/spec`: `PTC_SIZE`, `MAX_PAYLOAD_ATTESTATIONS`, `BUILDER_REGISTRY_LIMIT`, and `BUILDER_PENDING_WITHDRAWALS_LIMIT`.
-- Fixed missing `DOMAIN_PROPOSER_PREFERENCES` (0x0d000000) domain type from `/eth/v1/config/spec`.
+- Added missing ePBS values from `/eth/v1/config/spec`: `PTC_SIZE`, `MAX_PAYLOAD_ATTESTATIONS`, `BUILDER_REGISTRY_LIMIT`, and `BUILDER_PENDING_WITHDRAWALS_LIMIT`.
+- Added missing `DOMAIN_PROPOSER_PREFERENCES` (0x0d000000) domain type from `/eth/v1/config/spec`.

--- a/config/fieldparams/mainnet.go
+++ b/config/fieldparams/mainnet.go
@@ -52,5 +52,6 @@ const (
 	CellsPerBlob    = 64  // CellsPerBlob refers to the number of cells in a (non-extended) blob.
 
 	// Introduced in Gloas network upgrade.
-	PTCSize = 512 // PTCSize is the size of the payload timeliness committee.
+	PTCSize                = 512 // PTCSize is the size of the payload timeliness committee.
+	MaxPayloadAttestations = 4   // MaxPayloadAttestations is the maximum number of payload attestations in a block.
 )

--- a/config/fieldparams/minimal.go
+++ b/config/fieldparams/minimal.go
@@ -52,5 +52,6 @@ const (
 	CellsPerBlob    = 64  // CellsPerBlob refers to the number of cells in a (non-extended) blob.
 
 	// Introduced in Gloas network upgrade.
-	PTCSize = 2 // PTCSize is the size of the payload timeliness committee.
+	PTCSize                = 2 // PTCSize is the size of the payload timeliness committee.
+	MaxPayloadAttestations = 4 // MaxPayloadAttestations is the maximum number of payload attestations in a block.
 )

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -150,6 +150,7 @@ type BeaconChainConfig struct {
 	DomainBLSToExecutionChange        [4]byte `yaml:"DOMAIN_BLS_TO_EXECUTION_CHANGE" spec:"true"`        // DomainBLSToExecutionChange defines the BLS signature domain to change withdrawal addresses to ETH1 prefix
 	DomainBeaconBuilder               [4]byte `yaml:"DOMAIN_BEACON_BUILDER" spec:"true"`                 // DomainBeaconBuilder defines the BLS signature domain for beacon block builder.
 	DomainPTCAttester                 [4]byte `yaml:"DOMAIN_PTC_ATTESTER" spec:"true"`                   // DomainPTCAttester defines the BLS signature domain for payload transaction committee attester.
+	DomainProposerPreferences         [4]byte `yaml:"DOMAIN_PROPOSER_PREFERENCES" spec:"true"`           // DomainProposerPreferences defines the BLS signature domain for proposer preferences.
 
 	// Prysm constants.
 	GenesisValidatorsRoot          [32]byte        // GenesisValidatorsRoot is the root hash of the genesis validators.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -195,6 +195,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	DomainBLSToExecutionChange:        bytesutil.Uint32ToBytes4(0x0A000000),
 	DomainBeaconBuilder:               bytesutil.Uint32ToBytes4(0x0B000000),
 	DomainPTCAttester:                 bytesutil.Uint32ToBytes4(0x0C000000),
+	DomainProposerPreferences:         bytesutil.Uint32ToBytes4(0x0D000000),
 
 	// Prysm constants.
 	GenesisValidatorsRoot:          [32]byte{75, 54, 61, 185, 78, 40, 97, 32, 215, 110, 185, 5, 52, 15, 221, 78, 84, 191, 233, 240, 107, 243, 63, 246, 207, 90, 210, 127, 81, 27, 254, 149},


### PR DESCRIPTION
Add PTC_SIZE, MAX_PAYLOAD_ATTESTATIONS, BUILDER_REGISTRY_LIMIT, and BUILDER_PENDING_WITHDRAWALS_LIMIT as fieldparams-derived constants exposed via the config spec endpoint. Also add DOMAIN_PROPOSER_PREFERENCE (0x0d000000) to the BeaconChainConfig struct and mainnet config.


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
5. A changelog entry is required for user facing issues.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
