### PR TITLE
Fastssz update to allow generics

### DIFF
--- a/changelog/pvl-fastssz-generic.md
+++ b/changelog/pvl-fastssz-generic.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Updated fastssz to commit [c57e478](https://github.com/OffchainLabs/fastssz/commit/c57e478b88da1094d2b4182dc15ec990a11c3130) to allow for generics in ssz code generation 

--- a/deps.bzl
+++ b/deps.bzl
@@ -2841,8 +2841,8 @@ def prysm_deps():
     go_repository(
         name = "com_github_prysmaticlabs_fastssz",
         importpath = "github.com/prysmaticlabs/fastssz",
-        sum = "h1:ASmh3y4ALne2OoabF5pPL8OcIpBko8gFMg5018MxkBI=",
-        version = "v0.0.0-20251103153600-259302269bfc",
+        sum = "h1:by+quGludklRjZWzNJHPpp5Xwfzk41e85F7w0aWICb8=",
+        version = "v0.0.0-20260401175048-c57e478b88da",
     )
     go_repository(
         name = "com_github_prysmaticlabs_go_bitfield",

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/prom2json v1.3.0
-	github.com/prysmaticlabs/fastssz v0.0.0-20251103153600-259302269bfc
+	github.com/prysmaticlabs/fastssz v0.0.0-20260401175048-c57e478b88da
 	github.com/prysmaticlabs/prombbolt v0.0.0-20210126082820-9b7adba6db7c
 	github.com/prysmaticlabs/protoc-gen-go-cast v0.0.0-20230228205207-28762a7b9294
 	github.com/r3labs/sse/v2 v2.10.0

--- a/go.sum
+++ b/go.sum
@@ -900,8 +900,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/prometheus/prom2json v1.3.0 h1:BlqrtbT9lLH3ZsOVhXPsHzFrApCTKRifB7gjJuypu6Y=
 github.com/prometheus/prom2json v1.3.0/go.mod h1:rMN7m0ApCowcoDlypBHlkNbp5eJQf/+1isKykIP5ZnM=
-github.com/prysmaticlabs/fastssz v0.0.0-20251103153600-259302269bfc h1:ASmh3y4ALne2OoabF5pPL8OcIpBko8gFMg5018MxkBI=
-github.com/prysmaticlabs/fastssz v0.0.0-20251103153600-259302269bfc/go.mod h1:h2OlIZD/M6wFvV3YMZbW16lFgh3Rsye00G44J2cwLyU=
+github.com/prysmaticlabs/fastssz v0.0.0-20260401175048-c57e478b88da h1:by+quGludklRjZWzNJHPpp5Xwfzk41e85F7w0aWICb8=
+github.com/prysmaticlabs/fastssz v0.0.0-20260401175048-c57e478b88da/go.mod h1:6lF+KRHYePGWv4zcbdfmq+EoCy1rch1Ew/oyZmi6AZ0=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20210108222456-8e92c3709aa0/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
 github.com/prysmaticlabs/gohashtree v0.0.5-beta h1:ct41mg7HyIZd7uoSM/ud23f+3DxQG9tlMlQG+BVX23c=
 github.com/prysmaticlabs/gohashtree v0.0.5-beta/go.mod h1:HRuvtXLZ4WkaB1MItToVH2e8ZwKwZPY5/Rcby+CvvLY=

--- a/proto/engine/v1/engine.ssz.go
+++ b/proto/engine/v1/engine.ssz.go
@@ -30,7 +30,7 @@ func (w *WithdrawalRequest) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, w.ValidatorPubkey...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, w.Amount)
+	dst = ssz.MarshalUint(dst, w.Amount)
 
 	return
 }
@@ -56,7 +56,7 @@ func (w *WithdrawalRequest) UnmarshalSSZ(buf []byte) error {
 	w.ValidatorPubkey = append(w.ValidatorPubkey, buf[20:68]...)
 
 	// Field (2) 'Amount'
-	w.Amount = ssz.UnmarshallUint64(buf[68:76])
+	w.Amount = ssz.UnmarshallUint[uint64](buf[68:76])
 
 	return err
 }
@@ -91,7 +91,7 @@ func (w *WithdrawalRequest) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(w.ValidatorPubkey)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(w.Amount)
+	ssz.PutUint(hh, w.Amount)
 
 	hh.Merkleize(indx)
 	return
@@ -121,7 +121,7 @@ func (d *DepositRequest) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.WithdrawalCredentials...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, d.Amount)
+	dst = ssz.MarshalUint(dst, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -131,7 +131,7 @@ func (d *DepositRequest) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.Signature...)
 
 	// Field (4) 'Index'
-	dst = ssz.MarshalUint64(dst, d.Index)
+	dst = ssz.MarshalUint(dst, d.Index)
 
 	return
 }
@@ -157,7 +157,7 @@ func (d *DepositRequest) UnmarshalSSZ(buf []byte) error {
 	d.WithdrawalCredentials = append(d.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'Amount'
-	d.Amount = ssz.UnmarshallUint64(buf[80:88])
+	d.Amount = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Signature'
 	if cap(d.Signature) == 0 {
@@ -166,7 +166,7 @@ func (d *DepositRequest) UnmarshalSSZ(buf []byte) error {
 	d.Signature = append(d.Signature, buf[88:184]...)
 
 	// Field (4) 'Index'
-	d.Index = ssz.UnmarshallUint64(buf[184:192])
+	d.Index = ssz.UnmarshallUint[uint64](buf[184:192])
 
 	return err
 }
@@ -201,7 +201,7 @@ func (d *DepositRequest) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.WithdrawalCredentials)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(d.Amount)
+	ssz.PutUint(hh, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -211,7 +211,7 @@ func (d *DepositRequest) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.Signature)
 
 	// Field (4) 'Index'
-	hh.PutUint64(d.Index)
+	ssz.PutUint(hh, d.Index)
 
 	hh.Merkleize(indx)
 	return
@@ -593,16 +593,16 @@ func (e *ExecutionPayload) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, e.PrevRandao...)
 
 	// Field (6) 'BlockNumber'
-	dst = ssz.MarshalUint64(dst, e.BlockNumber)
+	dst = ssz.MarshalUint(dst, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, e.GasLimit)
+	dst = ssz.MarshalUint(dst, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	dst = ssz.MarshalUint64(dst, e.GasUsed)
+	dst = ssz.MarshalUint(dst, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, e.Timestamp)
+	dst = ssz.MarshalUint(dst, e.Timestamp)
 
 	// Offset (10) 'ExtraData'
 	dst = ssz.WriteOffset(dst, offset)
@@ -707,16 +707,16 @@ func (e *ExecutionPayload) UnmarshalSSZ(buf []byte) error {
 	e.PrevRandao = append(e.PrevRandao, buf[372:404]...)
 
 	// Field (6) 'BlockNumber'
-	e.BlockNumber = ssz.UnmarshallUint64(buf[404:412])
+	e.BlockNumber = ssz.UnmarshallUint[uint64](buf[404:412])
 
 	// Field (7) 'GasLimit'
-	e.GasLimit = ssz.UnmarshallUint64(buf[412:420])
+	e.GasLimit = ssz.UnmarshallUint[uint64](buf[412:420])
 
 	// Field (8) 'GasUsed'
-	e.GasUsed = ssz.UnmarshallUint64(buf[420:428])
+	e.GasUsed = ssz.UnmarshallUint[uint64](buf[420:428])
 
 	// Field (9) 'Timestamp'
-	e.Timestamp = ssz.UnmarshallUint64(buf[428:436])
+	e.Timestamp = ssz.UnmarshallUint[uint64](buf[428:436])
 
 	// Offset (10) 'ExtraData'
 	if o10 = ssz.ReadOffset(buf[436:440]); o10 > size {
@@ -849,16 +849,16 @@ func (e *ExecutionPayload) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.PrevRandao)
 
 	// Field (6) 'BlockNumber'
-	hh.PutUint64(e.BlockNumber)
+	ssz.PutUint(hh, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	hh.PutUint64(e.GasLimit)
+	ssz.PutUint(hh, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	hh.PutUint64(e.GasUsed)
+	ssz.PutUint(hh, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	hh.PutUint64(e.Timestamp)
+	ssz.PutUint(hh, e.Timestamp)
 
 	// Field (10) 'ExtraData'
 	{
@@ -966,16 +966,16 @@ func (e *ExecutionPayloadCapella) MarshalSSZTo(buf []byte) (dst []byte, err erro
 	dst = append(dst, e.PrevRandao...)
 
 	// Field (6) 'BlockNumber'
-	dst = ssz.MarshalUint64(dst, e.BlockNumber)
+	dst = ssz.MarshalUint(dst, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, e.GasLimit)
+	dst = ssz.MarshalUint(dst, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	dst = ssz.MarshalUint64(dst, e.GasUsed)
+	dst = ssz.MarshalUint(dst, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, e.Timestamp)
+	dst = ssz.MarshalUint(dst, e.Timestamp)
 
 	// Offset (10) 'ExtraData'
 	dst = ssz.WriteOffset(dst, offset)
@@ -1095,16 +1095,16 @@ func (e *ExecutionPayloadCapella) UnmarshalSSZ(buf []byte) error {
 	e.PrevRandao = append(e.PrevRandao, buf[372:404]...)
 
 	// Field (6) 'BlockNumber'
-	e.BlockNumber = ssz.UnmarshallUint64(buf[404:412])
+	e.BlockNumber = ssz.UnmarshallUint[uint64](buf[404:412])
 
 	// Field (7) 'GasLimit'
-	e.GasLimit = ssz.UnmarshallUint64(buf[412:420])
+	e.GasLimit = ssz.UnmarshallUint[uint64](buf[412:420])
 
 	// Field (8) 'GasUsed'
-	e.GasUsed = ssz.UnmarshallUint64(buf[420:428])
+	e.GasUsed = ssz.UnmarshallUint[uint64](buf[420:428])
 
 	// Field (9) 'Timestamp'
-	e.Timestamp = ssz.UnmarshallUint64(buf[428:436])
+	e.Timestamp = ssz.UnmarshallUint[uint64](buf[428:436])
 
 	// Offset (10) 'ExtraData'
 	if o10 = ssz.ReadOffset(buf[436:440]); o10 > size {
@@ -1263,16 +1263,16 @@ func (e *ExecutionPayloadCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.PrevRandao)
 
 	// Field (6) 'BlockNumber'
-	hh.PutUint64(e.BlockNumber)
+	ssz.PutUint(hh, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	hh.PutUint64(e.GasLimit)
+	ssz.PutUint(hh, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	hh.PutUint64(e.GasUsed)
+	ssz.PutUint(hh, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	hh.PutUint64(e.Timestamp)
+	ssz.PutUint(hh, e.Timestamp)
 
 	// Field (10) 'ExtraData'
 	{
@@ -1396,16 +1396,16 @@ func (e *ExecutionPayloadDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error)
 	dst = append(dst, e.PrevRandao...)
 
 	// Field (6) 'BlockNumber'
-	dst = ssz.MarshalUint64(dst, e.BlockNumber)
+	dst = ssz.MarshalUint(dst, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, e.GasLimit)
+	dst = ssz.MarshalUint(dst, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	dst = ssz.MarshalUint64(dst, e.GasUsed)
+	dst = ssz.MarshalUint(dst, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, e.Timestamp)
+	dst = ssz.MarshalUint(dst, e.Timestamp)
 
 	// Offset (10) 'ExtraData'
 	dst = ssz.WriteOffset(dst, offset)
@@ -1437,10 +1437,10 @@ func (e *ExecutionPayloadDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error)
 	offset += len(e.Withdrawals) * 44
 
 	// Field (15) 'BlobGasUsed'
-	dst = ssz.MarshalUint64(dst, e.BlobGasUsed)
+	dst = ssz.MarshalUint(dst, e.BlobGasUsed)
 
 	// Field (16) 'ExcessBlobGas'
-	dst = ssz.MarshalUint64(dst, e.ExcessBlobGas)
+	dst = ssz.MarshalUint(dst, e.ExcessBlobGas)
 
 	// Field (10) 'ExtraData'
 	if size := len(e.ExtraData); size > 32 {
@@ -1531,16 +1531,16 @@ func (e *ExecutionPayloadDeneb) UnmarshalSSZ(buf []byte) error {
 	e.PrevRandao = append(e.PrevRandao, buf[372:404]...)
 
 	// Field (6) 'BlockNumber'
-	e.BlockNumber = ssz.UnmarshallUint64(buf[404:412])
+	e.BlockNumber = ssz.UnmarshallUint[uint64](buf[404:412])
 
 	// Field (7) 'GasLimit'
-	e.GasLimit = ssz.UnmarshallUint64(buf[412:420])
+	e.GasLimit = ssz.UnmarshallUint[uint64](buf[412:420])
 
 	// Field (8) 'GasUsed'
-	e.GasUsed = ssz.UnmarshallUint64(buf[420:428])
+	e.GasUsed = ssz.UnmarshallUint[uint64](buf[420:428])
 
 	// Field (9) 'Timestamp'
-	e.Timestamp = ssz.UnmarshallUint64(buf[428:436])
+	e.Timestamp = ssz.UnmarshallUint[uint64](buf[428:436])
 
 	// Offset (10) 'ExtraData'
 	if o10 = ssz.ReadOffset(buf[436:440]); o10 > size {
@@ -1574,10 +1574,10 @@ func (e *ExecutionPayloadDeneb) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (15) 'BlobGasUsed'
-	e.BlobGasUsed = ssz.UnmarshallUint64(buf[512:520])
+	e.BlobGasUsed = ssz.UnmarshallUint[uint64](buf[512:520])
 
 	// Field (16) 'ExcessBlobGas'
-	e.ExcessBlobGas = ssz.UnmarshallUint64(buf[520:528])
+	e.ExcessBlobGas = ssz.UnmarshallUint[uint64](buf[520:528])
 
 	// Field (10) 'ExtraData'
 	{
@@ -1705,16 +1705,16 @@ func (e *ExecutionPayloadDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.PrevRandao)
 
 	// Field (6) 'BlockNumber'
-	hh.PutUint64(e.BlockNumber)
+	ssz.PutUint(hh, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	hh.PutUint64(e.GasLimit)
+	ssz.PutUint(hh, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	hh.PutUint64(e.GasUsed)
+	ssz.PutUint(hh, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	hh.PutUint64(e.Timestamp)
+	ssz.PutUint(hh, e.Timestamp)
 
 	// Field (10) 'ExtraData'
 	{
@@ -1782,10 +1782,10 @@ func (e *ExecutionPayloadDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (15) 'BlobGasUsed'
-	hh.PutUint64(e.BlobGasUsed)
+	ssz.PutUint(hh, e.BlobGasUsed)
 
 	// Field (16) 'ExcessBlobGas'
-	hh.PutUint64(e.ExcessBlobGas)
+	ssz.PutUint(hh, e.ExcessBlobGas)
 
 	hh.Merkleize(indx)
 	return
@@ -2100,16 +2100,16 @@ func (e *ExecutionPayloadHeader) MarshalSSZTo(buf []byte) (dst []byte, err error
 	dst = append(dst, e.PrevRandao...)
 
 	// Field (6) 'BlockNumber'
-	dst = ssz.MarshalUint64(dst, e.BlockNumber)
+	dst = ssz.MarshalUint(dst, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, e.GasLimit)
+	dst = ssz.MarshalUint(dst, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	dst = ssz.MarshalUint64(dst, e.GasUsed)
+	dst = ssz.MarshalUint(dst, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, e.Timestamp)
+	dst = ssz.MarshalUint(dst, e.Timestamp)
 
 	// Offset (10) 'ExtraData'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2194,16 +2194,16 @@ func (e *ExecutionPayloadHeader) UnmarshalSSZ(buf []byte) error {
 	e.PrevRandao = append(e.PrevRandao, buf[372:404]...)
 
 	// Field (6) 'BlockNumber'
-	e.BlockNumber = ssz.UnmarshallUint64(buf[404:412])
+	e.BlockNumber = ssz.UnmarshallUint[uint64](buf[404:412])
 
 	// Field (7) 'GasLimit'
-	e.GasLimit = ssz.UnmarshallUint64(buf[412:420])
+	e.GasLimit = ssz.UnmarshallUint[uint64](buf[412:420])
 
 	// Field (8) 'GasUsed'
-	e.GasUsed = ssz.UnmarshallUint64(buf[420:428])
+	e.GasUsed = ssz.UnmarshallUint[uint64](buf[420:428])
 
 	// Field (9) 'Timestamp'
-	e.Timestamp = ssz.UnmarshallUint64(buf[428:436])
+	e.Timestamp = ssz.UnmarshallUint[uint64](buf[428:436])
 
 	// Offset (10) 'ExtraData'
 	if o10 = ssz.ReadOffset(buf[436:440]); o10 > size {
@@ -2308,16 +2308,16 @@ func (e *ExecutionPayloadHeader) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.PrevRandao)
 
 	// Field (6) 'BlockNumber'
-	hh.PutUint64(e.BlockNumber)
+	ssz.PutUint(hh, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	hh.PutUint64(e.GasLimit)
+	ssz.PutUint(hh, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	hh.PutUint64(e.GasUsed)
+	ssz.PutUint(hh, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	hh.PutUint64(e.Timestamp)
+	ssz.PutUint(hh, e.Timestamp)
 
 	// Field (10) 'ExtraData'
 	{
@@ -2409,16 +2409,16 @@ func (e *ExecutionPayloadHeaderCapella) MarshalSSZTo(buf []byte) (dst []byte, er
 	dst = append(dst, e.PrevRandao...)
 
 	// Field (6) 'BlockNumber'
-	dst = ssz.MarshalUint64(dst, e.BlockNumber)
+	dst = ssz.MarshalUint(dst, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, e.GasLimit)
+	dst = ssz.MarshalUint(dst, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	dst = ssz.MarshalUint64(dst, e.GasUsed)
+	dst = ssz.MarshalUint(dst, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, e.Timestamp)
+	dst = ssz.MarshalUint(dst, e.Timestamp)
 
 	// Offset (10) 'ExtraData'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2510,16 +2510,16 @@ func (e *ExecutionPayloadHeaderCapella) UnmarshalSSZ(buf []byte) error {
 	e.PrevRandao = append(e.PrevRandao, buf[372:404]...)
 
 	// Field (6) 'BlockNumber'
-	e.BlockNumber = ssz.UnmarshallUint64(buf[404:412])
+	e.BlockNumber = ssz.UnmarshallUint[uint64](buf[404:412])
 
 	// Field (7) 'GasLimit'
-	e.GasLimit = ssz.UnmarshallUint64(buf[412:420])
+	e.GasLimit = ssz.UnmarshallUint[uint64](buf[412:420])
 
 	// Field (8) 'GasUsed'
-	e.GasUsed = ssz.UnmarshallUint64(buf[420:428])
+	e.GasUsed = ssz.UnmarshallUint[uint64](buf[420:428])
 
 	// Field (9) 'Timestamp'
-	e.Timestamp = ssz.UnmarshallUint64(buf[428:436])
+	e.Timestamp = ssz.UnmarshallUint[uint64](buf[428:436])
 
 	// Offset (10) 'ExtraData'
 	if o10 = ssz.ReadOffset(buf[436:440]); o10 > size {
@@ -2630,16 +2630,16 @@ func (e *ExecutionPayloadHeaderCapella) HashTreeRootWith(hh *ssz.Hasher) (err er
 	hh.PutBytes(e.PrevRandao)
 
 	// Field (6) 'BlockNumber'
-	hh.PutUint64(e.BlockNumber)
+	ssz.PutUint(hh, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	hh.PutUint64(e.GasLimit)
+	ssz.PutUint(hh, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	hh.PutUint64(e.GasUsed)
+	ssz.PutUint(hh, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	hh.PutUint64(e.Timestamp)
+	ssz.PutUint(hh, e.Timestamp)
 
 	// Field (10) 'ExtraData'
 	{
@@ -2738,16 +2738,16 @@ func (e *ExecutionPayloadHeaderDeneb) MarshalSSZTo(buf []byte) (dst []byte, err 
 	dst = append(dst, e.PrevRandao...)
 
 	// Field (6) 'BlockNumber'
-	dst = ssz.MarshalUint64(dst, e.BlockNumber)
+	dst = ssz.MarshalUint(dst, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, e.GasLimit)
+	dst = ssz.MarshalUint(dst, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	dst = ssz.MarshalUint64(dst, e.GasUsed)
+	dst = ssz.MarshalUint(dst, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, e.Timestamp)
+	dst = ssz.MarshalUint(dst, e.Timestamp)
 
 	// Offset (10) 'ExtraData'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2782,10 +2782,10 @@ func (e *ExecutionPayloadHeaderDeneb) MarshalSSZTo(buf []byte) (dst []byte, err 
 	dst = append(dst, e.WithdrawalsRoot...)
 
 	// Field (15) 'BlobGasUsed'
-	dst = ssz.MarshalUint64(dst, e.BlobGasUsed)
+	dst = ssz.MarshalUint(dst, e.BlobGasUsed)
 
 	// Field (16) 'ExcessBlobGas'
-	dst = ssz.MarshalUint64(dst, e.ExcessBlobGas)
+	dst = ssz.MarshalUint(dst, e.ExcessBlobGas)
 
 	// Field (10) 'ExtraData'
 	if size := len(e.ExtraData); size > 32 {
@@ -2845,16 +2845,16 @@ func (e *ExecutionPayloadHeaderDeneb) UnmarshalSSZ(buf []byte) error {
 	e.PrevRandao = append(e.PrevRandao, buf[372:404]...)
 
 	// Field (6) 'BlockNumber'
-	e.BlockNumber = ssz.UnmarshallUint64(buf[404:412])
+	e.BlockNumber = ssz.UnmarshallUint[uint64](buf[404:412])
 
 	// Field (7) 'GasLimit'
-	e.GasLimit = ssz.UnmarshallUint64(buf[412:420])
+	e.GasLimit = ssz.UnmarshallUint[uint64](buf[412:420])
 
 	// Field (8) 'GasUsed'
-	e.GasUsed = ssz.UnmarshallUint64(buf[420:428])
+	e.GasUsed = ssz.UnmarshallUint[uint64](buf[420:428])
 
 	// Field (9) 'Timestamp'
-	e.Timestamp = ssz.UnmarshallUint64(buf[428:436])
+	e.Timestamp = ssz.UnmarshallUint[uint64](buf[428:436])
 
 	// Offset (10) 'ExtraData'
 	if o10 = ssz.ReadOffset(buf[436:440]); o10 > size {
@@ -2890,10 +2890,10 @@ func (e *ExecutionPayloadHeaderDeneb) UnmarshalSSZ(buf []byte) error {
 	e.WithdrawalsRoot = append(e.WithdrawalsRoot, buf[536:568]...)
 
 	// Field (15) 'BlobGasUsed'
-	e.BlobGasUsed = ssz.UnmarshallUint64(buf[568:576])
+	e.BlobGasUsed = ssz.UnmarshallUint[uint64](buf[568:576])
 
 	// Field (16) 'ExcessBlobGas'
-	e.ExcessBlobGas = ssz.UnmarshallUint64(buf[576:584])
+	e.ExcessBlobGas = ssz.UnmarshallUint[uint64](buf[576:584])
 
 	// Field (10) 'ExtraData'
 	{
@@ -2971,16 +2971,16 @@ func (e *ExecutionPayloadHeaderDeneb) HashTreeRootWith(hh *ssz.Hasher) (err erro
 	hh.PutBytes(e.PrevRandao)
 
 	// Field (6) 'BlockNumber'
-	hh.PutUint64(e.BlockNumber)
+	ssz.PutUint(hh, e.BlockNumber)
 
 	// Field (7) 'GasLimit'
-	hh.PutUint64(e.GasLimit)
+	ssz.PutUint(hh, e.GasLimit)
 
 	// Field (8) 'GasUsed'
-	hh.PutUint64(e.GasUsed)
+	ssz.PutUint(hh, e.GasUsed)
 
 	// Field (9) 'Timestamp'
-	hh.PutUint64(e.Timestamp)
+	ssz.PutUint(hh, e.Timestamp)
 
 	// Field (10) 'ExtraData'
 	{
@@ -3023,10 +3023,10 @@ func (e *ExecutionPayloadHeaderDeneb) HashTreeRootWith(hh *ssz.Hasher) (err erro
 	hh.PutBytes(e.WithdrawalsRoot)
 
 	// Field (15) 'BlobGasUsed'
-	hh.PutUint64(e.BlobGasUsed)
+	ssz.PutUint(hh, e.BlobGasUsed)
 
 	// Field (16) 'ExcessBlobGas'
-	hh.PutUint64(e.ExcessBlobGas)
+	ssz.PutUint(hh, e.ExcessBlobGas)
 
 	hh.Merkleize(indx)
 	return
@@ -3042,10 +3042,10 @@ func (w *Withdrawal) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Index'
-	dst = ssz.MarshalUint64(dst, w.Index)
+	dst = ssz.MarshalUint(dst, w.Index)
 
 	// Field (1) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(w.ValidatorIndex))
+	dst = ssz.MarshalUint(dst, w.ValidatorIndex)
 
 	// Field (2) 'Address'
 	if size := len(w.Address); size != 20 {
@@ -3055,7 +3055,7 @@ func (w *Withdrawal) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, w.Address...)
 
 	// Field (3) 'Amount'
-	dst = ssz.MarshalUint64(dst, w.Amount)
+	dst = ssz.MarshalUint(dst, w.Amount)
 
 	return
 }
@@ -3069,10 +3069,10 @@ func (w *Withdrawal) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Index'
-	w.Index = ssz.UnmarshallUint64(buf[0:8])
+	w.Index = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'ValidatorIndex'
-	w.ValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	w.ValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'Address'
 	if cap(w.Address) == 0 {
@@ -3081,7 +3081,7 @@ func (w *Withdrawal) UnmarshalSSZ(buf []byte) error {
 	w.Address = append(w.Address, buf[16:36]...)
 
 	// Field (3) 'Amount'
-	w.Amount = ssz.UnmarshallUint64(buf[36:44])
+	w.Amount = ssz.UnmarshallUint[uint64](buf[36:44])
 
 	return err
 }
@@ -3102,10 +3102,10 @@ func (w *Withdrawal) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Index'
-	hh.PutUint64(w.Index)
+	ssz.PutUint(hh, w.Index)
 
 	// Field (1) 'ValidatorIndex'
-	hh.PutUint64(uint64(w.ValidatorIndex))
+	ssz.PutUint(hh, w.ValidatorIndex)
 
 	// Field (2) 'Address'
 	if size := len(w.Address); size != 20 {
@@ -3115,7 +3115,7 @@ func (w *Withdrawal) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(w.Address)
 
 	// Field (3) 'Amount'
-	hh.PutUint64(w.Amount)
+	ssz.PutUint(hh, w.Amount)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/eth/v1/gateway.ssz.go
+++ b/proto/eth/v1/gateway.ssz.go
@@ -146,7 +146,7 @@ func (a *AggregateAttestationAndProof) MarshalSSZTo(buf []byte) (dst []byte, err
 	offset := int(108)
 
 	// Field (0) 'AggregatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(a.AggregatorIndex))
+	dst = ssz.MarshalUint(dst, a.AggregatorIndex)
 
 	// Offset (1) 'Aggregate'
 	dst = ssz.WriteOffset(dst, offset)
@@ -182,7 +182,7 @@ func (a *AggregateAttestationAndProof) UnmarshalSSZ(buf []byte) error {
 	var o1 uint64
 
 	// Field (0) 'AggregatorIndex'
-	a.AggregatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	a.AggregatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Offset (1) 'Aggregate'
 	if o1 = ssz.ReadOffset(buf[8:12]); o1 > size {
@@ -235,7 +235,7 @@ func (a *AggregateAttestationAndProof) HashTreeRootWith(hh *ssz.Hasher) (err err
 	indx := hh.Index()
 
 	// Field (0) 'AggregatorIndex'
-	hh.PutUint64(uint64(a.AggregatorIndex))
+	ssz.PutUint(hh, a.AggregatorIndex)
 
 	// Field (1) 'Aggregate'
 	if err = a.Aggregate.HashTreeRootWith(hh); err != nil {
@@ -372,10 +372,10 @@ func (a *AttestationData) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(a.Slot))
+	dst = ssz.MarshalUint(dst, a.Slot)
 
 	// Field (1) 'Index'
-	dst = ssz.MarshalUint64(dst, uint64(a.Index))
+	dst = ssz.MarshalUint(dst, a.Index)
 
 	// Field (2) 'BeaconBlockRoot'
 	if size := len(a.BeaconBlockRoot); size != 32 {
@@ -412,10 +412,10 @@ func (a *AttestationData) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	a.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	a.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'Index'
-	a.Index = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.CommitteeIndex(ssz.UnmarshallUint64(buf[8:16]))
+	a.Index = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.CommitteeIndex](buf[8:16])
 
 	// Field (2) 'BeaconBlockRoot'
 	if cap(a.BeaconBlockRoot) == 0 {
@@ -458,10 +458,10 @@ func (a *AttestationData) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(a.Slot))
+	ssz.PutUint(hh, a.Slot)
 
 	// Field (1) 'Index'
-	hh.PutUint64(uint64(a.Index))
+	ssz.PutUint(hh, a.Index)
 
 	// Field (2) 'BeaconBlockRoot'
 	if size := len(a.BeaconBlockRoot); size != 32 {
@@ -494,7 +494,7 @@ func (c *Checkpoint) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Epoch'
-	dst = ssz.MarshalUint64(dst, uint64(c.Epoch))
+	dst = ssz.MarshalUint(dst, c.Epoch)
 
 	// Field (1) 'Root'
 	if size := len(c.Root); size != 32 {
@@ -515,7 +515,7 @@ func (c *Checkpoint) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Epoch'
-	c.Epoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[0:8]))
+	c.Epoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[0:8])
 
 	// Field (1) 'Root'
 	if cap(c.Root) == 0 {
@@ -542,7 +542,7 @@ func (c *Checkpoint) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Epoch'
-	hh.PutUint64(uint64(c.Epoch))
+	ssz.PutUint(hh, c.Epoch)
 
 	// Field (1) 'Root'
 	if size := len(c.Root); size != 32 {
@@ -566,10 +566,10 @@ func (b *BeaconBlock) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -612,10 +612,10 @@ func (b *BeaconBlock) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -674,10 +674,10 @@ func (b *BeaconBlock) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1565,10 +1565,10 @@ func (v *VoluntaryExit) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Epoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.Epoch))
+	dst = ssz.MarshalUint(dst, v.Epoch)
 
 	// Field (1) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(v.ValidatorIndex))
+	dst = ssz.MarshalUint(dst, v.ValidatorIndex)
 
 	return
 }
@@ -1582,10 +1582,10 @@ func (v *VoluntaryExit) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Epoch'
-	v.Epoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[0:8]))
+	v.Epoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[0:8])
 
 	// Field (1) 'ValidatorIndex'
-	v.ValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	v.ValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	return err
 }
@@ -1606,10 +1606,10 @@ func (v *VoluntaryExit) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Epoch'
-	hh.PutUint64(uint64(v.Epoch))
+	ssz.PutUint(hh, v.Epoch)
 
 	// Field (1) 'ValidatorIndex'
-	hh.PutUint64(uint64(v.ValidatorIndex))
+	ssz.PutUint(hh, v.ValidatorIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -1715,7 +1715,7 @@ func (e *Eth1Data) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, e.DepositRoot...)
 
 	// Field (1) 'DepositCount'
-	dst = ssz.MarshalUint64(dst, e.DepositCount)
+	dst = ssz.MarshalUint(dst, e.DepositCount)
 
 	// Field (2) 'BlockHash'
 	if size := len(e.BlockHash); size != 32 {
@@ -1742,7 +1742,7 @@ func (e *Eth1Data) UnmarshalSSZ(buf []byte) error {
 	e.DepositRoot = append(e.DepositRoot, buf[0:32]...)
 
 	// Field (1) 'DepositCount'
-	e.DepositCount = ssz.UnmarshallUint64(buf[32:40])
+	e.DepositCount = ssz.UnmarshallUint[uint64](buf[32:40])
 
 	// Field (2) 'BlockHash'
 	if cap(e.BlockHash) == 0 {
@@ -1776,7 +1776,7 @@ func (e *Eth1Data) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.DepositRoot)
 
 	// Field (1) 'DepositCount'
-	hh.PutUint64(e.DepositCount)
+	ssz.PutUint(hh, e.DepositCount)
 
 	// Field (2) 'BlockHash'
 	if size := len(e.BlockHash); size != 32 {
@@ -1799,10 +1799,10 @@ func (b *BeaconBlockHeader) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1837,10 +1837,10 @@ func (b *BeaconBlockHeader) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -1879,10 +1879,10 @@ func (b *BeaconBlockHeader) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -2027,7 +2027,7 @@ func (i *IndexedAttestation) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(i.AttestingIndices); ii++ {
-		dst = ssz.MarshalUint64(dst, i.AttestingIndices[ii])
+		dst = ssz.MarshalUint(dst, i.AttestingIndices[ii])
 	}
 
 	return
@@ -2074,9 +2074,9 @@ func (i *IndexedAttestation) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		i.AttestingIndices = ssz.ExtendUint64(i.AttestingIndices, num)
+		i.AttestingIndices = ssz.ExtendUint(i.AttestingIndices, num)
 		for ii := 0; ii < num; ii++ {
-			i.AttestingIndices[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			i.AttestingIndices[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -2109,7 +2109,7 @@ func (i *IndexedAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range i.AttestingIndices {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2239,7 +2239,7 @@ func (d *Deposit_Data) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.WithdrawalCredentials...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, d.Amount)
+	dst = ssz.MarshalUint(dst, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -2272,7 +2272,7 @@ func (d *Deposit_Data) UnmarshalSSZ(buf []byte) error {
 	d.WithdrawalCredentials = append(d.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'Amount'
-	d.Amount = ssz.UnmarshallUint64(buf[80:88])
+	d.Amount = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Signature'
 	if cap(d.Signature) == 0 {
@@ -2313,7 +2313,7 @@ func (d *Deposit_Data) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.WithdrawalCredentials)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(d.Amount)
+	ssz.PutUint(hh, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -2350,22 +2350,22 @@ func (v *Validator) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, v.WithdrawalCredentials...)
 
 	// Field (2) 'EffectiveBalance'
-	dst = ssz.MarshalUint64(dst, v.EffectiveBalance)
+	dst = ssz.MarshalUint(dst, v.EffectiveBalance)
 
 	// Field (3) 'Slashed'
 	dst = ssz.MarshalBool(dst, v.Slashed)
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.ActivationEligibilityEpoch))
+	dst = ssz.MarshalUint(dst, v.ActivationEligibilityEpoch)
 
 	// Field (5) 'ActivationEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.ActivationEpoch))
+	dst = ssz.MarshalUint(dst, v.ActivationEpoch)
 
 	// Field (6) 'ExitEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.ExitEpoch))
+	dst = ssz.MarshalUint(dst, v.ExitEpoch)
 
 	// Field (7) 'WithdrawableEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.WithdrawableEpoch))
+	dst = ssz.MarshalUint(dst, v.WithdrawableEpoch)
 
 	return
 }
@@ -2391,7 +2391,7 @@ func (v *Validator) UnmarshalSSZ(buf []byte) error {
 	v.WithdrawalCredentials = append(v.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'EffectiveBalance'
-	v.EffectiveBalance = ssz.UnmarshallUint64(buf[80:88])
+	v.EffectiveBalance = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Slashed'
 	v.Slashed, err = ssz.DecodeBool(buf[88:89])
@@ -2400,16 +2400,16 @@ func (v *Validator) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	v.ActivationEligibilityEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[89:97]))
+	v.ActivationEligibilityEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[89:97])
 
 	// Field (5) 'ActivationEpoch'
-	v.ActivationEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[97:105]))
+	v.ActivationEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[97:105])
 
 	// Field (6) 'ExitEpoch'
-	v.ExitEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[105:113]))
+	v.ExitEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[105:113])
 
 	// Field (7) 'WithdrawableEpoch'
-	v.WithdrawableEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[113:121]))
+	v.WithdrawableEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[113:121])
 
 	return err
 }
@@ -2444,22 +2444,22 @@ func (v *Validator) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(v.WithdrawalCredentials)
 
 	// Field (2) 'EffectiveBalance'
-	hh.PutUint64(v.EffectiveBalance)
+	ssz.PutUint(hh, v.EffectiveBalance)
 
 	// Field (3) 'Slashed'
 	hh.PutBool(v.Slashed)
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	hh.PutUint64(uint64(v.ActivationEligibilityEpoch))
+	ssz.PutUint(hh, v.ActivationEligibilityEpoch)
 
 	// Field (5) 'ActivationEpoch'
-	hh.PutUint64(uint64(v.ActivationEpoch))
+	ssz.PutUint(hh, v.ActivationEpoch)
 
 	// Field (6) 'ExitEpoch'
-	hh.PutUint64(uint64(v.ExitEpoch))
+	ssz.PutUint(hh, v.ExitEpoch)
 
 	// Field (7) 'WithdrawableEpoch'
-	hh.PutUint64(uint64(v.WithdrawableEpoch))
+	ssz.PutUint(hh, v.WithdrawableEpoch)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/prysm/v1alpha1/altair.ssz.go
+++ b/proto/prysm/v1alpha1/altair.ssz.go
@@ -126,10 +126,10 @@ func (b *BeaconBlockAltair) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -172,10 +172,10 @@ func (b *BeaconBlockAltair) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -234,10 +234,10 @@ func (b *BeaconBlockAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -907,7 +907,7 @@ func (b *BeaconStateAltair) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(2736629)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -917,7 +917,7 @@ func (b *BeaconStateAltair) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -978,7 +978,7 @@ func (b *BeaconStateAltair) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -1007,7 +1007,7 @@ func (b *BeaconStateAltair) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -1110,7 +1110,7 @@ func (b *BeaconStateAltair) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -1133,7 +1133,7 @@ func (b *BeaconStateAltair) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	return
@@ -1151,7 +1151,7 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -1160,7 +1160,7 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -1219,7 +1219,7 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -1241,9 +1241,9 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -1366,9 +1366,9 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -1403,9 +1403,9 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -1449,7 +1449,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -1459,7 +1459,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -1546,7 +1546,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -1572,7 +1572,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -1605,7 +1605,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -1664,7 +1664,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -1696,10 +1696,10 @@ func (s *SyncAggregatorSelectionData) MarshalSSZTo(buf []byte) (dst []byte, err 
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(s.Slot))
+	dst = ssz.MarshalUint(dst, s.Slot)
 
 	// Field (1) 'SubcommitteeIndex'
-	dst = ssz.MarshalUint64(dst, s.SubcommitteeIndex)
+	dst = ssz.MarshalUint(dst, s.SubcommitteeIndex)
 
 	return
 }
@@ -1713,10 +1713,10 @@ func (s *SyncAggregatorSelectionData) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	s.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	s.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'SubcommitteeIndex'
-	s.SubcommitteeIndex = ssz.UnmarshallUint64(buf[8:16])
+	s.SubcommitteeIndex = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	return err
 }
@@ -1737,10 +1737,10 @@ func (s *SyncAggregatorSelectionData) HashTreeRootWith(hh *ssz.Hasher) (err erro
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(s.Slot))
+	ssz.PutUint(hh, s.Slot)
 
 	// Field (1) 'SubcommitteeIndex'
-	hh.PutUint64(s.SubcommitteeIndex)
+	ssz.PutUint(hh, s.SubcommitteeIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -1937,7 +1937,7 @@ func (l *LightClientUpdateAltair) MarshalSSZTo(buf []byte) (dst []byte, err erro
 	}
 
 	// Field (6) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	return
 }
@@ -2001,7 +2001,7 @@ func (l *LightClientUpdateAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (6) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[25360:25368]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[25360:25368])
 
 	return err
 }
@@ -2076,7 +2076,7 @@ func (l *LightClientUpdateAltair) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (6) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -2129,7 +2129,7 @@ func (l *LightClientFinalityUpdateAltair) MarshalSSZTo(buf []byte) (dst []byte, 
 	}
 
 	// Field (4) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	return
 }
@@ -2176,7 +2176,7 @@ func (l *LightClientFinalityUpdateAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[576:584]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[576:584])
 
 	return err
 }
@@ -2229,7 +2229,7 @@ func (l *LightClientFinalityUpdateAltair) HashTreeRootWith(hh *ssz.Hasher) (err 
 	}
 
 	// Field (4) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -2261,7 +2261,7 @@ func (l *LightClientOptimisticUpdateAltair) MarshalSSZTo(buf []byte) (dst []byte
 	}
 
 	// Field (2) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	return
 }
@@ -2291,7 +2291,7 @@ func (l *LightClientOptimisticUpdateAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[272:280]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[272:280])
 
 	return err
 }
@@ -2322,7 +2322,7 @@ func (l *LightClientOptimisticUpdateAltair) HashTreeRootWith(hh *ssz.Hasher) (er
 	}
 
 	// Field (2) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -2401,7 +2401,7 @@ func (s *SyncCommitteeMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(s.Slot))
+	dst = ssz.MarshalUint(dst, s.Slot)
 
 	// Field (1) 'BlockRoot'
 	if size := len(s.BlockRoot); size != 32 {
@@ -2411,7 +2411,7 @@ func (s *SyncCommitteeMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	dst = append(dst, s.BlockRoot...)
 
 	// Field (2) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(s.ValidatorIndex))
+	dst = ssz.MarshalUint(dst, s.ValidatorIndex)
 
 	// Field (3) 'Signature'
 	if size := len(s.Signature); size != 96 {
@@ -2432,7 +2432,7 @@ func (s *SyncCommitteeMessage) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	s.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	s.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'BlockRoot'
 	if cap(s.BlockRoot) == 0 {
@@ -2441,7 +2441,7 @@ func (s *SyncCommitteeMessage) UnmarshalSSZ(buf []byte) error {
 	s.BlockRoot = append(s.BlockRoot, buf[8:40]...)
 
 	// Field (2) 'ValidatorIndex'
-	s.ValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[40:48]))
+	s.ValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[40:48])
 
 	// Field (3) 'Signature'
 	if cap(s.Signature) == 0 {
@@ -2468,7 +2468,7 @@ func (s *SyncCommitteeMessage) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(s.Slot))
+	ssz.PutUint(hh, s.Slot)
 
 	// Field (1) 'BlockRoot'
 	if size := len(s.BlockRoot); size != 32 {
@@ -2478,7 +2478,7 @@ func (s *SyncCommitteeMessage) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(s.BlockRoot)
 
 	// Field (2) 'ValidatorIndex'
-	hh.PutUint64(uint64(s.ValidatorIndex))
+	ssz.PutUint(hh, s.ValidatorIndex)
 
 	// Field (3) 'Signature'
 	if size := len(s.Signature); size != 96 {
@@ -2584,7 +2584,7 @@ func (c *ContributionAndProof) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	dst = buf
 
 	// Field (0) 'AggregatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(c.AggregatorIndex))
+	dst = ssz.MarshalUint(dst, c.AggregatorIndex)
 
 	// Field (1) 'Contribution'
 	if c.Contribution == nil {
@@ -2613,7 +2613,7 @@ func (c *ContributionAndProof) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'AggregatorIndex'
-	c.AggregatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	c.AggregatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Field (1) 'Contribution'
 	if c.Contribution == nil {
@@ -2648,7 +2648,7 @@ func (c *ContributionAndProof) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'AggregatorIndex'
-	hh.PutUint64(uint64(c.AggregatorIndex))
+	ssz.PutUint(hh, c.AggregatorIndex)
 
 	// Field (1) 'Contribution'
 	if err = c.Contribution.HashTreeRootWith(hh); err != nil {
@@ -2676,7 +2676,7 @@ func (s *SyncCommitteeContribution) MarshalSSZTo(buf []byte) (dst []byte, err er
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(s.Slot))
+	dst = ssz.MarshalUint(dst, s.Slot)
 
 	// Field (1) 'BlockRoot'
 	if size := len(s.BlockRoot); size != 32 {
@@ -2686,7 +2686,7 @@ func (s *SyncCommitteeContribution) MarshalSSZTo(buf []byte) (dst []byte, err er
 	dst = append(dst, s.BlockRoot...)
 
 	// Field (2) 'SubcommitteeIndex'
-	dst = ssz.MarshalUint64(dst, s.SubcommitteeIndex)
+	dst = ssz.MarshalUint(dst, s.SubcommitteeIndex)
 
 	// Field (3) 'AggregationBits'
 	if size := len(s.AggregationBits); size != 16 {
@@ -2714,7 +2714,7 @@ func (s *SyncCommitteeContribution) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	s.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	s.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'BlockRoot'
 	if cap(s.BlockRoot) == 0 {
@@ -2723,7 +2723,7 @@ func (s *SyncCommitteeContribution) UnmarshalSSZ(buf []byte) error {
 	s.BlockRoot = append(s.BlockRoot, buf[8:40]...)
 
 	// Field (2) 'SubcommitteeIndex'
-	s.SubcommitteeIndex = ssz.UnmarshallUint64(buf[40:48])
+	s.SubcommitteeIndex = ssz.UnmarshallUint[uint64](buf[40:48])
 
 	// Field (3) 'AggregationBits'
 	if cap(s.AggregationBits) == 0 {
@@ -2756,7 +2756,7 @@ func (s *SyncCommitteeContribution) HashTreeRootWith(hh *ssz.Hasher) (err error)
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(s.Slot))
+	ssz.PutUint(hh, s.Slot)
 
 	// Field (1) 'BlockRoot'
 	if size := len(s.BlockRoot); size != 32 {
@@ -2766,7 +2766,7 @@ func (s *SyncCommitteeContribution) HashTreeRootWith(hh *ssz.Hasher) (err error)
 	hh.PutBytes(s.BlockRoot)
 
 	// Field (2) 'SubcommitteeIndex'
-	hh.PutUint64(s.SubcommitteeIndex)
+	ssz.PutUint(hh, s.SubcommitteeIndex)
 
 	// Field (3) 'AggregationBits'
 	if size := len(s.AggregationBits); size != 16 {

--- a/proto/prysm/v1alpha1/bellatrix.ssz.go
+++ b/proto/prysm/v1alpha1/bellatrix.ssz.go
@@ -127,10 +127,10 @@ func (b *BeaconBlockBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -173,10 +173,10 @@ func (b *BeaconBlockBellatrix) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -235,10 +235,10 @@ func (b *BeaconBlockBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -873,10 +873,10 @@ func (b *BlindedBeaconBlockBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err 
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -919,10 +919,10 @@ func (b *BlindedBeaconBlockBellatrix) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -981,10 +981,10 @@ func (b *BlindedBeaconBlockBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err erro
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1510,7 +1510,7 @@ func (b *BeaconStateBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	offset := int(2736633)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -1520,7 +1520,7 @@ func (b *BeaconStateBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -1581,7 +1581,7 @@ func (b *BeaconStateBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -1610,7 +1610,7 @@ func (b *BeaconStateBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -1720,7 +1720,7 @@ func (b *BeaconStateBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -1743,7 +1743,7 @@ func (b *BeaconStateBellatrix) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	// Field (24) 'LatestExecutionPayloadHeader'
@@ -1766,7 +1766,7 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21, o24 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -1775,7 +1775,7 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -1834,7 +1834,7 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -1856,9 +1856,9 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -1986,9 +1986,9 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -2023,9 +2023,9 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -2086,7 +2086,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -2096,7 +2096,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -2183,7 +2183,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -2209,7 +2209,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2242,7 +2242,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -2301,7 +2301,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 

--- a/proto/prysm/v1alpha1/capella.ssz.go
+++ b/proto/prysm/v1alpha1/capella.ssz.go
@@ -127,10 +127,10 @@ func (b *BeaconBlockCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -173,10 +173,10 @@ func (b *BeaconBlockCapella) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -235,10 +235,10 @@ func (b *BeaconBlockCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -930,10 +930,10 @@ func (b *BlindedBeaconBlockCapella) MarshalSSZTo(buf []byte) (dst []byte, err er
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -976,10 +976,10 @@ func (b *BlindedBeaconBlockCapella) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -1038,10 +1038,10 @@ func (b *BlindedBeaconBlockCapella) HashTreeRootWith(hh *ssz.Hasher) (err error)
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1944,7 +1944,7 @@ func (b *BeaconStateCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(2736653)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -1954,7 +1954,7 @@ func (b *BeaconStateCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -2015,7 +2015,7 @@ func (b *BeaconStateCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2044,7 +2044,7 @@ func (b *BeaconStateCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -2114,10 +2114,10 @@ func (b *BeaconStateCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += b.LatestExecutionPayloadHeader.SizeSSZ()
 
 	// Field (25) 'NextWithdrawalIndex'
-	dst = ssz.MarshalUint64(dst, b.NextWithdrawalIndex)
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.NextWithdrawalValidatorIndex))
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalValidatorIndex)
 
 	// Offset (27) 'HistoricalSummaries'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2164,7 +2164,7 @@ func (b *BeaconStateCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -2187,7 +2187,7 @@ func (b *BeaconStateCapella) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	// Field (24) 'LatestExecutionPayloadHeader'
@@ -2221,7 +2221,7 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21, o24, o27 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -2230,7 +2230,7 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -2289,7 +2289,7 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -2311,9 +2311,9 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -2383,10 +2383,10 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	b.NextWithdrawalIndex = ssz.UnmarshallUint64(buf[2736633:2736641])
+	b.NextWithdrawalIndex = ssz.UnmarshallUint[uint64](buf[2736633:2736641])
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	b.NextWithdrawalValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[2736641:2736649]))
+	b.NextWithdrawalValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[2736641:2736649])
 
 	// Offset (27) 'HistoricalSummaries'
 	if o27 = ssz.ReadOffset(buf[2736649:2736653]); o27 > size || o24 > o27 {
@@ -2452,9 +2452,9 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -2489,9 +2489,9 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -2573,7 +2573,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -2583,7 +2583,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -2670,7 +2670,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -2696,7 +2696,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2729,7 +2729,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -2788,7 +2788,7 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2812,10 +2812,10 @@ func (b *BeaconStateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	hh.PutUint64(b.NextWithdrawalIndex)
+	ssz.PutUint(hh, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	hh.PutUint64(uint64(b.NextWithdrawalValidatorIndex))
+	ssz.PutUint(hh, b.NextWithdrawalValidatorIndex)
 
 	// Field (27) 'HistoricalSummaries'
 	{
@@ -3053,7 +3053,7 @@ func (l *LightClientUpdateCapella) MarshalSSZTo(buf []byte) (dst []byte, err err
 	}
 
 	// Field (6) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -3128,7 +3128,7 @@ func (l *LightClientUpdateCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (6) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[25144:25152]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[25144:25152])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -3237,7 +3237,7 @@ func (l *LightClientUpdateCapella) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 	}
 
 	// Field (6) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -3289,7 +3289,7 @@ func (l *LightClientFinalityUpdateCapella) MarshalSSZTo(buf []byte) (dst []byte,
 	}
 
 	// Field (4) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -3347,7 +3347,7 @@ func (l *LightClientFinalityUpdateCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[360:368]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[360:368])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -3434,7 +3434,7 @@ func (l *LightClientFinalityUpdateCapella) HashTreeRootWith(hh *ssz.Hasher) (err
 	}
 
 	// Field (4) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -3466,7 +3466,7 @@ func (l *LightClientOptimisticUpdateCapella) MarshalSSZTo(buf []byte) (dst []byt
 	}
 
 	// Field (2) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -3505,7 +3505,7 @@ func (l *LightClientOptimisticUpdateCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[164:172]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[164:172])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -3553,7 +3553,7 @@ func (l *LightClientOptimisticUpdateCapella) HashTreeRootWith(hh *ssz.Hasher) (e
 	}
 
 	// Field (2) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -3801,7 +3801,7 @@ func (b *BLSToExecutionChange) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	dst = buf
 
 	// Field (0) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ValidatorIndex))
+	dst = ssz.MarshalUint(dst, b.ValidatorIndex)
 
 	// Field (1) 'FromBlsPubkey'
 	if size := len(b.FromBlsPubkey); size != 48 {
@@ -3829,7 +3829,7 @@ func (b *BLSToExecutionChange) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'ValidatorIndex'
-	b.ValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	b.ValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Field (1) 'FromBlsPubkey'
 	if cap(b.FromBlsPubkey) == 0 {
@@ -3862,7 +3862,7 @@ func (b *BLSToExecutionChange) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'ValidatorIndex'
-	hh.PutUint64(uint64(b.ValidatorIndex))
+	ssz.PutUint(hh, b.ValidatorIndex)
 
 	// Field (1) 'FromBlsPubkey'
 	if size := len(b.FromBlsPubkey); size != 48 {

--- a/proto/prysm/v1alpha1/deneb.ssz.go
+++ b/proto/prysm/v1alpha1/deneb.ssz.go
@@ -545,10 +545,10 @@ func (b *BeaconBlockDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -591,10 +591,10 @@ func (b *BeaconBlockDeneb) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -653,10 +653,10 @@ func (b *BeaconBlockDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1408,10 +1408,10 @@ func (b *BlindedBeaconBlockDeneb) MarshalSSZTo(buf []byte) (dst []byte, err erro
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1454,10 +1454,10 @@ func (b *BlindedBeaconBlockDeneb) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -1516,10 +1516,10 @@ func (b *BlindedBeaconBlockDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -2566,7 +2566,7 @@ func (b *BlobSidecar) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Index'
-	dst = ssz.MarshalUint64(dst, b.Index)
+	dst = ssz.MarshalUint(dst, b.Index)
 
 	// Field (1) 'Blob'
 	if size := len(b.Blob); size != 131072 {
@@ -2622,7 +2622,7 @@ func (b *BlobSidecar) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Index'
-	b.Index = ssz.UnmarshallUint64(buf[0:8])
+	b.Index = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'Blob'
 	if cap(b.Blob) == 0 {
@@ -2678,7 +2678,7 @@ func (b *BlobSidecar) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Index'
-	hh.PutUint64(b.Index)
+	ssz.PutUint(hh, b.Index)
 
 	// Field (1) 'Blob'
 	if size := len(b.Blob); size != 131072 {
@@ -2738,7 +2738,7 @@ func (b *BeaconStateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(2736653)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -2748,7 +2748,7 @@ func (b *BeaconStateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -2809,7 +2809,7 @@ func (b *BeaconStateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2838,7 +2838,7 @@ func (b *BeaconStateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -2908,10 +2908,10 @@ func (b *BeaconStateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += b.LatestExecutionPayloadHeader.SizeSSZ()
 
 	// Field (25) 'NextWithdrawalIndex'
-	dst = ssz.MarshalUint64(dst, b.NextWithdrawalIndex)
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.NextWithdrawalValidatorIndex))
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalValidatorIndex)
 
 	// Offset (27) 'HistoricalSummaries'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2958,7 +2958,7 @@ func (b *BeaconStateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -2981,7 +2981,7 @@ func (b *BeaconStateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	// Field (24) 'LatestExecutionPayloadHeader'
@@ -3015,7 +3015,7 @@ func (b *BeaconStateDeneb) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21, o24, o27 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -3024,7 +3024,7 @@ func (b *BeaconStateDeneb) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -3083,7 +3083,7 @@ func (b *BeaconStateDeneb) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -3105,9 +3105,9 @@ func (b *BeaconStateDeneb) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -3177,10 +3177,10 @@ func (b *BeaconStateDeneb) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	b.NextWithdrawalIndex = ssz.UnmarshallUint64(buf[2736633:2736641])
+	b.NextWithdrawalIndex = ssz.UnmarshallUint[uint64](buf[2736633:2736641])
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	b.NextWithdrawalValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[2736641:2736649]))
+	b.NextWithdrawalValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[2736641:2736649])
 
 	// Offset (27) 'HistoricalSummaries'
 	if o27 = ssz.ReadOffset(buf[2736649:2736653]); o27 > size || o24 > o27 {
@@ -3246,9 +3246,9 @@ func (b *BeaconStateDeneb) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -3283,9 +3283,9 @@ func (b *BeaconStateDeneb) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -3367,7 +3367,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -3377,7 +3377,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -3464,7 +3464,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -3490,7 +3490,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -3523,7 +3523,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -3582,7 +3582,7 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -3606,10 +3606,10 @@ func (b *BeaconStateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	hh.PutUint64(b.NextWithdrawalIndex)
+	ssz.PutUint(hh, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	hh.PutUint64(uint64(b.NextWithdrawalValidatorIndex))
+	ssz.PutUint(hh, b.NextWithdrawalValidatorIndex)
 
 	// Field (27) 'HistoricalSummaries'
 	{
@@ -3648,7 +3648,7 @@ func (b *BlobIdentifier) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.BlockRoot...)
 
 	// Field (1) 'Index'
-	dst = ssz.MarshalUint64(dst, b.Index)
+	dst = ssz.MarshalUint(dst, b.Index)
 
 	return
 }
@@ -3668,7 +3668,7 @@ func (b *BlobIdentifier) UnmarshalSSZ(buf []byte) error {
 	b.BlockRoot = append(b.BlockRoot, buf[0:32]...)
 
 	// Field (1) 'Index'
-	b.Index = ssz.UnmarshallUint64(buf[32:40])
+	b.Index = ssz.UnmarshallUint[uint64](buf[32:40])
 
 	return err
 }
@@ -3696,7 +3696,7 @@ func (b *BlobIdentifier) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.BlockRoot)
 
 	// Field (1) 'Index'
-	hh.PutUint64(b.Index)
+	ssz.PutUint(hh, b.Index)
 
 	hh.Merkleize(indx)
 	return
@@ -3918,7 +3918,7 @@ func (l *LightClientUpdateDeneb) MarshalSSZTo(buf []byte) (dst []byte, err error
 	}
 
 	// Field (6) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -3993,7 +3993,7 @@ func (l *LightClientUpdateDeneb) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (6) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[25144:25152]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[25144:25152])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -4102,7 +4102,7 @@ func (l *LightClientUpdateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (6) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -4154,7 +4154,7 @@ func (l *LightClientFinalityUpdateDeneb) MarshalSSZTo(buf []byte) (dst []byte, e
 	}
 
 	// Field (4) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -4212,7 +4212,7 @@ func (l *LightClientFinalityUpdateDeneb) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[360:368]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[360:368])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -4299,7 +4299,7 @@ func (l *LightClientFinalityUpdateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err e
 	}
 
 	// Field (4) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -4331,7 +4331,7 @@ func (l *LightClientOptimisticUpdateDeneb) MarshalSSZTo(buf []byte) (dst []byte,
 	}
 
 	// Field (2) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -4370,7 +4370,7 @@ func (l *LightClientOptimisticUpdateDeneb) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[164:172]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[164:172])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -4418,7 +4418,7 @@ func (l *LightClientOptimisticUpdateDeneb) HashTreeRootWith(hh *ssz.Hasher) (err
 	}
 
 	// Field (2) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/prysm/v1alpha1/electra.ssz.go
+++ b/proto/prysm/v1alpha1/electra.ssz.go
@@ -127,7 +127,7 @@ func (a *AggregateAttestationAndProofElectra) MarshalSSZTo(buf []byte) (dst []by
 	offset := int(108)
 
 	// Field (0) 'AggregatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(a.AggregatorIndex))
+	dst = ssz.MarshalUint(dst, a.AggregatorIndex)
 
 	// Offset (1) 'Aggregate'
 	dst = ssz.WriteOffset(dst, offset)
@@ -163,7 +163,7 @@ func (a *AggregateAttestationAndProofElectra) UnmarshalSSZ(buf []byte) error {
 	var o1 uint64
 
 	// Field (0) 'AggregatorIndex'
-	a.AggregatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	a.AggregatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Offset (1) 'Aggregate'
 	if o1 = ssz.ReadOffset(buf[8:12]); o1 > size {
@@ -216,7 +216,7 @@ func (a *AggregateAttestationAndProofElectra) HashTreeRootWith(hh *ssz.Hasher) (
 	indx := hh.Index()
 
 	// Field (0) 'AggregatorIndex'
-	hh.PutUint64(uint64(a.AggregatorIndex))
+	ssz.PutUint(hh, a.AggregatorIndex)
 
 	// Field (1) 'Aggregate'
 	if err = a.Aggregate.HashTreeRootWith(hh); err != nil {
@@ -393,10 +393,10 @@ func (s *SingleAttestation) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'CommitteeId'
-	dst = ssz.MarshalUint64(dst, uint64(s.CommitteeId))
+	dst = ssz.MarshalUint(dst, s.CommitteeId)
 
 	// Field (1) 'AttesterIndex'
-	dst = ssz.MarshalUint64(dst, uint64(s.AttesterIndex))
+	dst = ssz.MarshalUint(dst, s.AttesterIndex)
 
 	// Field (2) 'Data'
 	if s.Data == nil {
@@ -425,10 +425,10 @@ func (s *SingleAttestation) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'CommitteeId'
-	s.CommitteeId = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.CommitteeIndex(ssz.UnmarshallUint64(buf[0:8]))
+	s.CommitteeId = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.CommitteeIndex](buf[0:8])
 
 	// Field (1) 'AttesterIndex'
-	s.AttesterIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	s.AttesterIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'Data'
 	if s.Data == nil {
@@ -463,10 +463,10 @@ func (s *SingleAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'CommitteeId'
-	hh.PutUint64(uint64(s.CommitteeId))
+	ssz.PutUint(hh, s.CommitteeId)
 
 	// Field (1) 'AttesterIndex'
-	hh.PutUint64(uint64(s.AttesterIndex))
+	ssz.PutUint(hh, s.AttesterIndex)
 
 	// Field (2) 'Data'
 	if err = s.Data.HashTreeRootWith(hh); err != nil {
@@ -1359,10 +1359,10 @@ func (b *BeaconBlockElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1405,10 +1405,10 @@ func (b *BeaconBlockElectra) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -1467,10 +1467,10 @@ func (b *BeaconBlockElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -2261,10 +2261,10 @@ func (b *BlindedBeaconBlockElectra) MarshalSSZTo(buf []byte) (dst []byte, err er
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -2307,10 +2307,10 @@ func (b *BlindedBeaconBlockElectra) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -2369,10 +2369,10 @@ func (b *BlindedBeaconBlockElectra) HashTreeRootWith(hh *ssz.Hasher) (err error)
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -3206,7 +3206,7 @@ func (i *IndexedAttestationElectra) MarshalSSZTo(buf []byte) (dst []byte, err er
 		return
 	}
 	for ii := 0; ii < len(i.AttestingIndices); ii++ {
-		dst = ssz.MarshalUint64(dst, i.AttestingIndices[ii])
+		dst = ssz.MarshalUint(dst, i.AttestingIndices[ii])
 	}
 
 	return
@@ -3253,9 +3253,9 @@ func (i *IndexedAttestationElectra) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		i.AttestingIndices = ssz.ExtendUint64(i.AttestingIndices, num)
+		i.AttestingIndices = ssz.ExtendUint(i.AttestingIndices, num)
 		for ii := 0; ii < num; ii++ {
-			i.AttestingIndices[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			i.AttestingIndices[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -3288,7 +3288,7 @@ func (i *IndexedAttestationElectra) HashTreeRootWith(hh *ssz.Hasher) (err error)
 		}
 		subIndx := hh.Index()
 		for _, i := range i.AttestingIndices {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -3323,7 +3323,7 @@ func (b *BeaconStateElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(2736713)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -3333,7 +3333,7 @@ func (b *BeaconStateElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -3394,7 +3394,7 @@ func (b *BeaconStateElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -3423,7 +3423,7 @@ func (b *BeaconStateElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -3493,32 +3493,32 @@ func (b *BeaconStateElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += b.LatestExecutionPayloadHeader.SizeSSZ()
 
 	// Field (25) 'NextWithdrawalIndex'
-	dst = ssz.MarshalUint64(dst, b.NextWithdrawalIndex)
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.NextWithdrawalValidatorIndex))
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalValidatorIndex)
 
 	// Offset (27) 'HistoricalSummaries'
 	dst = ssz.WriteOffset(dst, offset)
 	offset += len(b.HistoricalSummaries) * 64
 
 	// Field (28) 'DepositRequestsStartIndex'
-	dst = ssz.MarshalUint64(dst, b.DepositRequestsStartIndex)
+	dst = ssz.MarshalUint(dst, b.DepositRequestsStartIndex)
 
 	// Field (29) 'DepositBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.DepositBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.DepositBalanceToConsume)
 
 	// Field (30) 'ExitBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.ExitBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.ExitBalanceToConsume)
 
 	// Field (31) 'EarliestExitEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.EarliestExitEpoch))
+	dst = ssz.MarshalUint(dst, b.EarliestExitEpoch)
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.ConsolidationBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.ConsolidationBalanceToConsume)
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.EarliestConsolidationEpoch))
+	dst = ssz.MarshalUint(dst, b.EarliestConsolidationEpoch)
 
 	// Offset (34) 'PendingDeposits'
 	dst = ssz.WriteOffset(dst, offset)
@@ -3573,7 +3573,7 @@ func (b *BeaconStateElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -3596,7 +3596,7 @@ func (b *BeaconStateElectra) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	// Field (24) 'LatestExecutionPayloadHeader'
@@ -3663,7 +3663,7 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21, o24, o27, o34, o35, o36 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -3672,7 +3672,7 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -3731,7 +3731,7 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -3753,9 +3753,9 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -3825,10 +3825,10 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	b.NextWithdrawalIndex = ssz.UnmarshallUint64(buf[2736633:2736641])
+	b.NextWithdrawalIndex = ssz.UnmarshallUint[uint64](buf[2736633:2736641])
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	b.NextWithdrawalValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[2736641:2736649]))
+	b.NextWithdrawalValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[2736641:2736649])
 
 	// Offset (27) 'HistoricalSummaries'
 	if o27 = ssz.ReadOffset(buf[2736649:2736653]); o27 > size || o24 > o27 {
@@ -3836,22 +3836,22 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (28) 'DepositRequestsStartIndex'
-	b.DepositRequestsStartIndex = ssz.UnmarshallUint64(buf[2736653:2736661])
+	b.DepositRequestsStartIndex = ssz.UnmarshallUint[uint64](buf[2736653:2736661])
 
 	// Field (29) 'DepositBalanceToConsume'
-	b.DepositBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736661:2736669]))
+	b.DepositBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736661:2736669])
 
 	// Field (30) 'ExitBalanceToConsume'
-	b.ExitBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736669:2736677]))
+	b.ExitBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736669:2736677])
 
 	// Field (31) 'EarliestExitEpoch'
-	b.EarliestExitEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[2736677:2736685]))
+	b.EarliestExitEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[2736677:2736685])
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	b.ConsolidationBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736685:2736693]))
+	b.ConsolidationBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736685:2736693])
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	b.EarliestConsolidationEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[2736693:2736701]))
+	b.EarliestConsolidationEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[2736693:2736701])
 
 	// Offset (34) 'PendingDeposits'
 	if o34 = ssz.ReadOffset(buf[2736701:2736705]); o34 > size || o27 > o34 {
@@ -3927,9 +3927,9 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -3964,9 +3964,9 @@ func (b *BeaconStateElectra) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -4111,7 +4111,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -4121,7 +4121,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -4208,7 +4208,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -4234,7 +4234,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -4267,7 +4267,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -4326,7 +4326,7 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -4350,10 +4350,10 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	hh.PutUint64(b.NextWithdrawalIndex)
+	ssz.PutUint(hh, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	hh.PutUint64(uint64(b.NextWithdrawalValidatorIndex))
+	ssz.PutUint(hh, b.NextWithdrawalValidatorIndex)
 
 	// Field (27) 'HistoricalSummaries'
 	{
@@ -4372,22 +4372,22 @@ func (b *BeaconStateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (28) 'DepositRequestsStartIndex'
-	hh.PutUint64(b.DepositRequestsStartIndex)
+	ssz.PutUint(hh, b.DepositRequestsStartIndex)
 
 	// Field (29) 'DepositBalanceToConsume'
-	hh.PutUint64(uint64(b.DepositBalanceToConsume))
+	ssz.PutUint(hh, b.DepositBalanceToConsume)
 
 	// Field (30) 'ExitBalanceToConsume'
-	hh.PutUint64(uint64(b.ExitBalanceToConsume))
+	ssz.PutUint(hh, b.ExitBalanceToConsume)
 
 	// Field (31) 'EarliestExitEpoch'
-	hh.PutUint64(uint64(b.EarliestExitEpoch))
+	ssz.PutUint(hh, b.EarliestExitEpoch)
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	hh.PutUint64(uint64(b.ConsolidationBalanceToConsume))
+	ssz.PutUint(hh, b.ConsolidationBalanceToConsume)
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	hh.PutUint64(uint64(b.EarliestConsolidationEpoch))
+	ssz.PutUint(hh, b.EarliestConsolidationEpoch)
 
 	// Field (34) 'PendingDeposits'
 	{
@@ -4465,7 +4465,7 @@ func (p *PendingDeposit) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, p.WithdrawalCredentials...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, p.Amount)
+	dst = ssz.MarshalUint(dst, p.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(p.Signature); size != 96 {
@@ -4475,7 +4475,7 @@ func (p *PendingDeposit) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, p.Signature...)
 
 	// Field (4) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(p.Slot))
+	dst = ssz.MarshalUint(dst, p.Slot)
 
 	return
 }
@@ -4501,7 +4501,7 @@ func (p *PendingDeposit) UnmarshalSSZ(buf []byte) error {
 	p.WithdrawalCredentials = append(p.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'Amount'
-	p.Amount = ssz.UnmarshallUint64(buf[80:88])
+	p.Amount = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Signature'
 	if cap(p.Signature) == 0 {
@@ -4510,7 +4510,7 @@ func (p *PendingDeposit) UnmarshalSSZ(buf []byte) error {
 	p.Signature = append(p.Signature, buf[88:184]...)
 
 	// Field (4) 'Slot'
-	p.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[184:192]))
+	p.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[184:192])
 
 	return err
 }
@@ -4545,7 +4545,7 @@ func (p *PendingDeposit) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(p.WithdrawalCredentials)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(p.Amount)
+	ssz.PutUint(hh, p.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(p.Signature); size != 96 {
@@ -4555,7 +4555,7 @@ func (p *PendingDeposit) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(p.Signature)
 
 	// Field (4) 'Slot'
-	hh.PutUint64(uint64(p.Slot))
+	ssz.PutUint(hh, p.Slot)
 
 	hh.Merkleize(indx)
 	return
@@ -4571,13 +4571,13 @@ func (p *PendingPartialWithdrawal) MarshalSSZTo(buf []byte) (dst []byte, err err
 	dst = buf
 
 	// Field (0) 'Index'
-	dst = ssz.MarshalUint64(dst, uint64(p.Index))
+	dst = ssz.MarshalUint(dst, p.Index)
 
 	// Field (1) 'Amount'
-	dst = ssz.MarshalUint64(dst, p.Amount)
+	dst = ssz.MarshalUint(dst, p.Amount)
 
 	// Field (2) 'WithdrawableEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(p.WithdrawableEpoch))
+	dst = ssz.MarshalUint(dst, p.WithdrawableEpoch)
 
 	return
 }
@@ -4591,13 +4591,13 @@ func (p *PendingPartialWithdrawal) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Index'
-	p.Index = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	p.Index = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Field (1) 'Amount'
-	p.Amount = ssz.UnmarshallUint64(buf[8:16])
+	p.Amount = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Field (2) 'WithdrawableEpoch'
-	p.WithdrawableEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[16:24]))
+	p.WithdrawableEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[16:24])
 
 	return err
 }
@@ -4618,13 +4618,13 @@ func (p *PendingPartialWithdrawal) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 	indx := hh.Index()
 
 	// Field (0) 'Index'
-	hh.PutUint64(uint64(p.Index))
+	ssz.PutUint(hh, p.Index)
 
 	// Field (1) 'Amount'
-	hh.PutUint64(p.Amount)
+	ssz.PutUint(hh, p.Amount)
 
 	// Field (2) 'WithdrawableEpoch'
-	hh.PutUint64(uint64(p.WithdrawableEpoch))
+	ssz.PutUint(hh, p.WithdrawableEpoch)
 
 	hh.Merkleize(indx)
 	return
@@ -4640,10 +4640,10 @@ func (p *PendingConsolidation) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	dst = buf
 
 	// Field (0) 'SourceIndex'
-	dst = ssz.MarshalUint64(dst, uint64(p.SourceIndex))
+	dst = ssz.MarshalUint(dst, p.SourceIndex)
 
 	// Field (1) 'TargetIndex'
-	dst = ssz.MarshalUint64(dst, uint64(p.TargetIndex))
+	dst = ssz.MarshalUint(dst, p.TargetIndex)
 
 	return
 }
@@ -4657,10 +4657,10 @@ func (p *PendingConsolidation) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'SourceIndex'
-	p.SourceIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	p.SourceIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Field (1) 'TargetIndex'
-	p.TargetIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	p.TargetIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	return err
 }
@@ -4681,10 +4681,10 @@ func (p *PendingConsolidation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'SourceIndex'
-	hh.PutUint64(uint64(p.SourceIndex))
+	ssz.PutUint(hh, p.SourceIndex)
 
 	// Field (1) 'TargetIndex'
-	hh.PutUint64(uint64(p.TargetIndex))
+	ssz.PutUint(hh, p.TargetIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -4906,7 +4906,7 @@ func (l *LightClientUpdateElectra) MarshalSSZTo(buf []byte) (dst []byte, err err
 	}
 
 	// Field (6) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -4981,7 +4981,7 @@ func (l *LightClientUpdateElectra) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (6) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[25208:25216]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[25208:25216])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -5090,7 +5090,7 @@ func (l *LightClientUpdateElectra) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 	}
 
 	// Field (6) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -5142,7 +5142,7 @@ func (l *LightClientFinalityUpdateElectra) MarshalSSZTo(buf []byte) (dst []byte,
 	}
 
 	// Field (4) 'SignatureSlot'
-	dst = ssz.MarshalUint64(dst, uint64(l.SignatureSlot))
+	dst = ssz.MarshalUint(dst, l.SignatureSlot)
 
 	// Field (0) 'AttestedHeader'
 	if dst, err = l.AttestedHeader.MarshalSSZTo(dst); err != nil {
@@ -5200,7 +5200,7 @@ func (l *LightClientFinalityUpdateElectra) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'SignatureSlot'
-	l.SignatureSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[392:400]))
+	l.SignatureSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[392:400])
 
 	// Field (0) 'AttestedHeader'
 	{
@@ -5287,7 +5287,7 @@ func (l *LightClientFinalityUpdateElectra) HashTreeRootWith(hh *ssz.Hasher) (err
 	}
 
 	// Field (4) 'SignatureSlot'
-	hh.PutUint64(uint64(l.SignatureSlot))
+	ssz.PutUint(hh, l.SignatureSlot)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/prysm/v1alpha1/fulu.ssz.go
+++ b/proto/prysm/v1alpha1/fulu.ssz.go
@@ -654,10 +654,10 @@ func (b *BlindedBeaconBlockFulu) MarshalSSZTo(buf []byte) (dst []byte, err error
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -700,10 +700,10 @@ func (b *BlindedBeaconBlockFulu) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -762,10 +762,10 @@ func (b *BlindedBeaconBlockFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -801,7 +801,7 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(2737225)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -811,7 +811,7 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -872,7 +872,7 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -901,7 +901,7 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -971,32 +971,32 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += b.LatestExecutionPayloadHeader.SizeSSZ()
 
 	// Field (25) 'NextWithdrawalIndex'
-	dst = ssz.MarshalUint64(dst, b.NextWithdrawalIndex)
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.NextWithdrawalValidatorIndex))
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalValidatorIndex)
 
 	// Offset (27) 'HistoricalSummaries'
 	dst = ssz.WriteOffset(dst, offset)
 	offset += len(b.HistoricalSummaries) * 64
 
 	// Field (28) 'DepositRequestsStartIndex'
-	dst = ssz.MarshalUint64(dst, b.DepositRequestsStartIndex)
+	dst = ssz.MarshalUint(dst, b.DepositRequestsStartIndex)
 
 	// Field (29) 'DepositBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.DepositBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.DepositBalanceToConsume)
 
 	// Field (30) 'ExitBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.ExitBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.ExitBalanceToConsume)
 
 	// Field (31) 'EarliestExitEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.EarliestExitEpoch))
+	dst = ssz.MarshalUint(dst, b.EarliestExitEpoch)
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.ConsolidationBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.ConsolidationBalanceToConsume)
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.EarliestConsolidationEpoch))
+	dst = ssz.MarshalUint(dst, b.EarliestConsolidationEpoch)
 
 	// Offset (34) 'PendingDeposits'
 	dst = ssz.WriteOffset(dst, offset)
@@ -1016,7 +1016,7 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 64; ii++ {
-		dst = ssz.MarshalUint64(dst, b.ProposerLookahead[ii])
+		dst = ssz.MarshalUint(dst, b.ProposerLookahead[ii])
 	}
 
 	// Field (7) 'HistoricalRoots'
@@ -1060,7 +1060,7 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -1083,7 +1083,7 @@ func (b *BeaconStateFulu) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	// Field (24) 'LatestExecutionPayloadHeader'
@@ -1150,7 +1150,7 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21, o24, o27, o34, o35, o36 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -1159,7 +1159,7 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -1218,7 +1218,7 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -1240,9 +1240,9 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -1312,10 +1312,10 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	b.NextWithdrawalIndex = ssz.UnmarshallUint64(buf[2736633:2736641])
+	b.NextWithdrawalIndex = ssz.UnmarshallUint[uint64](buf[2736633:2736641])
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	b.NextWithdrawalValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[2736641:2736649]))
+	b.NextWithdrawalValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[2736641:2736649])
 
 	// Offset (27) 'HistoricalSummaries'
 	if o27 = ssz.ReadOffset(buf[2736649:2736653]); o27 > size || o24 > o27 {
@@ -1323,22 +1323,22 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (28) 'DepositRequestsStartIndex'
-	b.DepositRequestsStartIndex = ssz.UnmarshallUint64(buf[2736653:2736661])
+	b.DepositRequestsStartIndex = ssz.UnmarshallUint[uint64](buf[2736653:2736661])
 
 	// Field (29) 'DepositBalanceToConsume'
-	b.DepositBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736661:2736669]))
+	b.DepositBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736661:2736669])
 
 	// Field (30) 'ExitBalanceToConsume'
-	b.ExitBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736669:2736677]))
+	b.ExitBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736669:2736677])
 
 	// Field (31) 'EarliestExitEpoch'
-	b.EarliestExitEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[2736677:2736685]))
+	b.EarliestExitEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[2736677:2736685])
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	b.ConsolidationBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736685:2736693]))
+	b.ConsolidationBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736685:2736693])
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	b.EarliestConsolidationEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[2736693:2736701]))
+	b.EarliestConsolidationEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[2736693:2736701])
 
 	// Offset (34) 'PendingDeposits'
 	if o34 = ssz.ReadOffset(buf[2736701:2736705]); o34 > size || o27 > o34 {
@@ -1356,9 +1356,9 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (37) 'ProposerLookahead'
-	b.ProposerLookahead = ssz.ExtendUint64(b.ProposerLookahead, 64)
+	b.ProposerLookahead = ssz.ExtendUint(b.ProposerLookahead, 64)
 	for ii := 0; ii < 64; ii++ {
-		b.ProposerLookahead[ii] = ssz.UnmarshallUint64(buf[2736713:2737225][ii*8 : (ii+1)*8])
+		b.ProposerLookahead[ii] = ssz.UnmarshallUint[uint64](buf[2736713:2737225][ii*8 : (ii+1)*8])
 	}
 
 	// Field (7) 'HistoricalRoots'
@@ -1420,9 +1420,9 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -1457,9 +1457,9 @@ func (b *BeaconStateFulu) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -1604,7 +1604,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -1614,7 +1614,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -1701,7 +1701,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -1727,7 +1727,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -1760,7 +1760,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -1819,7 +1819,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -1843,10 +1843,10 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	hh.PutUint64(b.NextWithdrawalIndex)
+	ssz.PutUint(hh, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	hh.PutUint64(uint64(b.NextWithdrawalValidatorIndex))
+	ssz.PutUint(hh, b.NextWithdrawalValidatorIndex)
 
 	// Field (27) 'HistoricalSummaries'
 	{
@@ -1865,22 +1865,22 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (28) 'DepositRequestsStartIndex'
-	hh.PutUint64(b.DepositRequestsStartIndex)
+	ssz.PutUint(hh, b.DepositRequestsStartIndex)
 
 	// Field (29) 'DepositBalanceToConsume'
-	hh.PutUint64(uint64(b.DepositBalanceToConsume))
+	ssz.PutUint(hh, b.DepositBalanceToConsume)
 
 	// Field (30) 'ExitBalanceToConsume'
-	hh.PutUint64(uint64(b.ExitBalanceToConsume))
+	ssz.PutUint(hh, b.ExitBalanceToConsume)
 
 	// Field (31) 'EarliestExitEpoch'
-	hh.PutUint64(uint64(b.EarliestExitEpoch))
+	ssz.PutUint(hh, b.EarliestExitEpoch)
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	hh.PutUint64(uint64(b.ConsolidationBalanceToConsume))
+	ssz.PutUint(hh, b.ConsolidationBalanceToConsume)
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	hh.PutUint64(uint64(b.EarliestConsolidationEpoch))
+	ssz.PutUint(hh, b.EarliestConsolidationEpoch)
 
 	// Field (34) 'PendingDeposits'
 	{
@@ -1938,7 +1938,7 @@ func (b *BeaconStateFulu) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.ProposerLookahead {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -1958,7 +1958,7 @@ func (d *DataColumnSidecar) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(356)
 
 	// Field (0) 'Index'
-	dst = ssz.MarshalUint64(dst, d.Index)
+	dst = ssz.MarshalUint(dst, d.Index)
 
 	// Offset (1) 'Column'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2047,7 +2047,7 @@ func (d *DataColumnSidecar) UnmarshalSSZ(buf []byte) error {
 	var o1, o2, o3 uint64
 
 	// Field (0) 'Index'
-	d.Index = ssz.UnmarshallUint64(buf[0:8])
+	d.Index = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Offset (1) 'Column'
 	if o1 = ssz.ReadOffset(buf[8:12]); o1 > size {
@@ -2161,7 +2161,7 @@ func (d *DataColumnSidecar) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Index'
-	hh.PutUint64(d.Index)
+	ssz.PutUint(hh, d.Index)
 
 	// Field (1) 'Column'
 	{
@@ -2273,7 +2273,7 @@ func (d *DataColumnsByRootIdentifier) MarshalSSZTo(buf []byte) (dst []byte, err 
 		return
 	}
 	for ii := 0; ii < len(d.Columns); ii++ {
-		dst = ssz.MarshalUint64(dst, d.Columns[ii])
+		dst = ssz.MarshalUint(dst, d.Columns[ii])
 	}
 
 	return
@@ -2312,9 +2312,9 @@ func (d *DataColumnsByRootIdentifier) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		d.Columns = ssz.ExtendUint64(d.Columns, num)
+		d.Columns = ssz.ExtendUint(d.Columns, num)
 		for ii := 0; ii < num; ii++ {
-			d.Columns[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			d.Columns[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -2354,7 +2354,7 @@ func (d *DataColumnsByRootIdentifier) HashTreeRootWith(hh *ssz.Hasher) (err erro
 		}
 		subIndx := hh.Index()
 		for _, i := range d.Columns {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2390,7 +2390,7 @@ func (s *StatusV2) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, s.FinalizedRoot...)
 
 	// Field (2) 'FinalizedEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(s.FinalizedEpoch))
+	dst = ssz.MarshalUint(dst, s.FinalizedEpoch)
 
 	// Field (3) 'HeadRoot'
 	if size := len(s.HeadRoot); size != 32 {
@@ -2400,10 +2400,10 @@ func (s *StatusV2) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, s.HeadRoot...)
 
 	// Field (4) 'HeadSlot'
-	dst = ssz.MarshalUint64(dst, uint64(s.HeadSlot))
+	dst = ssz.MarshalUint(dst, s.HeadSlot)
 
 	// Field (5) 'EarliestAvailableSlot'
-	dst = ssz.MarshalUint64(dst, uint64(s.EarliestAvailableSlot))
+	dst = ssz.MarshalUint(dst, s.EarliestAvailableSlot)
 
 	return
 }
@@ -2429,7 +2429,7 @@ func (s *StatusV2) UnmarshalSSZ(buf []byte) error {
 	s.FinalizedRoot = append(s.FinalizedRoot, buf[4:36]...)
 
 	// Field (2) 'FinalizedEpoch'
-	s.FinalizedEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[36:44]))
+	s.FinalizedEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[36:44])
 
 	// Field (3) 'HeadRoot'
 	if cap(s.HeadRoot) == 0 {
@@ -2438,10 +2438,10 @@ func (s *StatusV2) UnmarshalSSZ(buf []byte) error {
 	s.HeadRoot = append(s.HeadRoot, buf[44:76]...)
 
 	// Field (4) 'HeadSlot'
-	s.HeadSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[76:84]))
+	s.HeadSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[76:84])
 
 	// Field (5) 'EarliestAvailableSlot'
-	s.EarliestAvailableSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[84:92]))
+	s.EarliestAvailableSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[84:92])
 
 	return err
 }
@@ -2476,7 +2476,7 @@ func (s *StatusV2) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(s.FinalizedRoot)
 
 	// Field (2) 'FinalizedEpoch'
-	hh.PutUint64(uint64(s.FinalizedEpoch))
+	ssz.PutUint(hh, s.FinalizedEpoch)
 
 	// Field (3) 'HeadRoot'
 	if size := len(s.HeadRoot); size != 32 {
@@ -2486,10 +2486,10 @@ func (s *StatusV2) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(s.HeadRoot)
 
 	// Field (4) 'HeadSlot'
-	hh.PutUint64(uint64(s.HeadSlot))
+	ssz.PutUint(hh, s.HeadSlot)
 
 	// Field (5) 'EarliestAvailableSlot'
-	hh.PutUint64(uint64(s.EarliestAvailableSlot))
+	ssz.PutUint(hh, s.EarliestAvailableSlot)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/prysm/v1alpha1/gloas.ssz.go
+++ b/proto/prysm/v1alpha1/gloas.ssz.go
@@ -53,19 +53,19 @@ func (e *ExecutionPayloadBid) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, e.FeeRecipient...)
 
 	// Field (5) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, e.GasLimit)
+	dst = ssz.MarshalUint(dst, e.GasLimit)
 
 	// Field (6) 'BuilderIndex'
-	dst = ssz.MarshalUint64(dst, uint64(e.BuilderIndex))
+	dst = ssz.MarshalUint(dst, e.BuilderIndex)
 
 	// Field (7) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(e.Slot))
+	dst = ssz.MarshalUint(dst, e.Slot)
 
 	// Field (8) 'Value'
-	dst = ssz.MarshalUint64(dst, uint64(e.Value))
+	dst = ssz.MarshalUint(dst, e.Value)
 
 	// Field (9) 'ExecutionPayment'
-	dst = ssz.MarshalUint64(dst, uint64(e.ExecutionPayment))
+	dst = ssz.MarshalUint(dst, e.ExecutionPayment)
 
 	// Offset (10) 'BlobKzgCommitments'
 	dst = ssz.WriteOffset(dst, offset)
@@ -129,19 +129,19 @@ func (e *ExecutionPayloadBid) UnmarshalSSZ(buf []byte) error {
 	e.FeeRecipient = append(e.FeeRecipient, buf[128:148]...)
 
 	// Field (5) 'GasLimit'
-	e.GasLimit = ssz.UnmarshallUint64(buf[148:156])
+	e.GasLimit = ssz.UnmarshallUint[uint64](buf[148:156])
 
 	// Field (6) 'BuilderIndex'
-	e.BuilderIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex(ssz.UnmarshallUint64(buf[156:164]))
+	e.BuilderIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex](buf[156:164])
 
 	// Field (7) 'Slot'
-	e.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[164:172]))
+	e.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[164:172])
 
 	// Field (8) 'Value'
-	e.Value = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[172:180]))
+	e.Value = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[172:180])
 
 	// Field (9) 'ExecutionPayment'
-	e.ExecutionPayment = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[180:188]))
+	e.ExecutionPayment = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[180:188])
 
 	// Offset (10) 'BlobKzgCommitments'
 	if o10 = ssz.ReadOffset(buf[188:192]); o10 > size {
@@ -225,19 +225,19 @@ func (e *ExecutionPayloadBid) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.FeeRecipient)
 
 	// Field (5) 'GasLimit'
-	hh.PutUint64(e.GasLimit)
+	ssz.PutUint(hh, e.GasLimit)
 
 	// Field (6) 'BuilderIndex'
-	hh.PutUint64(uint64(e.BuilderIndex))
+	ssz.PutUint(hh, e.BuilderIndex)
 
 	// Field (7) 'Slot'
-	hh.PutUint64(uint64(e.Slot))
+	ssz.PutUint(hh, e.Slot)
 
 	// Field (8) 'Value'
-	hh.PutUint64(uint64(e.Value))
+	ssz.PutUint(hh, e.Value)
 
 	// Field (9) 'ExecutionPayment'
-	hh.PutUint64(uint64(e.ExecutionPayment))
+	ssz.PutUint(hh, e.ExecutionPayment)
 
 	// Field (10) 'BlobKzgCommitments'
 	{
@@ -381,10 +381,10 @@ func (p *ProposerPreferences) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'ProposalSlot'
-	dst = ssz.MarshalUint64(dst, uint64(p.ProposalSlot))
+	dst = ssz.MarshalUint(dst, p.ProposalSlot)
 
 	// Field (1) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(p.ValidatorIndex))
+	dst = ssz.MarshalUint(dst, p.ValidatorIndex)
 
 	// Field (2) 'FeeRecipient'
 	if size := len(p.FeeRecipient); size != 20 {
@@ -394,7 +394,7 @@ func (p *ProposerPreferences) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, p.FeeRecipient...)
 
 	// Field (3) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, p.GasLimit)
+	dst = ssz.MarshalUint(dst, p.GasLimit)
 
 	return
 }
@@ -408,10 +408,10 @@ func (p *ProposerPreferences) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'ProposalSlot'
-	p.ProposalSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	p.ProposalSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ValidatorIndex'
-	p.ValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	p.ValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'FeeRecipient'
 	if cap(p.FeeRecipient) == 0 {
@@ -420,7 +420,7 @@ func (p *ProposerPreferences) UnmarshalSSZ(buf []byte) error {
 	p.FeeRecipient = append(p.FeeRecipient, buf[16:36]...)
 
 	// Field (3) 'GasLimit'
-	p.GasLimit = ssz.UnmarshallUint64(buf[36:44])
+	p.GasLimit = ssz.UnmarshallUint[uint64](buf[36:44])
 
 	return err
 }
@@ -441,10 +441,10 @@ func (p *ProposerPreferences) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'ProposalSlot'
-	hh.PutUint64(uint64(p.ProposalSlot))
+	ssz.PutUint(hh, p.ProposalSlot)
 
 	// Field (1) 'ValidatorIndex'
-	hh.PutUint64(uint64(p.ValidatorIndex))
+	ssz.PutUint(hh, p.ValidatorIndex)
 
 	// Field (2) 'FeeRecipient'
 	if size := len(p.FeeRecipient); size != 20 {
@@ -454,7 +454,7 @@ func (p *ProposerPreferences) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(p.FeeRecipient)
 
 	// Field (3) 'GasLimit'
-	hh.PutUint64(p.GasLimit)
+	ssz.PutUint(hh, p.GasLimit)
 
 	hh.Merkleize(indx)
 	return
@@ -560,7 +560,7 @@ func (p *PayloadAttestationData) MarshalSSZTo(buf []byte) (dst []byte, err error
 	dst = append(dst, p.BeaconBlockRoot...)
 
 	// Field (1) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(p.Slot))
+	dst = ssz.MarshalUint(dst, p.Slot)
 
 	// Field (2) 'PayloadPresent'
 	dst = ssz.MarshalBool(dst, p.PayloadPresent)
@@ -586,7 +586,7 @@ func (p *PayloadAttestationData) UnmarshalSSZ(buf []byte) error {
 	p.BeaconBlockRoot = append(p.BeaconBlockRoot, buf[0:32]...)
 
 	// Field (1) 'Slot'
-	p.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[32:40]))
+	p.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[32:40])
 
 	// Field (2) 'PayloadPresent'
 	p.PayloadPresent, err = ssz.DecodeBool(buf[40:41])
@@ -626,7 +626,7 @@ func (p *PayloadAttestationData) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(p.BeaconBlockRoot)
 
 	// Field (1) 'Slot'
-	hh.PutUint64(uint64(p.Slot))
+	ssz.PutUint(hh, p.Slot)
 
 	// Field (2) 'PayloadPresent'
 	hh.PutBool(p.PayloadPresent)
@@ -751,7 +751,7 @@ func (p *PayloadAttestationMessage) MarshalSSZTo(buf []byte) (dst []byte, err er
 	dst = buf
 
 	// Field (0) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(p.ValidatorIndex))
+	dst = ssz.MarshalUint(dst, p.ValidatorIndex)
 
 	// Field (1) 'Data'
 	if p.Data == nil {
@@ -780,7 +780,7 @@ func (p *PayloadAttestationMessage) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'ValidatorIndex'
-	p.ValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	p.ValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Field (1) 'Data'
 	if p.Data == nil {
@@ -815,7 +815,7 @@ func (p *PayloadAttestationMessage) HashTreeRootWith(hh *ssz.Hasher) (err error)
 	indx := hh.Index()
 
 	// Field (0) 'ValidatorIndex'
-	hh.PutUint64(uint64(p.ValidatorIndex))
+	ssz.PutUint(hh, p.ValidatorIndex)
 
 	// Field (1) 'Data'
 	if err = p.Data.HashTreeRootWith(hh); err != nil {
@@ -844,10 +844,10 @@ func (b *BeaconBlockGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -890,10 +890,10 @@ func (b *BeaconBlockGloas) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -952,10 +952,10 @@ func (b *BeaconBlockGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1704,7 +1704,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(2741117)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -1714,7 +1714,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -1775,7 +1775,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -1804,7 +1804,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -1874,32 +1874,32 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += b.LatestExecutionPayloadBid.SizeSSZ()
 
 	// Field (25) 'NextWithdrawalIndex'
-	dst = ssz.MarshalUint64(dst, b.NextWithdrawalIndex)
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.NextWithdrawalValidatorIndex))
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalValidatorIndex)
 
 	// Offset (27) 'HistoricalSummaries'
 	dst = ssz.WriteOffset(dst, offset)
 	offset += len(b.HistoricalSummaries) * 64
 
 	// Field (28) 'DepositRequestsStartIndex'
-	dst = ssz.MarshalUint64(dst, b.DepositRequestsStartIndex)
+	dst = ssz.MarshalUint(dst, b.DepositRequestsStartIndex)
 
 	// Field (29) 'DepositBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.DepositBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.DepositBalanceToConsume)
 
 	// Field (30) 'ExitBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.ExitBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.ExitBalanceToConsume)
 
 	// Field (31) 'EarliestExitEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.EarliestExitEpoch))
+	dst = ssz.MarshalUint(dst, b.EarliestExitEpoch)
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	dst = ssz.MarshalUint64(dst, uint64(b.ConsolidationBalanceToConsume))
+	dst = ssz.MarshalUint(dst, b.ConsolidationBalanceToConsume)
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.EarliestConsolidationEpoch))
+	dst = ssz.MarshalUint(dst, b.EarliestConsolidationEpoch)
 
 	// Offset (34) 'PendingDeposits'
 	dst = ssz.WriteOffset(dst, offset)
@@ -1919,7 +1919,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 64; ii++ {
-		dst = ssz.MarshalUint64(dst, b.ProposerLookahead[ii])
+		dst = ssz.MarshalUint(dst, b.ProposerLookahead[ii])
 	}
 
 	// Offset (38) 'Builders'
@@ -1927,7 +1927,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Builders) * 93
 
 	// Field (39) 'NextWithdrawalBuilderIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.NextWithdrawalBuilderIndex))
+	dst = ssz.MarshalUint(dst, b.NextWithdrawalBuilderIndex)
 
 	// Field (40) 'ExecutionPayloadAvailability'
 	if size := len(b.ExecutionPayloadAvailability); size != 1024 {
@@ -2003,7 +2003,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -2026,7 +2026,7 @@ func (b *BeaconStateGloas) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	// Field (24) 'LatestExecutionPayloadBid'
@@ -2126,7 +2126,7 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21, o24, o27, o34, o35, o36, o38, o42, o44 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -2135,7 +2135,7 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -2194,7 +2194,7 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -2216,9 +2216,9 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -2288,10 +2288,10 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	b.NextWithdrawalIndex = ssz.UnmarshallUint64(buf[2736633:2736641])
+	b.NextWithdrawalIndex = ssz.UnmarshallUint[uint64](buf[2736633:2736641])
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	b.NextWithdrawalValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[2736641:2736649]))
+	b.NextWithdrawalValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[2736641:2736649])
 
 	// Offset (27) 'HistoricalSummaries'
 	if o27 = ssz.ReadOffset(buf[2736649:2736653]); o27 > size || o24 > o27 {
@@ -2299,22 +2299,22 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (28) 'DepositRequestsStartIndex'
-	b.DepositRequestsStartIndex = ssz.UnmarshallUint64(buf[2736653:2736661])
+	b.DepositRequestsStartIndex = ssz.UnmarshallUint[uint64](buf[2736653:2736661])
 
 	// Field (29) 'DepositBalanceToConsume'
-	b.DepositBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736661:2736669]))
+	b.DepositBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736661:2736669])
 
 	// Field (30) 'ExitBalanceToConsume'
-	b.ExitBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736669:2736677]))
+	b.ExitBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736669:2736677])
 
 	// Field (31) 'EarliestExitEpoch'
-	b.EarliestExitEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[2736677:2736685]))
+	b.EarliestExitEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[2736677:2736685])
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	b.ConsolidationBalanceToConsume = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[2736685:2736693]))
+	b.ConsolidationBalanceToConsume = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[2736685:2736693])
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	b.EarliestConsolidationEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[2736693:2736701]))
+	b.EarliestConsolidationEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[2736693:2736701])
 
 	// Offset (34) 'PendingDeposits'
 	if o34 = ssz.ReadOffset(buf[2736701:2736705]); o34 > size || o27 > o34 {
@@ -2332,9 +2332,9 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (37) 'ProposerLookahead'
-	b.ProposerLookahead = ssz.ExtendUint64(b.ProposerLookahead, 64)
+	b.ProposerLookahead = ssz.ExtendUint(b.ProposerLookahead, 64)
 	for ii := 0; ii < 64; ii++ {
-		b.ProposerLookahead[ii] = ssz.UnmarshallUint64(buf[2736713:2737225][ii*8 : (ii+1)*8])
+		b.ProposerLookahead[ii] = ssz.UnmarshallUint[uint64](buf[2736713:2737225][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (38) 'Builders'
@@ -2343,7 +2343,7 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (39) 'NextWithdrawalBuilderIndex'
-	b.NextWithdrawalBuilderIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex(ssz.UnmarshallUint64(buf[2737229:2737237]))
+	b.NextWithdrawalBuilderIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex](buf[2737229:2737237])
 
 	// Field (40) 'ExecutionPayloadAvailability'
 	if cap(b.ExecutionPayloadAvailability) == 0 {
@@ -2437,9 +2437,9 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -2474,9 +2474,9 @@ func (b *BeaconStateGloas) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -2684,7 +2684,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -2694,7 +2694,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -2781,7 +2781,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -2807,7 +2807,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2840,7 +2840,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -2899,7 +2899,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2923,10 +2923,10 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (25) 'NextWithdrawalIndex'
-	hh.PutUint64(b.NextWithdrawalIndex)
+	ssz.PutUint(hh, b.NextWithdrawalIndex)
 
 	// Field (26) 'NextWithdrawalValidatorIndex'
-	hh.PutUint64(uint64(b.NextWithdrawalValidatorIndex))
+	ssz.PutUint(hh, b.NextWithdrawalValidatorIndex)
 
 	// Field (27) 'HistoricalSummaries'
 	{
@@ -2945,22 +2945,22 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (28) 'DepositRequestsStartIndex'
-	hh.PutUint64(b.DepositRequestsStartIndex)
+	ssz.PutUint(hh, b.DepositRequestsStartIndex)
 
 	// Field (29) 'DepositBalanceToConsume'
-	hh.PutUint64(uint64(b.DepositBalanceToConsume))
+	ssz.PutUint(hh, b.DepositBalanceToConsume)
 
 	// Field (30) 'ExitBalanceToConsume'
-	hh.PutUint64(uint64(b.ExitBalanceToConsume))
+	ssz.PutUint(hh, b.ExitBalanceToConsume)
 
 	// Field (31) 'EarliestExitEpoch'
-	hh.PutUint64(uint64(b.EarliestExitEpoch))
+	ssz.PutUint(hh, b.EarliestExitEpoch)
 
 	// Field (32) 'ConsolidationBalanceToConsume'
-	hh.PutUint64(uint64(b.ConsolidationBalanceToConsume))
+	ssz.PutUint(hh, b.ConsolidationBalanceToConsume)
 
 	// Field (33) 'EarliestConsolidationEpoch'
-	hh.PutUint64(uint64(b.EarliestConsolidationEpoch))
+	ssz.PutUint(hh, b.EarliestConsolidationEpoch)
 
 	// Field (34) 'PendingDeposits'
 	{
@@ -3018,7 +3018,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.ProposerLookahead {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -3040,7 +3040,7 @@ func (b *BeaconStateGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (39) 'NextWithdrawalBuilderIndex'
-	hh.PutUint64(uint64(b.NextWithdrawalBuilderIndex))
+	ssz.PutUint(hh, b.NextWithdrawalBuilderIndex)
 
 	// Field (40) 'ExecutionPayloadAvailability'
 	if size := len(b.ExecutionPayloadAvailability); size != 1024 {
@@ -3113,7 +3113,7 @@ func (b *BuilderPendingPayment) MarshalSSZTo(buf []byte) (dst []byte, err error)
 	dst = buf
 
 	// Field (0) 'Weight'
-	dst = ssz.MarshalUint64(dst, uint64(b.Weight))
+	dst = ssz.MarshalUint(dst, b.Weight)
 
 	// Field (1) 'Withdrawal'
 	if b.Withdrawal == nil {
@@ -3135,7 +3135,7 @@ func (b *BuilderPendingPayment) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Weight'
-	b.Weight = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[0:8]))
+	b.Weight = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[0:8])
 
 	// Field (1) 'Withdrawal'
 	if b.Withdrawal == nil {
@@ -3164,7 +3164,7 @@ func (b *BuilderPendingPayment) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Weight'
-	hh.PutUint64(uint64(b.Weight))
+	ssz.PutUint(hh, b.Weight)
 
 	// Field (1) 'Withdrawal'
 	if err = b.Withdrawal.HashTreeRootWith(hh); err != nil {
@@ -3192,10 +3192,10 @@ func (b *BuilderPendingWithdrawal) MarshalSSZTo(buf []byte) (dst []byte, err err
 	dst = append(dst, b.FeeRecipient...)
 
 	// Field (1) 'Amount'
-	dst = ssz.MarshalUint64(dst, uint64(b.Amount))
+	dst = ssz.MarshalUint(dst, b.Amount)
 
 	// Field (2) 'BuilderIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.BuilderIndex))
+	dst = ssz.MarshalUint(dst, b.BuilderIndex)
 
 	return
 }
@@ -3215,10 +3215,10 @@ func (b *BuilderPendingWithdrawal) UnmarshalSSZ(buf []byte) error {
 	b.FeeRecipient = append(b.FeeRecipient, buf[0:20]...)
 
 	// Field (1) 'Amount'
-	b.Amount = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[20:28]))
+	b.Amount = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[20:28])
 
 	// Field (2) 'BuilderIndex'
-	b.BuilderIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex(ssz.UnmarshallUint64(buf[28:36]))
+	b.BuilderIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex](buf[28:36])
 
 	return err
 }
@@ -3246,10 +3246,10 @@ func (b *BuilderPendingWithdrawal) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 	hh.PutBytes(b.FeeRecipient)
 
 	// Field (1) 'Amount'
-	hh.PutUint64(uint64(b.Amount))
+	ssz.PutUint(hh, b.Amount)
 
 	// Field (2) 'BuilderIndex'
-	hh.PutUint64(uint64(b.BuilderIndex))
+	ssz.PutUint(hh, b.BuilderIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -3266,7 +3266,7 @@ func (d *DataColumnSidecarGloas) MarshalSSZTo(buf []byte) (dst []byte, err error
 	offset := int(56)
 
 	// Field (0) 'Index'
-	dst = ssz.MarshalUint64(dst, d.Index)
+	dst = ssz.MarshalUint(dst, d.Index)
 
 	// Offset (1) 'Column'
 	dst = ssz.WriteOffset(dst, offset)
@@ -3277,7 +3277,7 @@ func (d *DataColumnSidecarGloas) MarshalSSZTo(buf []byte) (dst []byte, err error
 	offset += len(d.KzgProofs) * 48
 
 	// Field (3) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(d.Slot))
+	dst = ssz.MarshalUint(dst, d.Slot)
 
 	// Field (4) 'BeaconBlockRoot'
 	if size := len(d.BeaconBlockRoot); size != 32 {
@@ -3327,7 +3327,7 @@ func (d *DataColumnSidecarGloas) UnmarshalSSZ(buf []byte) error {
 	var o1, o2 uint64
 
 	// Field (0) 'Index'
-	d.Index = ssz.UnmarshallUint64(buf[0:8])
+	d.Index = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Offset (1) 'Column'
 	if o1 = ssz.ReadOffset(buf[8:12]); o1 > size {
@@ -3344,7 +3344,7 @@ func (d *DataColumnSidecarGloas) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (3) 'Slot'
-	d.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[16:24]))
+	d.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[16:24])
 
 	// Field (4) 'BeaconBlockRoot'
 	if cap(d.BeaconBlockRoot) == 0 {
@@ -3409,7 +3409,7 @@ func (d *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Index'
-	hh.PutUint64(d.Index)
+	ssz.PutUint(hh, d.Index)
 
 	// Field (1) 'Column'
 	{
@@ -3450,7 +3450,7 @@ func (d *DataColumnSidecarGloas) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (3) 'Slot'
-	hh.PutUint64(uint64(d.Slot))
+	ssz.PutUint(hh, d.Slot)
 
 	// Field (4) 'BeaconBlockRoot'
 	if size := len(d.BeaconBlockRoot); size != 32 {
@@ -3488,7 +3488,7 @@ func (e *ExecutionPayloadEnvelope) MarshalSSZTo(buf []byte) (dst []byte, err err
 	offset += e.ExecutionRequests.SizeSSZ()
 
 	// Field (2) 'BuilderIndex'
-	dst = ssz.MarshalUint64(dst, uint64(e.BuilderIndex))
+	dst = ssz.MarshalUint(dst, e.BuilderIndex)
 
 	// Field (3) 'BeaconBlockRoot'
 	if size := len(e.BeaconBlockRoot); size != 32 {
@@ -3498,7 +3498,7 @@ func (e *ExecutionPayloadEnvelope) MarshalSSZTo(buf []byte) (dst []byte, err err
 	dst = append(dst, e.BeaconBlockRoot...)
 
 	// Field (4) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(e.Slot))
+	dst = ssz.MarshalUint(dst, e.Slot)
 
 	// Field (5) 'StateRoot'
 	if size := len(e.StateRoot); size != 32 {
@@ -3546,7 +3546,7 @@ func (e *ExecutionPayloadEnvelope) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'BuilderIndex'
-	e.BuilderIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex(ssz.UnmarshallUint64(buf[8:16]))
+	e.BuilderIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex](buf[8:16])
 
 	// Field (3) 'BeaconBlockRoot'
 	if cap(e.BeaconBlockRoot) == 0 {
@@ -3555,7 +3555,7 @@ func (e *ExecutionPayloadEnvelope) UnmarshalSSZ(buf []byte) error {
 	e.BeaconBlockRoot = append(e.BeaconBlockRoot, buf[16:48]...)
 
 	// Field (4) 'Slot'
-	e.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[48:56]))
+	e.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[48:56])
 
 	// Field (5) 'StateRoot'
 	if cap(e.StateRoot) == 0 {
@@ -3626,7 +3626,7 @@ func (e *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 	}
 
 	// Field (2) 'BuilderIndex'
-	hh.PutUint64(uint64(e.BuilderIndex))
+	ssz.PutUint(hh, e.BuilderIndex)
 
 	// Field (3) 'BeaconBlockRoot'
 	if size := len(e.BeaconBlockRoot); size != 32 {
@@ -3636,7 +3636,7 @@ func (e *ExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err error) 
 	hh.PutBytes(e.BeaconBlockRoot)
 
 	// Field (4) 'Slot'
-	hh.PutUint64(uint64(e.Slot))
+	ssz.PutUint(hh, e.Slot)
 
 	// Field (5) 'StateRoot'
 	if size := len(e.StateRoot); size != 32 {
@@ -3783,7 +3783,7 @@ func (b *BlindedExecutionPayloadEnvelope) MarshalSSZTo(buf []byte) (dst []byte, 
 	offset += b.ExecutionRequests.SizeSSZ()
 
 	// Field (2) 'BuilderIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.BuilderIndex))
+	dst = ssz.MarshalUint(dst, b.BuilderIndex)
 
 	// Field (3) 'BeaconBlockRoot'
 	if size := len(b.BeaconBlockRoot); size != 32 {
@@ -3793,7 +3793,7 @@ func (b *BlindedExecutionPayloadEnvelope) MarshalSSZTo(buf []byte) (dst []byte, 
 	dst = append(dst, b.BeaconBlockRoot...)
 
 	// Field (4) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (5) 'StateRoot'
 	if size := len(b.StateRoot); size != 32 {
@@ -3844,7 +3844,7 @@ func (b *BlindedExecutionPayloadEnvelope) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'BuilderIndex'
-	b.BuilderIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex(ssz.UnmarshallUint64(buf[36:44]))
+	b.BuilderIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.BuilderIndex](buf[36:44])
 
 	// Field (3) 'BeaconBlockRoot'
 	if cap(b.BeaconBlockRoot) == 0 {
@@ -3853,7 +3853,7 @@ func (b *BlindedExecutionPayloadEnvelope) UnmarshalSSZ(buf []byte) error {
 	b.BeaconBlockRoot = append(b.BeaconBlockRoot, buf[44:76]...)
 
 	// Field (4) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[76:84]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[76:84])
 
 	// Field (5) 'StateRoot'
 	if cap(b.StateRoot) == 0 {
@@ -3915,7 +3915,7 @@ func (b *BlindedExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err 
 	}
 
 	// Field (2) 'BuilderIndex'
-	hh.PutUint64(uint64(b.BuilderIndex))
+	ssz.PutUint(hh, b.BuilderIndex)
 
 	// Field (3) 'BeaconBlockRoot'
 	if size := len(b.BeaconBlockRoot); size != 32 {
@@ -3925,7 +3925,7 @@ func (b *BlindedExecutionPayloadEnvelope) HashTreeRootWith(hh *ssz.Hasher) (err 
 	hh.PutBytes(b.BeaconBlockRoot)
 
 	// Field (4) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (5) 'StateRoot'
 	if size := len(b.StateRoot); size != 32 {
@@ -4085,13 +4085,13 @@ func (b *Builder) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.ExecutionAddress...)
 
 	// Field (3) 'Balance'
-	dst = ssz.MarshalUint64(dst, uint64(b.Balance))
+	dst = ssz.MarshalUint(dst, b.Balance)
 
 	// Field (4) 'DepositEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.DepositEpoch))
+	dst = ssz.MarshalUint(dst, b.DepositEpoch)
 
 	// Field (5) 'WithdrawableEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(b.WithdrawableEpoch))
+	dst = ssz.MarshalUint(dst, b.WithdrawableEpoch)
 
 	return
 }
@@ -4123,13 +4123,13 @@ func (b *Builder) UnmarshalSSZ(buf []byte) error {
 	b.ExecutionAddress = append(b.ExecutionAddress, buf[49:69]...)
 
 	// Field (3) 'Balance'
-	b.Balance = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei(ssz.UnmarshallUint64(buf[69:77]))
+	b.Balance = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Gwei](buf[69:77])
 
 	// Field (4) 'DepositEpoch'
-	b.DepositEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[77:85]))
+	b.DepositEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[77:85])
 
 	// Field (5) 'WithdrawableEpoch'
-	b.WithdrawableEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[85:93]))
+	b.WithdrawableEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[85:93])
 
 	return err
 }
@@ -4171,13 +4171,13 @@ func (b *Builder) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.ExecutionAddress)
 
 	// Field (3) 'Balance'
-	hh.PutUint64(uint64(b.Balance))
+	ssz.PutUint(hh, b.Balance)
 
 	// Field (4) 'DepositEpoch'
-	hh.PutUint64(uint64(b.DepositEpoch))
+	ssz.PutUint(hh, b.DepositEpoch)
 
 	// Field (5) 'WithdrawableEpoch'
-	hh.PutUint64(uint64(b.WithdrawableEpoch))
+	ssz.PutUint(hh, b.WithdrawableEpoch)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/prysm/v1alpha1/non-core.ssz.go
+++ b/proto/prysm/v1alpha1/non-core.ssz.go
@@ -107,10 +107,10 @@ func (v *ValidatorRegistrationV1) MarshalSSZTo(buf []byte) (dst []byte, err erro
 	dst = append(dst, v.FeeRecipient...)
 
 	// Field (1) 'GasLimit'
-	dst = ssz.MarshalUint64(dst, v.GasLimit)
+	dst = ssz.MarshalUint(dst, v.GasLimit)
 
 	// Field (2) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, v.Timestamp)
+	dst = ssz.MarshalUint(dst, v.Timestamp)
 
 	// Field (3) 'Pubkey'
 	if size := len(v.Pubkey); size != 48 {
@@ -137,10 +137,10 @@ func (v *ValidatorRegistrationV1) UnmarshalSSZ(buf []byte) error {
 	v.FeeRecipient = append(v.FeeRecipient, buf[0:20]...)
 
 	// Field (1) 'GasLimit'
-	v.GasLimit = ssz.UnmarshallUint64(buf[20:28])
+	v.GasLimit = ssz.UnmarshallUint[uint64](buf[20:28])
 
 	// Field (2) 'Timestamp'
-	v.Timestamp = ssz.UnmarshallUint64(buf[28:36])
+	v.Timestamp = ssz.UnmarshallUint[uint64](buf[28:36])
 
 	// Field (3) 'Pubkey'
 	if cap(v.Pubkey) == 0 {
@@ -174,10 +174,10 @@ func (v *ValidatorRegistrationV1) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(v.FeeRecipient)
 
 	// Field (1) 'GasLimit'
-	hh.PutUint64(v.GasLimit)
+	ssz.PutUint(hh, v.GasLimit)
 
 	// Field (2) 'Timestamp'
-	hh.PutUint64(v.Timestamp)
+	ssz.PutUint(hh, v.Timestamp)
 
 	// Field (3) 'Pubkey'
 	if size := len(v.Pubkey); size != 48 {
@@ -438,13 +438,13 @@ func (b *BeaconBlocksByRangeRequest) MarshalSSZTo(buf []byte) (dst []byte, err e
 	dst = buf
 
 	// Field (0) 'StartSlot'
-	dst = ssz.MarshalUint64(dst, uint64(b.StartSlot))
+	dst = ssz.MarshalUint(dst, b.StartSlot)
 
 	// Field (1) 'Count'
-	dst = ssz.MarshalUint64(dst, b.Count)
+	dst = ssz.MarshalUint(dst, b.Count)
 
 	// Field (2) 'Step'
-	dst = ssz.MarshalUint64(dst, b.Step)
+	dst = ssz.MarshalUint(dst, b.Step)
 
 	return
 }
@@ -458,13 +458,13 @@ func (b *BeaconBlocksByRangeRequest) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'StartSlot'
-	b.StartSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.StartSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'Count'
-	b.Count = ssz.UnmarshallUint64(buf[8:16])
+	b.Count = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Field (2) 'Step'
-	b.Step = ssz.UnmarshallUint64(buf[16:24])
+	b.Step = ssz.UnmarshallUint[uint64](buf[16:24])
 
 	return err
 }
@@ -485,13 +485,13 @@ func (b *BeaconBlocksByRangeRequest) HashTreeRootWith(hh *ssz.Hasher) (err error
 	indx := hh.Index()
 
 	// Field (0) 'StartSlot'
-	hh.PutUint64(uint64(b.StartSlot))
+	ssz.PutUint(hh, b.StartSlot)
 
 	// Field (1) 'Count'
-	hh.PutUint64(b.Count)
+	ssz.PutUint(hh, b.Count)
 
 	// Field (2) 'Step'
-	hh.PutUint64(b.Step)
+	ssz.PutUint(hh, b.Step)
 
 	hh.Merkleize(indx)
 	return
@@ -507,7 +507,7 @@ func (m *MetaDataV0) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'SeqNumber'
-	dst = ssz.MarshalUint64(dst, m.SeqNumber)
+	dst = ssz.MarshalUint(dst, m.SeqNumber)
 
 	// Field (1) 'Attnets'
 	if size := len(m.Attnets); size != 8 {
@@ -528,7 +528,7 @@ func (m *MetaDataV0) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'SeqNumber'
-	m.SeqNumber = ssz.UnmarshallUint64(buf[0:8])
+	m.SeqNumber = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'Attnets'
 	if cap(m.Attnets) == 0 {
@@ -555,7 +555,7 @@ func (m *MetaDataV0) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'SeqNumber'
-	hh.PutUint64(m.SeqNumber)
+	ssz.PutUint(hh, m.SeqNumber)
 
 	// Field (1) 'Attnets'
 	if size := len(m.Attnets); size != 8 {
@@ -578,7 +578,7 @@ func (m *MetaDataV1) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'SeqNumber'
-	dst = ssz.MarshalUint64(dst, m.SeqNumber)
+	dst = ssz.MarshalUint(dst, m.SeqNumber)
 
 	// Field (1) 'Attnets'
 	if size := len(m.Attnets); size != 8 {
@@ -606,7 +606,7 @@ func (m *MetaDataV1) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'SeqNumber'
-	m.SeqNumber = ssz.UnmarshallUint64(buf[0:8])
+	m.SeqNumber = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'Attnets'
 	if cap(m.Attnets) == 0 {
@@ -639,7 +639,7 @@ func (m *MetaDataV1) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'SeqNumber'
-	hh.PutUint64(m.SeqNumber)
+	ssz.PutUint(hh, m.SeqNumber)
 
 	// Field (1) 'Attnets'
 	if size := len(m.Attnets); size != 8 {
@@ -669,7 +669,7 @@ func (m *MetaDataV2) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'SeqNumber'
-	dst = ssz.MarshalUint64(dst, m.SeqNumber)
+	dst = ssz.MarshalUint(dst, m.SeqNumber)
 
 	// Field (1) 'Attnets'
 	if size := len(m.Attnets); size != 8 {
@@ -686,7 +686,7 @@ func (m *MetaDataV2) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, m.Syncnets...)
 
 	// Field (3) 'CustodyGroupCount'
-	dst = ssz.MarshalUint64(dst, m.CustodyGroupCount)
+	dst = ssz.MarshalUint(dst, m.CustodyGroupCount)
 
 	return
 }
@@ -700,7 +700,7 @@ func (m *MetaDataV2) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'SeqNumber'
-	m.SeqNumber = ssz.UnmarshallUint64(buf[0:8])
+	m.SeqNumber = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'Attnets'
 	if cap(m.Attnets) == 0 {
@@ -715,7 +715,7 @@ func (m *MetaDataV2) UnmarshalSSZ(buf []byte) error {
 	m.Syncnets = append(m.Syncnets, buf[16:17]...)
 
 	// Field (3) 'CustodyGroupCount'
-	m.CustodyGroupCount = ssz.UnmarshallUint64(buf[17:25])
+	m.CustodyGroupCount = ssz.UnmarshallUint[uint64](buf[17:25])
 
 	return err
 }
@@ -736,7 +736,7 @@ func (m *MetaDataV2) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'SeqNumber'
-	hh.PutUint64(m.SeqNumber)
+	ssz.PutUint(hh, m.SeqNumber)
 
 	// Field (1) 'Attnets'
 	if size := len(m.Attnets); size != 8 {
@@ -753,7 +753,7 @@ func (m *MetaDataV2) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(m.Syncnets)
 
 	// Field (3) 'CustodyGroupCount'
-	hh.PutUint64(m.CustodyGroupCount)
+	ssz.PutUint(hh, m.CustodyGroupCount)
 
 	hh.Merkleize(indx)
 	return
@@ -769,10 +769,10 @@ func (b *BlobSidecarsByRangeRequest) MarshalSSZTo(buf []byte) (dst []byte, err e
 	dst = buf
 
 	// Field (0) 'StartSlot'
-	dst = ssz.MarshalUint64(dst, uint64(b.StartSlot))
+	dst = ssz.MarshalUint(dst, b.StartSlot)
 
 	// Field (1) 'Count'
-	dst = ssz.MarshalUint64(dst, b.Count)
+	dst = ssz.MarshalUint(dst, b.Count)
 
 	return
 }
@@ -786,10 +786,10 @@ func (b *BlobSidecarsByRangeRequest) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'StartSlot'
-	b.StartSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.StartSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'Count'
-	b.Count = ssz.UnmarshallUint64(buf[8:16])
+	b.Count = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	return err
 }
@@ -810,10 +810,10 @@ func (b *BlobSidecarsByRangeRequest) HashTreeRootWith(hh *ssz.Hasher) (err error
 	indx := hh.Index()
 
 	// Field (0) 'StartSlot'
-	hh.PutUint64(uint64(b.StartSlot))
+	ssz.PutUint(hh, b.StartSlot)
 
 	// Field (1) 'Count'
-	hh.PutUint64(b.Count)
+	ssz.PutUint(hh, b.Count)
 
 	hh.Merkleize(indx)
 	return
@@ -830,10 +830,10 @@ func (d *DataColumnSidecarsByRangeRequest) MarshalSSZTo(buf []byte) (dst []byte,
 	offset := int(20)
 
 	// Field (0) 'StartSlot'
-	dst = ssz.MarshalUint64(dst, uint64(d.StartSlot))
+	dst = ssz.MarshalUint(dst, d.StartSlot)
 
 	// Field (1) 'Count'
-	dst = ssz.MarshalUint64(dst, d.Count)
+	dst = ssz.MarshalUint(dst, d.Count)
 
 	// Offset (2) 'Columns'
 	dst = ssz.WriteOffset(dst, offset)
@@ -845,7 +845,7 @@ func (d *DataColumnSidecarsByRangeRequest) MarshalSSZTo(buf []byte) (dst []byte,
 		return
 	}
 	for ii := 0; ii < len(d.Columns); ii++ {
-		dst = ssz.MarshalUint64(dst, d.Columns[ii])
+		dst = ssz.MarshalUint(dst, d.Columns[ii])
 	}
 
 	return
@@ -863,10 +863,10 @@ func (d *DataColumnSidecarsByRangeRequest) UnmarshalSSZ(buf []byte) error {
 	var o2 uint64
 
 	// Field (0) 'StartSlot'
-	d.StartSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	d.StartSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'Count'
-	d.Count = ssz.UnmarshallUint64(buf[8:16])
+	d.Count = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Offset (2) 'Columns'
 	if o2 = ssz.ReadOffset(buf[16:20]); o2 > size {
@@ -884,9 +884,9 @@ func (d *DataColumnSidecarsByRangeRequest) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		d.Columns = ssz.ExtendUint64(d.Columns, num)
+		d.Columns = ssz.ExtendUint(d.Columns, num)
 		for ii := 0; ii < num; ii++ {
-			d.Columns[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			d.Columns[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -912,10 +912,10 @@ func (d *DataColumnSidecarsByRangeRequest) HashTreeRootWith(hh *ssz.Hasher) (err
 	indx := hh.Index()
 
 	// Field (0) 'StartSlot'
-	hh.PutUint64(uint64(d.StartSlot))
+	ssz.PutUint(hh, d.StartSlot)
 
 	// Field (1) 'Count'
-	hh.PutUint64(d.Count)
+	ssz.PutUint(hh, d.Count)
 
 	// Field (2) 'Columns'
 	{
@@ -925,7 +925,7 @@ func (d *DataColumnSidecarsByRangeRequest) HashTreeRootWith(hh *ssz.Hasher) (err
 		}
 		subIndx := hh.Index()
 		for _, i := range d.Columns {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -947,10 +947,10 @@ func (e *ExecutionPayloadEnvelopesByRangeRequest) MarshalSSZTo(buf []byte) (dst 
 	dst = buf
 
 	// Field (0) 'StartSlot'
-	dst = ssz.MarshalUint64(dst, uint64(e.StartSlot))
+	dst = ssz.MarshalUint(dst, e.StartSlot)
 
 	// Field (1) 'Count'
-	dst = ssz.MarshalUint64(dst, e.Count)
+	dst = ssz.MarshalUint(dst, e.Count)
 
 	return
 }
@@ -964,10 +964,10 @@ func (e *ExecutionPayloadEnvelopesByRangeRequest) UnmarshalSSZ(buf []byte) error
 	}
 
 	// Field (0) 'StartSlot'
-	e.StartSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	e.StartSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'Count'
-	e.Count = ssz.UnmarshallUint64(buf[8:16])
+	e.Count = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	return err
 }
@@ -988,10 +988,10 @@ func (e *ExecutionPayloadEnvelopesByRangeRequest) HashTreeRootWith(hh *ssz.Hashe
 	indx := hh.Index()
 
 	// Field (0) 'StartSlot'
-	hh.PutUint64(uint64(e.StartSlot))
+	ssz.PutUint(hh, e.StartSlot)
 
 	// Field (1) 'Count'
-	hh.PutUint64(e.Count)
+	ssz.PutUint(hh, e.Count)
 
 	hh.Merkleize(indx)
 	return
@@ -1019,7 +1019,7 @@ func (d *DepositSnapshot) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.DepositRoot...)
 
 	// Field (2) 'DepositCount'
-	dst = ssz.MarshalUint64(dst, d.DepositCount)
+	dst = ssz.MarshalUint(dst, d.DepositCount)
 
 	// Field (3) 'ExecutionHash'
 	if size := len(d.ExecutionHash); size != 32 {
@@ -1029,7 +1029,7 @@ func (d *DepositSnapshot) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.ExecutionHash...)
 
 	// Field (4) 'ExecutionDepth'
-	dst = ssz.MarshalUint64(dst, d.ExecutionDepth)
+	dst = ssz.MarshalUint(dst, d.ExecutionDepth)
 
 	// Field (0) 'Finalized'
 	if size := len(d.Finalized); size > 32 {
@@ -1074,7 +1074,7 @@ func (d *DepositSnapshot) UnmarshalSSZ(buf []byte) error {
 	d.DepositRoot = append(d.DepositRoot, buf[4:36]...)
 
 	// Field (2) 'DepositCount'
-	d.DepositCount = ssz.UnmarshallUint64(buf[36:44])
+	d.DepositCount = ssz.UnmarshallUint[uint64](buf[36:44])
 
 	// Field (3) 'ExecutionHash'
 	if cap(d.ExecutionHash) == 0 {
@@ -1083,7 +1083,7 @@ func (d *DepositSnapshot) UnmarshalSSZ(buf []byte) error {
 	d.ExecutionHash = append(d.ExecutionHash, buf[44:76]...)
 
 	// Field (4) 'ExecutionDepth'
-	d.ExecutionDepth = ssz.UnmarshallUint64(buf[76:84])
+	d.ExecutionDepth = ssz.UnmarshallUint[uint64](buf[76:84])
 
 	// Field (0) 'Finalized'
 	{
@@ -1149,7 +1149,7 @@ func (d *DepositSnapshot) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.DepositRoot)
 
 	// Field (2) 'DepositCount'
-	hh.PutUint64(d.DepositCount)
+	ssz.PutUint(hh, d.DepositCount)
 
 	// Field (3) 'ExecutionHash'
 	if size := len(d.ExecutionHash); size != 32 {
@@ -1159,7 +1159,7 @@ func (d *DepositSnapshot) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.ExecutionHash)
 
 	// Field (4) 'ExecutionDepth'
-	hh.PutUint64(d.ExecutionDepth)
+	ssz.PutUint(hh, d.ExecutionDepth)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/prysm/v1alpha1/phase0.ssz.go
+++ b/proto/prysm/v1alpha1/phase0.ssz.go
@@ -126,7 +126,7 @@ func (a *AggregateAttestationAndProof) MarshalSSZTo(buf []byte) (dst []byte, err
 	offset := int(108)
 
 	// Field (0) 'AggregatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(a.AggregatorIndex))
+	dst = ssz.MarshalUint(dst, a.AggregatorIndex)
 
 	// Offset (1) 'Aggregate'
 	dst = ssz.WriteOffset(dst, offset)
@@ -162,7 +162,7 @@ func (a *AggregateAttestationAndProof) UnmarshalSSZ(buf []byte) error {
 	var o1 uint64
 
 	// Field (0) 'AggregatorIndex'
-	a.AggregatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	a.AggregatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Offset (1) 'Aggregate'
 	if o1 = ssz.ReadOffset(buf[8:12]); o1 > size {
@@ -215,7 +215,7 @@ func (a *AggregateAttestationAndProof) HashTreeRootWith(hh *ssz.Hasher) (err err
 	indx := hh.Index()
 
 	// Field (0) 'AggregatorIndex'
-	hh.PutUint64(uint64(a.AggregatorIndex))
+	ssz.PutUint(hh, a.AggregatorIndex)
 
 	// Field (1) 'Aggregate'
 	if err = a.Aggregate.HashTreeRootWith(hh); err != nil {
@@ -372,10 +372,10 @@ func (a *AttestationData) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(a.Slot))
+	dst = ssz.MarshalUint(dst, a.Slot)
 
 	// Field (1) 'CommitteeIndex'
-	dst = ssz.MarshalUint64(dst, uint64(a.CommitteeIndex))
+	dst = ssz.MarshalUint(dst, a.CommitteeIndex)
 
 	// Field (2) 'BeaconBlockRoot'
 	if size := len(a.BeaconBlockRoot); size != 32 {
@@ -412,10 +412,10 @@ func (a *AttestationData) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	a.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	a.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'CommitteeIndex'
-	a.CommitteeIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.CommitteeIndex(ssz.UnmarshallUint64(buf[8:16]))
+	a.CommitteeIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.CommitteeIndex](buf[8:16])
 
 	// Field (2) 'BeaconBlockRoot'
 	if cap(a.BeaconBlockRoot) == 0 {
@@ -458,10 +458,10 @@ func (a *AttestationData) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(a.Slot))
+	ssz.PutUint(hh, a.Slot)
 
 	// Field (1) 'CommitteeIndex'
-	hh.PutUint64(uint64(a.CommitteeIndex))
+	ssz.PutUint(hh, a.CommitteeIndex)
 
 	// Field (2) 'BeaconBlockRoot'
 	if size := len(a.BeaconBlockRoot); size != 32 {
@@ -494,7 +494,7 @@ func (c *Checkpoint) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Epoch'
-	dst = ssz.MarshalUint64(dst, uint64(c.Epoch))
+	dst = ssz.MarshalUint(dst, c.Epoch)
 
 	// Field (1) 'Root'
 	if size := len(c.Root); size != 32 {
@@ -515,7 +515,7 @@ func (c *Checkpoint) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Epoch'
-	c.Epoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[0:8]))
+	c.Epoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[0:8])
 
 	// Field (1) 'Root'
 	if cap(c.Root) == 0 {
@@ -542,7 +542,7 @@ func (c *Checkpoint) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Epoch'
-	hh.PutUint64(uint64(c.Epoch))
+	ssz.PutUint(hh, c.Epoch)
 
 	// Field (1) 'Root'
 	if size := len(c.Root); size != 32 {
@@ -675,10 +675,10 @@ func (b *BeaconBlock) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -721,10 +721,10 @@ func (b *BeaconBlock) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -783,10 +783,10 @@ func (b *BeaconBlock) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1404,7 +1404,7 @@ func (i *IndexedAttestation) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(i.AttestingIndices); ii++ {
-		dst = ssz.MarshalUint64(dst, i.AttestingIndices[ii])
+		dst = ssz.MarshalUint(dst, i.AttestingIndices[ii])
 	}
 
 	return
@@ -1451,9 +1451,9 @@ func (i *IndexedAttestation) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		i.AttestingIndices = ssz.ExtendUint64(i.AttestingIndices, num)
+		i.AttestingIndices = ssz.ExtendUint(i.AttestingIndices, num)
 		for ii := 0; ii < num; ii++ {
-			i.AttestingIndices[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			i.AttestingIndices[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -1486,7 +1486,7 @@ func (i *IndexedAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range i.AttestingIndices {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -1520,10 +1520,10 @@ func (b *BeaconBlockHeader) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(b.ProposerIndex))
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1558,10 +1558,10 @@ func (b *BeaconBlockHeader) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[0:8]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	b.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -1600,10 +1600,10 @@ func (b *BeaconBlockHeader) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(uint64(b.ProposerIndex))
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -1730,7 +1730,7 @@ func (e *Eth1Data) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, e.DepositRoot...)
 
 	// Field (1) 'DepositCount'
-	dst = ssz.MarshalUint64(dst, e.DepositCount)
+	dst = ssz.MarshalUint(dst, e.DepositCount)
 
 	// Field (2) 'BlockHash'
 	if size := len(e.BlockHash); size != 32 {
@@ -1757,7 +1757,7 @@ func (e *Eth1Data) UnmarshalSSZ(buf []byte) error {
 	e.DepositRoot = append(e.DepositRoot, buf[0:32]...)
 
 	// Field (1) 'DepositCount'
-	e.DepositCount = ssz.UnmarshallUint64(buf[32:40])
+	e.DepositCount = ssz.UnmarshallUint[uint64](buf[32:40])
 
 	// Field (2) 'BlockHash'
 	if cap(e.BlockHash) == 0 {
@@ -1791,7 +1791,7 @@ func (e *Eth1Data) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.DepositRoot)
 
 	// Field (1) 'DepositCount'
-	hh.PutUint64(e.DepositCount)
+	ssz.PutUint(hh, e.DepositCount)
 
 	// Field (2) 'BlockHash'
 	if size := len(e.BlockHash); size != 32 {
@@ -2083,10 +2083,10 @@ func (v *VoluntaryExit) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Epoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.Epoch))
+	dst = ssz.MarshalUint(dst, v.Epoch)
 
 	// Field (1) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, uint64(v.ValidatorIndex))
+	dst = ssz.MarshalUint(dst, v.ValidatorIndex)
 
 	return
 }
@@ -2100,10 +2100,10 @@ func (v *VoluntaryExit) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Epoch'
-	v.Epoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[0:8]))
+	v.Epoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[0:8])
 
 	// Field (1) 'ValidatorIndex'
-	v.ValidatorIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[8:16]))
+	v.ValidatorIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[8:16])
 
 	return err
 }
@@ -2124,10 +2124,10 @@ func (v *VoluntaryExit) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Epoch'
-	hh.PutUint64(uint64(v.Epoch))
+	ssz.PutUint(hh, v.Epoch)
 
 	// Field (1) 'ValidatorIndex'
-	hh.PutUint64(uint64(v.ValidatorIndex))
+	ssz.PutUint(hh, v.ValidatorIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -2157,7 +2157,7 @@ func (f *Fork) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, f.CurrentVersion...)
 
 	// Field (2) 'Epoch'
-	dst = ssz.MarshalUint64(dst, uint64(f.Epoch))
+	dst = ssz.MarshalUint(dst, f.Epoch)
 
 	return
 }
@@ -2183,7 +2183,7 @@ func (f *Fork) UnmarshalSSZ(buf []byte) error {
 	f.CurrentVersion = append(f.CurrentVersion, buf[4:8]...)
 
 	// Field (2) 'Epoch'
-	f.Epoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[8:16]))
+	f.Epoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[8:16])
 
 	return err
 }
@@ -2218,7 +2218,7 @@ func (f *Fork) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(f.CurrentVersion)
 
 	// Field (2) 'Epoch'
-	hh.PutUint64(uint64(f.Epoch))
+	ssz.PutUint(hh, f.Epoch)
 
 	hh.Merkleize(indx)
 	return
@@ -2248,22 +2248,22 @@ func (v *Validator) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, v.WithdrawalCredentials...)
 
 	// Field (2) 'EffectiveBalance'
-	dst = ssz.MarshalUint64(dst, v.EffectiveBalance)
+	dst = ssz.MarshalUint(dst, v.EffectiveBalance)
 
 	// Field (3) 'Slashed'
 	dst = ssz.MarshalBool(dst, v.Slashed)
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.ActivationEligibilityEpoch))
+	dst = ssz.MarshalUint(dst, v.ActivationEligibilityEpoch)
 
 	// Field (5) 'ActivationEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.ActivationEpoch))
+	dst = ssz.MarshalUint(dst, v.ActivationEpoch)
 
 	// Field (6) 'ExitEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.ExitEpoch))
+	dst = ssz.MarshalUint(dst, v.ExitEpoch)
 
 	// Field (7) 'WithdrawableEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.WithdrawableEpoch))
+	dst = ssz.MarshalUint(dst, v.WithdrawableEpoch)
 
 	return
 }
@@ -2289,7 +2289,7 @@ func (v *Validator) UnmarshalSSZ(buf []byte) error {
 	v.WithdrawalCredentials = append(v.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'EffectiveBalance'
-	v.EffectiveBalance = ssz.UnmarshallUint64(buf[80:88])
+	v.EffectiveBalance = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Slashed'
 	v.Slashed, err = ssz.DecodeBool(buf[88:89])
@@ -2298,16 +2298,16 @@ func (v *Validator) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	v.ActivationEligibilityEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[89:97]))
+	v.ActivationEligibilityEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[89:97])
 
 	// Field (5) 'ActivationEpoch'
-	v.ActivationEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[97:105]))
+	v.ActivationEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[97:105])
 
 	// Field (6) 'ExitEpoch'
-	v.ExitEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[105:113]))
+	v.ExitEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[105:113])
 
 	// Field (7) 'WithdrawableEpoch'
-	v.WithdrawableEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[113:121]))
+	v.WithdrawableEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[113:121])
 
 	return err
 }
@@ -2342,22 +2342,22 @@ func (v *Validator) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(v.WithdrawalCredentials)
 
 	// Field (2) 'EffectiveBalance'
-	hh.PutUint64(v.EffectiveBalance)
+	ssz.PutUint(hh, v.EffectiveBalance)
 
 	// Field (3) 'Slashed'
 	hh.PutBool(v.Slashed)
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	hh.PutUint64(uint64(v.ActivationEligibilityEpoch))
+	ssz.PutUint(hh, v.ActivationEligibilityEpoch)
 
 	// Field (5) 'ActivationEpoch'
-	hh.PutUint64(uint64(v.ActivationEpoch))
+	ssz.PutUint(hh, v.ActivationEpoch)
 
 	// Field (6) 'ExitEpoch'
-	hh.PutUint64(uint64(v.ExitEpoch))
+	ssz.PutUint(hh, v.ExitEpoch)
 
 	// Field (7) 'WithdrawableEpoch'
-	hh.PutUint64(uint64(v.WithdrawableEpoch))
+	ssz.PutUint(hh, v.WithdrawableEpoch)
 
 	hh.Merkleize(indx)
 	return
@@ -2387,7 +2387,7 @@ func (d *Deposit_Data) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.WithdrawalCredentials...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, d.Amount)
+	dst = ssz.MarshalUint(dst, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -2420,7 +2420,7 @@ func (d *Deposit_Data) UnmarshalSSZ(buf []byte) error {
 	d.WithdrawalCredentials = append(d.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'Amount'
-	d.Amount = ssz.UnmarshallUint64(buf[80:88])
+	d.Amount = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Signature'
 	if cap(d.Signature) == 0 {
@@ -2461,7 +2461,7 @@ func (d *Deposit_Data) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.WithdrawalCredentials)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(d.Amount)
+	ssz.PutUint(hh, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -2485,7 +2485,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(2687377)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -2495,7 +2495,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(b.Slot))
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -2556,7 +2556,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2585,7 +2585,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 8192; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochAttestations'
@@ -2674,7 +2674,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochAttestations'
@@ -2728,7 +2728,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -2737,7 +2737,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[40:48]))
+	b.Slot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -2796,7 +2796,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[524544:524552])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[524544:524552])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[524552:524556]); o11 > size || o9 > o11 {
@@ -2818,9 +2818,9 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 8192)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[2621712:2687248][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[2621712:2687248][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochAttestations'
@@ -2922,9 +2922,9 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -3015,7 +3015,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -3025,7 +3025,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(uint64(b.Slot))
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -3112,7 +3112,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -3138,7 +3138,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -3171,7 +3171,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -3257,10 +3257,10 @@ func (p *PendingAttestation) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	}
 
 	// Field (2) 'InclusionDelay'
-	dst = ssz.MarshalUint64(dst, uint64(p.InclusionDelay))
+	dst = ssz.MarshalUint(dst, p.InclusionDelay)
 
 	// Field (3) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, uint64(p.ProposerIndex))
+	dst = ssz.MarshalUint(dst, p.ProposerIndex)
 
 	// Field (0) 'AggregationBits'
 	if size := len(p.AggregationBits); size > 2048 {
@@ -3301,10 +3301,10 @@ func (p *PendingAttestation) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'InclusionDelay'
-	p.InclusionDelay = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[132:140]))
+	p.InclusionDelay = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[132:140])
 
 	// Field (3) 'ProposerIndex'
-	p.ProposerIndex = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[140:148]))
+	p.ProposerIndex = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[140:148])
 
 	// Field (0) 'AggregationBits'
 	{
@@ -3352,10 +3352,10 @@ func (p *PendingAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (2) 'InclusionDelay'
-	hh.PutUint64(uint64(p.InclusionDelay))
+	ssz.PutUint(hh, p.InclusionDelay)
 
 	// Field (3) 'ProposerIndex'
-	hh.PutUint64(uint64(p.ProposerIndex))
+	ssz.PutUint(hh, p.ProposerIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -3669,7 +3669,7 @@ func (d *DepositMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.WithdrawalCredentials...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, d.Amount)
+	dst = ssz.MarshalUint(dst, d.Amount)
 
 	return
 }
@@ -3695,7 +3695,7 @@ func (d *DepositMessage) UnmarshalSSZ(buf []byte) error {
 	d.WithdrawalCredentials = append(d.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'Amount'
-	d.Amount = ssz.UnmarshallUint64(buf[80:88])
+	d.Amount = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	return err
 }
@@ -3730,7 +3730,7 @@ func (d *DepositMessage) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.WithdrawalCredentials)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(d.Amount)
+	ssz.PutUint(hh, d.Amount)
 
 	hh.Merkleize(indx)
 	return
@@ -3862,7 +3862,7 @@ func (s *Status) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, s.FinalizedRoot...)
 
 	// Field (2) 'FinalizedEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(s.FinalizedEpoch))
+	dst = ssz.MarshalUint(dst, s.FinalizedEpoch)
 
 	// Field (3) 'HeadRoot'
 	if size := len(s.HeadRoot); size != 32 {
@@ -3872,7 +3872,7 @@ func (s *Status) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, s.HeadRoot...)
 
 	// Field (4) 'HeadSlot'
-	dst = ssz.MarshalUint64(dst, uint64(s.HeadSlot))
+	dst = ssz.MarshalUint(dst, s.HeadSlot)
 
 	return
 }
@@ -3898,7 +3898,7 @@ func (s *Status) UnmarshalSSZ(buf []byte) error {
 	s.FinalizedRoot = append(s.FinalizedRoot, buf[4:36]...)
 
 	// Field (2) 'FinalizedEpoch'
-	s.FinalizedEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[36:44]))
+	s.FinalizedEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[36:44])
 
 	// Field (3) 'HeadRoot'
 	if cap(s.HeadRoot) == 0 {
@@ -3907,7 +3907,7 @@ func (s *Status) UnmarshalSSZ(buf []byte) error {
 	s.HeadRoot = append(s.HeadRoot, buf[44:76]...)
 
 	// Field (4) 'HeadSlot'
-	s.HeadSlot = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot(ssz.UnmarshallUint64(buf[76:84]))
+	s.HeadSlot = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Slot](buf[76:84])
 
 	return err
 }
@@ -3942,7 +3942,7 @@ func (s *Status) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(s.FinalizedRoot)
 
 	// Field (2) 'FinalizedEpoch'
-	hh.PutUint64(uint64(s.FinalizedEpoch))
+	ssz.PutUint(hh, s.FinalizedEpoch)
 
 	// Field (3) 'HeadRoot'
 	if size := len(s.HeadRoot); size != 32 {
@@ -3952,7 +3952,7 @@ func (s *Status) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(s.HeadRoot)
 
 	// Field (4) 'HeadSlot'
-	hh.PutUint64(uint64(s.HeadSlot))
+	ssz.PutUint(hh, s.HeadSlot)
 
 	hh.Merkleize(indx)
 	return
@@ -3982,7 +3982,7 @@ func (e *ENRForkID) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, e.NextForkVersion...)
 
 	// Field (2) 'NextForkEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(e.NextForkEpoch))
+	dst = ssz.MarshalUint(dst, e.NextForkEpoch)
 
 	return
 }
@@ -4008,7 +4008,7 @@ func (e *ENRForkID) UnmarshalSSZ(buf []byte) error {
 	e.NextForkVersion = append(e.NextForkVersion, buf[4:8]...)
 
 	// Field (2) 'NextForkEpoch'
-	e.NextForkEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[8:16]))
+	e.NextForkEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[8:16])
 
 	return err
 }
@@ -4043,7 +4043,7 @@ func (e *ENRForkID) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.NextForkVersion)
 
 	// Field (2) 'NextForkEpoch'
-	hh.PutUint64(uint64(e.NextForkEpoch))
+	ssz.PutUint(hh, e.NextForkEpoch)
 
 	hh.Merkleize(indx)
 	return
@@ -4059,7 +4059,7 @@ func (v *ValidatorIdentity) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Index'
-	dst = ssz.MarshalUint64(dst, uint64(v.Index))
+	dst = ssz.MarshalUint(dst, v.Index)
 
 	// Field (1) 'Pubkey'
 	if size := len(v.Pubkey); size != 48 {
@@ -4069,7 +4069,7 @@ func (v *ValidatorIdentity) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, v.Pubkey...)
 
 	// Field (2) 'ActivationEpoch'
-	dst = ssz.MarshalUint64(dst, uint64(v.ActivationEpoch))
+	dst = ssz.MarshalUint(dst, v.ActivationEpoch)
 
 	return
 }
@@ -4083,7 +4083,7 @@ func (v *ValidatorIdentity) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Index'
-	v.Index = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex(ssz.UnmarshallUint64(buf[0:8]))
+	v.Index = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.ValidatorIndex](buf[0:8])
 
 	// Field (1) 'Pubkey'
 	if cap(v.Pubkey) == 0 {
@@ -4092,7 +4092,7 @@ func (v *ValidatorIdentity) UnmarshalSSZ(buf []byte) error {
 	v.Pubkey = append(v.Pubkey, buf[8:56]...)
 
 	// Field (2) 'ActivationEpoch'
-	v.ActivationEpoch = github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch(ssz.UnmarshallUint64(buf[56:64]))
+	v.ActivationEpoch = ssz.UnmarshallUint[github_com_OffchainLabs_prysm_v7_consensus_types_primitives.Epoch](buf[56:64])
 
 	return err
 }
@@ -4113,7 +4113,7 @@ func (v *ValidatorIdentity) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Index'
-	hh.PutUint64(uint64(v.Index))
+	ssz.PutUint(hh, v.Index)
 
 	// Field (1) 'Pubkey'
 	if size := len(v.Pubkey); size != 48 {
@@ -4123,7 +4123,7 @@ func (v *ValidatorIdentity) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(v.Pubkey)
 
 	// Field (2) 'ActivationEpoch'
-	hh.PutUint64(uint64(v.ActivationEpoch))
+	ssz.PutUint(hh, v.ActivationEpoch)
 
 	hh.Merkleize(indx)
 	return

--- a/proto/ssz_query/response.ssz.go
+++ b/proto/ssz_query/response.ssz.go
@@ -23,7 +23,7 @@ func (s *SSZQueryProof) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, s.Leaf...)
 
 	// Field (1) 'Gindex'
-	dst = ssz.MarshalUint64(dst, s.Gindex)
+	dst = ssz.MarshalUint(dst, s.Gindex)
 
 	// Offset (2) 'Proofs'
 	dst = ssz.WriteOffset(dst, offset)
@@ -63,7 +63,7 @@ func (s *SSZQueryProof) UnmarshalSSZ(buf []byte) error {
 	s.Leaf = append(s.Leaf, buf[0:32]...)
 
 	// Field (1) 'Gindex'
-	s.Gindex = ssz.UnmarshallUint64(buf[32:40])
+	s.Gindex = ssz.UnmarshallUint[uint64](buf[32:40])
 
 	// Offset (2) 'Proofs'
 	if o2 = ssz.ReadOffset(buf[40:44]); o2 > size {
@@ -119,7 +119,7 @@ func (s *SSZQueryProof) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(s.Leaf)
 
 	// Field (1) 'Gindex'
-	hh.PutUint64(s.Gindex)
+	ssz.PutUint(hh, s.Gindex)
 
 	// Field (2) 'Proofs'
 	{

--- a/proto/ssz_query/testing/test_containers.ssz.go
+++ b/proto/ssz_query/testing/test_containers.ssz.go
@@ -15,7 +15,7 @@ func (f *FixedNestedContainer) MarshalSSZTo(buf []byte) (dst []byte, err error) 
 	dst = buf
 
 	// Field (0) 'Value1'
-	dst = ssz.MarshalUint64(dst, f.Value1)
+	dst = ssz.MarshalUint(dst, f.Value1)
 
 	// Field (1) 'Value2'
 	if size := len(f.Value2); size != 32 {
@@ -36,7 +36,7 @@ func (f *FixedNestedContainer) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Value1'
-	f.Value1 = ssz.UnmarshallUint64(buf[0:8])
+	f.Value1 = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'Value2'
 	if cap(f.Value2) == 0 {
@@ -63,7 +63,7 @@ func (f *FixedNestedContainer) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Value1'
-	hh.PutUint64(f.Value1)
+	ssz.PutUint(hh, f.Value1)
 
 	// Field (1) 'Value2'
 	if size := len(f.Value2); size != 32 {
@@ -86,10 +86,10 @@ func (f *FixedTestContainer) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'FieldUint32'
-	dst = ssz.MarshalUint32(dst, f.FieldUint32)
+	dst = ssz.MarshalUint(dst, f.FieldUint32)
 
 	// Field (1) 'FieldUint64'
-	dst = ssz.MarshalUint64(dst, f.FieldUint64)
+	dst = ssz.MarshalUint(dst, f.FieldUint64)
 
 	// Field (2) 'FieldBool'
 	dst = ssz.MarshalBool(dst, f.FieldBool)
@@ -115,7 +115,7 @@ func (f *FixedTestContainer) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 24; ii++ {
-		dst = ssz.MarshalUint64(dst, f.VectorField[ii])
+		dst = ssz.MarshalUint(dst, f.VectorField[ii])
 	}
 
 	// Field (6) 'TwoDimensionBytesField'
@@ -164,10 +164,10 @@ func (f *FixedTestContainer) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'FieldUint32'
-	f.FieldUint32 = ssz.UnmarshallUint32(buf[0:4])
+	f.FieldUint32 = ssz.UnmarshallUint[uint32](buf[0:4])
 
 	// Field (1) 'FieldUint64'
-	f.FieldUint64 = ssz.UnmarshallUint64(buf[4:12])
+	f.FieldUint64 = ssz.UnmarshallUint[uint64](buf[4:12])
 
 	// Field (2) 'FieldBool'
 	f.FieldBool, err = ssz.DecodeBool(buf[12:13])
@@ -190,9 +190,9 @@ func (f *FixedTestContainer) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (5) 'VectorField'
-	f.VectorField = ssz.ExtendUint64(f.VectorField, 24)
+	f.VectorField = ssz.ExtendUint(f.VectorField, 24)
 	for ii := 0; ii < 24; ii++ {
-		f.VectorField[ii] = ssz.UnmarshallUint64(buf[85:277][ii*8 : (ii+1)*8])
+		f.VectorField[ii] = ssz.UnmarshallUint[uint64](buf[85:277][ii*8 : (ii+1)*8])
 	}
 
 	// Field (6) 'TwoDimensionBytesField'
@@ -241,10 +241,10 @@ func (f *FixedTestContainer) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'FieldUint32'
-	hh.PutUint32(f.FieldUint32)
+	ssz.PutUint(hh, f.FieldUint32)
 
 	// Field (1) 'FieldUint64'
-	hh.PutUint64(f.FieldUint64)
+	ssz.PutUint(hh, f.FieldUint64)
 
 	// Field (2) 'FieldBool'
 	hh.PutBool(f.FieldBool)
@@ -269,7 +269,7 @@ func (f *FixedTestContainer) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range f.VectorField {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -327,7 +327,7 @@ func (v *VariableNestedContainer) MarshalSSZTo(buf []byte) (dst []byte, err erro
 	offset := int(16)
 
 	// Field (0) 'Value1'
-	dst = ssz.MarshalUint64(dst, v.Value1)
+	dst = ssz.MarshalUint(dst, v.Value1)
 
 	// Offset (1) 'FieldListUint64'
 	dst = ssz.WriteOffset(dst, offset)
@@ -346,7 +346,7 @@ func (v *VariableNestedContainer) MarshalSSZTo(buf []byte) (dst []byte, err erro
 		return
 	}
 	for ii := 0; ii < len(v.FieldListUint64); ii++ {
-		dst = ssz.MarshalUint64(dst, v.FieldListUint64[ii])
+		dst = ssz.MarshalUint(dst, v.FieldListUint64[ii])
 	}
 
 	// Field (2) 'NestedListField'
@@ -384,7 +384,7 @@ func (v *VariableNestedContainer) UnmarshalSSZ(buf []byte) error {
 	var o1, o2 uint64
 
 	// Field (0) 'Value1'
-	v.Value1 = ssz.UnmarshallUint64(buf[0:8])
+	v.Value1 = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Offset (1) 'FieldListUint64'
 	if o1 = ssz.ReadOffset(buf[8:12]); o1 > size {
@@ -407,9 +407,9 @@ func (v *VariableNestedContainer) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		v.FieldListUint64 = ssz.ExtendUint64(v.FieldListUint64, num)
+		v.FieldListUint64 = ssz.ExtendUint(v.FieldListUint64, num)
 		for ii := 0; ii < num; ii++ {
-			v.FieldListUint64[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			v.FieldListUint64[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -464,7 +464,7 @@ func (v *VariableNestedContainer) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Value1'
-	hh.PutUint64(v.Value1)
+	ssz.PutUint(hh, v.Value1)
 
 	// Field (1) 'FieldListUint64'
 	{
@@ -474,7 +474,7 @@ func (v *VariableNestedContainer) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range v.FieldListUint64 {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -704,7 +704,7 @@ func (v *VariableTestContainer) MarshalSSZTo(buf []byte) (dst []byte, err error)
 		return
 	}
 	for ii := 0; ii < len(v.FieldListUint64); ii++ {
-		dst = ssz.MarshalUint64(dst, v.FieldListUint64[ii])
+		dst = ssz.MarshalUint(dst, v.FieldListUint64[ii])
 	}
 
 	// Field (2) 'FieldListContainer'
@@ -853,9 +853,9 @@ func (v *VariableTestContainer) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		v.FieldListUint64 = ssz.ExtendUint64(v.FieldListUint64, num)
+		v.FieldListUint64 = ssz.ExtendUint(v.FieldListUint64, num)
 		for ii := 0; ii < num; ii++ {
-			v.FieldListUint64[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			v.FieldListUint64[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -1024,7 +1024,7 @@ func (v *VariableTestContainer) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range v.FieldListUint64 {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Incorporates fastssz PR 19: https://github.com/OffchainLabs/fastssz/pull/19.

**Which issues(s) does this PR fix?**

This allows for use of []primitives.ValidatorIndex in ssz code generation.

**Other notes for review**

Most of the diff is regenerating ssz.go files. Review go.mod and deps.bzl carefully. 

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
