### PR TITLE
PTC duties no longer computed from a pre-Gloas state at the Fulu to Gloas fork boundary

### DIFF
--- a/beacon-chain/rpc/core/duties.go
+++ b/beacon-chain/rpc/core/duties.go
@@ -200,7 +200,7 @@ func (s *Service) PTCDuties(ctx context.Context, st state.BeaconState, epoch pri
 	_, span := trace.StartSpan(ctx, "coreService.PTCDuties")
 	defer span.End()
 
-	if len(indices) == 0 || epoch < params.BeaconConfig().GloasForkEpoch {
+	if len(indices) == 0 || epoch < params.BeaconConfig().GloasForkEpoch || st.Version() < version.Gloas {
 		return []*PTCDutyResult{}, nil
 	}
 

--- a/beacon-chain/rpc/core/duties_test.go
+++ b/beacon-chain/rpc/core/duties_test.go
@@ -210,6 +210,36 @@ func TestProposalDependentRootV2(t *testing.T) {
 	})
 }
 
+func TestPTCDuties_ForkBoundaryFuluToGloas(t *testing.T) {
+	helpers.ClearCache()
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 1 // Epoch 0 is Fulu, epoch 1 is GloAS.
+	params.OverrideBeaconConfig(cfg)
+
+	// Create a Fulu state at epoch 0 (last Fulu epoch before GloAS fork).
+	numVals := params.BeaconConfig().MinGenesisActiveValidatorCount
+	st, _ := util.DeterministicGenesisStateFulu(t, numVals)
+
+	indices := []primitives.ValidatorIndex{0, 1, 2}
+	s := &Service{}
+
+	t.Run("current Fulu epoch returns empty", func(t *testing.T) {
+		duties, rpcErr := s.PTCDuties(t.Context(), st, 0, indices)
+		require.Equal(t, (*RpcError)(nil), rpcErr)
+		assert.Equal(t, 0, len(duties), "pre-GloAS epoch should yield no PTC assignments")
+	})
+
+	t.Run("next epoch at GloAS boundary returns empty on Fulu state", func(t *testing.T) {
+		// Epoch 1 == GloasForkEpoch, so the epoch check passes, but the
+		// state is still Fulu — PTC should NOT be computed.
+		duties, rpcErr := s.PTCDuties(t.Context(), st, 1, indices)
+		require.Equal(t, (*RpcError)(nil), rpcErr)
+		assert.Equal(t, 0, len(duties),
+			"GloAS-epoch PTC must not be computed from a Fulu state")
+	})
+}
+
 func TestFindValidatorIndexInCommittee(t *testing.T) {
 	committee := []primitives.ValidatorIndex{10, 20, 30}
 	assert.Equal(t, uint64(0), findValidatorIndexInCommittee(committee, 10))

--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/builder/testing:go_default_library",
         "//beacon-chain/cache:go_default_library",
+        "//beacon-chain/core/gloas:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db/testing:go_default_library",

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -1245,7 +1245,7 @@ func ptcDuties(
 	epoch primitives.Epoch,
 	validators map[primitives.ValidatorIndex]struct{},
 ) ([]ptcDuty, error) {
-	if len(validators) == 0 {
+	if len(validators) == 0 || st.Version() < version.Gloas {
 		return nil, nil
 	}
 	startSlot, err := slots.EpochStart(epoch)

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	mockChain "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	builderTest "github.com/OffchainLabs/prysm/v7/beacon-chain/builder/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	dbutil "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
@@ -3225,7 +3226,9 @@ func TestGetPTCDuties(t *testing.T) {
 	genesisTime := time.Now()
 	// Need enough validators for PTC selection (PTC_SIZE is 512 on mainnet, 2 on minimal)
 	numVals := uint64(fieldparams.PTCSize * 2)
-	st, _ := util.DeterministicGenesisStateFulu(t, numVals)
+	fuluSt, _ := util.DeterministicGenesisStateFulu(t, numVals)
+	st, err := gloas.UpgradeToGloas(fuluSt)
+	require.NoError(t, err)
 	require.NoError(t, st.SetGenesisTime(genesisTime))
 	// Initialize the committee cache for epoch 0.
 	require.NoError(t, helpers.UpdateCommitteeCache(t.Context(), st, 0))
@@ -3505,6 +3508,64 @@ func TestGetPTCDuties(t *testing.T) {
 		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.StringContains(t, "can not be greater than next epoch", e.Message)
+	})
+}
+
+// TestGetPTCDuties_ForkBoundary verifies that requesting PTC duties for the
+// first GloAS epoch while the state is still Fulu returns empty data instead of
+// crashing or returning wrong committee assignments.
+func TestGetPTCDuties_ForkBoundary(t *testing.T) {
+	helpers.ClearCache()
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GloasForkEpoch = 1 // Epoch 0 = Fulu, epoch 1 = GloAS.
+	params.OverrideBeaconConfig(cfg)
+
+	slot := primitives.Slot(0)
+	genesisTime := time.Now()
+	numVals := uint64(fieldparams.PTCSize * 2)
+	st, _ := util.DeterministicGenesisStateFulu(t, numVals)
+	require.NoError(t, st.SetGenesisTime(genesisTime))
+	require.NoError(t, helpers.UpdateCommitteeCache(t.Context(), st, 0))
+
+	genesisRoot := [32]byte{1, 2, 3}
+	db := dbutil.SetupDB(t)
+	require.NoError(t, db.SaveGenesisBlockRoot(t.Context(), genesisRoot))
+
+	mockChainService := &mockChain.ChainService{Genesis: genesisTime, State: st, Slot: &slot}
+	s := &Server{
+		Stater:                &testutil.MockStater{BeaconState: st},
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		TimeFetcher:           mockChainService,
+		HeadFetcher:           mockChainService,
+		OptimisticModeFetcher: mockChainService,
+		BeaconDB:              db,
+	}
+
+	t.Run("next epoch at GloAS boundary returns empty on Fulu state", func(t *testing.T) {
+		// Request PTC duties for epoch 1 (GloasForkEpoch). The handler accepts
+		// this as a next-epoch request but the state is Fulu — PTC data must be empty.
+		var indices []string
+		for i := range numVals {
+			indices = append(indices, strconv.FormatUint(i, 10))
+		}
+		indicesJSON, err := json.Marshal(indices)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost,
+			"http://www.example.com/eth/v1/validator/duties/ptc/{epoch}",
+			bytes.NewReader(indicesJSON))
+		request.SetPathValue("epoch", "1")
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.GetPTCDuties(writer, request)
+		require.Equal(t, http.StatusOK, writer.Code,
+			"endpoint must not error at the fork boundary")
+		resp := &structs.GetPTCDutiesResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		assert.Equal(t, 0, len(resp.Data),
+			"PTC duties must be empty when state is Fulu and requested epoch is GloAS")
 	})
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v2_test.go
@@ -643,24 +643,19 @@ func TestGetDutiesV2_SyncNotReady(t *testing.T) {
 	assert.ErrorContains(t, "Syncing to latest head", err)
 }
 
-// ptcTestState creates a genesis beacon state suitable for PTC testing:
-// - GloasForkEpoch = 0 (active from genesis)
-// - MaxEffectiveBalanceElectra = MaxEffectiveBalance (all validators accepted into PTC)
-// - MinGenesisActiveValidatorCount validators
+// ptcTestState creates a deterministic Fulu genesis state, upgrades it to Gloas,
+// and returns the upgraded state plus validator pubkeys for duty requests.
 // Callers must have already called params.SetupTestConfigCleanup and overridden
 // GloasForkEpoch and MaxEffectiveBalanceElectra in the beacon config.
 func ptcTestState(t *testing.T) (beaconstate.BeaconState, [][]byte) {
 	t.Helper()
-	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
-	deposits, _, err := util.DeterministicDepositsAndKeys(depChainStart)
+	numVals := params.BeaconConfig().MinGenesisActiveValidatorCount
+	fuluSt, keys := util.DeterministicGenesisStateFulu(t, numVals)
+	st, err := gloas.UpgradeToGloas(fuluSt)
 	require.NoError(t, err)
-	eth1Data, err := util.DeterministicEth1Data(len(deposits))
-	require.NoError(t, err)
-	st, err := transition.GenesisBeaconState(t.Context(), deposits, 0, eth1Data)
-	require.NoError(t, err)
-	pubKeys := make([][]byte, depChainStart)
-	for i, d := range deposits {
-		pubKeys[i] = d.Data.PublicKey
+	pubKeys := make([][]byte, numVals)
+	for i := range numVals {
+		pubKeys[i] = keys[i].PublicKey().Marshal()
 	}
 	return st, pubKeys
 }
@@ -846,5 +841,63 @@ func TestGetDutiesV2_PTC_OK(t *testing.T) {
 	}
 	if currentCount == 0 {
 		t.Error("expected some current-epoch PTC assignments")
+	}
+}
+
+// TestGetDutiesV2_PTC_ForkBoundary verifies that when the current epoch is
+// the last Fulu epoch and the next epoch is GloAS, the endpoint does not
+// crash and next-epoch PTC duties are empty (state is Fulu, not GloAS).
+func TestGetDutiesV2_PTC_ForkBoundary(t *testing.T) {
+	helpers.ClearCache()
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 1 // Epoch 0 = Fulu, epoch 1 = GloAS.
+	cfg.MaxEffectiveBalanceElectra = cfg.MaxEffectiveBalance
+	params.OverrideBeaconConfig(cfg)
+
+	// Create a Fulu state at epoch 0.
+	numVals := params.BeaconConfig().MinGenesisActiveValidatorCount
+	st, keys := util.DeterministicGenesisStateFulu(t, numVals)
+	pubKeys := make([][]byte, numVals)
+	for i := range numVals {
+		pubKeys[i] = keys[i].PublicKey().Marshal()
+	}
+
+	genesis := util.NewBeaconBlock()
+	genesisRoot, err := genesis.Block.HashTreeRoot()
+	require.NoError(t, err)
+
+	chain := &mockChain.ChainService{
+		State: st, Root: genesisRoot[:], Genesis: time.Now(),
+	}
+	vs := &Server{
+		HeadFetcher:       chain,
+		TimeFetcher:       chain,
+		ForkchoiceFetcher: chain,
+		SyncChecker:       &mockSync.Sync{IsSyncing: false},
+		PayloadIDCache:    cache.NewPayloadIDCache(),
+		CoreService:       &core.Service{},
+	}
+
+	req := &ethpb.DutiesRequest{
+		PublicKeys: pubKeys,
+		Epoch:      0, // Last Fulu epoch.
+	}
+	res, err := vs.GetDutiesV2(t.Context(), req)
+	require.NoError(t, err, "dutiesv2 must not error at the fork boundary")
+
+	// Current epoch (0) is before GloAS fork — no PTC.
+	for _, d := range res.CurrentEpochDuties {
+		if len(d.PtcSlots) > 0 {
+			t.Errorf("validator %d: expected no current-epoch PTC in Fulu, got %v", d.ValidatorIndex, d.PtcSlots)
+		}
+	}
+
+	// Next epoch (1) is GloAS, but the state is Fulu — PTC must be empty.
+	for _, d := range res.NextEpochDuties {
+		if len(d.PtcSlots) > 0 {
+			t.Errorf("validator %d: expected no next-epoch PTC from Fulu state at fork boundary, got %v",
+				d.ValidatorIndex, d.PtcSlots)
+		}
 	}
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v3_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/duties_v3_test.go
@@ -6,6 +6,7 @@ import (
 
 	mockChain "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/altair"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	dbutil "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
@@ -320,7 +321,9 @@ func TestGetPTCDuties_OK(t *testing.T) {
 	params.OverrideBeaconConfig(cfg)
 
 	numVals := uint64(fieldparams.PTCSize + 64)
-	bs, _ := util.DeterministicGenesisStateFulu(t, numVals)
+	fuluSt, _ := util.DeterministicGenesisStateFulu(t, numVals)
+	bs, err := gloas.UpgradeToGloas(fuluSt)
+	require.NoError(t, err)
 	require.NoError(t, helpers.UpdateCommitteeCache(t.Context(), bs, 0))
 
 	genesisRoot := [32]byte{0xaa}

--- a/changelog/satushh_fix-ptc-duties-fork-boundary.md
+++ b/changelog/satushh_fix-ptc-duties-fork-boundary.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- PTC duties no longer computed from a pre-Gloas state at the Fulu to Gloas fork boundary

--- a/changelog/satushh_fix-ptc-duties-fork-boundary.md
+++ b/changelog/satushh_fix-ptc-duties-fork-boundary.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- PTC duties no longer computed from a pre-Gloas state at the Fulu to Gloas fork boundary
+- PTC duties no longer computed from a pre-Gloas state at the Fulu to Gloas fork boundary.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

At fork boundary the PTC was computed from a pre-Gloas state. So this PR adds a state version check to avoid doing that. 

Added extra tests to cover it. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [ ] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
