### PR TITLE
only send header once per peer per group and fix tests for a green ra…

### DIFF
--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
@@ -71,6 +72,7 @@ type PartialColumnBroadcaster struct {
 	peerFeedback      func(topic string, peer peer.ID, kind pubsub.PeerFeedbackKind) error
 	publishPartialCol func(topic string, groupID []byte, col *blocks.PartialDataColumn) error
 	stop              chan struct{}
+	stopOnce          sync.Once
 	callbacks         ColumnCallbacks
 	// map topic -> *pubsub.Topic
 	topics                           map[string]*pubsub.Topic
@@ -81,7 +83,9 @@ type PartialColumnBroadcaster struct {
 	groupTTL        map[string]int8
 	// validHeaderCache caches validated headers by group ID (works across topics)
 	validHeaderCache map[string]*ethpb.PartialDataColumnHeader
-	incomingReq      chan request
+	// map groupID -> map[peer.ID]bool
+	headerSentCache map[string]map[peer.ID]bool
+	incomingReq     chan request
 }
 
 type requestKind uint8
@@ -159,6 +163,9 @@ func NewBroadcaster(logger *logrus.Logger) *PartialColumnBroadcaster {
 		partialMsgStore:  make(map[string]map[string]*verification.PartialColumnVerifier),
 		groupTTL:         make(map[string]int8),
 		validHeaderCache: make(map[string]*ethpb.PartialDataColumnHeader),
+		headerSentCache:  make(map[string]map[peer.ID]bool),
+		stop:             make(chan struct{}),
+
 		// GossipSub sends the messages to this channel. The buffer should be
 		// big enough to avoid dropping messages. We don't want to block the gossipsub event loop for this.
 		incomingReq: make(chan request, 128*16),
@@ -231,7 +238,10 @@ func (p *PartialColumnBroadcaster) AppendPubSubOpts(opts []pubsub.Option) []pubs
 		func(ps *pubsub.PubSub) error {
 			p.peerFeedback = ps.PeerFeedback
 			p.publishPartialCol = func(topic string, groupID []byte, col *blocks.PartialDataColumn) error {
-				return pubsub.PublishPartial(ps, topic, groupID, col.PublishActions)
+				if _, ok := p.headerSentCache[string(groupID)]; !ok {
+					p.headerSentCache[string(groupID)] = make(map[peer.ID]bool)
+				}
+				return pubsub.PublishPartial(ps, topic, groupID, col.PublishActionsFn(p.headerSentCache[string(groupID)]))
 			}
 			return nil
 		},
@@ -244,7 +254,6 @@ func (p *PartialColumnBroadcaster) AppendPubSubOpts(opts []pubsub.Option) []pubs
 // Note: The event loop is blocking and so the broadcaster should be started in a goroutine.
 func (p *PartialColumnBroadcaster) Start(callbacks ColumnCallbacks) {
 	p.callbacks = callbacks
-	p.stop = make(chan struct{})
 	p.loop()
 }
 
@@ -264,6 +273,7 @@ func (p *PartialColumnBroadcaster) loop() {
 
 				delete(p.groupTTL, groupID)
 				delete(p.validHeaderCache, groupID)
+				delete(p.headerSentCache, groupID)
 				for topic, msgStore := range p.partialMsgStore {
 					delete(msgStore, groupID)
 					if len(msgStore) == 0 {
@@ -416,9 +426,18 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpc incomingPartialRPC) err
 
 	if ourVerifier == nil && hasMessage {
 		header, headerWasCached := p.getHeader(groupID, message)
-		if len(message.Header) == 0 {
+		if header == nil {
 			return nil
 		}
+
+		// downscore peer if invalid header
+		if header.SignedBlockHeader == nil || header.SignedBlockHeader.Header == nil {
+			p.logger.WithFields(rpc.logFields()).Debug("Header is missing signed block header or header")
+			_ = p.peerFeedback(topicID, rpc.from, pubsub.PeerFeedbackInvalidMessage)
+			return errors.New("header is missing signed block header or header")
+		}
+
+		// downscore peer if invalid header
 		root, err := header.SignedBlockHeader.Header.HashTreeRoot()
 		if err != nil {
 			p.logger.WithFields(rpc.logFields()).WithError(err).Debug("Failed to get root from header")
@@ -440,6 +459,7 @@ func (p *PartialColumnBroadcaster) handleIncomingRPC(rpc incomingPartialRPC) err
 		}
 
 		if !headerWasCached {
+			p.logger.WithFields(rpc.logFields()).Debug("Handling header as it was previously not cached for this group")
 			p.handleHeader(rpc, header)
 		}
 
@@ -680,9 +700,9 @@ func (p *PartialColumnBroadcaster) handleCellsValidated(cells *cellsValidated) e
 }
 
 func (p *PartialColumnBroadcaster) Stop() {
-	if p.stop != nil {
+	p.stopOnce.Do(func() {
 		close(p.stop)
-	}
+	})
 }
 
 // Publish publishes partial columns for the given topics.

--- a/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
+++ b/beacon-chain/p2p/partialdatacolumnbroadcaster/partial_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -96,6 +97,7 @@ type publishedColumn struct {
 }
 
 type mockPubSub struct {
+	mu                       sync.Mutex
 	publishedPartialColumns  []publishedColumn
 	peerFeedbackCalls        []peerFeedbackCall
 	publishPartialMessageErr error
@@ -114,7 +116,7 @@ func newMockPubSub(publisherr, peerFeebackErr error) *mockPubSub {
 func (m *mockPubSub) assertPartialColumnsPublished(t *testing.T, topic string, expected []*blocks.PartialDataColumn) {
 	t.Helper()
 
-	actual := m.publishedPartialColumns
+	actual := m.publishedColumnsSnapshot()
 
 	require.Equal(t, len(expected), len(actual))
 	if len(expected) == 0 {
@@ -128,6 +130,8 @@ func (m *mockPubSub) assertPartialColumnsPublished(t *testing.T, topic string, e
 }
 
 func (m *mockPubSub) peerFeedback(topic string, id peer.ID, kind pubsub.PeerFeedbackKind) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.peerFeedbackCalls = append(m.peerFeedbackCalls, peerFeedbackCall{
 		peerID: id,
 		topic:  topic,
@@ -137,9 +141,35 @@ func (m *mockPubSub) peerFeedback(topic string, id peer.ID, kind pubsub.PeerFeed
 }
 
 func (m *mockPubSub) publishPartialCol(topic string, groupID []byte, col *blocks.PartialDataColumn) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.publishedPartialColumns = append(m.publishedPartialColumns, publishedColumn{col, topic})
 	retErr := m.publishPartialMessageErr
 	return retErr
+}
+
+func (m *mockPubSub) peerFeedbackCallsSnapshot() []peerFeedbackCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.peerFeedbackCalls)
+}
+
+func (m *mockPubSub) publishedColumnsSnapshot() []publishedColumn {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.publishedPartialColumns)
+}
+
+func (m *mockPubSub) peerFeedbackCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.peerFeedbackCalls)
+}
+
+func (m *mockPubSub) publishedColumnCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.publishedPartialColumns)
 }
 
 func newBroadcasterHarness(t *testing.T, ps *mockPubSub) *broadcasterHarness {
@@ -419,12 +449,12 @@ func waitForPeerFeedbackCalls(t *testing.T, ps *mockPubSub, expected int) {
 	defer ticker.Stop()
 
 	for {
-		if len(ps.peerFeedbackCalls) >= expected {
+		if ps.peerFeedbackCallCount() >= expected {
 			return
 		}
 		select {
 		case <-deadline.C:
-			t.Fatalf("expected at least %d peer feedback calls, got %d", expected, len(ps.peerFeedbackCalls))
+			t.Fatalf("expected at least %d peer feedback calls, got %d", expected, ps.peerFeedbackCallCount())
 		case <-ticker.C:
 		}
 	}
@@ -965,10 +995,11 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 
 			if tt.expectPeerFeedbackCall {
 				waitForPeerFeedbackCalls(t, ps, 1)
-				require.Equal(t, tt.expectPeerFeedback, ps.peerFeedbackCalls[0].kind)
-				require.Equal(t, setup.inputRPC.from, ps.peerFeedbackCalls[0].peerID)
+				feedbackCalls := ps.peerFeedbackCallsSnapshot()
+				require.Equal(t, tt.expectPeerFeedback, feedbackCalls[0].kind)
+				require.Equal(t, setup.inputRPC.from, feedbackCalls[0].peerID)
 			} else {
-				require.Equal(t, 0, len(ps.peerFeedbackCalls))
+				require.Equal(t, 0, ps.peerFeedbackCallCount())
 			}
 
 			stored := h.broadcaster.getDataColumn(setup.inputRPC.GetTopicID(), setup.inputRPC.GroupID)
@@ -976,7 +1007,7 @@ func TestPartialColumnBroadcaster_handleIncomingRPC(t *testing.T) {
 				require.NotNil(t, stored)
 				ps.assertPartialColumnsPublished(t, setup.inputRPC.GetTopicID(), []*blocks.PartialDataColumn{stored})
 			} else {
-				require.Equal(t, 0, len(ps.publishedPartialColumns))
+				require.Equal(t, 0, ps.publishedColumnCount())
 			}
 
 			if tt.expectedStoreColumn != nil {
@@ -1202,7 +1233,7 @@ func TestPartialColumnBroadcaster_handleCellsValidated(t *testing.T) {
 				ps.assertPartialColumnsPublished(t, topic, []*blocks.PartialDataColumn{stored})
 
 			} else {
-				require.Equal(t, 0, len(ps.publishedPartialColumns))
+				require.Equal(t, 0, ps.publishedColumnCount())
 			}
 
 			if tt.expectHandle {

--- a/consensus-types/blocks/partialdatacolumn.go
+++ b/consensus-types/blocks/partialdatacolumn.go
@@ -14,8 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ partialmessages.PublishActionsFn[PartialDataColumnPeerState] = (*PartialDataColumn)(nil).PublishActions
-
 // CellProofBundle contains a cell, its proof, and the corresponding
 // commitment/index information.
 type CellProofBundle struct {
@@ -219,35 +217,45 @@ func (p *PartialDataColumn) cellsToSendForPeer(peerMeta *ethpb.PartialDataColumn
 // eagerPushBytes builds SSZ-encoded PartialDataColumnSidecar for the initial eager push.
 // When byBlockProposer is true, all available cells and proofs are included.
 // Otherwise, only the header is sent (no cells).
-func (p *PartialDataColumn) eagerPushBytes(includeCellAndProofs bool) ([]byte, error) {
-	outHeader := &ethpb.PartialDataColumnHeader{
-		KzgCommitments:               p.KzgCommitments,
-		SignedBlockHeader:            p.SignedBlockHeader,
-		KzgCommitmentsInclusionProof: p.KzgCommitmentsInclusionProof,
+func (p *PartialDataColumn) eagerPushBytes(remote peer.ID, includeCellAndProofs bool, includeHeader bool) (encoded []byte, err error) {
+	log.WithFields(logrus.Fields{
+		"peer":                 remote,
+		"index":                p.Index,
+		"includeHeader":        includeHeader,
+		"includeCellAndProofs": includeCellAndProofs,
+	}).Debug("Eager push")
+
+	if !includeHeader && (!includeCellAndProofs || p.Included.Count() == 0) {
+		return nil, nil
+	}
+	outMessage := &ethpb.PartialDataColumnSidecar{}
+
+	if includeHeader {
+		outMessage.Header = []*ethpb.PartialDataColumnHeader{{
+			KzgCommitments:               p.KzgCommitments,
+			SignedBlockHeader:            p.SignedBlockHeader,
+			KzgCommitmentsInclusionProof: p.KzgCommitmentsInclusionProof,
+		}}
 	}
 
 	if !includeCellAndProofs {
-		outMessage := &ethpb.PartialDataColumnSidecar{
-			CellsPresentBitmap: bitfield.NewBitlist(uint64(len(p.KzgCommitments))),
-			Header:             []*ethpb.PartialDataColumnHeader{outHeader},
-		}
-		return outMessage.MarshalSSZ()
+		outMessage.CellsPresentBitmap = bitfield.NewBitlist(uint64(len(p.KzgCommitments)))
+		encoded, err = outMessage.MarshalSSZ()
+		return encoded, err
 	}
 
 	nCells := p.Included.Count()
-	outMessage := &ethpb.PartialDataColumnSidecar{
-		CellsPresentBitmap: slices.Clone(p.Included),
-		PartialColumn:      make([][]byte, 0, nCells),
-		KzgProofs:          make([][]byte, 0, nCells),
-		Header:             []*ethpb.PartialDataColumnHeader{outHeader},
-	}
+	outMessage.CellsPresentBitmap = slices.Clone(p.Included)
+	outMessage.PartialColumn = make([][]byte, 0, nCells)
+	outMessage.KzgProofs = make([][]byte, 0, nCells)
 	for i := range p.Included.Len() {
 		if p.Included.BitAt(i) {
 			outMessage.PartialColumn = append(outMessage.PartialColumn, p.Column[i])
 			outMessage.KzgProofs = append(outMessage.KzgProofs, p.KzgProofs[i])
 		}
 	}
-	return outMessage.MarshalSSZ()
+	encoded, err = outMessage.MarshalSSZ()
+	return encoded, err
 }
 
 // PartsMetadata returns SSZ-encoded PartialDataColumnPartsMetadata.
@@ -272,31 +280,44 @@ func MergeAvailableIntoPartsMetadata(base *ethpb.PartialDataColumnPartsMetadata,
 	return base, nil
 }
 
-func (p *PartialDataColumn) PublishActions(peerStates map[peer.ID]PartialDataColumnPeerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, partialmessages.PublishAction] {
-	return func(yield func(peer.ID, partialmessages.PublishAction) bool) {
-		for peer, peerState := range peerStates {
-			nextState, action := p.forPeer(peer, peerRequestsPartial(peer), peerState)
-			if action.Err == nil {
-				// Only update state if there was no error.
-				peerStates[peer] = nextState
-			}
-			if !yield(peer, action) {
-				return
+func (p *PartialDataColumn) PublishActionsFn(headerSentCache map[peer.ID]bool) partialmessages.PublishActionsFn[PartialDataColumnPeerState] {
+	return func(peerStates map[peer.ID]PartialDataColumnPeerState, peerRequestsPartial func(peer.ID) bool) iter.Seq2[peer.ID, partialmessages.PublishAction] {
+		return func(yield func(peer.ID, partialmessages.PublishAction) bool) {
+			for peer, peerState := range peerStates {
+				nextState, action, includeHeader := p.forPeer(peer, peerRequestsPartial(peer), peerState, !headerSentCache[peer])
+				if action.Err == nil {
+					v := headerSentCache[peer]
+					headerSentCache[peer] = headerSentCache[peer] || includeHeader
+					if v != headerSentCache[peer] {
+						log.WithFields(logrus.Fields{
+							"peer":            peer,
+							"index":           p.Index,
+							"includeHeader":   includeHeader,
+							"headerSentCache": headerSentCache[peer],
+						}).Debug("Header sent cache updated")
+					}
+					// Only update state if there was no error.
+					peerStates[peer] = nextState
+				}
+				if !yield(peer, action) {
+					return
+				}
 			}
 		}
 	}
 }
 
 // forPeer returns the next peer state and the publish action for this peer
-func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerState PartialDataColumnPeerState) (PartialDataColumnPeerState, partialmessages.PublishAction) {
+func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerState PartialDataColumnPeerState, includeHeader bool) (PartialDataColumnPeerState, partialmessages.PublishAction,
+	bool) {
 	peerState = ClonePeerState(peerState)
 
 	// Eager push - we don't know what the peer has and message has been requested.
 	// Set RecvdState so subsequent calls skip the eager push path.
 	if requestedMessage && peerState.Recvd == nil {
-		encoded, err := p.eagerPushBytes(p.byBlockProposer)
+		encoded, err := p.eagerPushBytes(remote, p.byBlockProposer, includeHeader)
 		if err != nil {
-			return peerState, partialmessages.PublishAction{Err: err}
+			return peerState, partialmessages.PublishAction{Err: err}, false
 		}
 		myPartsMeta := p.newPartsMetadata()
 		if p.byBlockProposer {
@@ -316,12 +337,12 @@ func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerS
 		peerState.Sent = myPartsMeta
 		encodedMeta, err := marshalPartsMetadata(myPartsMeta)
 		if err != nil {
-			return peerState, partialmessages.PublishAction{Err: err}
+			return peerState, partialmessages.PublishAction{Err: err}, false
 		}
 		return peerState, partialmessages.PublishAction{
 			EncodedPartialMessage: encoded,
 			EncodedPartsMetadata:  encodedMeta,
-		}
+		}, includeHeader
 	}
 
 	var cellsSent bitfield.Bitlist
@@ -334,12 +355,12 @@ func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerS
 		var err error
 		encodedMsg, cellsSent, err = p.cellsToSendForPeer(recvdMeta)
 		if err != nil {
-			return peerState, partialmessages.PublishAction{Err: err}
+			return peerState, partialmessages.PublishAction{Err: err}, false
 		}
 		if cellsSent != nil && cellsSent.Count() != 0 {
 			newRecvd, err := MergeAvailableIntoPartsMetadata(recvdMeta, cellsSent)
 			if err != nil {
-				return peerState, partialmessages.PublishAction{Err: err}
+				return peerState, partialmessages.PublishAction{Err: err}, false
 			}
 			peerState.Recvd = newRecvd
 		}
@@ -356,7 +377,7 @@ func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerS
 		} else {
 			contains, err := sentMeta.Available.Contains(myPartsMeta.Available)
 			if err != nil {
-				return peerState, partialmessages.PublishAction{Err: err}
+				return peerState, partialmessages.PublishAction{Err: err}, false
 			}
 			shouldSendPartsMetadata = !contains
 		}
@@ -366,14 +387,14 @@ func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerS
 		var err error
 		partsMetadataToSend, err = marshalPartsMetadata(myPartsMeta)
 		if err != nil {
-			return peerState, partialmessages.PublishAction{Err: err}
+			return peerState, partialmessages.PublishAction{Err: err}, false
 		}
 		if sentMeta == nil {
 			peerState.Sent = myPartsMeta
 		} else {
 			sentMeta, err = MergeAvailableIntoPartsMetadata(sentMeta, myPartsMeta.Available)
 			if err != nil {
-				return peerState, partialmessages.PublishAction{Err: err}
+				return peerState, partialmessages.PublishAction{Err: err}, false
 			}
 			sentMeta.Requests = myPartsMeta.Requests
 			peerState.Sent = sentMeta
@@ -383,7 +404,7 @@ func (p *PartialDataColumn) forPeer(remote peer.ID, requestedMessage bool, peerS
 	return peerState, partialmessages.PublishAction{
 		EncodedPartialMessage: encodedMsg,
 		EncodedPartsMetadata:  partsMetadataToSend,
-	}
+	}, false
 }
 
 // CellsToVerifyFromPartialMessage returns cells from the partial message that need to be verified.

--- a/consensus-types/blocks/partialdatacolumn_test.go
+++ b/consensus-types/blocks/partialdatacolumn_test.go
@@ -446,7 +446,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			name: "nominal",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0)
-				encoded, err := p.eagerPushBytes(false)
+				encoded, err := p.eagerPushBytes(peer.ID("test-peer"), false, true)
 				require.NoError(t, err)
 				msg := mustDecodeSidecar(t, encoded)
 				require.Equal(t, 1, len(msg.Header))
@@ -461,7 +461,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
 				p.KzgCommitments[0] = []byte{1}
-				_, err := p.eagerPushBytes(false)
+				_, err := p.eagerPushBytes(peer.ID("test-peer"), false, true)
 				require.ErrorContains(t, "KzgCommitments", err)
 			},
 		},
@@ -470,7 +470,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
 				p.KzgCommitmentsInclusionProof = p.KzgCommitmentsInclusionProof[:3]
-				_, err := p.eagerPushBytes(false)
+				_, err := p.eagerPushBytes(peer.ID("test-peer"), false, true)
 				require.ErrorContains(t, "KzgCommitmentsInclusionProof", err)
 			},
 		},
@@ -478,7 +478,7 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			name: "byBlockProposer includes cells and proofs",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumnWithOpts(t, 3, []uint64{0, 2}, WithByBlockProposer())
-				encoded, err := p.eagerPushBytes(true)
+				encoded, err := p.eagerPushBytes(peer.ID("test-peer"), true, true)
 				require.NoError(t, err)
 				msg := mustDecodeSidecar(t, encoded)
 				require.Equal(t, 1, len(msg.Header))
@@ -501,12 +501,59 @@ func TestPartialDataColumn_eagerPushBytes(t *testing.T) {
 			name: "byBlockProposer with no cells still works",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumnWithOpts(t, 2, nil, WithByBlockProposer())
-				encoded, err := p.eagerPushBytes(true)
+				encoded, err := p.eagerPushBytes(peer.ID("test-peer"), true, true)
 				require.NoError(t, err)
 				msg := mustDecodeSidecar(t, encoded)
 				require.Equal(t, 1, len(msg.Header))
 				require.Equal(t, 0, len(msg.PartialColumn))
 				require.Equal(t, 0, len(msg.KzgProofs))
+			},
+		},
+		{
+			name: "includeHeader false and includeCellAndProofs false returns nil",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumn(t, 3, 0)
+				encoded, err := p.eagerPushBytes(peer.ID("test-peer"), false, false)
+				require.NoError(t, err)
+				require.IsNil(t, encoded)
+			},
+		},
+		{
+			name: "includeHeader false with byBlockProposer includes cells but no header",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumnWithOpts(t, 3, []uint64{0, 2}, WithByBlockProposer())
+				encoded, err := p.eagerPushBytes(peer.ID("test-peer"), true, false)
+				require.NoError(t, err)
+				require.NotNil(t, encoded)
+				msg := mustDecodeSidecar(t, encoded)
+				require.Equal(t, 0, len(msg.Header))
+				require.Equal(t, 2, len(msg.PartialColumn))
+				require.Equal(t, 2, len(msg.KzgProofs))
+				bitmap := bitfield.Bitlist(msg.CellsPresentBitmap)
+				require.Equal(t, true, bitmap.BitAt(0))
+				require.Equal(t, false, bitmap.BitAt(1))
+				require.Equal(t, true, bitmap.BitAt(2))
+			},
+		},
+		{
+			name: "includeHeader false with byBlockProposer no cells returns nil",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumnWithOpts(t, 2, nil, WithByBlockProposer())
+				encoded, err := p.eagerPushBytes(peer.ID("test-peer"), true, false)
+				require.NoError(t, err)
+				require.IsNil(t, encoded)
+			},
+		},
+		{
+			name: "includeHeader true with includeCellAndProofs false sends header only",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumn(t, 3, 0)
+				encoded, err := p.eagerPushBytes(peer.ID("test-peer"), false, true)
+				require.NoError(t, err)
+				msg := mustDecodeSidecar(t, encoded)
+				require.Equal(t, 1, len(msg.Header))
+				require.Equal(t, 0, len(msg.PartialColumn))
+				require.Equal(t, uint64(0), bitfield.Bitlist(msg.CellsPresentBitmap).Count())
 			},
 		},
 	}
@@ -586,8 +633,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
 				var initial PartialDataColumnPeerState
-				nextState, action := p.forPeer(peer.ID("peer-a"), true, initial)
+				nextState, action, headerIncluded := p.forPeer(peer.ID("peer-a"), true, initial, true)
 				require.NoError(t, action.Err)
+				require.Equal(t, true, headerIncluded)
 				require.NotNil(t, action.EncodedPartialMessage)
 				require.NotNil(t, action.EncodedPartsMetadata)
 				require.NotNil(t, nextState.Recvd)
@@ -607,11 +655,11 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			name: "eager push not repeated when peerState preserved",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 2, 0)
-				state, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{})
+				state, action, _ := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{}, true)
 				require.NoError(t, action.Err)
 				require.NotNil(t, state.Recvd)
 				// Second call with the returned state should not send eager push again.
-				next, action := p.forPeer(peer.ID("peer-a"), true, state)
+				next, action, _ := p.forPeer(peer.ID("peer-a"), true, state, true)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage) // no cells to send (peer has no requests)
 				require.IsNil(t, action.EncodedPartsMetadata)  // partsMetadata already sent, no change
@@ -622,7 +670,7 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			name: "requested false sends only parts metadata",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0)
-				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{})
+				next, action, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{}, true)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage)
 				require.NotNil(t, action.EncodedPartsMetadata)
@@ -633,12 +681,12 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			name: "recvdState with mismatched length",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0)
-				_, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+				_, action, _ := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
 					Recvd: &ethpb.PartialDataColumnPartsMetadata{
 						Available: testBitlist(2),
 						Requests:  testBitlist(2, 0, 1),
 					},
-				})
+				}, true)
 				require.ErrorContains(t, "peer metadata bitmap length mismatch", action.Err)
 			},
 		},
@@ -649,9 +697,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				initialMeta := testPeerMeta(4, nil, allSet(4))
 				initialAvailable := slices.Clone(initialMeta.Available)
 				initialRequests := slices.Clone(initialMeta.Requests)
-				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
 					Recvd: initialMeta,
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.NotNil(t, action.EncodedPartialMessage)
 				require.NotNil(t, action.EncodedPartsMetadata)
@@ -686,9 +734,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(3, 1),
 					Requests:  testBitlist(3, allSet(3)...),
 				}
-				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
 					Recvd: recvd,
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage)
 				require.DeepEqual(t, recvd.Available, next.Recvd.Available)
@@ -699,9 +747,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			name: "requested true nil SentState peer requests nothing",
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 0, 1, 2)
-				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
 					Recvd: testPeerMeta(3, nil, nil), // no requests
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage) // no cells requested
 				require.NotNil(t, action.EncodedPartsMetadata) // partsMetadata sent because Sent was nil
@@ -714,9 +762,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			run: func(t *testing.T) {
 				// We have cells 0, 1, 2. Peer has none but only requests 0 and 2.
 				p := mustNewPartialColumn(t, 3, 0, 1, 2)
-				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
 					Recvd: testPeerMeta(3, nil, []uint64{0, 2}),
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.NotNil(t, action.EncodedPartialMessage)
 				require.NotNil(t, action.EncodedPartsMetadata)
@@ -738,9 +786,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumn(t, 3, 1)
 				myMeta := p.newPartsMetadata()
-				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
 					Sent: myMeta,
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage)
 				require.IsNil(t, action.EncodedPartsMetadata)
@@ -758,9 +806,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(3, 0, 1),
 					Requests:  testBitlist(3, allSet(3)...), // all requested, same as newPartsMetadata
 				}
-				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
 					Sent: sentMeta,
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage)
 				require.IsNil(t, action.EncodedPartsMetadata) // no resend because sentMeta.Available contains ours
@@ -778,9 +826,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(3, 0),
 					Requests:  testBitlist(3, allSet(3)...),
 				}
-				next, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
 					Sent: sentMeta,
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.IsNil(t, action.EncodedPartialMessage) // not requested, no cells
 				require.NotNil(t, action.EncodedPartsMetadata) // metadata resent because available changed
@@ -795,7 +843,7 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 			run: func(t *testing.T) {
 				// First call: we have cell 0 only, Sent is nil.
 				p := mustNewPartialColumn(t, 3, 0)
-				state1, action1 := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{})
+				state1, action1, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{}, true)
 				require.NoError(t, action1.Err)
 				require.NotNil(t, action1.EncodedPartsMetadata)
 				require.Equal(t, true, bitfield.Bitlist(state1.Sent.Available).BitAt(0))
@@ -805,7 +853,7 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				p.ExtendFromVerifiedCell(1, []byte{0xAA}, []byte{0xBB})
 
 				// Second call: Sent has {0}, we now have {0,1}. Should trigger resend.
-				state2, action2 := p.forPeer(peer.ID("peer-a"), false, state1)
+				state2, action2, _ := p.forPeer(peer.ID("peer-a"), false, state1, true)
 				require.NoError(t, action2.Err)
 				require.NotNil(t, action2.EncodedPartsMetadata)
 				// Merged: {0} | {0,1} = {0,1}
@@ -814,7 +862,7 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				require.Equal(t, false, bitfield.Bitlist(state2.Sent.Available).BitAt(2))
 
 				// Third call: Sent has {0,1}, we still have {0,1}. No resend.
-				_, action3 := p.forPeer(peer.ID("peer-a"), false, state2)
+				_, action3, _ := p.forPeer(peer.ID("peer-a"), false, state2, true)
 				require.NoError(t, action3.Err)
 				require.IsNil(t, action3.EncodedPartsMetadata)
 			},
@@ -829,9 +877,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(3, 0),
 					Requests:  testBitlist(3, 0, 1), // mismatch: we request all 3
 				}
-				state1, action1 := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+				state1, action1, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
 					Sent: sentMeta,
-				})
+				}, true)
 				require.NoError(t, action1.Err)
 				require.NotNil(t, action1.EncodedPartsMetadata) // resent because Requests differ
 				// Requests should now match our current requests (all 3).
@@ -843,7 +891,7 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 				require.Equal(t, false, bitfield.Bitlist(state1.Sent.Available).BitAt(1))
 
 				// Second call with corrected Sent should converge (no resend).
-				_, action2 := p.forPeer(peer.ID("peer-a"), false, state1)
+				_, action2, _ := p.forPeer(peer.ID("peer-a"), false, state1, true)
 				require.NoError(t, action2.Err)
 				require.IsNil(t, action2.EncodedPartsMetadata) // converged, no resend
 			},
@@ -858,9 +906,9 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(2, 0),
 					Requests:  testBitlist(3, allSet(3)...), // Requests match length so we reach Contains check
 				}
-				_, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+				_, action, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
 					Sent: sentMeta,
-				})
+				}, true)
 				require.ErrorContains(t, "different lengths", action.Err)
 			},
 		},
@@ -877,10 +925,10 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Requests:  testBitlist(3, allSet(3)...),
 				}
 				recvdMeta := testPeerMeta(3, nil, allSet(3))
-				next, action := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+				next, action, _ := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
 					Sent:  sentMeta,
 					Recvd: recvdMeta,
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.NotNil(t, action.EncodedPartialMessage) // cells sent to peer
 				require.NotNil(t, action.EncodedPartsMetadata)  // metadata resent because available changed
@@ -904,11 +952,60 @@ func TestPartialDataColumn_ForPeer(t *testing.T) {
 					Available: testBitlist(4, 0, 1), // same as ours
 					Requests:  testBitlist(4, 0, 1), // only 2 requests
 				}
-				_, action := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
+				_, action, _ := p.forPeer(peer.ID("peer-a"), false, PartialDataColumnPeerState{
 					Sent: sentMeta,
-				})
+				}, true)
 				require.NoError(t, action.Err)
 				require.NotNil(t, action.EncodedPartsMetadata) // resent because Requests differ (we request all 4)
+			},
+		},
+		{
+			name: "eager push includeHeader false sends no message for non-proposer",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumn(t, 2, 0)
+				var initial PartialDataColumnPeerState
+				nextState, action, headerIncluded := p.forPeer(peer.ID("peer-a"), true, initial, false)
+				require.NoError(t, action.Err)
+				require.Equal(t, false, headerIncluded)
+				// No header and no cells to send for non-proposer → nil encoded message.
+				require.IsNil(t, action.EncodedPartialMessage)
+				// Parts metadata is still sent.
+				require.NotNil(t, action.EncodedPartsMetadata)
+				// Recvd should still be initialized so eager push is not retried.
+				require.NotNil(t, nextState.Recvd)
+			},
+		},
+		{
+			name: "eager push includeHeader false for proposer sends cells without header",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumnWithOpts(t, 3, []uint64{0, 1, 2}, WithByBlockProposer())
+				var initial PartialDataColumnPeerState
+				nextState, action, headerIncluded := p.forPeer(peer.ID("peer-a"), true, initial, false)
+				require.NoError(t, action.Err)
+				require.Equal(t, false, headerIncluded)
+				require.NotNil(t, action.EncodedPartialMessage)
+				require.NotNil(t, action.EncodedPartsMetadata)
+				// Decode and verify no header but cells are present.
+				decoded := mustDecodeSidecar(t, action.EncodedPartialMessage)
+				require.Equal(t, 0, len(decoded.Header))
+				require.Equal(t, 3, len(decoded.PartialColumn))
+				require.Equal(t, 3, len(decoded.KzgProofs))
+				// Recvd should reflect cells we pushed.
+				require.NotNil(t, nextState.Recvd)
+				require.Equal(t, uint64(3), bitfield.Bitlist(nextState.Recvd.Available).Count())
+			},
+		},
+		{
+			name: "non-eager path always returns includeHeader false",
+			run: func(t *testing.T) {
+				p := mustNewPartialColumn(t, 3, 0, 1, 2)
+				// Set up state with Recvd so we skip the eager push path.
+				recvdMeta := testPeerMeta(3, nil, allSet(3))
+				_, action, headerIncluded := p.forPeer(peer.ID("peer-a"), true, PartialDataColumnPeerState{
+					Recvd: recvdMeta,
+				}, true)
+				require.NoError(t, action.Err)
+				require.Equal(t, false, headerIncluded) // non-eager path never reports header included
 			},
 		},
 	}
@@ -928,8 +1025,9 @@ func TestPartialDataColumn_ForPeer_ByBlockProposer(t *testing.T) {
 			run: func(t *testing.T) {
 				p := mustNewPartialColumnWithOpts(t, 4, []uint64{0, 1, 2, 3}, WithByBlockProposer())
 				var initial PartialDataColumnPeerState
-				nextState, action := p.forPeer(peer.ID("peer-a"), true, initial)
+				nextState, action, headerIncluded := p.forPeer(peer.ID("peer-a"), true, initial, true)
 				require.NoError(t, action.Err)
+				require.Equal(t, true, headerIncluded)
 				require.NotNil(t, action.EncodedPartialMessage)
 				require.NotNil(t, action.EncodedPartsMetadata)
 

--- a/proto/prysm/v1alpha1/partial_data_columns.pb.go
+++ b/proto/prysm/v1alpha1/partial_data_columns.pb.go
@@ -7,12 +7,13 @@
 package eth
 
 import (
-	_ "github.com/OffchainLabs/prysm/v7/proto/eth/ext"
-	github_com_OffchainLabs_go_bitfield "github.com/OffchainLabs/go-bitfield"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	github_com_OffchainLabs_go_bitfield "github.com/OffchainLabs/go-bitfield"
+	_ "github.com/OffchainLabs/prysm/v7/proto/eth/ext"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (


### PR DESCRIPTION
Closes https://github.com/OffchainLabs/prysm/issues/16580.

**What type of PR is this?**
Optimisation

**What does this PR do? Why is it needed?**
- This PR ensures we only push the header once per peer per group (block root) across all columns.
- It also ensures that all the partial data column tests are green when race detector is enabled.


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
