### PR TITLE
`ProcessEffectiveBalanceUpdates`: Avoid copying a validator when the computed effective balance is unchanged.

### DIFF
--- a/beacon-chain/core/electra/effective_balance_updates.go
+++ b/beacon-chain/core/electra/effective_balance_updates.go
@@ -51,8 +51,10 @@ func ProcessEffectiveBalanceUpdates(st state.BeaconState) error {
 
 		if balance+downwardThreshold < val.EffectiveBalance() || val.EffectiveBalance()+upwardThreshold < balance {
 			effectiveBal := min(balance-balance%effBalanceInc, effectiveBalanceLimit)
-			newVal = val.Copy()
-			newVal.EffectiveBalance = effectiveBal
+			if effectiveBal != val.EffectiveBalance() {
+				newVal = val.Copy()
+				newVal.EffectiveBalance = effectiveBal
+			}
 		}
 		return newVal, nil
 	}

--- a/beacon-chain/state/fieldtrie/BUILD.bazel
+++ b/beacon-chain/state/fieldtrie/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "field_trie.go",
         "field_trie_helpers.go",
+        "metrics.go",
     ],
     importpath = "github.com/OffchainLabs/prysm/v7/beacon-chain/state/fieldtrie",
     visibility = ["//visibility:public"],
@@ -16,6 +17,8 @@ go_library(
         "//math:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
 )
 

--- a/beacon-chain/state/fieldtrie/field_trie.go
+++ b/beacon-chain/state/fieldtrie/field_trie.go
@@ -102,6 +102,9 @@ func NewFieldTrie(field types.FieldIndex, fieldInfo types.DataType, elements any
 func (f *FieldTrie) RecomputeTrie(indices []uint64, elements any) ([32]byte, error) {
 	f.Lock()
 	defer f.Unlock()
+
+	fieldTrieRecomputeIndicesSummary.WithLabelValues(f.field.String()).Observe(float64(len(indices)))
+
 	var fieldRoot [32]byte
 	if len(indices) == 0 {
 		return f.TrieRoot()

--- a/beacon-chain/state/fieldtrie/metrics.go
+++ b/beacon-chain/state/fieldtrie/metrics.go
@@ -1,0 +1,13 @@
+package fieldtrie
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	fieldTrieRecomputeIndicesSummary = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name: "field_trie_recompute_indices",
+		Help: "Distribution of the number of changed indices per RecomputeTrie call.",
+	}, []string{"field"})
+)

--- a/changelog/manu-0x00-dirty.md
+++ b/changelog/manu-0x00-dirty.md
@@ -1,0 +1,7 @@
+### Added
+
+- Prometheus summary metric (`field_trie_recompute_indices`) tracking the number of changed indices per `RecomputeTrie` call, broken down by field.
+
+### Fixed
+
+- `ProcessEffectiveBalanceUpdates`: avoid copying a validator when the computed effective balance is unchanged, reducing unnecessary allocations.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
In (electra) `ProcessEffectiveBalanceUpdates`, a `0x00...` validator with a balance > 33.25 ETH enters in the
```go
if balance+downwardThreshold < val.EffectiveBalance() || val.EffectiveBalance()+upwardThreshold < balance {
...
}
```

condition.

The validator is copied (`newVal = val.Copy()`) and returned, **even if the effective balance did not actually change**.
As a consequence, this validator is considered as "dirty" in the validators field trie, and all the corresponding branches are re-computed when computing the hash trie root of the the validators field trie of the beacon state.

This PR adopts the same behavior as before Electra:
https://github.com/OffchainLabs/prysm/blob/6f437b561a794a1f667cf000be0fa10b4234b85a/beacon-chain/core/electra/effective_balance_updates.go#L32-L63

and copies/considers dirty the validator only if its effective balance changed. 

**Which issues(s) does this PR fix?**
- https://github.com/OffchainLabs/prysm/issues/16630

**Other notes for review**
The first commit only introduces a new metric showing the issue.
The second commit actually solves the issue.

**Before this PR:**
**~9.400 validators** considered as dirty on mainnet every epoch

<img width="942" height="308" alt="image" src="https://github.com/user-attachments/assets/31da9c92-aa0f-4d71-a402-92ed62738803" />


**After this PR:**
**~15 validators** considered as dirty on mainnet every epoch (reduction of ~x620).

<img width="946" height="312" alt="image" src="https://github.com/user-attachments/assets/afc5e72a-ccda-4636-87d9-dab2fbbf5c1c" />


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
