### PR TITLE
Fix logging level bug for non text formats

### DIFF
--- a/changelog/bastin_fix-logging-level-bug.md
+++ b/changelog/bastin_fix-logging-level-bug.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix logging level bug for non-text formats.

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -213,13 +213,20 @@ func before(ctx *cli.Context) error {
 			Identifier:    logs.LogTargetUser,
 		})
 	case "fluentd":
-		f := joonix.NewFormatter()
+		// disabling logrus default output so we can control it via hooks
+		logrus.SetOutput(io.Discard)
 
+		f := joonix.NewFormatter()
 		if err := joonix.DisableTimestampFormat(f); err != nil {
 			panic(err) // lint:nopanic -- This shouldn't happen, but crashing immediately at startup is OK.
 		}
 
-		logrus.SetFormatter(f)
+		logrus.AddHook(&logs.WriterHook{
+			Formatter:     f,
+			Writer:        os.Stderr,
+			AllowedLevels: logrus.AllLevels[:verbosityLevel+1],
+			Identifier:    logs.LogTargetUser,
+		})
 	case "json":
 		// disabling logrus default output so we can control it via hooks
 		logrus.SetOutput(io.Discard)

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -239,7 +239,7 @@ func before(ctx *cli.Context) error {
 			Identifier:    logs.LogTargetUser,
 		})
 	case "journald":
-		if err := journald.Enable(); err != nil {
+		if err := journald.Enable(verbosityLevel); err != nil {
 			return err
 		}
 	default:

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -221,8 +221,15 @@ func before(ctx *cli.Context) error {
 
 		logrus.SetFormatter(f)
 	case "json":
-		logrus.SetFormatter(&logrus.JSONFormatter{
-			TimestampFormat: "2006-01-02 15:04:05.00",
+		// disabling logrus default output so we can control it via hooks
+		logrus.SetOutput(io.Discard)
+		logrus.AddHook(&logs.WriterHook{
+			Formatter: &logrus.JSONFormatter{
+				TimestampFormat: "2006-01-02 15:04:05.00",
+			},
+			Writer:        os.Stderr,
+			AllowedLevels: logrus.AllLevels[:verbosityLevel+1],
+			Identifier:    logs.LogTargetUser,
 		})
 	case "journald":
 		if err := journald.Enable(); err != nil {

--- a/cmd/client-stats/main.go
+++ b/cmd/client-stats/main.go
@@ -77,7 +77,7 @@ func main() {
 				TimestampFormat: "2006-01-02 15:04:05.00",
 			})
 		case "journald":
-			if err := journald.Enable(); err != nil {
+			if err := journald.Enable(level); err != nil {
 				return err
 			}
 		default:

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -217,7 +217,7 @@ func main() {
 					Identifier:    logs.LogTargetUser,
 				})
 			case "journald":
-				if err := journald.Enable(); err != nil {
+				if err := journald.Enable(verbosityLevel); err != nil {
 					return err
 				}
 			default:

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -197,8 +197,15 @@ func main() {
 				}
 				logrus.SetFormatter(f)
 			case "json":
-				logrus.SetFormatter(&logrus.JSONFormatter{
-					TimestampFormat: "2006-01-02 15:04:05.00",
+				// disabling logrus default output so we can control it via hooks
+				logrus.SetOutput(io.Discard)
+				logrus.AddHook(&logs.WriterHook{
+					Formatter: &logrus.JSONFormatter{
+						TimestampFormat: "2006-01-02 15:04:05.00",
+					},
+					Writer:        os.Stderr,
+					AllowedLevels: logrus.AllLevels[:verbosityLevel+1],
+					Identifier:    logs.LogTargetUser,
 				})
 			case "journald":
 				if err := journald.Enable(); err != nil {

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -191,11 +191,20 @@ func main() {
 					Identifier:    logs.LogTargetUser,
 				})
 			case "fluentd":
+				// disabling logrus default output so we can control it via hooks
+				logrus.SetOutput(io.Discard)
+
 				f := joonix.NewFormatter()
 				if err := joonix.DisableTimestampFormat(f); err != nil {
 					panic(err) // lint:nopanic -- This shouldn't happen, but crashing immediately at startup is OK.
 				}
-				logrus.SetFormatter(f)
+
+				logrus.AddHook(&logs.WriterHook{
+					Formatter:     f,
+					Writer:        os.Stderr,
+					AllowedLevels: logrus.AllLevels[:verbosityLevel+1],
+					Identifier:    logs.LogTargetUser,
+				})
 			case "json":
 				// disabling logrus default output so we can control it via hooks
 				logrus.SetOutput(io.Discard)

--- a/monitoring/journald/BUILD.bazel
+++ b/monitoring/journald/BUILD.bazel
@@ -10,12 +10,48 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v7/monitoring/journald",
     visibility = ["//visibility:public"],
     deps = select({
+        "@io_bazel_rules_go//go/platform:aix": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
         "@io_bazel_rules_go//go/platform:android": [
             "@com_github_coreos_go_systemd//journal:go_default_library",
             "@com_github_sirupsen_logrus//:go_default_library",
         ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:illumos": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:js": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "@com_github_coreos_go_systemd//journal:go_default_library",
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "@com_github_sirupsen_logrus//:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
             "@com_github_sirupsen_logrus//:go_default_library",
         ],
         "//conditions:default": [],

--- a/monitoring/journald/journald.go
+++ b/monitoring/journald/journald.go
@@ -4,9 +4,11 @@ package journald
 
 import (
 	"fmt"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Enable returns an error on non-Linux systems
-func Enable() error {
+func Enable(_ logrus.Level) error {
 	return fmt.Errorf("journald is not supported in this platform")
 }

--- a/monitoring/journald/journald_linux.go
+++ b/monitoring/journald/journald_linux.go
@@ -11,11 +11,11 @@ import (
 
 // Enable adds the Journal hook if journal is enabled
 // Sets log output to ioutil.Discard so stdout isn't captured.
-func Enable() error {
+func Enable(logLevel logrus.Level) error {
 	if !journal.Enabled() {
 		logrus.Warning("Journal not available but user requests we log to it. Ignoring")
 	} else {
-		logrus.AddHook(&JournalHook{})
+		logrus.AddHook(&JournalHook{level: logLevel})
 		logrus.SetOutput(io.Discard)
 	}
 	return nil

--- a/monitoring/journald/journalhook_linux.go
+++ b/monitoring/journald/journalhook_linux.go
@@ -12,7 +12,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type JournalHook struct{}
+type JournalHook struct {
+	level logrus.Level
+}
 
 var (
 	severityMap = map[logrus.Level]journal.Priority{
@@ -65,12 +67,5 @@ func (hook *JournalHook) Fire(entry *logrus.Entry) error {
 
 // Levels returns a slice of `Levels` the hook is fired for.
 func (hook *JournalHook) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.PanicLevel,
-		logrus.FatalLevel,
-		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
-	}
+	return logrus.AllLevels[:hook.level+1]
 }


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
There is a bug that makes non-text format logs not respect the `--verbosity` flag. This PR introduces a fix for `json`, `fluentd`, and `journald` log formats.

**How to test:**
if you run the beacon node without this PR using `--log-format json|fluentd|journald` paired with `--verbosity info` you see that debug logs are printing. then run with this PR to see that it respects the verbosity flag. you can test with different verbosity levels.
you can see journald logs using `journalctl -f`.

**Note for reviewer:**
each commit is separate and adds a fix for a format. both for beacon-chain and validator.

This doesn't change the behavior of the ephemeral log file. that is always debug, and always text format. 