### PR TITLE
fix: use attestation slot epoch for fork digest in gossip topic validation

### DIFF
--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -251,11 +251,7 @@ func (s *Service) validateUnaggregatedAttTopic(ctx context.Context, a eth.Att, b
 	}
 	subnet := helpers.ComputeSubnetForAttestation(valCount, a)
 	format := p2p.GossipTypeMapping[reflect.TypeFor[*eth.Attestation]()]
-	digest, err := s.currentForkDigest()
-	if err != nil {
-		tracing.AnnotateError(span, err)
-		return pubsub.ValidationIgnore, err
-	}
+	digest := params.ForkDigest(slots.ToEpoch(a.GetData().Slot))
 	if !strings.HasPrefix(t, fmt.Sprintf(format, digest, subnet)) {
 		return pubsub.ValidationReject, errors.New("attestation's subnet does not match with pubsub topic")
 	}

--- a/changelog/potuz_use_right_digest.md
+++ b/changelog/potuz_use_right_digest.md
@@ -1,0 +1,2 @@
+### Fixed
+- Use the attestation's fork digest instead of the current one. 


### PR DESCRIPTION

The attestation gossip validator was using currentForkDigest() to build the expected topic prefix. This fails at fork boundaries because the beacon node subscribes to the next fork's topics one epoch early: a message arriving on the upcoming fork's topic would be compared against the current fork digest, causing a spurious reject with the misleading error "attestation's subnet does not match with pubsub topic".

Use the attestation's own slot epoch to derive the correct fork digest instead, so the validation matches the topic the attestation was actually published on.