### PR TITLE
Fix flaky TestVerifyConnectivity by using local TCP listener

### DIFF
--- a/beacon-chain/p2p/utils_test.go
+++ b/beacon-chain/p2p/utils_test.go
@@ -2,6 +2,8 @@ package p2p
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"testing"
 
 	testDB "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
@@ -14,10 +16,23 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
-// Test `verifyConnectivity` function by trying to connect to google.com (successfully)
-// and then by connecting to an unreachable IP and ensuring that a log is emitted
+// Test `verifyConnectivity` function by trying to connect to a local listener (successfully)
+// and then by connecting to an unreachable IP and ensuring that a log is emitted.
 func TestVerifyConnectivity(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
+
+	// Start a local TCP listener so we have a reliably reachable address.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, ln.Close())
+	}()
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	var port uint
+	_, err = fmt.Sscanf(portStr, "%d", &port)
+	require.NoError(t, err)
+
 	hook := logTest.NewGlobal()
 	cases := []struct {
 		address              string
@@ -25,7 +40,7 @@ func TestVerifyConnectivity(t *testing.T) {
 		expectedConnectivity bool
 		name                 string
 	}{
-		{"142.250.68.46", 80, true, "Dialing a reachable IP: 142.250.68.46:80"}, // google.com
+		{host, port, true, "Dialing a reachable local listener"},
 		{"123.123.123.123", 19000, false, "Dialing an unreachable IP: 123.123.123.123:19000"},
 	}
 	for _, tc := range cases {

--- a/changelog/terence_fix-flaky-connectivity-test.md
+++ b/changelog/terence_fix-flaky-connectivity-test.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix flaky `TestVerifyConnectivity` by using a local TCP listener instead of an external Google IP.


### PR DESCRIPTION
  - Replace hardcoded external Google IP (`142.250.68.46:80`) in `TestVerifyConnectivity` with a local TCP listener
  - The Google IP became unreachable, causing CI flakes across all PRs
  - Local listener is deterministic and has no external dependency