### PR TITLE
 Fix payload attributes to use expected withdrawals from state when empty

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -371,88 +371,91 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 	}
 
 	v := st.Version()
-
-	if v >= version.Gloas {
-		withdrawals, err := st.PayloadWithdrawals()
-		if err != nil {
-			log.WithError(err).Error("Could not get payload withdrawals to get payload attribute")
-			return emptyAttri
-		}
-
-		attr, err := payloadattribute.New(&enginev1.PayloadAttributesV3{
-			Timestamp:             uint64(t.Unix()),
-			PrevRandao:            prevRando,
-			SuggestedFeeRecipient: val.FeeRecipient[:],
-			Withdrawals:           withdrawals,
-			ParentBeaconBlockRoot: headRoot,
-		})
-		if err != nil {
-			log.WithError(err).Error("Could not get payload attribute")
-			return emptyAttri
-		}
-
-		return attr
+	switch {
+	case v >= version.Gloas:
+		return payloadAttributesGloas(st, uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot)
+	case v >= version.Deneb:
+		return payloadAttributesDeneb(st, uint64(t.Unix()), prevRando, val.FeeRecipient[:], headRoot)
+	case v >= version.Capella:
+		return payloadAttributesCapella(st, uint64(t.Unix()), prevRando, val.FeeRecipient[:])
+	case v >= version.Bellatrix:
+		return payloadAttributesBellatrix(uint64(t.Unix()), prevRando, val.FeeRecipient[:])
+	default:
+		log.WithField("version", version.String(v)).Error("Could not get payload attribute due to unknown state version")
+		return payloadattribute.EmptyWithVersion(v)
 	}
+}
 
-	if v >= version.Deneb {
-		withdrawals, _, err := st.ExpectedWithdrawals()
-		if err != nil {
-			log.WithError(err).Error("Could not get expected withdrawals to get payload attribute")
-			return emptyAttri
-		}
-
-		attr, err := payloadattribute.New(&enginev1.PayloadAttributesV3{
-			Timestamp:             uint64(t.Unix()),
-			PrevRandao:            prevRando,
-			SuggestedFeeRecipient: val.FeeRecipient[:],
-			Withdrawals:           withdrawals,
-			ParentBeaconBlockRoot: headRoot,
-		})
-		if err != nil {
-			log.WithError(err).Error("Could not get payload attribute")
-			return emptyAttri
-		}
-
-		return attr
+func payloadAttributesGloas(st state.BeaconState, timestamp uint64, prevRandao, feeRecipient, parentBeaconBlockRoot []byte) payloadattribute.Attributer {
+	withdrawals, err := st.WithdrawalsForPayload()
+	if err != nil {
+		log.WithError(err).Error("Could not get payload withdrawals to get payload attribute")
+		return payloadattribute.EmptyWithVersion(st.Version())
 	}
-
-	if v >= version.Capella {
-		withdrawals, _, err := st.ExpectedWithdrawals()
-		if err != nil {
-			log.WithError(err).Error("Could not get expected withdrawals to get payload attribute")
-			return emptyAttri
-		}
-
-		attr, err := payloadattribute.New(&enginev1.PayloadAttributesV2{
-			Timestamp:             uint64(t.Unix()),
-			PrevRandao:            prevRando,
-			SuggestedFeeRecipient: val.FeeRecipient[:],
-			Withdrawals:           withdrawals,
-		})
-		if err != nil {
-			log.WithError(err).Error("Could not get payload attribute")
-			return emptyAttri
-		}
-
-		return attr
+	attr, err := payloadattribute.New(&enginev1.PayloadAttributesV3{
+		Timestamp:             timestamp,
+		PrevRandao:            prevRandao,
+		SuggestedFeeRecipient: feeRecipient,
+		Withdrawals:           withdrawals,
+		ParentBeaconBlockRoot: parentBeaconBlockRoot,
+	})
+	if err != nil {
+		log.WithError(err).Error("Could not get payload attribute")
+		return payloadattribute.EmptyWithVersion(st.Version())
 	}
+	return attr
+}
 
-	if v >= version.Bellatrix {
-		attr, err := payloadattribute.New(&enginev1.PayloadAttributes{
-			Timestamp:             uint64(t.Unix()),
-			PrevRandao:            prevRando,
-			SuggestedFeeRecipient: val.FeeRecipient[:],
-		})
-		if err != nil {
-			log.WithError(err).Error("Could not get payload attribute")
-			return emptyAttri
-		}
-
-		return attr
+func payloadAttributesDeneb(st state.BeaconState, timestamp uint64, prevRandao, feeRecipient, parentBeaconBlockRoot []byte) payloadattribute.Attributer {
+	withdrawals, _, err := st.ExpectedWithdrawals()
+	if err != nil {
+		log.WithError(err).Error("Could not get expected withdrawals to get payload attribute")
+		return payloadattribute.EmptyWithVersion(st.Version())
 	}
+	attr, err := payloadattribute.New(&enginev1.PayloadAttributesV3{
+		Timestamp:             timestamp,
+		PrevRandao:            prevRandao,
+		SuggestedFeeRecipient: feeRecipient,
+		Withdrawals:           withdrawals,
+		ParentBeaconBlockRoot: parentBeaconBlockRoot,
+	})
+	if err != nil {
+		log.WithError(err).Error("Could not get payload attribute")
+		return payloadattribute.EmptyWithVersion(st.Version())
+	}
+	return attr
+}
 
-	log.WithField("version", version.String(st.Version())).Error("Could not get payload attribute due to unknown state version")
-	return emptyAttri
+func payloadAttributesCapella(st state.BeaconState, timestamp uint64, prevRandao, feeRecipient []byte) payloadattribute.Attributer {
+	withdrawals, _, err := st.ExpectedWithdrawals()
+	if err != nil {
+		log.WithError(err).Error("Could not get expected withdrawals to get payload attribute")
+		return payloadattribute.EmptyWithVersion(st.Version())
+	}
+	attr, err := payloadattribute.New(&enginev1.PayloadAttributesV2{
+		Timestamp:             timestamp,
+		PrevRandao:            prevRandao,
+		SuggestedFeeRecipient: feeRecipient,
+		Withdrawals:           withdrawals,
+	})
+	if err != nil {
+		log.WithError(err).Error("Could not get payload attribute")
+		return payloadattribute.EmptyWithVersion(st.Version())
+	}
+	return attr
+}
+
+func payloadAttributesBellatrix(timestamp uint64, prevRandao, feeRecipient []byte) payloadattribute.Attributer {
+	attr, err := payloadattribute.New(&enginev1.PayloadAttributes{
+		Timestamp:             timestamp,
+		PrevRandao:            prevRandao,
+		SuggestedFeeRecipient: feeRecipient,
+	})
+	if err != nil {
+		log.WithError(err).Error("Could not get payload attribute")
+		return payloadattribute.EmptyWithVersion(version.Bellatrix)
+	}
+	return attr
 }
 
 // removeInvalidBlockAndState removes the invalid block, blob and its corresponding state from the cache and DB.

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -372,6 +372,28 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 
 	v := st.Version()
 
+	if v >= version.Gloas {
+		withdrawals, err := st.PayloadWithdrawals()
+		if err != nil {
+			log.WithError(err).Error("Could not get payload withdrawals to get payload attribute")
+			return emptyAttri
+		}
+
+		attr, err := payloadattribute.New(&enginev1.PayloadAttributesV3{
+			Timestamp:             uint64(t.Unix()),
+			PrevRandao:            prevRando,
+			SuggestedFeeRecipient: val.FeeRecipient[:],
+			Withdrawals:           withdrawals,
+			ParentBeaconBlockRoot: headRoot,
+		})
+		if err != nil {
+			log.WithError(err).Error("Could not get payload attribute")
+			return emptyAttri
+		}
+
+		return attr
+	}
+
 	if v >= version.Deneb {
 		withdrawals, _, err := st.ExpectedWithdrawals()
 		if err != nil {

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -138,7 +138,7 @@ func (s *Service) getPayloadAttributeGloas(ctx context.Context, st state.ReadOnl
 		return emptyAttri
 	}
 
-	withdrawals, err := st.PayloadWithdrawals()
+	withdrawals, err := st.WithdrawalsForPayload()
 	if err != nil {
 		log.WithError(err).Error("Could not get payload withdrawals to get payload attribute")
 		return emptyAttri

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -138,9 +138,9 @@ func (s *Service) getPayloadAttributeGloas(ctx context.Context, st state.ReadOnl
 		return emptyAttri
 	}
 
-	withdrawals, _, err := st.ExpectedWithdrawals()
+	withdrawals, err := st.PayloadWithdrawals()
 	if err != nil {
-		log.WithError(err).Error("Could not get expected withdrawals to get payload attribute")
+		log.WithError(err).Error("Could not get payload withdrawals to get payload attribute")
 		return emptyAttri
 	}
 

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -694,7 +694,15 @@ func (s *Server) computePayloadAttributes(ctx context.Context, st state.ReadOnly
 		})
 	}
 
-	w, _, err := st.ExpectedWithdrawals()
+	var (
+		w   []*engine.Withdrawal
+		err error
+	)
+	if v >= version.Gloas {
+		w, err = st.PayloadWithdrawals()
+	} else {
+		w, _, err = st.ExpectedWithdrawals()
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get withdrawals from head state")
 	}

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -699,7 +699,7 @@ func (s *Server) computePayloadAttributes(ctx context.Context, st state.ReadOnly
 		err error
 	)
 	if v >= version.Gloas {
-		w, err = st.PayloadWithdrawals()
+		w, err = st.WithdrawalsForPayload()
 	} else {
 		w, _, err = st.ExpectedWithdrawals()
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -136,6 +136,21 @@ func (vs *Server) getLocalPayloadFromEngine(
 	}
 	var attr payloadattribute.Attributer
 	switch {
+	case st.Version() >= version.Gloas:
+		withdrawals, err := st.PayloadWithdrawals()
+		if err != nil {
+			return nil, err
+		}
+		attr, err = payloadattribute.New(&enginev1.PayloadAttributesV3{
+			Timestamp:             uint64(t.Unix()),
+			PrevRandao:            random,
+			SuggestedFeeRecipient: val.FeeRecipient[:],
+			Withdrawals:           withdrawals,
+			ParentBeaconBlockRoot: parentRoot[:],
+		})
+		if err != nil {
+			return nil, err
+		}
 	case st.Version() >= version.Deneb:
 		withdrawals, _, err := st.ExpectedWithdrawals()
 		if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -137,7 +137,7 @@ func (vs *Server) getLocalPayloadFromEngine(
 	var attr payloadattribute.Attributer
 	switch {
 	case st.Version() >= version.Gloas:
-		withdrawals, err := st.PayloadWithdrawals()
+		withdrawals, err := st.WithdrawalsForPayload()
 		if err != nil {
 			return nil, err
 		}

--- a/beacon-chain/state/interfaces_gloas.go
+++ b/beacon-chain/state/interfaces_gloas.go
@@ -70,6 +70,7 @@ type readOnlyGloasFields interface {
 	IsParentBlockFull() (bool, error)
 	ExpectedWithdrawalsGloas() (ExpectedWithdrawalsGloasResult, error)
 	PayloadExpectedWithdrawals() ([]*enginev1.Withdrawal, error)
+	PayloadWithdrawals() ([]*enginev1.Withdrawal, error)
 }
 
 // ExpectedWithdrawalsGloasResult bundles the expected withdrawals and related counters

--- a/beacon-chain/state/interfaces_gloas.go
+++ b/beacon-chain/state/interfaces_gloas.go
@@ -70,7 +70,7 @@ type readOnlyGloasFields interface {
 	IsParentBlockFull() (bool, error)
 	ExpectedWithdrawalsGloas() (ExpectedWithdrawalsGloasResult, error)
 	PayloadExpectedWithdrawals() ([]*enginev1.Withdrawal, error)
-	PayloadWithdrawals() ([]*enginev1.Withdrawal, error)
+	WithdrawalsForPayload() ([]*enginev1.Withdrawal, error)
 }
 
 // ExpectedWithdrawalsGloasResult bundles the expected withdrawals and related counters

--- a/beacon-chain/state/state-native/getters_gloas.go
+++ b/beacon-chain/state/state-native/getters_gloas.go
@@ -652,16 +652,16 @@ func (b *BeaconState) PayloadExpectedWithdrawals() ([]*enginev1.Withdrawal, erro
 	return b.payloadExpectedWithdrawalsVal(), nil
 }
 
-// PayloadWithdrawals returns the withdrawals that should be included in the
+// WithdrawalsForPayload returns the withdrawals that should be included in the
 // execution payload for the current slot. If the parent block was full,
 // fresh withdrawals are computed via ExpectedWithdrawalsGloas; otherwise
 // the existing payload_expected_withdrawals from state are reused unchanged.
 // This method does not acquire a lock directly; it delegates to
 // IsParentBlockFull, ExpectedWithdrawalsGloas, and PayloadExpectedWithdrawals
 // which each acquire their own read lock.
-func (b *BeaconState) PayloadWithdrawals() ([]*enginev1.Withdrawal, error) {
+func (b *BeaconState) WithdrawalsForPayload() ([]*enginev1.Withdrawal, error) {
 	if b.version < version.Gloas {
-		return nil, errNotSupported("PayloadWithdrawals", b.version)
+		return nil, errNotSupported("WithdrawalsForPayload", b.version)
 	}
 
 	full, err := b.IsParentBlockFull()

--- a/beacon-chain/state/state-native/getters_gloas.go
+++ b/beacon-chain/state/state-native/getters_gloas.go
@@ -652,6 +652,32 @@ func (b *BeaconState) PayloadExpectedWithdrawals() ([]*enginev1.Withdrawal, erro
 	return b.payloadExpectedWithdrawalsVal(), nil
 }
 
+// PayloadWithdrawals returns the withdrawals that should be included in the
+// execution payload for the current slot. If the parent block was full,
+// fresh withdrawals are computed via ExpectedWithdrawalsGloas; otherwise
+// the existing payload_expected_withdrawals from state are reused unchanged.
+// This method does not acquire a lock directly; it delegates to
+// IsParentBlockFull, ExpectedWithdrawalsGloas, and PayloadExpectedWithdrawals
+// which each acquire their own read lock.
+func (b *BeaconState) PayloadWithdrawals() ([]*enginev1.Withdrawal, error) {
+	if b.version < version.Gloas {
+		return nil, errNotSupported("PayloadWithdrawals", b.version)
+	}
+
+	full, err := b.IsParentBlockFull()
+	if err != nil {
+		return nil, err
+	}
+	if full {
+		result, err := b.ExpectedWithdrawalsGloas()
+		if err != nil {
+			return nil, err
+		}
+		return result.Withdrawals, nil
+	}
+	return b.PayloadExpectedWithdrawals()
+}
+
 // NextWithdrawalBuilderIndex returns the next withdrawal builder index.
 func (b *BeaconState) NextWithdrawalBuilderIndex() (primitives.BuilderIndex, error) {
 	if b.version < version.Gloas {

--- a/beacon-chain/state/state-native/getters_gloas_test.go
+++ b/beacon-chain/state/state-native/getters_gloas_test.go
@@ -834,11 +834,11 @@ func TestPayloadExpectedWithdrawals(t *testing.T) {
 	})
 }
 
-func TestPayloadWithdrawals(t *testing.T) {
+func TestWithdrawalsForPayload(t *testing.T) {
 	t.Run("returns error before gloas", func(t *testing.T) {
 		st := &BeaconState{version: version.Fulu}
-		_, err := st.PayloadWithdrawals()
-		require.ErrorContains(t, "PayloadWithdrawals", err)
+		_, err := st.WithdrawalsForPayload()
+		require.ErrorContains(t, "WithdrawalsForPayload", err)
 	})
 
 	t.Run("returns existing withdrawals when parent empty", func(t *testing.T) {
@@ -855,7 +855,7 @@ func TestPayloadWithdrawals(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		got, err := st.PayloadWithdrawals()
+		got, err := st.WithdrawalsForPayload()
 		require.NoError(t, err)
 		require.DeepEqual(t, existing, got)
 	})
@@ -876,7 +876,7 @@ func TestPayloadWithdrawals(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		got, err := st.PayloadWithdrawals()
+		got, err := st.WithdrawalsForPayload()
 		require.NoError(t, err)
 		// Fresh computation with no validators yields empty, not the stale value.
 		require.Equal(t, 0, len(got))

--- a/beacon-chain/state/state-native/getters_gloas_test.go
+++ b/beacon-chain/state/state-native/getters_gloas_test.go
@@ -834,6 +834,55 @@ func TestPayloadExpectedWithdrawals(t *testing.T) {
 	})
 }
 
+func TestPayloadWithdrawals(t *testing.T) {
+	t.Run("returns error before gloas", func(t *testing.T) {
+		st := &BeaconState{version: version.Fulu}
+		_, err := st.PayloadWithdrawals()
+		require.ErrorContains(t, "PayloadWithdrawals", err)
+	})
+
+	t.Run("returns existing withdrawals when parent empty", func(t *testing.T) {
+		existing := []*enginev1.Withdrawal{
+			{Index: 5, ValidatorIndex: 10, Address: bytes.Repeat([]byte{0x26}, 20), Amount: 100},
+		}
+		// Parent is empty: bid block hash differs from latest block hash.
+		st, err := InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+			LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
+				BlockHash: bytes.Repeat([]byte{0xAA}, 32),
+			},
+			LatestBlockHash:            bytes.Repeat([]byte{0xBB}, 32),
+			PayloadExpectedWithdrawals: existing,
+		})
+		require.NoError(t, err)
+
+		got, err := st.PayloadWithdrawals()
+		require.NoError(t, err)
+		require.DeepEqual(t, existing, got)
+	})
+
+	t.Run("computes fresh withdrawals when parent full", func(t *testing.T) {
+		hash := bytes.Repeat([]byte{0xAB}, 32)
+		stale := []*enginev1.Withdrawal{
+			{Index: 1, ValidatorIndex: 2, Address: bytes.Repeat([]byte{0x01}, 20), Amount: 999},
+		}
+		// Parent is full: bid block hash == latest block hash.
+		// With no validators/pending withdrawals, fresh computation returns empty.
+		st, err := InitializeFromProtoGloas(&ethpb.BeaconStateGloas{
+			LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
+				BlockHash: hash,
+			},
+			LatestBlockHash:            hash,
+			PayloadExpectedWithdrawals: stale,
+		})
+		require.NoError(t, err)
+
+		got, err := st.PayloadWithdrawals()
+		require.NoError(t, err)
+		// Fresh computation with no validators yields empty, not the stale value.
+		require.Equal(t, 0, len(got))
+	})
+}
+
 func TestExecutionPayloadAvailabilityVector(t *testing.T) {
 	t.Run("returns error before gloas", func(t *testing.T) {
 		stIface, err := InitializeFromProtoElectra(&ethpb.BeaconStateElectra{})

--- a/changelog/terence_fix-gloas-payload-withdrawals.md
+++ b/changelog/terence_fix-gloas-payload-withdrawals.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix Gloas payload attributes to use `PayloadExpectedWithdrawals` from state when parent block is empty, preventing withdrawal mismatch errors in execution payload envelope verification.


### PR DESCRIPTION
  - When the parent block is empty in Gloas, `process_withdrawals` returns early and does not update `payload_expected_withdrawals` in the beacon state. However, the proposer and FCU attribute builders were always computing fresh withdrawals via `ExpectedWithdrawals()`, causing a mismatch when the execution payload envelope is verified against`state.payload_expected_withdrawals`.
  - We adds a `PayloadWithdrawals()` state getter that branches on `IsParentBlockFull()`: computes fresh withdrawals via `ExpectedWithdrawalsGloas()` when full, returns the existing `PayloadExpectedWithdrawals()` when empty.
  - Patches three call sites: `proposer_execution_payload.go`, `execution_engine.go`, and `gloas.go`.