### PR TITLE
Fix minimal preset and register ProduceBlockV4 endpoint

### DIFF
--- a/api/server/structs/conversions_block.go
+++ b/api/server/structs/conversions_block.go
@@ -3002,6 +3002,16 @@ func (b *SignedBeaconBlockGloas) ToConsensus() (*eth.SignedBeaconBlockGloas, err
 	}, nil
 }
 
+func (b *SignedBeaconBlockGloas) ToGeneric() (*eth.GenericSignedBeaconBlock, error) {
+	signed, err := b.ToConsensus()
+	if err != nil {
+		return nil, err
+	}
+	return &eth.GenericSignedBeaconBlock{
+		Block: &eth.GenericSignedBeaconBlock_Gloas{Gloas: signed},
+	}, nil
+}
+
 func (b *BeaconBlockGloas) ToConsensus() (*eth.BeaconBlockGloas, error) {
 	if b == nil {
 		return nil, errNilValue

--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -394,6 +394,16 @@ func (s *Service) validatorEndpoints(
 			methods: []string{http.MethodGet},
 		},
 		{
+			template: "/eth/v4/validator/blocks/{slot}",
+			name:     namespace + ".ProduceBlockV4",
+			middleware: []middleware.Middleware{
+				middleware.AcceptHeaderHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),
+				middleware.AcceptEncodingHeaderHandler(),
+			},
+			handler: server.ProduceBlockV4,
+			methods: []string{http.MethodGet},
+		},
+		{
 			template: "/eth/v1/validator/beacon_committee_selections",
 			name:     namespace + ".BeaconCommitteeSelections",
 			middleware: []middleware.Middleware{

--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -643,6 +643,7 @@ func (s *Server) publishBlockSSZ(ctx context.Context, w http.ResponseWriter, r *
 }
 
 var sszDecoders = map[string]blockDecoder{
+	version.String(version.Gloas):     decodeGloasSSZ,
 	version.String(version.Fulu):      decodeFuluSSZ,
 	version.String(version.Electra):   decodeElectraSSZ,
 	version.String(version.Deneb):     decodeDenebSSZ,
@@ -658,6 +659,18 @@ func decodeSSZToGenericBlock(versionHeader string, body []byte) (*eth.GenericSig
 		return decoder(body)
 	}
 	return nil, errors.New("body does not represent a valid block type")
+}
+
+func decodeGloasSSZ(body []byte) (*eth.GenericSignedBeaconBlock, error) {
+	gloasBlock := &eth.SignedBeaconBlockGloas{}
+	if err := gloasBlock.UnmarshalSSZ(body); err != nil {
+		return nil, decodingError(
+			version.String(version.Gloas), err,
+		)
+	}
+	return &eth.GenericSignedBeaconBlock{
+		Block: &eth.GenericSignedBeaconBlock_Gloas{Gloas: gloasBlock},
+	}, nil
 }
 
 func decodeFuluSSZ(body []byte) (*eth.GenericSignedBeaconBlock, error) {
@@ -798,6 +811,7 @@ func (s *Server) publishBlock(ctx context.Context, w http.ResponseWriter, r *htt
 }
 
 var jsonDecoders = map[string]blockDecoder{
+	version.String(version.Gloas):     decodeGloasJSON,
 	version.String(version.Fulu):      decodeFuluJSON,
 	version.String(version.Electra):   decodeElectraJSON,
 	version.String(version.Deneb):     decodeDenebJSON,
@@ -813,6 +827,13 @@ func decodeJSONToGenericBlock(versionHeader string, body []byte) (*eth.GenericSi
 		return decoder(body)
 	}
 	return nil, fmt.Errorf("body does not represent a valid block type")
+}
+
+func decodeGloasJSON(body []byte) (*eth.GenericSignedBeaconBlock, error) {
+	return decodeGenericJSON[*structs.SignedBeaconBlockGloas](
+		body,
+		version.String(version.Gloas),
+	)
 }
 
 func decodeFuluJSON(body []byte) (*eth.GenericSignedBeaconBlock, error) {

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -209,6 +209,12 @@ func (s *Server) produceBlockV3(ctx context.Context, w http.ResponseWriter, r *h
 		handleProduceFuluV3(w, isSSZ, fuluBlockContents, v1alpha1resp.PayloadValue, consensusBlockValue)
 		return
 	}
+	gloasBlock, ok := v1alpha1resp.Block.(*eth.GenericBeaconBlock_Gloas)
+	if ok {
+		w.Header().Set(api.VersionHeader, version.String(version.Gloas))
+		handleProduceGloasV4(w, isSSZ, gloasBlock, v1alpha1resp.PayloadValue, consensusBlockValue)
+		return
+	}
 }
 
 func getConsensusBlockValue(ctx context.Context, blockRewardsFetcher rewards.BlockRewardsFetcher, i interface{} /* block as argument */) (string, *httputil.DefaultJsonError) {

--- a/beacon-chain/rpc/eth/validator/handlers_gloas.go
+++ b/beacon-chain/rpc/eth/validator/handlers_gloas.go
@@ -1,17 +1,19 @@
 package validator
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/OffchainLabs/prysm/v7/api/server/structs"
 	"github.com/OffchainLabs/prysm/v7/network/httputil"
+	eth "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/runtime/version"
 )
 
 // ProduceBlockV4 requests a beacon node to produce a valid Gloas block.
-//
-// TODO: Implement Gloas-specific block production.
 // Endpoint: GET /eth/v4/validator/blocks/{slot}
 func (s *Server) ProduceBlockV4(w http.ResponseWriter, r *http.Request) {
-	httputil.HandleError(w, "ProduceBlockV4 not yet implemented", http.StatusNotImplemented)
+	s.ProduceBlockV3(w, r)
 }
 
 // ExecutionPayloadEnvelope retrieves a cached execution payload envelope.
@@ -28,4 +30,40 @@ func (s *Server) ExecutionPayloadEnvelope(w http.ResponseWriter, r *http.Request
 // Endpoint: POST /eth/v1/beacon/execution_payload_envelope
 func (s *Server) PublishExecutionPayloadEnvelope(w http.ResponseWriter, r *http.Request) {
 	httputil.HandleError(w, "PublishExecutionPayloadEnvelope not yet implemented", http.StatusNotImplemented)
+}
+
+func handleProduceGloasV4(
+	w http.ResponseWriter,
+	isSSZ bool,
+	blk *eth.GenericBeaconBlock_Gloas,
+	executionPayloadValue string,
+	consensusBlockValue string,
+) {
+	if isSSZ {
+		sszResp, err := blk.Gloas.MarshalSSZ()
+		if err != nil {
+			httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		httputil.WriteSsz(w, sszResp)
+		return
+	}
+
+	block, err := structs.BeaconBlockGloasFromConsensus(blk.Gloas)
+	if err != nil {
+		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonBytes, err := json.Marshal(block)
+	if err != nil {
+		httputil.HandleError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	httputil.WriteJson(w, &structs.ProduceBlockV3Response{
+		Version:                 version.String(version.Gloas),
+		ExecutionPayloadBlinded: false,
+		ExecutionPayloadValue:   executionPayloadValue,
+		ConsensusBlockValue:     consensusBlockValue,
+		Data:                    jsonBytes,
+	})
 }

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -80,6 +80,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.MaxWithdrawalsPerPayload = 4
 	minimalConfig.MaxBlsToExecutionChanges = 16
 	minimalConfig.MaxValidatorsPerWithdrawalsSweep = 16
+	minimalConfig.MaxBuildersPerWithdrawalsSweep = 16
 
 	// Signature domains
 	minimalConfig.DomainBeaconProposer = bytesutil.ToBytes4(bytesutil.Bytes4(0))


### PR DESCRIPTION
Fixes:
```sh
Apr-01 08:02:41.127[]                error: Error on block duties slot=34 - produceBlockV4 failed with status 404: 404 page not found

Error: produceBlockV4 failed with status 404: 404 page not found

    at ApiResponse.error (file:///usr/app/packages/api/src/utils/client/response.ts:165:12)
    at ApiResponse.assertOk (file:///usr/app/packages/api/src/utils/client/response.ts:156:18)
    at ApiResponse.value (file:///usr/app/packages/api/src/utils/client/response.ts:105:10)
    at BlockProposingService.createAndPublishBlockGloas (file:///usr/app/packages/validator/src/services/block.ts:205:28)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async Promise.all (index 0)
```


## Summary
- Add missing `MaxBuildersPerWithdrawalsSweep` override in minimal preset (was inheriting mainnet value `16384` instead of correct value `16`, per [consensus-specs](https://github.com/ethereum/consensus-specs/blob/master/presets/minimal/gloas.yaml#L23))
- Register `/eth/v4/validator/blocks/{slot}` endpoint and implement `ProduceBlockV4` by delegating to `ProduceBlockV3` with Gloas block handling, fixing 404 when using Lodestar VC

## Test plan
- [x] `go build ./config/params/ ./beacon-chain/rpc/...` passes
- [ ] Verify Lodestar VC can produce blocks via `/eth/v4/validator/blocks/{slot}`
- [ ] Verify minimal preset spec tests pass with the corrected value

🤖 Generated with [Claude Code](https://claude.com/claude-code)