### PR TITLE
fix: advance state when needed to get correct proposer lookahead to validate proposer preferences

### DIFF
--- a/beacon-chain/sync/validate_signed_proposer_preferences.go
+++ b/beacon-chain/sync/validate_signed_proposer_preferences.go
@@ -3,9 +3,13 @@ package sync
 import (
 	"context"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -40,18 +44,28 @@ func (s *Service) validateSignedProposerPreferencesGossip(ctx context.Context, p
 		return pubsub.ValidationReject, errNilMessage
 	}
 
-	st, err := s.cfg.chain.HeadStateReadOnly(ctx)
+	headStateRO, err := s.cfg.chain.HeadStateReadOnly(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 
 	v := s.newSignedProposerPreferencesVerifier(signedPreferences, verification.SignedProposerPreferencesGossipRequirements)
 	// [IGNORE] preferences.proposal_slot is in the next epoch.
-	if err := v.VerifyNextEpoch(st); err != nil {
+	if err := v.VerifyNextEpoch(headStateRO); err != nil {
 		return pubsub.ValidationIgnore, err
 	}
+
+	// Ensure the state's lookahead covers the proposal slot's epoch.
+	// The lookahead spans [stateEpoch, stateEpoch+1]. If the proposal
+	// epoch is more than one epoch ahead of the state, advance the state
+	// so the lookahead is current.
+	st, err := s.proposerPreferencesState(ctx, headStateRO, signedPreferences.Message.ProposalSlot)
+	if err != nil {
+		return pubsub.ValidationIgnore, err
+	}
+
 	// [REJECT] preferences.validator_index is present at the correct slot in the
-	// next epoch's portion of state.proposer_lookahead.
+	// proposer lookahead for the proposal slot.
 	if err := v.VerifyValidProposalSlot(st); err != nil {
 		return pubsub.ValidationReject, err
 	}
@@ -71,6 +85,40 @@ func (s *Service) validateSignedProposerPreferencesGossip(ctx context.Context, p
 	s.proposerPreferencesCache.Add(slot, signedPreferences.Message.FeeRecipient, signedPreferences.Message.GasLimit)
 	msg.ValidatorData = signedPreferences
 	return pubsub.ValidationAccept, nil
+}
+
+// proposerPreferencesState returns a state whose lookahead covers the proposal
+// slot. If the head state's epoch is the same as or one less than the proposal
+// epoch, the head state is returned as-is. Otherwise the state is advanced to
+// the first slot of the epoch before the proposal epoch so the lookahead is
+// up to date.
+func (s *Service) proposerPreferencesState(ctx context.Context, headStateRO state.ReadOnlyBeaconState, proposalSlot primitives.Slot) (state.ReadOnlyBeaconState, error) {
+	stateEpoch := slots.ToEpoch(headStateRO.Slot())
+	proposalEpoch := slots.ToEpoch(proposalSlot)
+
+	// Lookahead covers [stateEpoch, stateEpoch+1], so if the proposal
+	// epoch falls within that range the head state is sufficient.
+	if proposalEpoch == stateEpoch || proposalEpoch == stateEpoch+1 {
+		return headStateRO, nil
+	}
+
+	// State is too far behind — advance it to the first slot of the epoch
+	// before the proposal epoch. After advancement the lookahead covers
+	// [proposalEpoch-1, proposalEpoch], so the proposal slot is accessible
+	// in the next-epoch portion.
+	targetSlot, err := slots.EpochStart(proposalEpoch - 1)
+	if err != nil {
+		return nil, err
+	}
+	headRoot, err := s.cfg.chain.HeadRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	headState, err := s.cfg.chain.HeadState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, targetSlot)
 }
 
 func (s *Service) signedProposerPreferencesSubscriber(_ context.Context, msg proto.Message) error {

--- a/beacon-chain/verification/signed_proposer_preferences.go
+++ b/beacon-chain/verification/signed_proposer_preferences.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
@@ -45,7 +46,14 @@ func (v *ProposerPreferencesVerifier) VerifyNextEpoch(st state.ReadOnlyBeaconSta
 	return nil
 }
 
-// VerifyValidProposalSlot verifies the validator matches the state's next-epoch proposer lookahead entry for the proposal slot.
+// VerifyValidProposalSlot verifies the validator matches the proposer
+// lookahead entry for the proposal slot. The lookahead covers two epochs
+// relative to the state: indices [0, SlotsPerEpoch) for the state's epoch
+// and [SlotsPerEpoch, 2*SlotsPerEpoch) for the next epoch.
+//
+// The caller must ensure that the state's epoch is either equal to or one
+// less than the proposal slot's epoch. If the state is further behind, it
+// should be advanced before calling this method.
 func (v *ProposerPreferencesVerifier) VerifyValidProposalSlot(st state.ReadOnlyBeaconState) (err error) {
 	defer v.record(RequireProposerPreferencesProposalSlotValid, &err)
 
@@ -55,7 +63,21 @@ func (v *ProposerPreferencesVerifier) VerifyValidProposalSlot(st state.ReadOnlyB
 		return errors.Wrap(err, "failed to get proposer lookahead")
 	}
 
-	slotIndex := params.BeaconConfig().SlotsPerEpoch + (msg.ProposalSlot % params.BeaconConfig().SlotsPerEpoch)
+	spe := params.BeaconConfig().SlotsPerEpoch
+	stateEpoch := slots.ToEpoch(st.Slot())
+	proposalEpoch := slots.ToEpoch(msg.ProposalSlot)
+
+	var slotIndex primitives.Slot
+	switch {
+	case proposalEpoch == stateEpoch:
+		slotIndex = msg.ProposalSlot % spe
+	case proposalEpoch == stateEpoch+1:
+		slotIndex = spe + (msg.ProposalSlot % spe)
+	default:
+		return fmt.Errorf("%w: proposal epoch %d out of range for state epoch %d",
+			ErrProposerPreferencesInvalidProposalSlot, proposalEpoch, stateEpoch)
+	}
+
 	if uint64(len(lookahead)) <= uint64(slotIndex) {
 		return fmt.Errorf("%w: proposer lookahead index %d out of bounds", ErrProposerPreferencesInvalidProposalSlot, slotIndex)
 	}

--- a/beacon-chain/verification/signed_proposer_preferences_test.go
+++ b/beacon-chain/verification/signed_proposer_preferences_test.go
@@ -29,14 +29,73 @@ func TestProposerPreferencesVerifier_VerifyNextEpoch(t *testing.T) {
 }
 
 func TestProposerPreferencesVerifier_VerifyValidProposalSlot(t *testing.T) {
-	st, _, signed := newSignedProposerPreferencesState(t, 31, 40, 3)
+	t.Run("proposal in next epoch", func(t *testing.T) {
+		// State at slot 31 (epoch 0 with SlotsPerEpoch=32), proposal at slot 40 (epoch 1).
+		// Proposal epoch == stateEpoch+1, so index into next-epoch portion.
+		st, _, signed := newSignedProposerPreferencesState(t, 31, 40, 3)
 
-	verifier := &ProposerPreferencesVerifier{results: newResults(RequireProposerPreferencesProposalSlotValid), p: signed}
-	require.NoError(t, verifier.VerifyValidProposalSlot(st))
+		verifier := &ProposerPreferencesVerifier{results: newResults(RequireProposerPreferencesProposalSlotValid), p: signed}
+		require.NoError(t, verifier.VerifyValidProposalSlot(st))
 
-	signed.Message.ValidatorIndex = 4
-	verifier = &ProposerPreferencesVerifier{results: newResults(RequireProposerPreferencesProposalSlotValid), p: signed}
-	require.ErrorIs(t, verifier.VerifyValidProposalSlot(st), ErrProposerPreferencesInvalidProposalSlot)
+		signed.Message.ValidatorIndex = 4
+		verifier = &ProposerPreferencesVerifier{results: newResults(RequireProposerPreferencesProposalSlotValid), p: signed}
+		require.ErrorIs(t, verifier.VerifyValidProposalSlot(st), ErrProposerPreferencesInvalidProposalSlot)
+	})
+
+	t.Run("proposal in same epoch", func(t *testing.T) {
+		// State at slot 35 (epoch 1), proposal at slot 40 (epoch 1).
+		// Proposal epoch == stateEpoch, so index into current-epoch portion.
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		validatorIndex := primitives.ValidatorIndex(7)
+		proposalSlot := primitives.Slot(40)
+		stateSlot := primitives.Slot(35)
+
+		st, keys := util.DeterministicGenesisStateFulu(t, 64)
+		require.NoError(t, st.SetSlot(stateSlot))
+		require.NoError(t, st.SetFork(&ethpb.Fork{
+			PreviousVersion: cfg.FuluForkVersion,
+			CurrentVersion:  cfg.GloasForkVersion,
+			Epoch:           0,
+		}))
+
+		spe := params.BeaconConfig().SlotsPerEpoch
+		lookaheadSize := int(uint64(params.BeaconConfig().MinSeedLookahead+1) * uint64(spe))
+		lookahead := make([]primitives.ValidatorIndex, lookaheadSize)
+		// Same epoch: index is proposalSlot % SlotsPerEpoch
+		lookahead[proposalSlot%spe] = validatorIndex
+		require.NoError(t, st.SetProposerLookahead(lookahead))
+
+		signed := &ethpb.SignedProposerPreferences{
+			Message: &ethpb.ProposerPreferences{
+				ProposalSlot:   proposalSlot,
+				ValidatorIndex: validatorIndex,
+				FeeRecipient:   bytes.Repeat([]byte{0x01}, 20),
+				GasLimit:       30_000_000,
+			},
+		}
+		signed.Signature = signProposerPreferencesWithConfigFork(t, keys[validatorIndex], signed.Message, st)
+
+		verifier := &ProposerPreferencesVerifier{results: newResults(RequireProposerPreferencesProposalSlotValid), p: signed}
+		require.NoError(t, verifier.VerifyValidProposalSlot(st))
+
+		signed.Message.ValidatorIndex = 99
+		verifier = &ProposerPreferencesVerifier{results: newResults(RequireProposerPreferencesProposalSlotValid), p: signed}
+		require.ErrorIs(t, verifier.VerifyValidProposalSlot(st), ErrProposerPreferencesInvalidProposalSlot)
+	})
+
+	t.Run("proposal epoch too far ahead", func(t *testing.T) {
+		// State at slot 31 (epoch 0), proposal at slot 72 (epoch 2).
+		// proposalEpoch > stateEpoch+1, so should error.
+		st, _, signed := newSignedProposerPreferencesState(t, 31, 40, 3)
+		signed.Message.ProposalSlot = 72
+
+		verifier := &ProposerPreferencesVerifier{results: newResults(RequireProposerPreferencesProposalSlotValid), p: signed}
+		require.ErrorIs(t, verifier.VerifyValidProposalSlot(st), ErrProposerPreferencesInvalidProposalSlot)
+	})
 }
 
 func TestProposerPreferencesVerifier_VerifySignature(t *testing.T) {


### PR DESCRIPTION
We lookup the proposer lookahead to validate if the validator who sent the proposer preference is indeed the proposer for the proposal slot. 

When proposer preferences are sent at epoch boundaries, the beacon state used in the gossip validation might be referring to the previous epoch of which lookahead might not contain the proposer of proposal slot. We get error logs as the below:
```
[2026-03-29 16:48:57.73] DEBUG sync: Gossip message was rejected agent=Prysm/v7.1.3-rc.3/a58fb9beebae3ef761268905eb90f855e7f29d9d error=proposer preferences validator is not assigned to the proposal slot: slot=89 got=92 want=214 gossipScore=32.72 multiaddress=/ip4/172.16.0.11/udp/13000/quic-v1 peerID=16Uiu2HAmJSuRHZsXcHpuZ9HWSskHQvqdGCvHmmCwipxg43qu5DWU topic=/eth2/4d21f163/proposer_preferences/ssz_snappy
```

This PR checks if the epoch of the state if either the same or the previous epoch of that of the proposer preferences proposal slot. If not, it is advanced to the first slot of the previous epoch corresponding to the proposer preferences proposal slot.

I have tested this on a local kurtosis devnet.

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
