### PR TITLE
fix: add missing ePBS values to /eth/v1/config/spec

### DIFF
--- a/beacon-chain/rpc/eth/config/BUILD.bazel
+++ b/beacon-chain/rpc/eth/config/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//api/server/structs:go_default_library",
+        "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//testing/assert:go_default_library",

--- a/beacon-chain/rpc/eth/config/handlers.go
+++ b/beacon-chain/rpc/eth/config/handlers.go
@@ -191,6 +191,11 @@ func prepareConfigSpec() (map[string]any, error) {
 	data["KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH"] = convertValueForJSON(reflect.ValueOf(uint64(4)), "KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH")
 	// UPDATE_TIMEOUT is derived from SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD
 	data["UPDATE_TIMEOUT"] = convertValueForJSON(reflect.ValueOf(uint64(config.SlotsPerEpoch)*uint64(config.EpochsPerSyncCommitteePeriod)), "UPDATE_TIMEOUT")
+	// Add Gloas config values from fieldparams required by the /eth/v1/config/spec API.
+	data["PTC_SIZE"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.PTCSize)), "PTC_SIZE")
+	data["MAX_PAYLOAD_ATTESTATIONS"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.MaxPayloadAttestations)), "MAX_PAYLOAD_ATTESTATIONS")
+	data["BUILDER_REGISTRY_LIMIT"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.BuilderRegistryLimit)), "BUILDER_REGISTRY_LIMIT")
+	data["BUILDER_PENDING_WITHDRAWALS_LIMIT"] = convertValueForJSON(reflect.ValueOf(uint64(fieldparams.BuilderPendingWithdrawalsLimit)), "BUILDER_PENDING_WITHDRAWALS_LIMIT")
 
 	return data, nil
 }

--- a/beacon-chain/rpc/eth/config/handlers_test.go
+++ b/beacon-chain/rpc/eth/config/handlers_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -229,7 +231,7 @@ func TestGetSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
 	data, ok := resp.Data.(map[string]any)
 	require.Equal(t, true, ok)
-	assert.Equal(t, 198, len(data))
+	assert.Equal(t, 202, len(data))
 	for k, v := range data {
 		t.Run(k, func(t *testing.T) {
 			switch k {
@@ -651,6 +653,14 @@ func TestGetSpec(t *testing.T) {
 				assert.Equal(t, "128", v) // From fieldparams.NumberOfColumns
 			case "UPDATE_TIMEOUT":
 				assert.Equal(t, "1782", v) // SlotsPerEpoch (27) * EpochsPerSyncCommitteePeriod (66)
+			case "PTC_SIZE":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.PTCSize), 10), v)
+			case "MAX_PAYLOAD_ATTESTATIONS":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.MaxPayloadAttestations), 10), v)
+			case "BUILDER_REGISTRY_LIMIT":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.BuilderRegistryLimit), 10), v)
+			case "BUILDER_PENDING_WITHDRAWALS_LIMIT":
+				assert.Equal(t, strconv.FormatUint(uint64(fieldparams.BuilderPendingWithdrawalsLimit), 10), v)
 			default:
 				t.Errorf("Incorrect key: %s", k)
 			}

--- a/changelog/barnabasbusa_fix-epbs-config-spec.md
+++ b/changelog/barnabasbusa_fix-epbs-config-spec.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added missing ePBS values to `/eth/v1/config/spec`: `PTC_SIZE`, `MAX_PAYLOAD_ATTESTATIONS`, `BUILDER_REGISTRY_LIMIT`, and `BUILDER_PENDING_WITHDRAWALS_LIMIT`.

--- a/config/fieldparams/mainnet.go
+++ b/config/fieldparams/mainnet.go
@@ -52,5 +52,6 @@ const (
 	CellsPerBlob    = 64  // CellsPerBlob refers to the number of cells in a (non-extended) blob.
 
 	// Introduced in Gloas network upgrade.
-	PTCSize = 512 // PTCSize is the size of the payload timeliness committee.
+	PTCSize                = 512 // PTCSize is the size of the payload timeliness committee.
+	MaxPayloadAttestations = 4   // MaxPayloadAttestations is the maximum number of payload attestations in a block.
 )

--- a/config/fieldparams/minimal.go
+++ b/config/fieldparams/minimal.go
@@ -52,5 +52,6 @@ const (
 	CellsPerBlob    = 64  // CellsPerBlob refers to the number of cells in a (non-extended) blob.
 
 	// Introduced in Gloas network upgrade.
-	PTCSize = 2 // PTCSize is the size of the payload timeliness committee.
+	PTCSize                = 2 // PTCSize is the size of the payload timeliness committee.
+	MaxPayloadAttestations = 4 // MaxPayloadAttestations is the maximum number of payload attestations in a block.
 )


### PR DESCRIPTION
## Summary

- Add `PTC_SIZE`, `MAX_PAYLOAD_ATTESTATIONS`, `BUILDER_REGISTRY_LIMIT`, and `BUILDER_PENDING_WITHDRAWALS_LIMIT` as fieldparams-derived constants exposed via the config spec endpoint.
- Add `MaxPayloadAttestations` constant to fieldparams (mainnet and minimal configs).
- Update test expectations to include the new fields.

## Test plan

- [x] `TestGetSpec` passes with all 4 new values verified
- [ ] Verify `/eth/v1/config/spec` returns the new values on a running node

🤖 Generated with [Claude Code](https://claude.com/claude-code)