### PR TITLE
SSV

### DIFF
--- a/beacon-chain/sync/attestation_gossip_epoch_stats.go
+++ b/beacon-chain/sync/attestation_gossip_epoch_stats.go
@@ -1,0 +1,189 @@
+package sync
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// committeeAttGossipEpochStats aggregates committee-index (subnet) attestation gossip
+// validation outcomes per clock epoch. It is safe for concurrent use from pubsub validators.
+type committeeAttGossipEpochStats struct {
+	mu          sync.Mutex
+	initialized bool
+	epoch       primitives.Epoch
+	success     uint64
+	nonSuccess  map[string]uint64
+}
+
+func (a *committeeAttGossipEpochStats) observe(clock *startup.Clock, res pubsub.ValidationResult, reasonKey string) {
+	if clock == nil {
+		return
+	}
+	cur := clock.CurrentEpoch()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if !a.initialized {
+		a.initialized = true
+		a.epoch = cur
+		a.nonSuccess = make(map[string]uint64)
+	}
+
+	a.advanceEpochsLocked(cur)
+
+	if res == pubsub.ValidationAccept {
+		a.success++
+		return
+	}
+	if reasonKey == "" {
+		reasonKey = "non_success_unknown"
+	}
+	a.nonSuccess[reasonKey]++
+}
+
+// rotateOnly flushes any fully completed epochs when the clock has moved forward, including
+// epochs with no attestations (empty summary).
+func (a *committeeAttGossipEpochStats) rotateOnly(clock *startup.Clock) {
+	if clock == nil {
+		return
+	}
+	cur := clock.CurrentEpoch()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if !a.initialized {
+		return
+	}
+	a.advanceEpochsLocked(cur)
+}
+
+// advanceEpochsLocked logs and clears stats for each epoch in [a.epoch, cur) then aligns a.epoch to cur.
+// Caller must hold a.mu.
+func (a *committeeAttGossipEpochStats) advanceEpochsLocked(cur primitives.Epoch) {
+	for a.epoch < cur {
+		a.logEpochLocked()
+		a.epoch++
+		a.success = 0
+		a.nonSuccess = make(map[string]uint64)
+	}
+}
+
+func (a *committeeAttGossipEpochStats) logEpochLocked() {
+	fields := logrus.Fields{
+		"epoch":        a.epoch,
+		"successCount": a.success,
+	}
+	var total uint64
+	reasons := make([]string, 0, len(a.nonSuccess))
+	for k := range a.nonSuccess {
+		reasons = append(reasons, k)
+	}
+	sort.Strings(reasons)
+	for _, k := range reasons {
+		total += a.nonSuccess[k]
+	}
+	fields["nonSuccessTotal"] = total
+	if len(a.nonSuccess) > 0 {
+		byReason := make(map[string]uint64, len(a.nonSuccess))
+		for _, k := range reasons {
+			byReason[k] = a.nonSuccess[k]
+		}
+		fields["nonSuccessByReason"] = byReason
+	}
+	log.WithFields(fields).Info("Committee subnet attestation gossip validation epoch summary")
+}
+
+func classifyCommitteeAttGossipNonSuccess(res pubsub.ValidationResult, err error) string {
+	if res == pubsub.ValidationAccept {
+		return ""
+	}
+	if err == nil {
+		switch res {
+		case pubsub.ValidationIgnore:
+			return "ignore_unspecified"
+		case pubsub.ValidationReject:
+			return "reject_unspecified"
+		default:
+			return "non_success_unspecified"
+		}
+	}
+	if res == pubsub.ValidationReject {
+		return classifyCommitteeAttGossipReject(err)
+	}
+	return classifyCommitteeAttGossipIgnore(err)
+}
+
+func classifyCommitteeAttGossipReject(err error) string {
+	if errors.Is(err, p2p.ErrInvalidTopic) {
+		return "reject_invalid_topic"
+	}
+	if errors.Is(err, errWrongMessage) {
+		return "reject_wrong_message"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(strings.ToLower(msg), "nil attestation"):
+		return "reject_nil_attestation"
+	case strings.Contains(msg, "does not match target epoch"):
+		return "reject_slot_target_epoch_mismatch"
+	case strings.Contains(msg, "subnet does not match"):
+		return "reject_wrong_subnet_topic"
+	case strings.Contains(msg, "committee index") && strings.Contains(msg, "must be 0"):
+		return "reject_committee_index_electra"
+	case strings.Contains(msg, "committee index") && strings.Contains(msg, "must be < 2"):
+		return "reject_committee_index_gloas"
+	case strings.Contains(msg, "committee bits"):
+		return "reject_committee_bits"
+	case strings.Contains(msg, "committee index") && strings.Contains(msg, ">="):
+		return "reject_committee_index_out_of_range"
+	case strings.Contains(msg, "attestation bitfield"):
+		return "reject_attestation_bitfield"
+	case strings.Contains(msg, "attester") && strings.Contains(msg, "not a member"):
+		return "reject_attester_not_in_committee"
+	case strings.Contains(msg, "FFG and LMD votes are not consistent"):
+		return "reject_lmd_ffg_inconsistent"
+	case strings.Contains(msg, "bad block root"):
+		return "reject_bad_block_root"
+	}
+	if strings.Contains(strings.ToLower(msg), "signature") {
+		return "reject_signature_verification"
+	}
+	return "reject_other"
+}
+
+func classifyCommitteeAttGossipIgnore(err error) string {
+	if errors.Is(err, blockchain.ErrNotDescendantOfFinalized) {
+		return "ignore_not_descendant_of_finalized"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not within attestation propagation range"):
+		return "ignore_attestation_propagation_range"
+	case strings.Contains(msg, "execution payload for attested block has not been seen"):
+		return "ignore_payload_not_seen"
+	case strings.Contains(msg, "could not process attestation slot"):
+		return "ignore_attestation_slot_time"
+	case strings.Contains(msg, "source check point"):
+		return "ignore_source_checkpoint_mismatch"
+	case strings.Contains(msg, "target check point"):
+		return "ignore_target_checkpoint_mismatch"
+	}
+	return "ignore_other"
+}
+
+func committeeAttGossipSlotDuration() time.Duration {
+	return time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+}

--- a/beacon-chain/sync/attestation_gossip_epoch_stats_test.go
+++ b/beacon-chain/sync/attestation_gossip_epoch_stats_test.go
@@ -1,14 +1,30 @@
 package sync
 
 import (
+	"bytes"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/OffchainLabs/go-bitfield"
+	mockChain "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
+	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
+	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
+	lruwrpr "github.com/OffchainLabs/prysm/v7/cache/lru"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +79,212 @@ func TestCommitteeAttGossipEpochStats_rotateOnlyFlushesGap(t *testing.T) {
 	require.Zero(t, st.success)
 	require.Empty(t, st.nonSuccess)
 	st.mu.Unlock()
+}
+
+// committeeAttSummaryHook captures Info logs emitted when an epoch of committee
+// attestation gossip validation stats is flushed.
+type committeeAttSummaryHook struct {
+	mu        sync.Mutex
+	summaries []logrus.Entry
+}
+
+func (h *committeeAttSummaryHook) Levels() []logrus.Level {
+	return []logrus.Level{logrus.InfoLevel}
+}
+
+func (h *committeeAttSummaryHook) Fire(e *logrus.Entry) error {
+	if e.Message != "Committee subnet attestation gossip validation epoch summary" {
+		return nil
+	}
+	h.mu.Lock()
+	h.summaries = append(h.summaries, *e)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *committeeAttSummaryHook) last() (logrus.Entry, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.summaries) == 0 {
+		return logrus.Entry{}, false
+	}
+	return h.summaries[len(h.summaries)-1], true
+}
+
+// TestValidateCommitteeIndexBeaconAttestation_epochGossipSummary drives
+// validateCommitteeIndexBeaconAttestation with mixed outcomes (ignore/reject and
+// one fully valid accept) in the same clock epoch, advances the clock to the
+// next epoch, flushes stats, and asserts (and logs) the summary fields written
+// by committeeAttGossipEpochStats.
+func TestValidateCommitteeIndexBeaconAttestation_epochGossipSummary(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+
+	hook := &committeeAttSummaryHook{}
+	logrus.StandardLogger().AddHook(hook)
+	t.Cleanup(func() {
+		logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
+	})
+
+	// ValidateAttestationTime uses wall clock vs genesis (not cfg.clock.CurrentSlot). Keep genesis
+	// ~1 slot in the past so "current slot" is ~1 and a slot-1 attestation is in range.
+	slotDur := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
+	genesis := time.Now().Add(-slotDur)
+	vr := [32]byte{'B'}
+	var slot primitives.Slot
+	clock := startup.NewClock(genesis, vr, startup.WithNower(func() time.Time {
+		tt, err := slots.StartTime(genesis, slot)
+		require.NoError(t, err)
+		return tt
+	}))
+
+	p := p2ptest.NewTestP2P(t)
+	db := dbtest.SetupDB(t)
+	syncMock := &mockSync.Sync{IsSyncing: true}
+	ctx := t.Context()
+
+	chainSvc := &mockChain.ChainService{
+		Genesis:          genesis,
+		ValidatorsRoot:   vr,
+		DB:               db,
+		ValidAttestation: true,
+		Optimistic:       true,
+	}
+
+	s := &Service{
+		ctx: ctx,
+		cfg: &config{
+			initialSync:         syncMock,
+			p2p:                 p,
+			beaconDB:            db,
+			clock:               clock,
+			chain:               chainSvc,
+			attestationNotifier: (&mockChain.ChainService{}).OperationNotifier(),
+		},
+		blkRootToPendingAtts:             make(map[[32]byte][]any),
+		seenUnAggregatedAttestationCache: lruwrpr.New(seenUnaggregatedAttSize),
+		signatureChan:                    make(chan *signatureVerifier, verifierLimit),
+	}
+	s.initCaches()
+	go s.verifierRoutine()
+
+	dig, err := s.currentForkDigest()
+	require.NoError(t, err)
+	topic := fmt.Sprintf("/eth2/%x/beacon_attestation_0", dig)
+
+	// 1) Initial sync: ignore_initial_sync
+	_, err = s.validateCommitteeIndexBeaconAttestation(ctx, "", &pubsub.Message{
+		Message: &pubsubpb.Message{Topic: &topic},
+	})
+	require.NoError(t, err)
+
+	syncMock.IsSyncing = false
+
+	// 2) Nil topic: reject_invalid_topic
+	badTopicMsg := &pubsub.Message{Message: &pubsubpb.Message{Topic: nil}}
+	_, err = s.validateCommitteeIndexBeaconAttestation(ctx, "", badTopicMsg)
+	require.Error(t, err)
+
+	// 3) Slot 0 attestation: ignore_slot_zero
+	attSlot0 := &ethpb.Attestation{
+		AggregationBits: bitfield.Bitlist{0b11},
+		Data: &ethpb.AttestationData{
+			Slot:            0,
+			CommitteeIndex:  0,
+			BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+			Target:          &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, fieldparams.RootLength)},
+			Source:          &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, fieldparams.RootLength)},
+		},
+		Signature: make([]byte, fieldparams.BLSSignatureLength),
+	}
+	buf := new(bytes.Buffer)
+	_, encErr := p.Encoding().EncodeGossip(buf, attSlot0)
+	require.NoError(t, encErr)
+	_, err = s.validateCommitteeIndexBeaconAttestation(ctx, "", &pubsub.Message{
+		Message: &pubsubpb.Message{Data: buf.Bytes(), Topic: &topic},
+	})
+	require.NoError(t, err)
+
+	// 4) Fully valid attestation (accept): same setup as TestService_validateCommitteeIndexBeaconAttestation.
+	helpers.ClearCache()
+	blk := util.NewBeaconBlock()
+	blk.Block.Slot = 1
+	util.SaveBlock(t, ctx, db, blk)
+	validBlockRoot, err := blk.Block.HashTreeRoot()
+	require.NoError(t, err)
+	chainSvc.FinalizedCheckPoint = &ethpb.Checkpoint{
+		Root:  validBlockRoot[:],
+		Epoch: 0,
+	}
+	validators := uint64(64)
+	savedState, keys := util.DeterministicGenesisState(t, validators)
+	require.NoError(t, savedState.SetSlot(1))
+	require.NoError(t, db.SaveState(ctx, savedState, validBlockRoot))
+	chainSvc.State = savedState
+
+	slot = 1
+	dig, err = s.currentForkDigest()
+	require.NoError(t, err)
+	validTopic := fmt.Sprintf("/eth2/%x/beacon_attestation_1", dig)
+
+	validAtt := &ethpb.Attestation{
+		AggregationBits: bitfield.Bitlist{0b101},
+		Data: &ethpb.AttestationData{
+			BeaconBlockRoot: validBlockRoot[:],
+			CommitteeIndex:  0,
+			Slot:            1,
+			Target: &ethpb.Checkpoint{
+				Epoch: 0,
+				Root:  validBlockRoot[:],
+			},
+			Source: &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
+		},
+	}
+	com, err := helpers.BeaconCommitteeFromState(ctx, savedState, validAtt.GetData().Slot, validAtt.GetData().CommitteeIndex)
+	require.NoError(t, err)
+	domain, err := signing.Domain(savedState.Fork(), validAtt.GetData().Target.Epoch, params.BeaconConfig().DomainBeaconAttester, savedState.GenesisValidatorsRoot())
+	require.NoError(t, err)
+	attRoot, err := signing.ComputeSigningRoot(validAtt.GetData(), domain)
+	require.NoError(t, err)
+	for i := 0; ; i++ {
+		if validAtt.GetAggregationBits().BitAt(uint64(i)) {
+			validAtt.SetSignature(keys[com[i]].Sign(attRoot[:]).Marshal())
+			break
+		}
+	}
+	validBuf := new(bytes.Buffer)
+	_, encErr = p.Encoding().EncodeGossip(validBuf, validAtt)
+	require.NoError(t, encErr)
+	res, err := s.validateCommitteeIndexBeaconAttestation(ctx, "", &pubsub.Message{
+		Message: &pubsubpb.Message{Data: validBuf.Bytes(), Topic: &validTopic},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pubsub.ValidationAccept, res)
+
+	// Advance clock to next epoch and flush completed epoch 0.
+	slot = params.BeaconConfig().SlotsPerEpoch
+	s.committeeAttGossipEpochStats.rotateOnly(clock)
+
+	entry, ok := hook.last()
+	require.True(t, ok, "expected epoch summary log line")
+
+	epochVal, ok := entry.Data["epoch"].(primitives.Epoch)
+	require.True(t, ok, "epoch field type")
+	require.Equal(t, primitives.Epoch(0), epochVal)
+
+	successVal, ok := entry.Data["successCount"].(uint64)
+	require.True(t, ok, "successCount field type")
+	require.Equal(t, uint64(1), successVal)
+
+	totalVal, ok := entry.Data["nonSuccessTotal"].(uint64)
+	require.True(t, ok, "nonSuccessTotal field type")
+	require.Equal(t, uint64(3), totalVal)
+
+	byReason, ok := entry.Data["nonSuccessByReason"].(map[string]uint64)
+	require.True(t, ok, "nonSuccessByReason field type")
+	require.Equal(t, uint64(1), byReason["ignore_initial_sync"])
+	require.Equal(t, uint64(1), byReason["reject_invalid_topic"])
+	require.Equal(t, uint64(1), byReason["ignore_slot_zero"])
+
+	t.Logf("epoch gossip validation summary (epoch=%v success=%v nonSuccessTotal=%v byReason=%v)",
+		entry.Data["epoch"], entry.Data["successCount"], entry.Data["nonSuccessTotal"], byReason)
 }

--- a/beacon-chain/sync/attestation_gossip_epoch_stats_test.go
+++ b/beacon-chain/sync/attestation_gossip_epoch_stats_test.go
@@ -1,0 +1,66 @@
+package sync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitteeAttGossipEpochStats_epochRolloverOnObserve(t *testing.T) {
+	genesis := time.Unix(1_700_000_000, 0)
+	var slot primitives.Slot
+	cl := startup.NewClock(genesis, [32]byte{}, startup.WithNower(func() time.Time {
+		tt, err := slots.StartTime(genesis, slot)
+		require.NoError(t, err)
+		return tt
+	}))
+
+	var st committeeAttGossipEpochStats
+	st.observe(cl, pubsub.ValidationAccept, "")
+
+	st.mu.Lock()
+	require.Equal(t, slots.ToEpoch(0), st.epoch)
+	require.Equal(t, uint64(1), st.success)
+	require.Empty(t, st.nonSuccess)
+	st.mu.Unlock()
+
+	slot = params.BeaconConfig().SlotsPerEpoch
+	st.observe(cl, pubsub.ValidationReject, "reject_test")
+
+	st.mu.Lock()
+	require.Equal(t, slots.ToEpoch(slot), st.epoch)
+	require.Equal(t, uint64(0), st.success)
+	require.Equal(t, uint64(1), st.nonSuccess["reject_test"])
+	st.mu.Unlock()
+}
+
+func TestCommitteeAttGossipEpochStats_rotateOnlyFlushesGap(t *testing.T) {
+	genesis := time.Unix(1_700_000_000, 0)
+	var slot primitives.Slot
+	cl := startup.NewClock(genesis, [32]byte{}, startup.WithNower(func() time.Time {
+		tt, err := slots.StartTime(genesis, slot)
+		require.NoError(t, err)
+		return tt
+	}))
+
+	var st committeeAttGossipEpochStats
+	st.observe(cl, pubsub.ValidationAccept, "")
+	st.mu.Lock()
+	require.Equal(t, primitives.Epoch(0), st.epoch)
+	st.mu.Unlock()
+
+	slot = 2 * params.BeaconConfig().SlotsPerEpoch
+	st.rotateOnly(cl)
+
+	st.mu.Lock()
+	require.Equal(t, slots.ToEpoch(slot), st.epoch)
+	require.Zero(t, st.success)
+	require.Empty(t, st.nonSuccess)
+	st.mu.Unlock()
+}

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -206,6 +206,7 @@ type Service struct {
 	pendingPayloadEnvelopes              map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope
 	pendingEnvelopeLock                  sync.RWMutex
 	selfBuildSigFailures                 int
+	committeeAttGossipEpochStats         committeeAttGossipEpochStats
 }
 
 // NewService initializes new regular sync service.
@@ -325,6 +326,12 @@ func (s *Service) Start() {
 
 	// Update sync metrics.
 	async.RunEvery(s.ctx, syncMetricsInterval, s.updateMetrics)
+
+	// Flush per-epoch committee attestation gossip validation stats when epochs roll over,
+	// including epochs with no attestations.
+	async.RunEvery(s.ctx, committeeAttGossipSlotDuration(), func() {
+		s.committeeAttGossipEpochStats.rotateOnly(s.cfg.clock)
+	})
 
 	// Prune data column cache periodically on finalization.
 	async.RunEvery(s.ctx, 30*time.Second, s.pruneDataColumnCache)

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -41,18 +41,34 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	ctx context.Context,
 	pid peer.ID,
 	msg *pubsub.Message,
-) (pubsub.ValidationResult, error) {
+) (result pubsub.ValidationResult, err error) {
 	start := time.Now()
+	skipEpochStats := false
+	var auditReason string
 	defer func() {
 		attestationVerificationGossipSummary.Observe(float64(time.Since(start).Milliseconds()))
+		if skipEpochStats {
+			return
+		}
+		var reasonKey string
+		if result == pubsub.ValidationAccept {
+			reasonKey = ""
+		} else if auditReason != "" {
+			reasonKey = auditReason
+		} else {
+			reasonKey = classifyCommitteeAttGossipNonSuccess(result, err)
+		}
+		s.committeeAttGossipEpochStats.observe(s.cfg.clock, result, reasonKey)
 	}()
 
 	if pid == s.cfg.p2p.PeerID() {
+		skipEpochStats = true
 		return pubsub.ValidationAccept, nil
 	}
 	// Attestation processing requires the target block to be present in the database, so we'll skip
 	// validating or processing attestations until fully synced.
 	if s.cfg.initialSync.Syncing() {
+		auditReason = "ignore_initial_sync"
 		return pubsub.ValidationIgnore, nil
 	}
 
@@ -81,6 +97,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 
 	// Do not process slot 0 attestations.
 	if data.Slot == 0 {
+		auditReason = "ignore_slot_zero"
 		return pubsub.ValidationIgnore, nil
 	}
 
@@ -88,9 +105,11 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	// processing tolerance.
 	if err := helpers.ValidateAttestationTime(data.Slot, s.cfg.clock.GenesisTime(), earlyAttestationProcessingTolerance); err != nil {
 		tracing.AnnotateError(span, err)
+		auditReason = "ignore_attestation_propagation_time"
 		return pubsub.ValidationIgnore, err
 	}
 	if err := helpers.ValidateSlotTargetEpoch(data); err != nil {
+		auditReason = "reject_slot_target_epoch_mismatch"
 		return pubsub.ValidationReject, wrapAttestationError(err, att)
 	}
 
@@ -100,6 +119,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	attKey, err := generateUnaggregatedAttCacheKey(att)
 	if err != nil {
 		log.WithError(err).Error("Could not generate cache key for attestation tracking")
+		auditReason = "ignore_cache_key_error"
 		return pubsub.ValidationIgnore, nil
 	}
 
@@ -107,6 +127,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		// Verify this the first attestation received for the participating validator for the slot. This verification is here to return early if we've already seen this attestation.
 		// This verification is carried again later after all other validations to avoid TOCTOU issues.
 		if s.hasSeenUnaggregatedAtt(attKey) {
+			auditReason = "ignore_duplicate_early_check"
 			return pubsub.ValidationIgnore, nil
 		}
 		// Reject an attestation if it references an invalid block.
@@ -114,6 +135,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 			s.hasBadBlock(bytesutil.ToBytes32(data.Target.Root)) ||
 			s.hasBadBlock(bytesutil.ToBytes32(data.Source.Root)) {
 			attBadBlockCount.Inc()
+			auditReason = "reject_bad_block_root"
 			return pubsub.ValidationReject, wrapAttestationError(errors.New("attestation data references bad block root"), att)
 		}
 	}
@@ -124,38 +146,53 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 		// Block not yet available - save attestation to pending queue for later processing
 		// when the block arrives. Return ValidationIgnore so gossip doesn't potentially penalize the peer.
 		s.savePendingAtt(att)
+		auditReason = "ignore_pending_unknown_block"
 		return pubsub.ValidationIgnore, nil
 	}
 	// Block exists - verify it's in forkchoice (i.e., it's a descendant of the finalized checkpoint)
 	if !s.cfg.chain.InForkchoice(blockRoot) {
 		tracing.AnnotateError(span, blockchain.ErrNotDescendantOfFinalized)
+		auditReason = "ignore_not_descendant_of_finalized"
 		return pubsub.ValidationIgnore, blockchain.ErrNotDescendantOfFinalized
 	}
 	if err = s.cfg.chain.VerifyLmdFfgConsistency(ctx, att); err != nil {
 		tracing.AnnotateError(span, err)
 		attBadLmdConsistencyCount.Inc()
+		auditReason = "reject_lmd_ffg_inconsistent"
 		return pubsub.ValidationReject, wrapAttestationError(err, att)
 	}
 
 	preState, err := s.cfg.chain.AttestationTargetState(ctx, data.Target)
 	if err != nil {
 		tracing.AnnotateError(span, err)
+		auditReason = "ignore_attestation_target_state"
 		return pubsub.ValidationIgnore, err
 	}
 
 	validationRes, err := s.validateUnaggregatedAttTopic(ctx, att, preState, *msg.Topic)
 	if validationRes != pubsub.ValidationAccept {
+		if validationRes == pubsub.ValidationReject {
+			auditReason = "reject_subnet_or_committee_topic"
+		} else {
+			auditReason = "ignore_subnet_or_committee_topic"
+		}
 		return validationRes, wrapAttestationError(err, att)
 	}
 
 	committee, err := helpers.BeaconCommitteeFromState(ctx, preState, data.Slot, committeeIndex)
 	if err != nil {
 		tracing.AnnotateError(span, err)
+		auditReason = "ignore_beacon_committee_lookup"
 		return pubsub.ValidationIgnore, err
 	}
 
 	validationRes, err = validateAttesterData(ctx, att, committee)
 	if validationRes != pubsub.ValidationAccept {
+		if validationRes == pubsub.ValidationReject {
+			auditReason = "reject_attester_data"
+		} else {
+			auditReason = "ignore_attester_data"
+		}
 		return validationRes, wrapAttestationError(err, att)
 	}
 
@@ -169,6 +206,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 	if att.Version() >= version.Electra {
 		singleAtt, ok := att.(*eth.SingleAttestation)
 		if !ok {
+			auditReason = "ignore_wrong_electra_attestation_type"
 			return pubsub.ValidationIgnore, fmt.Errorf(
 				"attestation has wrong type (expected %T, got %T)",
 				&eth.SingleAttestation{}, att,
@@ -191,6 +229,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 
 	validationRes, err = s.validateUnaggregatedAttWithState(ctx, attForValidation, preState)
 	if validationRes != pubsub.ValidationAccept {
+		auditReason = "reject_attestation_signature"
 		return validationRes, wrapAttestationError(err, att)
 	}
 
@@ -231,6 +270,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(
 
 	if first := s.setSeenUnaggregatedAtt(attKey); !first {
 		// Another concurrent validation processed the same attestation meanwhile
+		auditReason = "ignore_duplicate_race"
 		return pubsub.ValidationIgnore, nil
 	}
 


### PR DESCRIPTION
Prompt history:

# Prompt digest: attestation verification & gossip epoch stats

This document summarizes the prompts that drove the work on committee-index attestation gossip validation, per-epoch success/failure stats, explicit audit reasons, and the related integration test.

---

## 1. Discovery (where things live)

| Prompt (paraphrased) | Outcome |
|----------------------|---------|
| Where do we verify attestations? | Mapped core paths: `beacon-chain/core/blocks/attestation.go`, `AttestationSignatureBatch`, gossip validators (`validate_beacon_attestation`, aggregates), block transition, `OnAttestation`, slashing/RPC call sites, etc. |
| What is the difference between `VerifyAttestationNoVerifySignature` and `validateCommitteeIndexBeaconAttestation`? Is the former called from the latter’s code path? | Clarified spec/state checks (no sig) vs libp2p gossip validator; confirmed **no** direct use of `VerifyAttestationNoVerifySignature` on the gossip path. |
| If `validateCommitteeIndexBeaconAttestation` is for P2P, where do attestations for `VerifyAttestationNoVerifySignature` come from? | Clarified sources: block bodies, proposer pool / RPC filtering, tests — not the attestation subnet gossip validator. |
| Is `validateCommitteeIndexBeaconAttestation` used for P2P? | Confirmed registration in `subscriber.go` on `AttestationSubnetTopicFormat`. |

---

## 2. Feature request (epoch-scoped stats under concurrency)

| Prompt (paraphrased) | Outcome |
|----------------------|---------|
| P2P has concurrency — track successful counts and unsuccessful counts with reasons per epoch; when the epoch finishes, log the output. | Added `committeeAttGossipEpochStats` (`attestation_gossip_epoch_stats.go`), `observe` / `rotateOnly`, per-slot ticker in `Service.Start`, defer recording in `validateCommitteeIndexBeaconAttestation`, and `classifyCommitteeAttGossipNonSuccess` plus explicit `auditReason` where validation returns `Ignore` with `nil` error. |

---

## 3. Hardening (explicit reasons)

| Prompt (paraphrased) | Outcome |
|----------------------|---------|
| Add missing `auditReason` for failed verification on specific ranges (`ValidateAttestationTime`, bad block root, fork choice / LMD–FFG / target state / subnet-topic / committee / attester data / Electra type / signature). | Set explicit `auditReason` (or reject vs ignore split) on those returns so epoch logs do not depend only on parsing wrapped errors. |

**Manually reverted:
Setting explicit auditReason (only ValidationIgnore with err == nil, where classification can’t infer a reason). Other reasons are digested by `classifyCommitteeAttGossipNonSuccess`.**

---

## 4. Build & integration test

| Prompt (paraphrased) | Outcome |
|----------------------|---------|
| Build this project. | Compile / test verification in the environment. |
| Add a test that outputs a summary of collected data within an epoch; put it in `attestation_gossip_epoch_stats_test.go`. | `TestValidateCommitteeIndexBeaconAttestation_epochGossipSummary` with a logrus hook, mixed outcomes, `rotateOnly` to flush epoch 0. |
| Run that test and fix issues. | Fixed `EncodeGossip` `(int, error)` handling, 96-byte attestation signature for SSZ decode, real fork digest via `currentForkDigest()` in the topic, and `err` assignment vs `:=` after `currentForkDigest()`. |
| Add one successful attestation to the epoch in that test. | Full valid path (block, state, BLS sign like `validate_beacon_attestation_test`); **genesis = `time.Now().Add(-slotDuration)`** because `ValidateAttestationTime` uses wall clock, not `cfg.clock`; assertions updated to `successCount == 1`. |

---

## 5. Meta

| Prompt (paraphrased) | Outcome |
|----------------------|---------|
| Digest and summarize the prompts (in Markdown). | Prior in-chat summary; this file is the durable copy. |

---





The test TestValidateCommitteeIndexBeaconAttestation_epochGossipSummary mirrors TestService_validateCommitteeIndexBeaconAttestation: save a slot-1 block + state, set chainSvc.State / FinalizedCheckPoint, sign an attestation for committee 0 with the correct subnet topic (beacon_attestation_1), and assert ValidationAccept.


```
/Users/inomurko/.asdf/shims/go test -test.fullpath=true -timeout 3000s -run ^TestValidateCommitteeIndexBeaconAttestation_epochGossipSummary$ github.com/OffchainLabs/prysm/v7/beacon-chain/sync -v -count=1
=== RUN   TestValidateCommitteeIndexBeaconAttestation_epochGossipSummary
    /Users/inomurko/opt/prysm/beacon-chain/sync/attestation_gossip_epoch_stats_test.go:288: 

epoch gossip validation summary (
epoch=0 
success=1 

nonSuccessTotal=3 
byReason=map[ignore_initial_sync:1 ignore_slot_zero:1 reject_invalid_topic:1])


--- PASS: TestValidateCommitteeIndexBeaconAttestation_epochGossipSummary (0.12s)
PASS
ok  	github.com/OffchainLabs/prysm/v7/beacon-chain/sync	0.926s
```