### PR TITLE
Fix empty blob KZG commitments in self-build execution payload bids

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid.go
@@ -120,6 +120,6 @@ func (vs *Server) createSelfBuildExecutionPayloadBid(
 		Slot:               block.Slot(),
 		Value:              0,
 		ExecutionPayment:   0,
-		BlobKzgCommitments: [][]byte{}, // TODO: handle DA in gloas
+		BlobKzgCommitments: local.BlobsBundler.GetKzgCommitments(),
 	}, nil
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bid_test.go
@@ -48,7 +48,7 @@ func TestSetSelfBuildExecutionPayloadBid(t *testing.T) {
 	local := &consensusblocks.GetPayloadResponse{
 		ExecutionData:     ed,
 		Bid:               bidValue,
-		BlobsBundler:      nil,
+		BlobsBundler:      &enginev1.BlobsBundle{},
 		ExecutionRequests: &enginev1.ExecutionRequests{},
 	}
 
@@ -75,6 +75,64 @@ func TestSetSelfBuildExecutionPayloadBid(t *testing.T) {
 	require.DeepEqual(t, parentRoot[:], bid.ParentBlockRoot)
 	require.Equal(t, primitives.Gwei(0), bid.Value)
 	require.Equal(t, primitives.Gwei(0), bid.ExecutionPayment)
+}
+
+func TestSetSelfBuildExecutionPayloadBid_BlobCommitments(t *testing.T) {
+	parentRoot := [32]byte{1, 2, 3}
+	slot := primitives.Slot(100)
+
+	sBlk, err := consensusblocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockGloas{
+		Block: &ethpb.BeaconBlockGloas{
+			Slot:       slot,
+			ParentRoot: parentRoot[:],
+			Body:       &ethpb.BeaconBlockBodyGloas{},
+		},
+	})
+	require.NoError(t, err)
+
+	payload := &enginev1.ExecutionPayloadDeneb{
+		ParentHash:    make([]byte, 32),
+		FeeRecipient:  make([]byte, 20),
+		StateRoot:     make([]byte, 32),
+		ReceiptsRoot:  make([]byte, 32),
+		LogsBloom:     make([]byte, 256),
+		PrevRandao:    make([]byte, 32),
+		BaseFeePerGas: make([]byte, 32),
+		BlockHash:     make([]byte, 32),
+		ExtraData:     make([]byte, 0),
+	}
+	ed, err := consensusblocks.WrappedExecutionPayloadDeneb(payload)
+	require.NoError(t, err)
+
+	// Create blob commitments matching what the EL would return.
+	commitments := [][]byte{
+		make([]byte, 48),
+		make([]byte, 48),
+		make([]byte, 48),
+	}
+	for i := range commitments {
+		commitments[i][0] = byte(i + 1)
+	}
+
+	local := &consensusblocks.GetPayloadResponse{
+		ExecutionData: ed,
+		BlobsBundler: &enginev1.BlobsBundle{
+			KzgCommitments: commitments,
+		},
+		ExecutionRequests: &enginev1.ExecutionRequests{},
+	}
+
+	vs := &Server{}
+	_, err = vs.setExecutionPayloadBid(t.Context(), sBlk, local, true)
+	require.NoError(t, err)
+
+	signedBid, err := sBlk.Block().Body().SignedExecutionPayloadBid()
+	require.NoError(t, err)
+	require.NotNil(t, signedBid.Message)
+
+	// Verify blob KZG commitments are set on the bid (not empty).
+	require.Equal(t, 3, len(signedBid.Message.BlobKzgCommitments))
+	require.DeepEqual(t, commitments, signedBid.Message.BlobKzgCommitments)
 }
 
 func TestSetSelfBuildExecutionPayloadBid_NilPayload(t *testing.T) {
@@ -127,6 +185,7 @@ func TestSetExecutionPayloadBid_PrefersP2PBid(t *testing.T) {
 	local := &consensusblocks.GetPayloadResponse{
 		ExecutionData:     ed,
 		Bid:               big.NewInt(0),
+		BlobsBundler:      &enginev1.BlobsBundle{},
 		ExecutionRequests: &enginev1.ExecutionRequests{},
 	}
 
@@ -199,6 +258,7 @@ func TestSetExecutionPayloadBid_PrefersLocalWhenHigherValue(t *testing.T) {
 	local := &consensusblocks.GetPayloadResponse{
 		ExecutionData:     ed,
 		Bid:               big.NewInt(2000_000_000_000),
+		BlobsBundler:      &enginev1.BlobsBundle{},
 		ExecutionRequests: &enginev1.ExecutionRequests{},
 	}
 
@@ -270,6 +330,7 @@ func TestSetExecutionPayloadBid_SelfBuildOnlyIgnoresCache(t *testing.T) {
 	local := &consensusblocks.GetPayloadResponse{
 		ExecutionData:     ed,
 		Bid:               big.NewInt(0),
+		BlobsBundler:      &enginev1.BlobsBundle{},
 		ExecutionRequests: &enginev1.ExecutionRequests{},
 	}
 
@@ -340,6 +401,7 @@ func TestSetExecutionPayloadBid_FallsBackToSelfBuildWhenNoCachedBid(t *testing.T
 	local := &consensusblocks.GetPayloadResponse{
 		ExecutionData:     ed,
 		Bid:               big.NewInt(0),
+		BlobsBundler:      &enginev1.BlobsBundle{},
 		ExecutionRequests: &enginev1.ExecutionRequests{},
 	}
 

--- a/changelog/tt_fix-self-build-blob-commitments.md
+++ b/changelog/tt_fix-self-build-blob-commitments.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Set blob KZG commitments from the EL blobs bundle in self-build execution payload bids instead of hardcoding empty commitments.


### PR DESCRIPTION
Fix self-build execution payload bids sending empty `BlobKzgCommitments` instead of the actual commitments from the EL's blobs bundle