### PR TITLE
eager push all cells for block proposer

### DIFF
--- a/beacon-chain/core/peerdas/validator.go
+++ b/beacon-chain/core/peerdas/validator.go
@@ -163,7 +163,8 @@ func DataColumnSidecars(cellsPerBlob [][]kzg.Cell, proofsPerBlob [][]kzg.Proof, 
 	return roSidecars, nil
 }
 
-func PartialColumns(included bitfield.Bitlist, cellsPerBlob [][]kzg.Cell, proofsPerBlob [][]kzg.Proof, src ConstructionPopulator) ([]blocks.PartialDataColumn, error) {
+func PartialColumns(included bitfield.Bitlist, cellsPerBlob [][]kzg.Cell, proofsPerBlob [][]kzg.Proof, src ConstructionPopulator,
+	opts ...blocks.PartialDataColumnOption) ([]blocks.PartialDataColumn, error) {
 	start := time.Now()
 	const numberOfColumns = uint64(fieldparams.NumberOfColumns)
 	cells, proofs, err := rotateRowsToCols(cellsPerBlob, proofsPerBlob, numberOfColumns)
@@ -177,7 +178,7 @@ func PartialColumns(included bitfield.Bitlist, cellsPerBlob [][]kzg.Cell, proofs
 
 	dataColumns := make([]blocks.PartialDataColumn, 0, numberOfColumns)
 	for idx := range numberOfColumns {
-		dc, err := blocks.NewPartialDataColumn(src.Root(), info.signedBlockHeader, idx, info.kzgCommitments, info.kzgInclusionProof)
+		dc, err := blocks.NewPartialDataColumn(src.Root(), info.signedBlockHeader, idx, info.kzgCommitments, info.kzgInclusionProof, opts...)
 		if err != nil {
 			return nil, errors.Wrap(err, "new ro data column")
 		}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -1016,6 +1016,7 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		PayloadIDCache:                   b.payloadIDCache,
 		LCStore:                          b.lcStore,
 		GraffitiInfo:                     web3Service.GraffitiInfo(),
+		BlockProposalEagerPushCells:      b.cliCtx.Bool(flags.BlockProposalEagerPushCells.Name),
 	})
 
 	return b.services.RegisterService(rpcService)

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -643,6 +643,7 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 			extended = true
 		}
 	}
+	p.logger.WithFields(logrus.Fields{"duration": cells.validationTook, "extended": extended}).Debug("Extended partial message")
 
 	columnIndexStr := strconv.FormatUint(ourDataColumn.Index, 10)
 	if extended {

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -582,12 +582,6 @@ func (p *PartialColumnBroadcaster) handlePartialCells(ourDataColumn *blocks.Part
 		partialMessageCellsReceivedTotal.WithLabelValues(columnIndexStr).Add(float64(len(cellIndices)))
 	}
 	if len(cellsToVerify) > 0 {
-		p.logger.WithFields(logrus.Fields{
-			"from":      rpc.from,
-			"column":    ourDataColumn.Index,
-			"cellCount": len(cellsToVerify),
-			"indices":   cellIndices,
-		}).Debug("Received cells from peer, submitting for KZG verification")
 		p.concurrentValidatorSemaphore <- struct{}{}
 		go func() {
 			defer func() {
@@ -600,12 +594,6 @@ func (p *PartialColumnBroadcaster) handlePartialCells(ourDataColumn *blocks.Part
 				_ = p.peerFeedback(topicId, rpc.from, pubsub.PeerFeedbackInvalidMessage)
 				return
 			}
-			p.logger.WithFields(logrus.Fields{
-				"from":      rpc.from,
-				"column":    ourDataColumn.Index,
-				"cellCount": len(cellsToVerify),
-				"duration":  time.Since(start),
-			}).Debug("KZG verification passed for received cells")
 			_ = p.peerFeedback(topicId, rpc.from, pubsub.PeerFeedbackUsefulMessage)
 			p.incomingReq <- request{
 				kind: requestKindCellsValidated,
@@ -655,14 +643,6 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 			extended = true
 		}
 	}
-	p.logger.WithFields(logrus.Fields{
-		"duration":       cells.validationTook,
-		"extended":       extended,
-		"column":         ourDataColumn.Index,
-		"cellsAdded":     len(cells.cells),
-		"totalIncluded":  ourDataColumn.Included.Count(),
-		"totalCommitted": len(ourDataColumn.KzgCommitments),
-	}).Debug("Processed KZG-verified cells into partial column")
 
 	columnIndexStr := strconv.FormatUint(ourDataColumn.Index, 10)
 	if extended {
@@ -679,16 +659,10 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 			return err
 		}
 		if ok {
-			p.logger.WithFields(logrus.Fields{
-				"column":        ourDataColumn.Index,
-				"totalIncluded": ourDataColumn.Included.Count(),
-			}).WithFields(cells.logFields()).Info("Completed partial column from received cells")
+			p.logger.WithFields(cells.logFields()).Info("Completed partial column")
 			go p.callbacks.HandleColumn(cells.topic, col)
 		} else {
-			p.logger.WithFields(logrus.Fields{
-				"column":        ourDataColumn.Index,
-				"totalIncluded": ourDataColumn.Included.Count(),
-			}).WithFields(cells.logFields()).Info("Extended partial column with received cells")
+			p.logger.WithFields(cells.logFields()).Info("Extended partial column")
 		}
 
 		if !ourDataColumn.Published {

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -582,6 +582,12 @@ func (p *PartialColumnBroadcaster) handlePartialCells(ourDataColumn *blocks.Part
 		partialMessageCellsReceivedTotal.WithLabelValues(columnIndexStr).Add(float64(len(cellIndices)))
 	}
 	if len(cellsToVerify) > 0 {
+		p.logger.WithFields(logrus.Fields{
+			"from":      rpc.from,
+			"column":    ourDataColumn.Index,
+			"cellCount": len(cellsToVerify),
+			"indices":   cellIndices,
+		}).Debug("Received cells from peer, submitting for KZG verification")
 		p.concurrentValidatorSemaphore <- struct{}{}
 		go func() {
 			defer func() {
@@ -594,6 +600,12 @@ func (p *PartialColumnBroadcaster) handlePartialCells(ourDataColumn *blocks.Part
 				_ = p.peerFeedback(topicId, rpc.from, pubsub.PeerFeedbackInvalidMessage)
 				return
 			}
+			p.logger.WithFields(logrus.Fields{
+				"from":      rpc.from,
+				"column":    ourDataColumn.Index,
+				"cellCount": len(cellsToVerify),
+				"duration":  time.Since(start),
+			}).Debug("KZG verification passed for received cells")
 			_ = p.peerFeedback(topicId, rpc.from, pubsub.PeerFeedbackUsefulMessage)
 			p.incomingReq <- request{
 				kind: requestKindCellsValidated,
@@ -643,7 +655,14 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 			extended = true
 		}
 	}
-	p.logger.WithFields(logrus.Fields{"duration": cells.validationTook, "extended": extended}).Debug("Extended partial message")
+	p.logger.WithFields(logrus.Fields{
+		"duration":       cells.validationTook,
+		"extended":       extended,
+		"column":         ourDataColumn.Index,
+		"cellsAdded":     len(cells.cells),
+		"totalIncluded":  ourDataColumn.Included.Count(),
+		"totalCommitted": len(ourDataColumn.KzgCommitments),
+	}).Debug("Processed KZG-verified cells into partial column")
 
 	columnIndexStr := strconv.FormatUint(ourDataColumn.Index, 10)
 	if extended {
@@ -660,10 +679,16 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 			return err
 		}
 		if ok {
-			p.logger.WithFields(cells.logFields()).Info("Completed partial column")
+			p.logger.WithFields(logrus.Fields{
+				"column":        ourDataColumn.Index,
+				"totalIncluded": ourDataColumn.Included.Count(),
+			}).WithFields(cells.logFields()).Info("Completed partial column from received cells")
 			go p.callbacks.HandleColumn(cells.topic, col)
 		} else {
-			p.logger.WithFields(cells.logFields()).Info("Extended partial column")
+			p.logger.WithFields(logrus.Fields{
+				"column":        ourDataColumn.Index,
+				"totalIncluded": ourDataColumn.Included.Count(),
+			}).WithFields(cells.logFields()).Info("Extended partial column with received cells")
 		}
 
 		if !ourDataColumn.Published {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -463,7 +463,12 @@ func (vs *Server) handleUnblindedBlock(
 
 		included := bitfield.NewBitlist(uint64(len(cellsPerBlob)))
 		included = included.Not() // all bits set to 1
-		partialColumns, err := peerdas.PartialColumns(included, cellsPerBlob, proofsPerBlob, peerdas.PopulateFromBlock(block))
+		var partialColumnOpts []blocks.PartialDataColumnOption
+		if vs.BlockProposalEagerPushCells {
+			log.Debug("Block proposer eager push cells enabled, including cells in eager push")
+			partialColumnOpts = append(partialColumnOpts, blocks.WithByBlockProposer())
+		}
+		partialColumns, err := peerdas.PartialColumns(included, cellsPerBlob, proofsPerBlob, peerdas.PopulateFromBlock(block), partialColumnOpts...)
 		if err != nil {
 			return nil, nil, nil, errors.Wrap(err, "data column sidcars")
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -77,6 +77,7 @@ type Server struct {
 	ExecutionPayloadEnvelopeReceiver blockchain.ExecutionPayloadEnvelopeReceiver
 	BlobReceiver                     blockchain.BlobReceiver
 	DataColumnReceiver               blockchain.DataColumnReceiver
+	BlockProposalEagerPushCells      bool
 	MockEth1Votes                    bool
 	Eth1BlockFetcher                 execution.POWBlockFetcher
 	PendingDepositsFetcher           depositsnapshot.PendingDepositsFetcher

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -98,6 +98,7 @@ type Config struct {
 	ExecutionChainInfoFetcher        execution.ChainInfoFetcher
 	GenesisTimeFetcher               blockchain.TimeFetcher
 	GenesisFetcher                   blockchain.GenesisFetcher
+	BlockProposalEagerPushCells      bool
 	MockEth1Votes                    bool
 	EnableDebugRPCEndpoints          bool
 	AttestationCache                 *cache.AttestationCache
@@ -266,6 +267,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		PayloadIDCache:                   s.cfg.PayloadIDCache,
 		AttestationStateFetcher:          s.cfg.AttestationReceiver,
 		GraffitiInfo:                     s.cfg.GraffitiInfo,
+		BlockProposalEagerPushCells:      s.cfg.BlockProposalEagerPushCells,
 	}
 	s.validatorServer = validatorServer
 	nodeServer := &nodev1alpha1.Server{

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -373,4 +373,9 @@ var (
 		Name:  "partial-data-columns",
 		Usage: "Enable cell-level dissemination for PeerDAS data columns",
 	}
+	// BlockProposalEagerPushCells enables eager pushing of all cells when proposing blocks.
+	BlockProposalEagerPushCells = &cli.BoolFlag{
+		Name:  "block-proposal-eager-push-cells",
+		Usage: "When proposing a block, eagerly push all cells and proofs to peers in the initial partial message",
+	}
 )

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -163,6 +163,7 @@ var appFlags = []cli.Flag{
 	flags.StateDiffExponents,
 	flags.DisableEphemeralLogFile,
 	flags.PartialDataColumns,
+	flags.BlockProposalEagerPushCells,
 }
 
 func init() {

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -76,6 +76,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.BatchVerifierLimit,
 			flags.StateDiffExponents,
 			flags.PartialDataColumns,
+			flags.BlockProposalEagerPushCells,
 		},
 	},
 	{

--- a/consensus-types/blocks/partialdatacolumn.go
+++ b/consensus-types/blocks/partialdatacolumn.go
@@ -219,14 +219,14 @@ func (p *PartialDataColumn) cellsToSendForPeer(peerMeta *ethpb.PartialDataColumn
 // eagerPushBytes builds SSZ-encoded PartialDataColumnSidecar for the initial eager push.
 // When byBlockProposer is true, all available cells and proofs are included.
 // Otherwise, only the header is sent (no cells).
-func (p *PartialDataColumn) eagerPushBytes() ([]byte, error) {
+func (p *PartialDataColumn) eagerPushBytes(includeCellAndProofs bool) ([]byte, error) {
 	outHeader := &ethpb.PartialDataColumnHeader{
 		KzgCommitments:               p.KzgCommitments,
 		SignedBlockHeader:            p.SignedBlockHeader,
 		KzgCommitmentsInclusionProof: p.KzgCommitmentsInclusionProof,
 	}
 
-	if !p.byBlockProposer {
+	if !includeCellAndProofs {
 		outMessage := &ethpb.PartialDataColumnSidecar{
 			CellsPresentBitmap: bitfield.NewBitlist(uint64(len(p.KzgCommitments))),
 			Header:             []*ethpb.PartialDataColumnHeader{outHeader},
@@ -294,7 +294,7 @@ func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerS
 	// Eager push - we don't know what the peer has and message has been requested.
 	// Set RecvdState so subsequent calls skip the eager push path.
 	if requestedMessage && peerState.Recvd == nil {
-		encoded, err := p.eagerPushBytes()
+		encoded, err := p.eagerPushBytes(p.byBlockProposer)
 		if err != nil {
 			return peerState, partialmessages.PublishAction{Err: err}
 		}

--- a/consensus-types/blocks/partialdatacolumn.go
+++ b/consensus-types/blocks/partialdatacolumn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p-pubsub/partialmessages"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var _ partialmessages.PublishActionsFn[PartialDataColumnPeerState] = (*PartialDataColumn)(nil).PublishActions
@@ -43,6 +44,22 @@ type PartialDataColumn struct {
 	// ourselves, as that is the point we know what cells we have or are
 	// missing.
 	Published bool
+
+	// byBlockProposer indicates this column was created by the block proposer.
+	// When true, the eager push will include all available cells and proofs
+	// rather than just the header.
+	byBlockProposer bool
+}
+
+// PartialDataColumnOption is a functional option for NewPartialDataColumn.
+type PartialDataColumnOption func(*PartialDataColumn)
+
+// WithByBlockProposer marks the partial data column as created by the block
+// proposer, causing eager pushes to include all available cells and proofs.
+func WithByBlockProposer() PartialDataColumnOption {
+	return func(p *PartialDataColumn) {
+		p.byBlockProposer = true
+	}
 }
 
 func NewPartialDataColumnFromVerifiedRODataColumn(c VerifiedRODataColumn) PartialDataColumn {
@@ -74,6 +91,7 @@ func NewPartialDataColumn(
 	columnIndex uint64,
 	kzgCommitments [][]byte,
 	kzgInclusionProof [][]byte,
+	opts ...PartialDataColumnOption,
 ) (PartialDataColumn, error) {
 	if signedBlockHeader == nil {
 		return PartialDataColumn{}, errors.New("signedBlockHeader is nil")
@@ -93,6 +111,9 @@ func NewPartialDataColumn(
 		root:              root,
 		groupID:           groupIdFromRoot(root),
 		Included:          bitfield.NewBitlist(uint64(len(sidecar.KzgCommitments))),
+	}
+	for _, opt := range opts {
+		opt(&c)
 	}
 	return c, nil
 }
@@ -195,16 +216,36 @@ func (p *PartialDataColumn) cellsToSendForPeer(peerMeta *ethpb.PartialDataColumn
 	return marshalled, meetsNeeds, nil
 }
 
-// eagerPushBytes builds SSZ-encoded PartialDataColumnSidecar with header only (no cells).
+// eagerPushBytes builds SSZ-encoded PartialDataColumnSidecar for the initial eager push.
+// When byBlockProposer is true, all available cells and proofs are included.
+// Otherwise, only the header is sent (no cells).
 func (p *PartialDataColumn) eagerPushBytes() ([]byte, error) {
 	outHeader := &ethpb.PartialDataColumnHeader{
 		KzgCommitments:               p.KzgCommitments,
 		SignedBlockHeader:            p.SignedBlockHeader,
 		KzgCommitmentsInclusionProof: p.KzgCommitmentsInclusionProof,
 	}
+
+	if !p.byBlockProposer {
+		outMessage := &ethpb.PartialDataColumnSidecar{
+			CellsPresentBitmap: bitfield.NewBitlist(uint64(len(p.KzgCommitments))),
+			Header:             []*ethpb.PartialDataColumnHeader{outHeader},
+		}
+		return outMessage.MarshalSSZ()
+	}
+
+	nCells := p.Included.Count()
 	outMessage := &ethpb.PartialDataColumnSidecar{
-		CellsPresentBitmap: bitfield.NewBitlist(uint64(len(p.KzgCommitments))),
+		CellsPresentBitmap: slices.Clone(p.Included),
+		PartialColumn:      make([][]byte, 0, nCells),
+		KzgProofs:          make([][]byte, 0, nCells),
 		Header:             []*ethpb.PartialDataColumnHeader{outHeader},
+	}
+	for i := range p.Included.Len() {
+		if p.Included.BitAt(i) {
+			outMessage.PartialColumn = append(outMessage.PartialColumn, p.Column[i])
+			outMessage.KzgProofs = append(outMessage.KzgProofs, p.KzgProofs[i])
+		}
 	}
 	return outMessage.MarshalSSZ()
 }
@@ -250,21 +291,36 @@ func (p *PartialDataColumn) PublishActions(peerStates map[peer.ID]PartialDataCol
 func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerState PartialDataColumnPeerState) (PartialDataColumnPeerState, partialmessages.PublishAction) {
 	peerState = ClonePeerState(peerState)
 
-	// Eager push header - we don't know what the peer has and message has been requested.
+	// Eager push - we don't know what the peer has and message has been requested.
 	// Set RecvdState so subsequent calls skip the eager push path.
 	if requestedMessage && peerState.Recvd == nil {
 		encoded, err := p.eagerPushBytes()
 		if err != nil {
 			return peerState, partialmessages.PublishAction{Err: err}
 		}
-		peerState.Recvd = NewPartsMetaWithNoAvailableAndNoRequests(p.NKzgCommitments())
-		myPartsMeta, err := marshalPartsMetadata(p.newPartsMetadata())
+		myPartsMeta := p.newPartsMetadata()
+		if p.byBlockProposer {
+			log.WithFields(logrus.Fields{
+				"peer":      remote,
+				"column":    p.Index,
+				"cellCount": p.Included.Count(),
+			}).Debug("Eager pushing cells to peer (block proposer)")
+			peerState.Recvd = &ethpb.PartialDataColumnPartsMetadata{
+				Available: slices.Clone(p.Included),
+				Requests:  bitfield.NewBitlist(p.NKzgCommitments()),
+			}
+		} else {
+			peerState.Recvd = NewPartsMetaWithNoAvailableAndNoRequests(p.NKzgCommitments())
+		}
+		// either ways, we're sending our parts metadata so update the sent state i.e. the peer's view of what we have.
+		peerState.Sent = myPartsMeta
+		encodedMeta, err := marshalPartsMetadata(myPartsMeta)
 		if err != nil {
 			return peerState, partialmessages.PublishAction{Err: err}
 		}
 		return peerState, partialmessages.PublishAction{
 			EncodedPartialMessage: encoded,
-			EncodedPartsMetadata:  myPartsMeta,
+			EncodedPartsMetadata:  encodedMeta,
 		}
 	}
 

--- a/consensus-types/blocks/partialdatacolumn_test.go
+++ b/consensus-types/blocks/partialdatacolumn_test.go
@@ -446,7 +446,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			name: "nominal",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0)
-				encoded, err := p.eagerPushBytes()
+				encoded, err := p.eagerPushBytes(false)
 				require.NoError(t, err)
 				msg := mustDecodeSidecar(t, encoded)
 				require.Equal(t, 1, len(msg.Header))
@@ -461,7 +461,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
 				p.KzgCommitments[0] = []byte{1}
-				_, err := p.eagerPushBytes()
+				_, err := p.eagerPushBytes(false)
 				require.ErrorContains(t, "KzgCommitments", err)
 			},
 		},
@@ -470,7 +470,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
 				p.KzgCommitmentsInclusionProof = p.KzgCommitmentsInclusionProof[:3]
-				_, err := p.eagerPushBytes()
+				_, err := p.eagerPushBytes(false)
 				require.ErrorContains(t, "KzgCommitmentsInclusionProof", err)
 			},
 		},
@@ -478,7 +478,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			name: "byBlockProposer includes cells and proofs",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumnWithOpts(t, 3, []uint64{0, 2}, WithByBlockProposer())
-				encoded, err := p.eagerPushBytes()
+				encoded, err := p.eagerPushBytes(true)
 				require.NoError(t, err)
 				msg := mustDecodeSidecar(t, encoded)
 				require.Equal(t, 1, len(msg.Header))
@@ -501,7 +501,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			name: "byBlockProposer with no cells still works",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumnWithOpts(t, 2, nil, WithByBlockProposer())
-				encoded, err := p.eagerPushBytes()
+				encoded, err := p.eagerPushBytes(true)
 				require.NoError(t, err)
 				msg := mustDecodeSidecar(t, encoded)
 				require.Equal(t, 1, len(msg.Header))

--- a/consensus-types/blocks/partialdatacolumn_test.go
+++ b/consensus-types/blocks/partialdatacolumn_test.go
@@ -96,6 +96,26 @@ func mustNewPartialColumn(t *testing.T, n int, included ...uint64) *PartialDataC
 	return mustNewPartialColumnWithSigLen(t, n, fieldparams.BLSSignatureLength, included...)
 }
 
+func mustNewPartialColumnWithOpts(t *testing.T, n int, included []uint64, opts ...PartialDataColumnOption) *PartialDataColumn {
+	t.Helper()
+	pdc, err := NewPartialDataColumn(
+		[fieldparams.RootLength]byte{},
+		testSignedHeader(true, fieldparams.BLSSignatureLength),
+		7,
+		sizedSlices(n, 48, 1),
+		sizedSlices(4, 32, 90),
+		opts...,
+	)
+	require.NoError(t, err)
+
+	for _, idx := range included {
+		pdc.Included.SetBitAt(idx, true)
+		pdc.Column[idx] = sizedSlices(1, 2048, byte(idx+1))[0]
+		pdc.KzgProofs[idx] = sizedSlices(1, 48, byte(idx+11))[0]
+	}
+	return &pdc
+}
+
 func mustDecodeSidecar(t *testing.T, encoded []byte) *ethpb.PartialDataColumnSidecar {
 	t.Helper()
 	var msg ethpb.PartialDataColumnSidecar
@@ -454,6 +474,41 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 				require.ErrorContains(t, "KzgCommitmentsInclusionProof", err)
 			},
 		},
+		{
+			name: "byBlockProposer includes cells and proofs",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumnWithOpts(t, 3, []uint64{0, 2}, WithByBlockProposer())
+				encoded, err := p.eagerPushBytes()
+				require.NoError(t, err)
+				msg := mustDecodeSidecar(t, encoded)
+				require.Equal(t, 1, len(msg.Header))
+				// Should include cells for indices 0 and 2.
+				require.Equal(t, 2, len(msg.PartialColumn))
+				require.Equal(t, 2, len(msg.KzgProofs))
+				bitmap := bitfield.Bitlist(msg.CellsPresentBitmap)
+				require.Equal(t, uint64(3), bitmap.Len())
+				require.Equal(t, true, bitmap.BitAt(0))
+				require.Equal(t, false, bitmap.BitAt(1))
+				require.Equal(t, true, bitmap.BitAt(2))
+				// Verify cell content matches.
+				require.DeepEqual(t, p.Column[0], msg.PartialColumn[0])
+				require.DeepEqual(t, p.Column[2], msg.PartialColumn[1])
+				require.DeepEqual(t, p.KzgProofs[0], msg.KzgProofs[0])
+				require.DeepEqual(t, p.KzgProofs[2], msg.KzgProofs[1])
+			},
+		},
+		{
+			name: "byBlockProposer with no cells still works",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumnWithOpts(t, 2, nil, WithByBlockProposer())
+				encoded, err := p.eagerPushBytes()
+				require.NoError(t, err)
+				msg := mustDecodeSidecar(t, encoded)
+				require.Equal(t, 1, len(msg.Header))
+				require.Equal(t, 0, len(msg.PartialColumn))
+				require.Equal(t, 0, len(msg.KzgProofs))
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -536,12 +591,16 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				require.NotNil(t, action.EncodedPartialMessage)
 				require.NotNil(t, action.EncodedPartsMetadata)
 				require.NotNil(t, nextState.Recvd)
-				require.IsNil(t, nextState.Sent)
 				require.Equal(t, uint64(0), bitfield.Bitlist(nextState.Recvd.Available).Count())
 				require.Equal(t, uint64(0), bitfield.Bitlist(nextState.Recvd.Requests).Count())
 				decoded := mustDecodeSidecar(t, action.EncodedPartialMessage)
 				require.Equal(t, 1, len(decoded.Header))
 				require.Equal(t, 0, len(decoded.PartialColumn))
+				// Sent should reflect our partsMetadata (available = our included, requests = all).
+				require.NotNil(t, nextState.Sent)
+				require.Equal(t, uint64(1), bitfield.Bitlist(nextState.Sent.Available).Count())
+				require.Equal(t, true, bitfield.Bitlist(nextState.Sent.Available).BitAt(0))
+				require.Equal(t, uint64(2), bitfield.Bitlist(nextState.Sent.Requests).Count())
 			},
 		},
 		{
@@ -555,7 +614,7 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				next, action := p.forPeer(peer.ID("peer-a"), true, state)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage) // no cells to send (peer has no requests)
-				require.NotNil(t, action.EncodedPartsMetadata) // partsMetadata is sent since SentState differs
+				require.IsNil(t, action.EncodedPartsMetadata)  // partsMetadata already sent, no change
 				require.NotNil(t, next.Recvd)
 			},
 		},
@@ -850,6 +909,61 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				})
 				require.NoError(t, action.Err)
 				require.NotNil(t, action.EncodedPartsMetadata) // resent because Requests differ (we request all 4)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}
+
+func TestPartialDataColumn_ForPeer_ByBlockProposer(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "eager push includes all cells and proofs",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumnWithOpts(t, 4, []uint64{0, 1, 2, 3}, WithByBlockProposer())
+				var initial PartialDataColumnPeerState
+				nextState, action := p.forPeer(peer.ID("peer-a"), true, initial)
+				require.NoError(t, action.Err)
+				require.NotNil(t, action.EncodedPartialMessage)
+				require.NotNil(t, action.EncodedPartsMetadata)
+
+				// Decode and verify the partial message includes cells.
+				decoded := mustDecodeSidecar(t, action.EncodedPartialMessage)
+				require.Equal(t, 1, len(decoded.Header))
+				require.Equal(t, 4, len(decoded.PartialColumn))
+				require.Equal(t, 4, len(decoded.KzgProofs))
+				bitmap := bitfield.Bitlist(decoded.CellsPresentBitmap)
+				require.Equal(t, uint64(4), bitmap.Count())
+
+				// Verify cell content.
+				require.DeepEqual(t, p.Column[0], decoded.PartialColumn[0])
+				require.DeepEqual(t, p.Column[3], decoded.PartialColumn[3])
+				require.DeepEqual(t, p.KzgProofs[0], decoded.KzgProofs[0])
+				require.DeepEqual(t, p.KzgProofs[3], decoded.KzgProofs[3])
+
+				// Recvd.Available should reflect the cells we pushed.
+				require.NotNil(t, nextState.Recvd)
+				require.Equal(t, uint64(4), bitfield.Bitlist(nextState.Recvd.Available).Count())
+				require.Equal(t, true, bitfield.Bitlist(nextState.Recvd.Available).BitAt(0))
+				require.Equal(t, true, bitfield.Bitlist(nextState.Recvd.Available).BitAt(3))
+
+				// Sent should reflect our partsMetadata: available = all 4 cells, requests = all 4.
+				require.NotNil(t, nextState.Sent)
+				require.Equal(t, uint64(4), bitfield.Bitlist(nextState.Sent.Available).Count())
+				require.Equal(t, true, bitfield.Bitlist(nextState.Sent.Available).BitAt(0))
+				require.Equal(t, true, bitfield.Bitlist(nextState.Sent.Available).BitAt(3))
+				require.Equal(t, uint64(4), bitfield.Bitlist(nextState.Sent.Requests).Count())
+				// Verify Sent matches the wire-encoded partsMetadata.
+				sentMetaWire, err := decodePartsMetadata(action.EncodedPartsMetadata, 4)
+				require.NoError(t, err)
+				require.DeepEqual(t, sentMetaWire.Available, nextState.Sent.Available)
+				require.DeepEqual(t, sentMetaWire.Requests, nextState.Sent.Requests)
 			},
 		},
 	}


### PR DESCRIPTION
This PR fulfills the spec requirement at  https://github.com/ethereum/consensus-specs/pull/4558/changes/c690ba4c00cab585713b156c7825217a502fc1dc . It allows block proposers to eager push all partial columns by setting the "--block-proposal-eager-push-cells" flag.