### PR TITLE
Gloas/forkchoice setup

### DIFF
--- a/beacon-chain/blockchain/setup_forkchoice.go
+++ b/beacon-chain/blockchain/setup_forkchoice.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
@@ -77,8 +78,12 @@ func (s *Service) setupForkchoiceTree(st state.BeaconState) error {
 		log.WithError(err).Error("Could not build forkchoice chain, starting with finalized block as head")
 		return nil
 	}
+	resolveChainPayloadStatus(chain)
 	s.cfg.ForkChoiceStore.Lock()
 	defer s.cfg.ForkChoiceStore.Unlock()
+	if err := s.markFinalizedRootFull(chain, fRoot); err != nil {
+		log.WithError(err).Error("Could not mark finalized root as full in forkchoice")
+	}
 	return s.cfg.ForkChoiceStore.InsertChain(s.ctx, chain)
 }
 
@@ -142,6 +147,68 @@ func (s *Service) setupForkchoiceRoot(st state.BeaconState) error {
 			}
 		}
 	}
+	return nil
+}
+
+// resolveChainPayloadStatus determines which blocks in the chain had their
+// execution payloads delivered by checking if consecutive blocks' bids indicate
+// payload delivery. For each pair of blocks (chain[i], chain[i+1]), if the next
+// block's bid parentBlockHash equals the current block's bid blockHash, the
+// current block's payload was delivered.
+func resolveChainPayloadStatus(chain []*forkchoicetypes.BlockAndCheckpoints) {
+	for i := 0; i < len(chain)-1; i++ {
+		curr := chain[i].Block.Block()
+		next := chain[i+1].Block.Block()
+		if curr.Version() < version.Gloas || next.Version() < version.Gloas {
+			continue
+		}
+		currBid, err := curr.Body().SignedExecutionPayloadBid()
+		if err != nil || currBid == nil || currBid.Message == nil {
+			continue
+		}
+		nextBid, err := next.Body().SignedExecutionPayloadBid()
+		if err != nil || nextBid == nil || nextBid.Message == nil {
+			continue
+		}
+		if bytes.Equal(nextBid.Message.ParentBlockHash, currBid.Message.BlockHash) {
+			chain[i].HasPayload = true
+		}
+	}
+}
+
+// markFinalizedRootFull checks whether the finalized root block's execution
+// payload was delivered by inspecting the first block in the chain. If the first
+// block's bid parentBlockHash equals the finalized block's bid blockHash, the
+// finalized block's payload was delivered and a full node must be created in
+// forkchoice. The caller must hold the forkchoice lock.
+func (s *Service) markFinalizedRootFull(chain []*forkchoicetypes.BlockAndCheckpoints, fRoot [32]byte) error {
+	if len(chain) == 0 {
+		return nil
+	}
+	firstBlock := chain[0].Block.Block()
+	if firstBlock.Version() < version.Gloas {
+		return nil
+	}
+	firstBid, err := firstBlock.Body().SignedExecutionPayloadBid()
+	if err != nil || firstBid == nil || firstBid.Message == nil {
+		return nil
+	}
+	fBlock, err := s.cfg.BeaconDB.Block(s.ctx, fRoot)
+	if err != nil {
+		return errors.Wrap(err, "could not get finalized block")
+	}
+	if fBlock.Block().Version() < version.Gloas {
+		return nil
+	}
+	fBid, err := fBlock.Block().Body().SignedExecutionPayloadBid()
+	if err != nil || fBid == nil || fBid.Message == nil {
+		return nil
+	}
+	if !bytes.Equal(firstBid.Message.ParentBlockHash, fBid.Message.BlockHash) {
+		return nil
+	}
+	// The finalized block's payload was delivered. Create the full node.
+	s.cfg.ForkChoiceStore.MarkFullNode(fRoot)
 	return nil
 }
 

--- a/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/gloas.go
@@ -372,6 +372,28 @@ func (s *Store) nodeTreeDump(ctx context.Context, n *Node, nodes []*forkchoice2.
 	return nodes, nil
 }
 
+// MarkFullNode creates a full payload node for an existing empty node at the
+// given beacon block root. This is used during forkchoice tree reconstruction on
+// startup to mark blocks whose execution payload was delivered. The caller must
+// hold the forkchoice write lock.
+func (f *ForkChoice) MarkFullNode(root [32]byte) {
+	s := f.store
+	en := s.emptyNodeByRoot[root]
+	if en == nil {
+		return
+	}
+	if _, ok := s.fullNodeByRoot[root]; ok {
+		return
+	}
+	s.fullNodeByRoot[root] = &PayloadNode{
+		node:       en.node,
+		optimistic: true,
+		timestamp:  time.Now(),
+		full:       true,
+		children:   make([]*Node, 0),
+	}
+}
+
 // InsertPayload inserts a full node into forkchoice after the Gloas fork.
 func (f *ForkChoice) InsertPayload(pe interfaces.ROExecutionPayloadEnvelope) error {
 	if pe.IsNil() {

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -112,4 +112,5 @@ type Setter interface {
 	SetBalancesByRooter(BalancesByRooter)
 	InsertSlashedIndex(context.Context, primitives.ValidatorIndex)
 	SetPTCVote(root [32]byte, ptcIdx uint64, payloadPresent, blobDataAvailable bool)
+	MarkFullNode(root [32]byte)
 }

--- a/changelog/potuz_fix_forkchoice_setup.md
+++ b/changelog/potuz_fix_forkchoice_setup.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed forkchoice initialization on Gloas.


### PR DESCRIPTION
Fix forkchoice tree setup missing full payload nodes on restart

During forkchoice tree reconstruction on node restart,
buildForkchoiceChain never set HasPayload on chain entries, so
InsertChain never created full payload nodes. When a child block's bid
references the parent's delivered payload hash, resolveParentPayloadStatus
looks for a full parent node that doesn't exist, causing "invalid parent
root" errors.

Add resolveChainPayloadStatus to determine which blocks had payloads
delivered by comparing consecutive bids. For the finalized root (tree
root), check the first chain block's bid to determine if a full node is
needed, and create it via the new MarkFullNode forkchoice method before
inserting the chain.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>