### PR TITLE
Use proposer preferences cache for payload attributes after Gloas

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -141,6 +141,7 @@ go_test(
         "service_test.go",
         "setup_forkchoice_test.go",
         "setup_test.go",
+        "tracked_proposer_test.go",
         "weak_subjectivity_checks_test.go",
     ],
     embed = [":go_default_library"],

--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -96,6 +96,15 @@ func WithTrackedValidatorsCache(c *cache.TrackedValidatorsCache) Option {
 	}
 }
 
+// WithProposerPreferencesCache sets the proposer preferences cache used to
+// look up fee recipient and gas limit from Gloas gossip preferences.
+func WithProposerPreferencesCache(c *cache.ProposerPreferencesCache) Option {
+	return func(s *Service) error {
+		s.cfg.ProposerPreferencesCache = c
+		return nil
+	}
+}
+
 // WithAttestationCache for attestation lifecycle after chain inclusion.
 func WithAttestationCache(c *cache.AttestationCache) Option {
 	return func(s *Service) error {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -73,30 +73,30 @@ type Service struct {
 
 // config options for the service.
 type config struct {
-	BeaconBlockBuf          int
-	ChainStartFetcher       execution.ChainStartFetcher
-	BeaconDB                db.HeadAccessDatabase
-	DepositCache            cache.DepositCache
-	PayloadIDCache          *cache.PayloadIDCache
+	BeaconBlockBuf           int
+	ChainStartFetcher        execution.ChainStartFetcher
+	BeaconDB                 db.HeadAccessDatabase
+	DepositCache             cache.DepositCache
+	PayloadIDCache           *cache.PayloadIDCache
 	TrackedValidatorsCache   *cache.TrackedValidatorsCache
 	ProposerPreferencesCache *cache.ProposerPreferencesCache
 	AttestationCache         *cache.AttestationCache
-	AttPool                 attestations.Pool
-	ExitPool                voluntaryexits.PoolManager
-	SlashingPool            slashings.PoolManager
-	BLSToExecPool           blstoexec.PoolManager
-	P2P                     p2p.Accessor
-	MaxRoutines             int
-	StateNotifier           statefeed.Notifier
-	ForkChoiceStore         f.ForkChoicer
-	AttService              *attestations.Service
-	StateGen                *stategen.State
-	SlasherAttestationsFeed *event.Feed
-	WeakSubjectivityCheckpt *ethpb.Checkpoint
-	BlockFetcher            execution.POWBlockFetcher
-	FinalizedStateAtStartUp state.BeaconState
-	ExecutionEngineCaller   execution.EngineCaller
-	SyncChecker             Checker
+	AttPool                  attestations.Pool
+	ExitPool                 voluntaryexits.PoolManager
+	SlashingPool             slashings.PoolManager
+	BLSToExecPool            blstoexec.PoolManager
+	P2P                      p2p.Accessor
+	MaxRoutines              int
+	StateNotifier            statefeed.Notifier
+	ForkChoiceStore          f.ForkChoicer
+	AttService               *attestations.Service
+	StateGen                 *stategen.State
+	SlasherAttestationsFeed  *event.Feed
+	WeakSubjectivityCheckpt  *ethpb.Checkpoint
+	BlockFetcher             execution.POWBlockFetcher
+	FinalizedStateAtStartUp  state.BeaconState
+	ExecutionEngineCaller    execution.EngineCaller
+	SyncChecker              Checker
 }
 
 // Checker is an interface used to determine if a node is in initial sync

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -78,8 +78,9 @@ type config struct {
 	BeaconDB                db.HeadAccessDatabase
 	DepositCache            cache.DepositCache
 	PayloadIDCache          *cache.PayloadIDCache
-	TrackedValidatorsCache  *cache.TrackedValidatorsCache
-	AttestationCache        *cache.AttestationCache
+	TrackedValidatorsCache   *cache.TrackedValidatorsCache
+	ProposerPreferencesCache *cache.ProposerPreferencesCache
+	AttestationCache         *cache.AttestationCache
 	AttPool                 attestations.Pool
 	ExitPool                voluntaryexits.PoolManager
 	SlashingPool            slashings.PoolManager

--- a/beacon-chain/blockchain/tracked_proposer.go
+++ b/beacon-chain/blockchain/tracked_proposer.go
@@ -8,11 +8,35 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 )
 
+// proposerPreference returns a TrackedValidator from the ProposerPreferencesCache
+// if a preference exists for the given slot.
+func (s *Service) proposerPreference(slot primitives.Slot) (cache.TrackedValidator, bool) {
+	if s.cfg.ProposerPreferencesCache == nil {
+		return cache.TrackedValidator{}, false
+	}
+	pref, ok := s.cfg.ProposerPreferencesCache.Get(slot)
+	if !ok {
+		return cache.TrackedValidator{}, false
+	}
+	var feeRecipient primitives.ExecutionAddress
+	copy(feeRecipient[:], pref.FeeRecipient)
+	return cache.TrackedValidator{Active: true, FeeRecipient: feeRecipient, GasLimit: pref.GasLimit}, true
+}
+
 // trackedProposer returns whether the beacon node was informed, via the
 // validators/prepare_proposer endpoint, of the proposer at the given slot.
 // It only returns true if the tracked proposer is present and active.
+//
+// When PrepareAllPayloads is enabled, the node prepares payloads for every
+// slot. After the Gloas fork, proposers broadcast their preferences (fee
+// recipient, gas limit) via gossip into the ProposerPreferencesCache. When
+// available, these preferences supply the fee recipient; otherwise the
+// default (burn address) is used.
 func (s *Service) trackedProposer(st state.ReadOnlyBeaconState, slot primitives.Slot) (cache.TrackedValidator, bool) {
 	if features.Get().PrepareAllPayloads {
+		if val, ok := s.proposerPreference(slot); ok {
+			return val, true
+		}
 		return cache.TrackedValidator{Active: true}, true
 	}
 	id, err := helpers.BeaconProposerIndexAtSlot(s.ctx, st, slot)
@@ -22,6 +46,9 @@ func (s *Service) trackedProposer(st state.ReadOnlyBeaconState, slot primitives.
 	val, ok := s.cfg.TrackedValidatorsCache.Validator(id)
 	if !ok {
 		return cache.TrackedValidator{}, false
+	}
+	if pref, ok := s.proposerPreference(slot); ok {
+		return pref, true
 	}
 	return val, val.Active
 }

--- a/beacon-chain/blockchain/tracked_proposer_test.go
+++ b/beacon-chain/blockchain/tracked_proposer_test.go
@@ -1,0 +1,83 @@
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/cache"
+	"github.com/OffchainLabs/prysm/v7/config/features"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestTrackedProposer_NotTracked(t *testing.T) {
+	service, _ := minimalTestService(t, WithPayloadIDCache(cache.NewPayloadIDCache()))
+	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
+	_, ok := service.trackedProposer(st, 0)
+	require.Equal(t, false, ok)
+}
+
+func TestTrackedProposer_Tracked(t *testing.T) {
+	service, _ := minimalTestService(t, WithPayloadIDCache(cache.NewPayloadIDCache()))
+	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
+	addr := common.HexToAddress("0x1234")
+	service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, FeeRecipient: primitives.ExecutionAddress(addr), Index: 0})
+	val, ok := service.trackedProposer(st, 0)
+	require.Equal(t, true, ok)
+	require.Equal(t, primitives.ExecutionAddress(addr), val.FeeRecipient)
+}
+
+func TestTrackedProposer_PrepareAllPayloads_Default(t *testing.T) {
+	resetCfg := features.InitWithReset(&features.Flags{PrepareAllPayloads: true})
+	defer resetCfg()
+
+	service, _ := minimalTestService(t, WithPayloadIDCache(cache.NewPayloadIDCache()))
+	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
+	val, ok := service.trackedProposer(st, 0)
+	require.Equal(t, true, ok)
+	require.Equal(t, true, val.Active)
+	require.Equal(t, params.BeaconConfig().EthBurnAddressHex, common.BytesToAddress(val.FeeRecipient[:]).String())
+}
+
+func TestTrackedProposer_PrepareAllPayloads_WithProposerPreference(t *testing.T) {
+	resetCfg := features.InitWithReset(&features.Flags{PrepareAllPayloads: true})
+	defer resetCfg()
+
+	prefCache := cache.NewProposerPreferencesCache()
+	service, _ := minimalTestService(t,
+		WithPayloadIDCache(cache.NewPayloadIDCache()),
+		WithProposerPreferencesCache(prefCache),
+	)
+	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
+
+	addr := common.HexToAddress("0xabcd")
+	prefCache.Add(0, addr.Bytes(), 42_000_000)
+
+	val, ok := service.trackedProposer(st, 0)
+	require.Equal(t, true, ok)
+	require.Equal(t, true, val.Active)
+	require.Equal(t, primitives.ExecutionAddress(addr), val.FeeRecipient)
+	require.Equal(t, uint64(42_000_000), val.GasLimit)
+}
+
+func TestTrackedProposer_TrackedWithProposerPreferenceOverride(t *testing.T) {
+	prefCache := cache.NewProposerPreferencesCache()
+	service, _ := minimalTestService(t,
+		WithPayloadIDCache(cache.NewPayloadIDCache()),
+		WithProposerPreferencesCache(prefCache),
+	)
+	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
+
+	trackedAddr := common.HexToAddress("0x1111")
+	prefAddr := common.HexToAddress("0x2222")
+	service.cfg.TrackedValidatorsCache.Set(cache.TrackedValidator{Active: true, FeeRecipient: primitives.ExecutionAddress(trackedAddr), Index: 0})
+	prefCache.Add(0, prefAddr.Bytes(), 50_000_000)
+
+	val, ok := service.trackedProposer(st, 0)
+	require.Equal(t, true, ok)
+	// Proposer preference overrides tracked validator.
+	require.Equal(t, primitives.ExecutionAddress(prefAddr), val.FeeRecipient)
+	require.Equal(t, uint64(50_000_000), val.GasLimit)
+}

--- a/beacon-chain/cache/tracked_validators.go
+++ b/beacon-chain/cache/tracked_validators.go
@@ -21,6 +21,7 @@ type (
 		Active       bool
 		FeeRecipient primitives.ExecutionAddress
 		Index        primitives.ValidatorIndex
+		GasLimit     uint64
 	}
 
 	TrackedValidatorsCache struct {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -775,6 +775,7 @@ func (b *BeaconNode) registerBlockchainService(fc forkchoice.ForkChoicer, gs *st
 		blockchain.WithBlobStorage(b.BlobStorage),
 		blockchain.WithDataColumnStorage(b.DataColumnStorage),
 		blockchain.WithTrackedValidatorsCache(b.trackedValidatorsCache),
+		blockchain.WithProposerPreferencesCache(b.proposerPreferencesCache),
 		blockchain.WithPayloadIDCache(b.payloadIDCache),
 		blockchain.WithSyncChecker(b.syncChecker),
 		blockchain.WithSlasherEnabled(b.slasherEnabled),

--- a/changelog/potuz_proposer_preferences_payload_attributes.md
+++ b/changelog/potuz_proposer_preferences_payload_attributes.md
@@ -1,0 +1,2 @@
+### Fixed
+- Use proposer preferences cache for payload attributes after Gloas fork.


### PR DESCRIPTION
## Summary
- Adds `ProposerPreferencesCache` to the blockchain service so `trackedProposer()` can use Gloas gossip preferences (fee recipient, gas limit) when constructing payload attributes for FCU
- When `PrepareAllPayloads` is enabled, checks the preferences cache first, falling back to the default burn address
- When a validator is tracked, checks the preferences cache to override the tracked validator's fee recipient
- Adds `GasLimit` field to `TrackedValidator` struct, populated from proposer preferences