### PR TITLE
Add beacon API endpoint to publish signed execution payload bids

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -910,6 +910,16 @@ func (s *Service) beaconEndpoints(
 			handler: server.GetExecutionPayloadEnvelope,
 			methods: []string{http.MethodGet},
 		},
+		{
+			template: "/eth/v2/beacon/execution_payload/bid",
+			name:     namespace + ".PublishSignedExecutionPayloadBid",
+			middleware: []middleware.Middleware{
+				middleware.ContentTypeHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.AcceptHeaderHandler([]string{api.JsonMediaType}),
+			},
+			handler: server.PublishSignedExecutionPayloadBid,
+			methods: []string{http.MethodPost},
+		},
 	}
 }
 

--- a/beacon-chain/rpc/endpoints_test.go
+++ b/beacon-chain/rpc/endpoints_test.go
@@ -34,6 +34,7 @@ func Test_endpoints(t *testing.T) {
 		"/eth/v1/beacon/states/{state_id}/pending_consolidations":      {http.MethodGet},
 		"/eth/v1/beacon/states/{state_id}/proposer_lookahead":          {http.MethodGet},
 		"/eth/v1/beacon/execution_payload_envelope/{block_id}":         {http.MethodGet},
+		"/eth/v2/beacon/execution_payload/bid":                         {http.MethodPost},
 		"/eth/v1/beacon/headers":                                       {http.MethodGet},
 		"/eth/v1/beacon/headers/{block_id}":                            {http.MethodGet},
 		"/eth/v2/beacon/blinded_blocks":                                {http.MethodPost},

--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "handlers_equivocation_test.go",
+        "handlers_gloas_bid_test.go",
         "handlers_gloas_test.go",
         "handlers_pool_test.go",
         "handlers_state_test.go",
@@ -133,6 +134,7 @@ go_test(
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@com_github_stretchr_testify//mock:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
         "@org_uber_go_mock//gomock:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/eth/beacon/handlers_gloas.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_gloas.go
@@ -1,6 +1,8 @@
 package beacon
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/OffchainLabs/prysm/v7/api"
@@ -9,6 +11,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/rpc/eth/shared"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
+	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 )
@@ -76,4 +79,55 @@ func (s *Server) GetExecutionPayloadEnvelope(w http.ResponseWriter, r *http.Requ
 		Finalized:           finalized,
 		Data:                jsonEnvelope,
 	})
+}
+
+// PublishSignedExecutionPayloadBid broadcasts a signed execution payload bid to the P2P network.
+func (s *Server) PublishSignedExecutionPayloadBid(w http.ResponseWriter, r *http.Request) {
+	ctx, span := trace.StartSpan(r.Context(), "beacon.PublishSignedExecutionPayloadBid")
+	defer span.End()
+
+	if shared.IsSyncing(ctx, w, s.SyncChecker, s.HeadFetcher, s.TimeFetcher, s.OptimisticModeFetcher) {
+		return
+	}
+
+	versionHeader := r.Header.Get(api.VersionHeader)
+	if versionHeader == "" {
+		httputil.HandleError(w, api.VersionHeader+" header is required", http.StatusBadRequest)
+		return
+	}
+
+	var signedBid *eth.SignedExecutionPayloadBid
+	if httputil.IsRequestSsz(r) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			httputil.HandleError(w, "Could not read request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		signedBid = &eth.SignedExecutionPayloadBid{}
+		if err := signedBid.UnmarshalSSZ(body); err != nil {
+			httputil.HandleError(w, "Could not unmarshal SSZ: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		var jsonBid structs.SignedExecutionPayloadBid
+		if err := json.NewDecoder(r.Body).Decode(&jsonBid); err != nil {
+			if errors.Is(err, io.EOF) {
+				httputil.HandleError(w, "No data submitted", http.StatusBadRequest)
+				return
+			}
+			httputil.HandleError(w, "Could not decode request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		var err error
+		signedBid, err = jsonBid.ToConsensus()
+		if err != nil {
+			httputil.HandleError(w, "Could not convert bid to consensus type: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	if err := s.Broadcaster.Broadcast(ctx, signedBid); err != nil {
+		httputil.HandleError(w, "Could not broadcast execution payload bid: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 }

--- a/beacon-chain/rpc/eth/beacon/handlers_gloas_bid_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_gloas_bid_test.go
@@ -1,0 +1,224 @@
+package beacon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/api"
+	"github.com/OffchainLabs/prysm/v7/api/server/structs"
+	chainMock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	p2pMock "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
+	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/assert"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func testJSONSignedBid() *structs.SignedExecutionPayloadBid {
+	hex32 := "0x" + strings.Repeat("00", 32)
+	hex20 := "0x" + strings.Repeat("00", 20)
+	hex96 := "0x" + strings.Repeat("00", 96)
+	return &structs.SignedExecutionPayloadBid{
+		Message: &structs.ExecutionPayloadBid{
+			ParentBlockHash:    hex32,
+			ParentBlockRoot:    hex32,
+			BlockHash:          hex32,
+			PrevRandao:         hex32,
+			FeeRecipient:       hex20,
+			GasLimit:           "30000000",
+			BuilderIndex:       "1",
+			Slot:               "100",
+			Value:              "0",
+			ExecutionPayment:   "0",
+			BlobKzgCommitments: []string{},
+		},
+		Signature: hex96,
+	}
+}
+
+func TestPublishSignedExecutionPayloadBid_NoVersionHeader(t *testing.T) {
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", nil)
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, true, bytes.Contains(w.Body.Bytes(), []byte("header is required")))
+}
+
+func TestPublishSignedExecutionPayloadBid_EmptyBody(t *testing.T) {
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", nil)
+	req.Header.Set(api.VersionHeader, "gloas")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, true, bytes.Contains(w.Body.Bytes(), []byte("No data submitted")))
+}
+
+func TestPublishSignedExecutionPayloadBid_Syncing(t *testing.T) {
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: true},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", nil)
+	req.Header.Set(api.VersionHeader, "gloas")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestPublishSignedExecutionPayloadBid_JSON(t *testing.T) {
+	broadcaster := &p2pMock.MockBroadcaster{}
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+		Broadcaster:           broadcaster,
+	}
+
+	bid := testJSONSignedBid()
+	body, err := json.Marshal(bid)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", bytes.NewReader(body))
+	req.Header.Set(api.VersionHeader, "gloas")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, len(broadcaster.BroadcastMessages))
+}
+
+func TestPublishSignedExecutionPayloadBid_MalformedJSON(t *testing.T) {
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", bytes.NewReader([]byte("{bad json")))
+	req.Header.Set(api.VersionHeader, "gloas")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, true, bytes.Contains(w.Body.Bytes(), []byte("Could not decode request body")))
+}
+
+func TestPublishSignedExecutionPayloadBid_InvalidSSZ(t *testing.T) {
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", bytes.NewReader([]byte{0x01, 0x02}))
+	req.Header.Set(api.VersionHeader, "gloas")
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, true, bytes.Contains(w.Body.Bytes(), []byte("Could not unmarshal SSZ")))
+}
+
+func TestPublishSignedExecutionPayloadBid_SSZ(t *testing.T) {
+	broadcaster := &p2pMock.MockBroadcaster{}
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+		Broadcaster:           broadcaster,
+	}
+
+	bid := &ethpb.SignedExecutionPayloadBid{
+		Message: &ethpb.ExecutionPayloadBid{
+			ParentBlockHash:  make([]byte, 32),
+			ParentBlockRoot:  make([]byte, 32),
+			BlockHash:        make([]byte, 32),
+			PrevRandao:       make([]byte, 32),
+			FeeRecipient:     make([]byte, 20),
+			GasLimit:         30000000,
+			BuilderIndex:     1,
+			Slot:             100,
+			Value:            0,
+			ExecutionPayment: 0,
+		},
+		Signature: make([]byte, 96),
+	}
+	sszBytes, err := bid.MarshalSSZ()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", bytes.NewReader(sszBytes))
+	req.Header.Set(api.VersionHeader, "gloas")
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, len(broadcaster.BroadcastMessages))
+}
+
+// errorBroadcaster is a test broadcaster that always returns an error.
+type errorBroadcaster struct{ p2pMock.MockBroadcaster }
+
+func (e *errorBroadcaster) Broadcast(_ context.Context, _ proto.Message) error {
+	return fmt.Errorf("broadcast failed")
+}
+
+func TestPublishSignedExecutionPayloadBid_BroadcastError(t *testing.T) {
+	s := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:           &chainMock.ChainService{},
+		TimeFetcher:           &chainMock.ChainService{},
+		OptimisticModeFetcher: &chainMock.ChainService{},
+		Broadcaster:           &errorBroadcaster{},
+	}
+
+	bid := testJSONSignedBid()
+	body, err := json.Marshal(bid)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/execution_payload/bid", bytes.NewReader(body))
+	req.Header.Set(api.VersionHeader, "gloas")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	w.Body = &bytes.Buffer{}
+
+	s.PublishSignedExecutionPayloadBid(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, true, bytes.Contains(w.Body.Bytes(), []byte("Could not broadcast")))
+}

--- a/changelog/potuz_submit_bid.md
+++ b/changelog/potuz_submit_bid.md
@@ -1,0 +1,2 @@
+### Added
+- Added endpoint to submit signed bids.


### PR DESCRIPTION
## Summary
- Adds `POST /eth/v2/beacon/execution_payload/bid` beacon API endpoint
- Accepts `SignedExecutionPayloadBid` as JSON or SSZ (Content-Type based)
- Broadcasts the bid to the P2P gossip network; the existing gossip subscriber handles caching