### PR TITLE
Hdiff: save hot states at tree boundaries

### DIFF
--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
@@ -51,6 +52,18 @@ func (s *State) ForceCheckpoint(ctx context.Context, blockRoot []byte) error {
 func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, st state.BeaconState) error {
 	ctx, span := trace.StartSpan(ctx, "stateGen.saveStateByRoot")
 	defer span.End()
+
+	// When state-diff is enabled, persist states that land on diff-tree
+	// boundaries unconditionally. The DB's SaveState dispatches to
+	// saveStateByDiff which no-ops for non-boundary slots, so this is
+	// safe to call on every slot. This bounds restart replay to the
+	// finest diff-tree granularity (~32 slots) instead of the entire
+	// finalized-to-head gap.
+	if features.Get().EnableStateDiff {
+		if err := s.beaconDB.SaveState(ctx, st, blockRoot); err != nil {
+			return err
+		}
+	}
 
 	// Duration can't be 0 to prevent panic for division.
 	duration := uint64(max(float64(s.saveHotStateDB.duration), 1))

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -3,8 +3,11 @@ package stategen
 import (
 	"testing"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/kv"
 	testDB "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	doublylinkedtree "github.com/OffchainLabs/prysm/v7/beacon-chain/forkchoice/doubly-linked-tree"
+	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
+	"github.com/OffchainLabs/prysm/v7/config/features"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -229,4 +232,63 @@ func TestEnableSaveHotStateToDB_AlreadyDisabled(t *testing.T) {
 	require.NoError(t, service.DisableSaveHotStateToDB(ctx))
 	require.LogsDoNotContain(t, hook, "Exiting mode to save hot states in DB")
 	require.Equal(t, false, service.saveHotStateDB.enabled)
+}
+
+// TestSaveState_StateDiff_SavesAtDiffTreeBoundary verifies that when
+// --enable-state-diff is active, saveStateByRoot persists hot states at
+// diff-tree boundary slots to the DB even when saveHotStateDB is disabled.
+// This caps the worst-case replay on restart to the finest diff-tree
+// granularity (2^5 = 32 slots by default) instead of the entire
+// finalized-to-head gap.
+func TestSaveState_StateDiff_SavesAtDiffTreeBoundary(t *testing.T) {
+	ctx := t.Context()
+	// Use small exponents [6, 5] => level 0 every 64 slots, level 1 every 32 slots.
+	globalFlags := flags.GlobalFlags{StateDiffExponents: []int{6, 5}}
+	flags.Init(&globalFlags)
+
+	beaconDB := testDB.SetupDB(t)
+	require.NoError(t, beaconDB.(*kv.Store).InitStateDiffCacheForTesting(t, 0))
+	resetCfg := features.InitWithReset(&features.Flags{EnableStateDiff: true})
+	defer resetCfg()
+
+	service := New(beaconDB, doublylinkedtree.New())
+	// Explicitly verify saveHotStateDB is NOT enabled — this is the normal
+	// initial-sync condition. The point is that diff-tree saves should happen
+	// regardless.
+	require.Equal(t, false, service.saveHotStateDB.enabled)
+
+	beaconState, _ := util.DeterministicGenesisState(t, 32)
+	// Slot 64 lands on a level-0 boundary (2^6 = 64). It should be saved.
+	require.NoError(t, beaconState.SetSlot(64))
+	r := [32]byte{'D'}
+	require.NoError(t, service.saveStateByRoot(ctx, r, beaconState))
+
+	assert.Equal(t, true, beaconDB.HasState(ctx, r),
+		"State at diff-tree boundary slot should be persisted to DB when state-diff is enabled")
+}
+
+// TestSaveState_StateDiff_SkipsNonBoundary verifies that when
+// --enable-state-diff is active, saveStateByRoot does NOT persist states
+// at slots that are not on any diff-tree boundary.
+func TestSaveState_StateDiff_SkipsNonBoundary(t *testing.T) {
+	ctx := t.Context()
+	globalFlags := flags.GlobalFlags{StateDiffExponents: []int{6, 5}}
+	flags.Init(&globalFlags)
+
+	beaconDB := testDB.SetupDB(t)
+	require.NoError(t, beaconDB.(*kv.Store).InitStateDiffCacheForTesting(t, 0))
+	resetCfg := features.InitWithReset(&features.Flags{EnableStateDiff: true})
+	defer resetCfg()
+
+	service := New(beaconDB, doublylinkedtree.New())
+	require.Equal(t, false, service.saveHotStateDB.enabled)
+
+	beaconState, _ := util.DeterministicGenesisState(t, 32)
+	// Slot 50 is NOT on any diff-tree boundary (not divisible by 32 or 64).
+	require.NoError(t, beaconState.SetSlot(50))
+	r := [32]byte{'E'}
+	require.NoError(t, service.saveStateByRoot(ctx, r, beaconState))
+
+	assert.Equal(t, false, beaconDB.HasState(ctx, r),
+		"State at non-boundary slot should NOT be persisted to DB")
 }

--- a/changelog/pvl-hdiff-save-hot-states.md
+++ b/changelog/pvl-hdiff-save-hot-states.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Hdiff now saves hot state diffs on every boundary rather than waiting for finality.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When performing a long initial sync, I found that states were not being progressively saved. If the client was improperly shut down, then it would be replaying many states on restart. 

**Which issues(s) does this PR fix?**

**Other notes for review**

Testing:
- Start initial sync from genesis with hdiff enabled
- Do an improper shutdown (restart your computer, kill -9, etc)
- Restart with debug logs and see "Starting stategen" service completes in a timely manner
  - A failure would be logs indicating hundreds or thousands of states being replayed. However long your node was on during step 1.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
