### PR TITLE
Fix MaxBuildersPerWithdrawalsSweep in minimal preset

### DIFF
--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -80,6 +80,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.MaxWithdrawalsPerPayload = 4
 	minimalConfig.MaxBlsToExecutionChanges = 16
 	minimalConfig.MaxValidatorsPerWithdrawalsSweep = 16
+	minimalConfig.MaxBuildersPerWithdrawalsSweep = 16
 
 	// Signature domains
 	minimalConfig.DomainBeaconProposer = bytesutil.ToBytes4(bytesutil.Bytes4(0))


### PR DESCRIPTION
## Summary
- The minimal preset was missing the `MaxBuildersPerWithdrawalsSweep` override, causing it to inherit the mainnet value of `16384` instead of the correct minimal value of `16`
- This aligns with the [consensus-specs minimal gloas preset](https://github.com/ethereum/consensus-specs/blob/master/presets/minimal/gloas.yaml#L23)

## Test plan
- [x] `go build ./config/params/` passes
- [ ] Verify minimal preset spec tests pass with the corrected value

🤖 Generated with [Claude Code](https://claude.com/claude-code)