### PR TITLE
Preallocate validatorKeys slice in insertValidatorHashes

### DIFF
--- a/beacon-chain/db/kv/migration_state_validators.go
+++ b/beacon-chain/db/kv/migration_state_validators.go
@@ -209,7 +209,7 @@ func stateBucketKeys(stateBucket *bolt.Bucket) ([][]byte, error) {
 
 func insertValidatorHashes(ctx context.Context, validators []*v1alpha1.Validator, valBkt *bolt.Bucket) ([]byte, error) {
 	// move all the validators in this state registry out to a new bucket.
-	var validatorKeys []byte
+	validatorKeys := make([]byte, 0, len(validators)*32)
 	for _, val := range validators {
 		valBytes, encodeErr := encode(ctx, val)
 		if encodeErr != nil {

--- a/changelog/satushh_preallocate-validators.md
+++ b/changelog/satushh_preallocate-validators.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Pre-allocate validatorKeys slice in insertValidatorHashes


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

Pre-allocate validatorKeys slice in insertValidatorHashes to avoid repeated reallocations during migration
