### PR TITLE
Fix proposer preferences blocking slot-critical path

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -216,6 +216,7 @@ func (v *ValidatorService) Start() {
 		interopKeysConfig:            v.interopKeysConfig,
 		domainDataCache:              cache,
 		voteStats:                    voteStats{startEpoch: primitives.Epoch(^uint64(0))},
+		lastProposerPrefsEpoch:       primitives.Epoch(^uint64(0)),
 		syncCommitteeStats:           syncCommitteeStats{},
 		submittedAtts:                make(map[submittedAttKey]*submittedAtt),
 		submittedAggregates:          make(map[submittedAttKey]*submittedAtt),

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -99,6 +99,7 @@ type validator struct {
 	walletInitializedChan        chan *wallet.Wallet
 	walletInitializedFeed        *event.Feed
 	graffitiOrderedIndex         uint64
+	lastProposerPrefsEpoch       primitives.Epoch
 	conn                         validatorHelpers.NodeConnection
 	submittedAtts                map[submittedAttKey]*submittedAtt
 	validatorsRegBatchSize       int
@@ -1021,17 +1022,68 @@ func (v *validator) buildProposerSettingsRequests(
 	return prepareProposerReqs
 }
 
+// proposerPreference holds the unsigned preference and the pubkey needed to sign it.
+type proposerPreference struct {
+	pubkey [fieldparams.BLSPubkeyLength]byte
+	pref   *ethpb.ProposerPreferences
+}
+
 // buildProposerPreferences creates signed proposer preferences for validators
-// that have proposer slots in the next epoch.
+// that have proposer slots in the next epoch. It only runs once per epoch to
+// avoid redundant signing and RPC calls on the slot-critical path.
 func (v *validator) buildProposerPreferences(
 	ctx context.Context,
 	km keymanager.IKeymanager,
 	slot primitives.Slot,
 ) []*ethpb.SignedProposerPreferences {
-	if slots.ToEpoch(slot) < params.BeaconConfig().GloasForkEpoch {
+	currentEpoch := slots.ToEpoch(slot)
+	gloasEpoch := params.BeaconConfig().GloasForkEpoch
+	if currentEpoch+1 < gloasEpoch {
+		return nil
+	}
+	// In the epoch before gloas, wait until mid-epoch so the gossip mesh
+	// has time to stabilize after the fork_watcher subscribes to gloas topics.
+	if currentEpoch+1 == gloasEpoch {
+		epochStart, err := slots.EpochStart(currentEpoch)
+		if err != nil {
+			return nil
+		}
+		if slot < epochStart+params.BeaconConfig().SlotsPerEpoch/2 {
+			return nil
+		}
+	}
+	// Only submit proposer preferences once per epoch.
+	if v.lastProposerPrefsEpoch == currentEpoch {
 		return nil
 	}
 
+	// Collect unsigned preferences under the read lock, then release
+	// it before signing so we don't hold dutiesLock during I/O.
+	unsigned := v.collectProposerPreferences(slot)
+	if len(unsigned) == 0 {
+		return nil
+	}
+
+	var signedPrefs []*ethpb.SignedProposerPreferences
+	var sigFailCount int
+	for _, u := range unsigned {
+		signedPref, err := v.signProposerPreferences(ctx, km, u.pubkey, u.pref)
+		if err != nil {
+			sigFailCount++
+			continue
+		}
+		signedPrefs = append(signedPrefs, signedPref)
+	}
+	if sigFailCount > 0 {
+		log.WithField("count", sigFailCount).Warn("Failed to sign proposer preferences")
+	}
+	v.lastProposerPrefsEpoch = currentEpoch
+	return signedPrefs
+}
+
+// collectProposerPreferences reads duty assignments under dutiesLock and
+// returns unsigned preferences that need signing.
+func (v *validator) collectProposerPreferences(slot primitives.Slot) []proposerPreference {
 	v.dutiesLock.RLock()
 	defer v.dutiesLock.RUnlock()
 
@@ -1046,8 +1098,7 @@ func (v *validator) buildProposerPreferences(
 	}
 
 	ps := v.ProposerSettings()
-	var signedPrefs []*ethpb.SignedProposerPreferences
-	var sigFailCount int
+	var unsigned []proposerPreference
 
 	for pk, duty := range nextDuties {
 		if len(duty.ProposerSlots) == 0 {
@@ -1080,25 +1131,18 @@ func (v *validator) buildProposerPreferences(
 		}
 
 		for _, proposalSlot := range duty.ProposerSlots {
-			pref := &ethpb.ProposerPreferences{
-				ProposalSlot:   proposalSlot,
-				ValidatorIndex: duty.ValidatorIndex,
-				FeeRecipient:   feeRecipient[:],
-				GasLimit:       gasLimit,
-			}
-
-			signedPref, err := v.signProposerPreferences(ctx, km, pk, pref)
-			if err != nil {
-				sigFailCount++
-				continue
-			}
-			signedPrefs = append(signedPrefs, signedPref)
+			unsigned = append(unsigned, proposerPreference{
+				pubkey: pk,
+				pref: &ethpb.ProposerPreferences{
+					ProposalSlot:   proposalSlot,
+					ValidatorIndex: duty.ValidatorIndex,
+					FeeRecipient:   feeRecipient[:],
+					GasLimit:       gasLimit,
+				},
+			})
 		}
 	}
-	if sigFailCount > 0 {
-		log.WithField("count", sigFailCount).Warn("Failed to sign proposer preferences")
-	}
-	return signedPrefs
+	return unsigned
 }
 
 func (v *validator) buildSignedRegReqs(

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -2210,6 +2210,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 		cfg.GloasForkEpoch = 0
 		params.OverrideBeaconConfig(cfg)
 
+		v.lastProposerPrefsEpoch = ^primitives.Epoch(0) // reset sentinel
 		v.duties = &dutyStore{}
 		v.duties.SetFromCombinedDutiesResponse(&ethpb.ValidatorDutiesContainer{
 			CurrentEpochDuties: []*ethpb.ValidatorDuty{
@@ -2250,6 +2251,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 		cfg.GloasForkEpoch = 0
 		params.OverrideBeaconConfig(cfg)
 
+		v.lastProposerPrefsEpoch = ^primitives.Epoch(0) // reset sentinel
 		slot1 := params.BeaconConfig().SlotsPerEpoch + 1
 		slot2 := params.BeaconConfig().SlotsPerEpoch + 5
 
@@ -2315,6 +2317,7 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 		cfg.GloasForkEpoch = 0
 		params.OverrideBeaconConfig(cfg)
 
+		v.lastProposerPrefsEpoch = ^primitives.Epoch(0) // reset sentinel
 		customFeeRecipient := feeRecipientFromString(t, "0x2222222222222222222222222222222222222222")
 		v.proposerSettings = &proposer.Settings{
 			DefaultConfig: &proposer.Option{
@@ -2376,6 +2379,44 @@ func TestValidator_buildProposerPreferences(t *testing.T) {
 				},
 			},
 		}
+	})
+
+	t.Run("only runs once per epoch", func(t *testing.T) {
+		cfg := params.BeaconConfig().Copy()
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		v.lastProposerPrefsEpoch = ^primitives.Epoch(0) // reset sentinel
+		v.duties = &dutyStore{}
+		v.duties.SetFromCombinedDutiesResponse(&ethpb.ValidatorDutiesContainer{
+			CurrentEpochDuties: []*ethpb.ValidatorDuty{
+				{
+					PublicKey:      kp.pub[:],
+					ValidatorIndex: 1,
+					Status:         ethpb.ValidatorStatus_ACTIVE,
+				},
+			},
+			NextEpochDuties: []*ethpb.ValidatorDuty{
+				{
+					PublicKey:      kp.pub[:],
+					ValidatorIndex: 1,
+					Status:         ethpb.ValidatorStatus_ACTIVE,
+					ProposerSlots:  []primitives.Slot{nextEpochProposerSlot},
+				},
+			},
+		})
+
+		// First call at slot 0 (epoch 0) should produce preferences.
+		prefs := v.buildProposerPreferences(t.Context(), km, 0)
+		require.Equal(t, 1, len(prefs))
+
+		// Second call at slot 1 (still epoch 0) should be skipped.
+		prefs = v.buildProposerPreferences(t.Context(), km, 1)
+		require.Equal(t, 0, len(prefs))
+
+		// Call at a slot in the next epoch should produce preferences again.
+		prefs = v.buildProposerPreferences(t.Context(), km, params.BeaconConfig().SlotsPerEpoch)
+		require.Equal(t, 1, len(prefs))
 	})
 }
 


### PR DESCRIPTION
## Summary
- `buildProposerPreferences` was running **every slot**, redundantly signing and submitting proposer preferences via RPC. This consumed time on the slot-critical path, causing `DeadlineExceeded` on sync committee duties and attestation slot mismatches (slot N vs N+1).
- Now only submits proposer preferences **once per epoch** using `lastProposerPrefsEpoch` tracking.
- Releases `dutiesLock.RLock` before signing operations to avoid holding the lock during I/O (RPC domain data fetch + keymanager signing).
- Restores the mid-epoch guard for the epoch before gloas fork that was lost in a prior rebase.

## Test plan
- [x] Existing `TestValidator_buildProposerPreferences` subtests pass
- [x] New `only_runs_once_per_epoch` test validates the epoch-level dedup
- [x] Full `go test ./validator/client/` passes (only pre-existing `TestEIP3076SpecTests` runfiles failure)
- [ ] Verify on devnet that sync committee and attestation errors no longer occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)