### PR TITLE
sync: reject index-1 atts when payload is unseen

### DIFF
--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -372,6 +372,8 @@ func validateAttestingIndex(
 // validateGloasCommitteeIndex validates committee index rules for Gloas fork.
 // [REJECT] attestation.data.index < 2. (New in Gloas)
 // [REJECT] attestation.data.index == 0 if block.slot == attestation.data.slot. (New in Gloas)
+// [REJECT] If attestation.data.index == 1, the execution payload for the block passes validation. (New in Gloas)
+// [IGNORE] When attestation.data.index == 1, the execution payload for the block has been seen. (New in Gloas)
 func (s *Service) validateGloasCommitteeIndex(data *eth.AttestationData) (pubsub.ValidationResult, error) {
 	if data.CommitteeIndex >= 2 {
 		return pubsub.ValidationReject, errors.New("attestation data's committee index must be < 2")
@@ -386,6 +388,16 @@ func (s *Service) validateGloasCommitteeIndex(data *eth.AttestationData) (pubsub
 		}
 		if slot == data.Slot {
 			return pubsub.ValidationReject, errors.New("same slot attestations must use committee index 0")
+		}
+		// [REJECT] If index == 1, the execution payload for the block must not be invalid.
+		if s.hasBadPayload(blockRoot) {
+			return pubsub.ValidationReject, errors.New("execution payload for attested block is invalid")
+		}
+		// [IGNORE] If index == 1, the execution payload for the block must have been seen.
+		// Request the payload envelope if not yet available.
+		if !s.cfg.chain.HasFullNode(blockRoot) {
+			go s.requestPayloadEnvelope(blockRoot)
+			return pubsub.ValidationIgnore, errors.New("execution payload for attested block has not been seen")
 		}
 	}
 

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -686,11 +686,16 @@ func Test_validateCommitteeIndexAndCount_Boundary(t *testing.T) {
 }
 
 func Test_validateGloasCommitteeIndex(t *testing.T) {
+	blockRoot := bytesutil.PadTo([]byte("blockroot"), 32)
+	blockRoot32 := bytesutil.ToBytes32(blockRoot)
+
 	tests := []struct {
 		name            string
 		committeeIndex  primitives.CommitteeIndex
 		attestationSlot primitives.Slot
 		blockSlot       primitives.Slot
+		hasFullNode     bool
+		hasBadPayload   bool
 		wantResult      pubsub.ValidationResult
 		wantErr         string
 	}{
@@ -711,14 +716,6 @@ func Test_validateGloasCommitteeIndex(t *testing.T) {
 			wantErr:         "",
 		},
 		{
-			name:            "committee index 1 different-slot should accept",
-			committeeIndex:  1,
-			attestationSlot: 10,
-			blockSlot:       9,
-			wantResult:      pubsub.ValidationAccept,
-			wantErr:         "",
-		},
-		{
 			name:            "committee index 1 same-slot should reject",
 			committeeIndex:  1,
 			attestationSlot: 10,
@@ -726,23 +723,59 @@ func Test_validateGloasCommitteeIndex(t *testing.T) {
 			wantResult:      pubsub.ValidationReject,
 			wantErr:         "same slot attestations must use committee index 0",
 		},
+		{
+			name:            "committee index 1 different-slot with bad payload should reject",
+			committeeIndex:  1,
+			attestationSlot: 10,
+			blockSlot:       9,
+			hasBadPayload:   true,
+			wantResult:      pubsub.ValidationReject,
+			wantErr:         "execution payload for attested block is invalid",
+		},
+		{
+			name:            "committee index 1 different-slot without full node should ignore",
+			committeeIndex:  1,
+			attestationSlot: 10,
+			blockSlot:       9,
+			hasFullNode:     false,
+			wantResult:      pubsub.ValidationIgnore,
+			wantErr:         "execution payload for attested block has not been seen",
+		},
+		{
+			name:            "committee index 1 different-slot with full node should accept",
+			committeeIndex:  1,
+			attestationSlot: 10,
+			blockSlot:       9,
+			hasFullNode:     true,
+			wantResult:      pubsub.ValidationAccept,
+			wantErr:         "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockChain := &mockChain.ChainService{
-				BlockSlot: tt.blockSlot,
+			mc := &mockChain.ChainService{
+				BlockSlot:           tt.blockSlot,
+				FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
+			}
+			if tt.hasFullNode {
+				mc.ForkchoiceRoots = map[[32]byte]bool{blockRoot32: true}
 			}
 			s := &Service{
 				cfg: &config{
-					chain: mockChain,
+					chain: mc,
+					p2p:   p2ptest.NewTestP2P(t),
 				},
+				badPayloadCache: lruwrpr.New(10),
+			}
+			if tt.hasBadPayload {
+				s.badPayloadCache.Add(string(blockRoot32[:]), true)
 			}
 
 			data := &ethpb.AttestationData{
 				Slot:            tt.attestationSlot,
 				CommitteeIndex:  tt.committeeIndex,
-				BeaconBlockRoot: bytesutil.PadTo([]byte("blockroot"), 32),
+				BeaconBlockRoot: blockRoot,
 			}
 
 			result, err := s.validateGloasCommitteeIndex(data)

--- a/changelog/t_reject-att-missing-payload.md
+++ b/changelog/t_reject-att-missing-payload.md
@@ -1,0 +1,2 @@
+### Fixed
+- Reject or ignore index-1 attestations when the execution payload for the attested block is invalid or has not been seen.


### PR DESCRIPTION
 This PR Implements the gossip validation rules from consensus-specs [#4939](https://github.com/ethereum/consensus-specs/pull/4939) That is:

  - [REJECT] attestations with `CommitteeIndex == 1` (payload-present vote) when the execution payload for the attested block is known invalid
  - [IGNORE] attestations with `CommitteeIndex == 1` when the execution payload has not been seen, and request the payload envelope via `ExecutionPayloadEnvelopesByRoot`

