### PR TITLE
Use highest bid cache to select P2P bid over self-build in proposer

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -88,51 +88,52 @@ type serviceFlagOpts struct {
 // full PoS node. It handles the lifecycle of the entire system and registers
 // services to a service registry.
 type BeaconNode struct {
-	cliCtx                   *cli.Context
-	ctx                      context.Context
-	cancel                   context.CancelFunc
-	services                 *runtime.ServiceRegistry
-	lock                     sync.RWMutex
-	stop                     chan struct{} // Channel to wait for termination notifications.
-	db                       db.Database
-	slasherDB                db.SlasherDatabase
-	attestationCache         *cache.AttestationCache
-	attestationPool          attestations.Pool
-	payloadAttestationPool   payloadattestation.PoolManager
-	exitPool                 voluntaryexits.PoolManager
-	slashingsPool            slashings.PoolManager
-	syncCommitteePool        synccommittee.Pool
-	blsToExecPool            blstoexec.PoolManager
-	depositCache             cache.DepositCache
-	trackedValidatorsCache   *cache.TrackedValidatorsCache
-	proposerPreferencesCache *cache.ProposerPreferencesCache
-	payloadIDCache           *cache.PayloadIDCache
-	stateFeed                *event.Feed
-	blockFeed                *event.Feed
-	opFeed                   *event.Feed
-	stateGen                 *stategen.State
-	collector                *bcnodeCollector
-	slasherBlockHeadersFeed  *event.Feed
-	slasherAttestationsFeed  *event.Feed
-	finalizedStateAtStartUp  state.BeaconState
-	serviceFlagOpts          *serviceFlagOpts
-	GenesisProviders         []genesis.Provider
-	CheckpointInitializer    checkpoint.Initializer
-	forkChoicer              forkchoice.ForkChoicer
-	ClockWaiter              startup.ClockWaiter
-	BackfillOpts             []backfill.ServiceOption
-	initialSyncComplete      chan struct{}
-	BlobStorage              *filesystem.BlobStorage
-	BlobStorageOptions       []filesystem.BlobStorageOption
-	DataColumnStorage        *filesystem.DataColumnStorage
-	DataColumnStorageOptions []filesystem.DataColumnStorageOption
-	verifyInitWaiter         *verification.InitializerWaiter
-	lhsp                     *verification.LazyHeadStateProvider
-	syncChecker              *initialsync.SyncChecker
-	slasherEnabled           bool
-	lcStore                  *lightclient.Store
-	ConfigOptions            []params.Option
-	SyncNeedsWaiter          func() (das.SyncNeeds, error)
+	cliCtx                          *cli.Context
+	ctx                             context.Context
+	cancel                          context.CancelFunc
+	services                        *runtime.ServiceRegistry
+	lock                            sync.RWMutex
+	stop                            chan struct{} // Channel to wait for termination notifications.
+	db                              db.Database
+	slasherDB                       db.SlasherDatabase
+	attestationCache                *cache.AttestationCache
+	attestationPool                 attestations.Pool
+	payloadAttestationPool          payloadattestation.PoolManager
+	exitPool                        voluntaryexits.PoolManager
+	slashingsPool                   slashings.PoolManager
+	syncCommitteePool               synccommittee.Pool
+	blsToExecPool                   blstoexec.PoolManager
+	depositCache                    cache.DepositCache
+	trackedValidatorsCache          *cache.TrackedValidatorsCache
+	proposerPreferencesCache        *cache.ProposerPreferencesCache
+	highestExecutionPayloadBidCache *cache.HighestExecutionPayloadBidCache
+	payloadIDCache                  *cache.PayloadIDCache
+	stateFeed                       *event.Feed
+	blockFeed                       *event.Feed
+	opFeed                          *event.Feed
+	stateGen                        *stategen.State
+	collector                       *bcnodeCollector
+	slasherBlockHeadersFeed         *event.Feed
+	slasherAttestationsFeed         *event.Feed
+	finalizedStateAtStartUp         state.BeaconState
+	serviceFlagOpts                 *serviceFlagOpts
+	GenesisProviders                []genesis.Provider
+	CheckpointInitializer           checkpoint.Initializer
+	forkChoicer                     forkchoice.ForkChoicer
+	ClockWaiter                     startup.ClockWaiter
+	BackfillOpts                    []backfill.ServiceOption
+	initialSyncComplete             chan struct{}
+	BlobStorage                     *filesystem.BlobStorage
+	BlobStorageOptions              []filesystem.BlobStorageOption
+	DataColumnStorage               *filesystem.DataColumnStorage
+	DataColumnStorageOptions        []filesystem.DataColumnStorageOption
+	verifyInitWaiter                *verification.InitializerWaiter
+	lhsp                            *verification.LazyHeadStateProvider
+	syncChecker                     *initialsync.SyncChecker
+	slasherEnabled                  bool
+	lcStore                         *lightclient.Store
+	ConfigOptions                   []params.Option
+	SyncNeedsWaiter                 func() (das.SyncNeeds, error)
 }
 
 // New creates a new node instance, sets up configuration options, and registers
@@ -174,14 +175,15 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, optFuncs []func(*cli.Co
 		// proposerPreferencesCache should remain separate. The tracked
 		// validators cache is local-node specific, while proposer preferences
 		// are global and include proposers we do not own.
-		proposerPreferencesCache: cache.NewProposerPreferencesCache(),
-		payloadIDCache:           cache.NewPayloadIDCache(),
-		slasherBlockHeadersFeed:  new(event.Feed),
-		slasherAttestationsFeed:  new(event.Feed),
-		serviceFlagOpts:          &serviceFlagOpts{},
-		initialSyncComplete:      make(chan struct{}),
-		syncChecker:              &initialsync.SyncChecker{},
-		slasherEnabled:           cliCtx.Bool(flags.SlasherFlag.Name),
+		proposerPreferencesCache:        cache.NewProposerPreferencesCache(),
+		highestExecutionPayloadBidCache: cache.NewHighestExecutionPayloadBidCache(),
+		payloadIDCache:                  cache.NewPayloadIDCache(),
+		slasherBlockHeadersFeed:         new(event.Feed),
+		slasherAttestationsFeed:         new(event.Feed),
+		serviceFlagOpts:                 &serviceFlagOpts{},
+		initialSyncComplete:             make(chan struct{}),
+		syncChecker:                     &initialsync.SyncChecker{},
+		slasherEnabled:                  cliCtx.Bool(flags.SlasherFlag.Name),
 	}
 
 	for _, opt := range opts {
@@ -863,6 +865,7 @@ func (b *BeaconNode) registerSyncService(initialSyncComplete chan struct{}, bFil
 		regularsync.WithAvailableBlocker(bFillStore),
 		regularsync.WithTrackedValidatorsCache(b.trackedValidatorsCache),
 		regularsync.WithProposerPreferencesCache(b.proposerPreferencesCache),
+		regularsync.WithHighestExecutionPayloadBidCache(b.highestExecutionPayloadBidCache),
 		regularsync.WithSlasherEnabled(b.slasherEnabled),
 		regularsync.WithLightClientStore(b.lcStore),
 		regularsync.WithBatchVerifierLimit(b.cliCtx.Int(flags.BatchVerifierLimit.Name)),
@@ -1020,6 +1023,7 @@ func (b *BeaconNode) registerRPCService(router *http.ServeMux) error {
 		DataColumnStorage:                b.DataColumnStorage,
 		TrackedValidatorsCache:           b.trackedValidatorsCache,
 		ProposerPreferencesCache:         b.proposerPreferencesCache,
+		HighestBidCache:                  b.highestExecutionPayloadBidCache,
 		PayloadIDCache:                   b.payloadIDCache,
 		LCStore:                          b.lcStore,
 		GraffitiInfo:                     web3Service.GraffitiInfo(),

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -255,6 +255,7 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 	})
 
 	winningBid := primitives.ZeroWei()
+	selfBuildEnvelope := true
 	var bundle enginev1.BlobsBundler
 	var local *blocks.GetPayloadResponse
 	if sBlk.Version() >= version.Bellatrix {
@@ -285,9 +286,14 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 				return nil, status.Errorf(codes.Internal, "Could not set execution data: %v", err)
 			}
 		} else {
-			if err := vs.setSelfBuildExecutionPayloadBid(ctx, sBlk, local); err != nil {
+			selfBuildOnly := local.OverrideBuilder || skipMevBoost
+			var isSelfBuild bool
+			isSelfBuild, err = vs.setExecutionPayloadBid(ctx, sBlk, local, selfBuildOnly)
+			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not set execution data for Gloas: %v", err)
 			}
+			// Track whether we need to cache the self-build envelope after the block is finalized.
+			selfBuildEnvelope = isSelfBuild
 		}
 	}
 
@@ -299,10 +305,12 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 	}
 	sBlk.SetStateRoot(sr)
 
-	// For Gloas, build and cache the execution payload envelope now that the block
-	// is fully built (state root set). The envelope needs the final block HTR as
-	// BeaconBlockRoot and the post-payload state root as StateRoot.
-	if sBlk.Version() >= version.Gloas {
+	// For Gloas self-build, cache the execution payload envelope now that the
+	// block is fully built (state root set). The envelope needs the final block
+	// HTR as BeaconBlockRoot and the post-payload state root as StateRoot.
+	// When a remote P2P bid was selected, the winning builder is responsible
+	// for producing the envelope, so we must not cache a self-build one.
+	if sBlk.Version() >= version.Gloas && selfBuildEnvelope {
 		if err := vs.storeExecutionPayloadEnvelope(sBlk, local); err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not build execution payload envelope: %v", err)
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -287,13 +287,10 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 			}
 		} else {
 			selfBuildOnly := local.OverrideBuilder || skipMevBoost
-			var isSelfBuild bool
-			isSelfBuild, err = vs.setExecutionPayloadBid(ctx, sBlk, local, selfBuildOnly)
+			selfBuildEnvelope, err = vs.setExecutionPayloadBid(ctx, sBlk, local, selfBuildOnly)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not set execution data for Gloas: %v", err)
 			}
-			// Track whether we need to cache the self-build envelope after the block is finalized.
-			selfBuildEnvelope = isSelfBuild
 		}
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -6,45 +6,78 @@ import (
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls/common"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
-// setSelfBuildExecutionPayloadBid creates an execution payload bid from the local payload
-// and sets it on the block body. The envelope is created and cached later by
-// storeExecutionPayloadEnvelope once the block is fully built.
-func (vs *Server) setSelfBuildExecutionPayloadBid(
+// setExecutionPayloadBid selects the best execution payload bid for the block.
+// When selfBuildOnly is false it compares the highest P2P bid from the cache
+// against the local EL block value and uses whichever is greater.
+// Returns true when a self-build bid was selected (the caller must cache the
+// execution payload envelope); false when a remote P2P bid was used.
+func (vs *Server) setExecutionPayloadBid(
 	ctx context.Context,
 	sBlk interfaces.SignedBeaconBlock,
 	local *consensusblocks.GetPayloadResponse,
-) error {
-	_, span := trace.StartSpan(ctx, "ProposerServer.setSelfBuildExecutionPayloadBid")
+	selfBuildOnly bool,
+) (bool, error) {
+	_, span := trace.StartSpan(ctx, "ProposerServer.setExecutionPayloadBid")
 	defer span.End()
 
 	if local == nil || local.ExecutionData == nil {
-		return errors.New("local execution payload is nil")
+		return false, errors.New("local execution payload is nil")
 	}
 
-	// Create execution payload bid from the local payload.
+	// Check the highest-bid cache for a P2P bid that beats the local EL value.
+	if !selfBuildOnly && vs.HighestBidCache != nil {
+		ed := local.ExecutionData
+		var parentHash [32]byte
+		copy(parentHash[:], ed.ParentHash())
+		parentRoot := sBlk.Block().ParentRoot()
+		if cached, ok := vs.HighestBidCache.Get(sBlk.Block().Slot(), parentHash, parentRoot); ok {
+			builderValueGwei := cached.Message.Value
+			localValueGwei := primitives.WeiToGwei(local.Bid)
+			if builderValueGwei > localValueGwei {
+				log.WithFields(logrus.Fields{
+					"slot":             sBlk.Block().Slot(),
+					"builderIndex":     cached.Message.BuilderIndex,
+					"builderValueGwei": builderValueGwei,
+					"localValueGwei":   localValueGwei,
+				}).Info("Using P2P execution payload bid over self-build")
+				if err := sBlk.SetSignedExecutionPayloadBid(cached); err != nil {
+					return false, errors.Wrap(err, "could not set cached P2P execution payload bid")
+				}
+				return false, nil
+			}
+			log.WithFields(logrus.Fields{
+				"slot":             sBlk.Block().Slot(),
+				"builderValueGwei": builderValueGwei,
+				"localValueGwei":   localValueGwei,
+			}).Info("Local EL value exceeds P2P bid, using self-build")
+		}
+	}
+
+	// Fall back to self-build bid.
 	bid, err := vs.createSelfBuildExecutionPayloadBid(local, sBlk.Block())
 	if err != nil {
-		return errors.Wrap(err, "could not create execution payload bid")
+		return false, errors.Wrap(err, "could not create execution payload bid")
 	}
 
 	// Per spec, self-build bids must use G2 point-at-infinity as the signature.
-	// Only the execution payload envelope requires a real signature from the proposer.
 	signedBid := &ethpb.SignedExecutionPayloadBid{
 		Message:   bid,
 		Signature: common.InfiniteSignature[:],
 	}
 	if err := sBlk.SetSignedExecutionPayloadBid(signedBid); err != nil {
-		return errors.Wrap(err, "could not set signed execution payload bid")
+		return false, errors.Wrap(err, "could not set signed execution payload bid")
 	}
 
-	return nil
+	return true, nil
 }
 
 // createSelfBuildExecutionPayloadBid creates an ExecutionPayloadBid for self-building,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -33,33 +33,11 @@ func (vs *Server) setExecutionPayloadBid(
 		return false, errors.New("local execution payload is nil")
 	}
 
-	// Check the highest-bid cache for a P2P bid that beats the local EL value.
-	if !selfBuildOnly && vs.HighestBidCache != nil {
-		ed := local.ExecutionData
-		var parentHash [32]byte
-		copy(parentHash[:], ed.ParentHash())
-		parentRoot := sBlk.Block().ParentRoot()
-		if cached, ok := vs.HighestBidCache.Get(sBlk.Block().Slot(), parentHash, parentRoot); ok {
-			builderValueGwei := cached.Message.Value
-			localValueGwei := primitives.WeiToGwei(local.Bid)
-			if builderValueGwei > localValueGwei {
-				log.WithFields(logrus.Fields{
-					"slot":             sBlk.Block().Slot(),
-					"builderIndex":     cached.Message.BuilderIndex,
-					"builderValueGwei": builderValueGwei,
-					"localValueGwei":   localValueGwei,
-				}).Info("Using P2P execution payload bid over self-build")
-				if err := sBlk.SetSignedExecutionPayloadBid(cached); err != nil {
-					return false, errors.Wrap(err, "could not set cached P2P execution payload bid")
-				}
-				return false, nil
-			}
-			log.WithFields(logrus.Fields{
-				"slot":             sBlk.Block().Slot(),
-				"builderValueGwei": builderValueGwei,
-				"localValueGwei":   localValueGwei,
-			}).Info("Local EL value exceeds P2P bid, using self-build")
+	if cached := vs.winningP2PBid(sBlk, local, selfBuildOnly); cached != nil {
+		if err := sBlk.SetSignedExecutionPayloadBid(cached); err != nil {
+			return false, errors.Wrap(err, "could not set cached P2P execution payload bid")
 		}
+		return false, nil
 	}
 
 	// Fall back to self-build bid.
@@ -78,6 +56,44 @@ func (vs *Server) setExecutionPayloadBid(
 	}
 
 	return true, nil
+}
+
+// winningP2PBid returns a cached P2P bid if one exists and exceeds the local EL value.
+func (vs *Server) winningP2PBid(
+	sBlk interfaces.SignedBeaconBlock,
+	local *consensusblocks.GetPayloadResponse,
+	selfBuildOnly bool,
+) *ethpb.SignedExecutionPayloadBid {
+	if selfBuildOnly || vs.HighestBidCache == nil {
+		return nil
+	}
+
+	ed := local.ExecutionData
+	var parentHash [32]byte
+	copy(parentHash[:], ed.ParentHash())
+	cached, ok := vs.HighestBidCache.Get(sBlk.Block().Slot(), parentHash, sBlk.Block().ParentRoot())
+	if !ok {
+		return nil
+	}
+
+	builderValueGwei := cached.Message.Value
+	localValueGwei := primitives.WeiToGwei(local.Bid)
+	if builderValueGwei <= localValueGwei {
+		log.WithFields(logrus.Fields{
+			"slot":             sBlk.Block().Slot(),
+			"builderValueGwei": builderValueGwei,
+			"localValueGwei":   localValueGwei,
+		}).Info("Local EL value exceeds P2P bid, using self-build")
+		return nil
+	}
+
+	log.WithFields(logrus.Fields{
+		"slot":             sBlk.Block().Slot(),
+		"builderIndex":     cached.Message.BuilderIndex,
+		"builderValueGwei": builderValueGwei,
+		"localValueGwei":   localValueGwei,
+	}).Info("Using P2P execution payload bid over self-build")
+	return cached
 }
 
 // createSelfBuildExecutionPayloadBid creates an ExecutionPayloadBid for self-building,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
@@ -53,8 +54,9 @@ func TestSetSelfBuildExecutionPayloadBid(t *testing.T) {
 
 	vs := &Server{}
 
-	err = vs.setSelfBuildExecutionPayloadBid(t.Context(), sBlk, local)
+	isSelfBuild, err := vs.setExecutionPayloadBid(t.Context(), sBlk, local, false)
 	require.NoError(t, err)
+	require.Equal(t, true, isSelfBuild)
 
 	// Verify the signed bid was set on the block.
 	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
@@ -87,9 +89,274 @@ func TestSetSelfBuildExecutionPayloadBid_NilPayload(t *testing.T) {
 
 	vs := &Server{}
 
-	err = vs.setSelfBuildExecutionPayloadBid(t.Context(), sBlk, nil)
+	_, err = vs.setExecutionPayloadBid(t.Context(), sBlk, nil, false)
 	require.ErrorContains(t, "local execution payload is nil", err)
 
-	err = vs.setSelfBuildExecutionPayloadBid(t.Context(), sBlk, &consensusblocks.GetPayloadResponse{})
+	_, err = vs.setExecutionPayloadBid(t.Context(), sBlk, &consensusblocks.GetPayloadResponse{}, false)
 	require.ErrorContains(t, "local execution payload is nil", err)
+}
+
+func TestSetExecutionPayloadBid_PrefersP2PBid(t *testing.T) {
+	parentHash := [32]byte{10, 20, 30}
+	parentRoot := [32]byte{1, 2, 3}
+	slot := primitives.Slot(100)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	payload := &enginev1.ExecutionPayloadDeneb{
+		ParentHash:    parentHash[:],
+		FeeRecipient:  make([]byte, 20),
+		StateRoot:     make([]byte, 32),
+		ReceiptsRoot:  make([]byte, 32),
+		LogsBloom:     make([]byte, 256),
+		PrevRandao:    make([]byte, 32),
+		BaseFeePerGas: make([]byte, 32),
+		BlockHash:     make([]byte, 32),
+		ExtraData:     make([]byte, 0),
+	}
+	ed, err := consensusblocks.WrappedExecutionPayloadDeneb(payload)
+	require.NoError(t, err)
+
+	local := &consensusblocks.GetPayloadResponse{
+		ExecutionData:     ed,
+		Bid:               big.NewInt(0),
+		ExecutionRequests: &enginev1.ExecutionRequests{},
+	}
+
+	// Populate the highest bid cache with a P2P bid.
+	p2pBid := &ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			Slot:               slot,
+			ParentBlockHash:    parentHash[:],
+			ParentBlockRoot:    parentRoot[:],
+			BlockHash:          make([]byte, 32),
+			BuilderIndex:       5,
+			Value:              1000,
+			ExecutionPayment:   500,
+			FeeRecipient:       make([]byte, 20),
+			GasLimit:           30_000_000,
+			PrevRandao:         make([]byte, 32),
+			BlobKzgCommitments: [][]byte{},
+		},
+		Signature: make([]byte, 96),
+	}
+
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	bidCache.SetIfHigher(p2pBid)
+
+	vs := &Server{HighestBidCache: bidCache}
+
+	isSelfBuild, err := vs.setExecutionPayloadBid(t.Context(), sBlk, local, false)
+	require.NoError(t, err)
+	require.Equal(t, false, isSelfBuild)
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.NotNil(t, signedBid)
+
+	// Should use the P2P bid, not the self-build bid.
+	require.Equal(t, primitives.BuilderIndex(5), signedBid.Message.BuilderIndex)
+	require.Equal(t, primitives.Gwei(1000), signedBid.Message.Value)
+	require.Equal(t, primitives.Gwei(500), signedBid.Message.ExecutionPayment)
+}
+
+func TestSetExecutionPayloadBid_PrefersLocalWhenHigherValue(t *testing.T) {
+	parentHash := [32]byte{10, 20, 30}
+	parentRoot := [32]byte{1, 2, 3}
+	slot := primitives.Slot(100)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	payload := &enginev1.ExecutionPayloadDeneb{
+		ParentHash:    parentHash[:],
+		FeeRecipient:  make([]byte, 20),
+		StateRoot:     make([]byte, 32),
+		ReceiptsRoot:  make([]byte, 32),
+		LogsBloom:     make([]byte, 256),
+		PrevRandao:    make([]byte, 32),
+		BaseFeePerGas: make([]byte, 32),
+		BlockHash:     make([]byte, 32),
+		ExtraData:     make([]byte, 0),
+	}
+	ed, err := consensusblocks.WrappedExecutionPayloadDeneb(payload)
+	require.NoError(t, err)
+
+	// Local bid is 2000 Gwei (in Wei: 2000 * 1e9).
+	local := &consensusblocks.GetPayloadResponse{
+		ExecutionData:     ed,
+		Bid:               big.NewInt(2000_000_000_000),
+		ExecutionRequests: &enginev1.ExecutionRequests{},
+	}
+
+	// P2P bid is only 1000 Gwei — local should win.
+	p2pBid := &ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			Slot:               slot,
+			ParentBlockHash:    parentHash[:],
+			ParentBlockRoot:    parentRoot[:],
+			BlockHash:          make([]byte, 32),
+			BuilderIndex:       5,
+			Value:              1000,
+			ExecutionPayment:   500,
+			FeeRecipient:       make([]byte, 20),
+			GasLimit:           30_000_000,
+			PrevRandao:         make([]byte, 32),
+			BlobKzgCommitments: [][]byte{},
+		},
+		Signature: make([]byte, 96),
+	}
+
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	bidCache.SetIfHigher(p2pBid)
+
+	vs := &Server{HighestBidCache: bidCache}
+
+	isSelfBuild, err := vs.setExecutionPayloadBid(t.Context(), sBlk, local, false)
+	require.NoError(t, err)
+	require.Equal(t, true, isSelfBuild)
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.NotNil(t, signedBid)
+
+	// Local value is higher, so self-build should be used.
+	require.Equal(t, params.BeaconConfig().BuilderIndexSelfBuild, signedBid.Message.BuilderIndex)
+	require.Equal(t, primitives.Gwei(0), signedBid.Message.Value)
+	require.DeepEqual(t, common.InfiniteSignature[:], signedBid.Signature)
+}
+
+func TestSetExecutionPayloadBid_SelfBuildOnlyIgnoresCache(t *testing.T) {
+	parentHash := [32]byte{10, 20, 30}
+	parentRoot := [32]byte{1, 2, 3}
+	slot := primitives.Slot(100)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	payload := &enginev1.ExecutionPayloadDeneb{
+		ParentHash:    parentHash[:],
+		FeeRecipient:  make([]byte, 20),
+		StateRoot:     make([]byte, 32),
+		ReceiptsRoot:  make([]byte, 32),
+		LogsBloom:     make([]byte, 256),
+		PrevRandao:    make([]byte, 32),
+		BaseFeePerGas: make([]byte, 32),
+		BlockHash:     make([]byte, 32),
+		ExtraData:     make([]byte, 0),
+	}
+	ed, err := consensusblocks.WrappedExecutionPayloadDeneb(payload)
+	require.NoError(t, err)
+
+	local := &consensusblocks.GetPayloadResponse{
+		ExecutionData:     ed,
+		Bid:               big.NewInt(0),
+		ExecutionRequests: &enginev1.ExecutionRequests{},
+	}
+
+	// P2P bid has higher value, but selfBuildOnly=true should force self-build.
+	p2pBid := &ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			Slot:               slot,
+			ParentBlockHash:    parentHash[:],
+			ParentBlockRoot:    parentRoot[:],
+			BlockHash:          make([]byte, 32),
+			BuilderIndex:       5,
+			Value:              1000,
+			ExecutionPayment:   500,
+			FeeRecipient:       make([]byte, 20),
+			GasLimit:           30_000_000,
+			PrevRandao:         make([]byte, 32),
+			BlobKzgCommitments: [][]byte{},
+		},
+		Signature: make([]byte, 96),
+	}
+
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	bidCache.SetIfHigher(p2pBid)
+
+	vs := &Server{HighestBidCache: bidCache}
+
+	isSelfBuild, err := vs.setExecutionPayloadBid(t.Context(), sBlk, local, true)
+	require.NoError(t, err)
+	require.Equal(t, true, isSelfBuild)
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.NotNil(t, signedBid)
+
+	// selfBuildOnly forces self-build even when P2P bid is higher.
+	require.Equal(t, params.BeaconConfig().BuilderIndexSelfBuild, signedBid.Message.BuilderIndex)
+	require.Equal(t, primitives.Gwei(0), signedBid.Message.Value)
+	require.DeepEqual(t, common.InfiniteSignature[:], signedBid.Signature)
+}
+
+func TestSetExecutionPayloadBid_FallsBackToSelfBuildWhenNoCachedBid(t *testing.T) {
+	parentRoot := [32]byte{1, 2, 3}
+	slot := primitives.Slot(100)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	payload := &enginev1.ExecutionPayloadDeneb{
+		ParentHash:    make([]byte, 32),
+		FeeRecipient:  make([]byte, 20),
+		StateRoot:     make([]byte, 32),
+		ReceiptsRoot:  make([]byte, 32),
+		LogsBloom:     make([]byte, 256),
+		PrevRandao:    make([]byte, 32),
+		BaseFeePerGas: make([]byte, 32),
+		BlockHash:     make([]byte, 32),
+		ExtraData:     make([]byte, 0),
+	}
+	ed, err := consensusblocks.WrappedExecutionPayloadDeneb(payload)
+	require.NoError(t, err)
+
+	local := &consensusblocks.GetPayloadResponse{
+		ExecutionData:     ed,
+		Bid:               big.NewInt(0),
+		ExecutionRequests: &enginev1.ExecutionRequests{},
+	}
+
+	// Empty cache — no P2P bids.
+	bidCache := cache.NewHighestExecutionPayloadBidCache()
+	vs := &Server{HighestBidCache: bidCache}
+
+	isSelfBuild, err := vs.setExecutionPayloadBid(t.Context(), sBlk, local, false)
+	require.NoError(t, err)
+	require.Equal(t, true, isSelfBuild)
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.NotNil(t, signedBid)
+
+	// Should fall back to self-build.
+	require.Equal(t, params.BeaconConfig().BuilderIndexSelfBuild, signedBid.Message.BuilderIndex)
+	require.Equal(t, primitives.Gwei(0), signedBid.Message.Value)
+	require.DeepEqual(t, common.InfiniteSignature[:], signedBid.Signature)
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -50,6 +50,7 @@ type Server struct {
 	PayloadIDCache                   *cache.PayloadIDCache
 	TrackedValidatorsCache           *cache.TrackedValidatorsCache
 	ProposerPreferencesCache         *cache.ProposerPreferencesCache
+	HighestBidCache                  *cache.HighestExecutionPayloadBidCache
 	executionPayloadEnvelopeMu       sync.RWMutex
 	executionPayloadEnvelope         *ethpb.ExecutionPayloadEnvelope
 	HeadFetcher                      blockchain.HeadFetcher

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -128,6 +128,7 @@ type Config struct {
 	DataColumnStorage                *filesystem.DataColumnStorage
 	TrackedValidatorsCache           *cache.TrackedValidatorsCache
 	ProposerPreferencesCache         *cache.ProposerPreferencesCache
+	HighestBidCache                  *cache.HighestExecutionPayloadBidCache
 	PayloadIDCache                   *cache.PayloadIDCache
 	LCStore                          *lightClient.Store
 	GraffitiInfo                     *execution.GraffitiInfo
@@ -265,6 +266,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		CoreService:                      coreService,
 		TrackedValidatorsCache:           s.cfg.TrackedValidatorsCache,
 		ProposerPreferencesCache:         s.cfg.ProposerPreferencesCache,
+		HighestBidCache:                  s.cfg.HighestBidCache,
 		PayloadIDCache:                   s.cfg.PayloadIDCache,
 		AttestationStateFetcher:          s.cfg.AttestationReceiver,
 		GraffitiInfo:                     s.cfg.GraffitiInfo,

--- a/beacon-chain/sync/options.go
+++ b/beacon-chain/sync/options.go
@@ -222,6 +222,13 @@ func WithProposerPreferencesCache(c *cache.ProposerPreferencesCache) Option {
 	}
 }
 
+func WithHighestExecutionPayloadBidCache(c *cache.HighestExecutionPayloadBidCache) Option {
+	return func(s *Service) error {
+		s.highestExecutionPayloadBidCache = c
+		return nil
+	}
+}
+
 func WithPayloadAttestationPool(pool payloadattestation.PoolManager) Option {
 	return func(s *Service) error {
 		s.cfg.payloadAttestationPool = pool

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -396,7 +396,9 @@ func (s *Service) initCaches() {
 	s.seenBlockCache = lruwrpr.New(seenBlockSize)
 	s.seenPayloadEnvelopeCache = lruwrpr.New(seenPayloadEnvelopeSize)
 	s.seenExecutionPayloadBidCache = newSlotAwareCache(seenExecutionPayloadBidSize)
-	s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
+	if s.highestExecutionPayloadBidCache == nil {
+		s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
+	}
 	s.seenBlobCache = lruwrpr.New(seenBlockSize * params.BeaconConfig().DeprecatedMaxBlobsPerBlockElectra)
 	s.seenDataColumnCache = newSlotAwareCache(seenDataColumnSize)
 	s.seenAggregatedAttestationCache = lruwrpr.New(seenAggregatedAttSize)

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -396,9 +396,7 @@ func (s *Service) initCaches() {
 	s.seenBlockCache = lruwrpr.New(seenBlockSize)
 	s.seenPayloadEnvelopeCache = lruwrpr.New(seenPayloadEnvelopeSize)
 	s.seenExecutionPayloadBidCache = newSlotAwareCache(seenExecutionPayloadBidSize)
-	if s.highestExecutionPayloadBidCache == nil {
-		s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
-	}
+	s.highestExecutionPayloadBidCache = cache.NewHighestExecutionPayloadBidCache()
 	s.seenBlobCache = lruwrpr.New(seenBlockSize * params.BeaconConfig().DeprecatedMaxBlobsPerBlockElectra)
 	s.seenDataColumnCache = newSlotAwareCache(seenDataColumnSize)
 	s.seenAggregatedAttestationCache = lruwrpr.New(seenAggregatedAttSize)

--- a/changelog/terence_use-highest-bid-cache-for-proposer.md
+++ b/changelog/terence_use-highest-bid-cache-for-proposer.md
@@ -1,0 +1,3 @@
+### Added
+
+- Use highest execution payload bid cache to select P2P bid over self-build when proposing Gloas blocks.


### PR DESCRIPTION
  - Share the `HighestExecutionPayloadBidCache` between the sync and proposer layers. The cache is now created in node.go and injected into both the sync service and the validator RPC server.
  - When building a Gloas block, compare the highest P2P bid value against the local EL block value and use the highest with respect to self build flag
  - Respect OverrideBuilder and skipMevBoost flags in the Gloas path
  - Skip caching the self-build execution payload envelope when a remote P2P bid wins. The winning builder is responsible for producing the envelope, caching a self-build envelope