### PR TITLE
Downgrade genesis forkchoice balance underflow warning to debug

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -325,15 +325,20 @@ func (f *ForkChoice) updateBalances() error {
 			if pn != nil && vote.currentRoot != zHash {
 				if pending {
 					if pn.node.balance < oldBalance {
-						log.WithFields(logrus.Fields{
-							"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
-							"oldBalance":                 oldBalance,
-							"nodeBalance":                pn.node.balance,
-							"nodeWeight":                 pn.node.weight,
-							"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
-							"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
-							"previousProposerBoostScore": f.store.previousProposerBoostScore,
-						}).Warning("node with invalid balance, setting it to zero")
+						if pn.node.slot == 0 {
+							log.WithField("nodeRoot", fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:]))).
+								Debug("Genesis node pending balance underflow, clamping to zero")
+						} else {
+							log.WithFields(logrus.Fields{
+								"nodeRoot":                   fmt.Sprintf("%#x", bytesutil.Trunc(vote.currentRoot[:])),
+								"oldBalance":                 oldBalance,
+								"nodeBalance":                pn.node.balance,
+								"nodeWeight":                 pn.node.weight,
+								"proposerBoostRoot":          fmt.Sprintf("%#x", bytesutil.Trunc(f.store.proposerBoostRoot[:])),
+								"previousProposerBoostRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(f.store.previousProposerBoostRoot[:])),
+								"previousProposerBoostScore": f.store.previousProposerBoostScore,
+							}).Warning("node with invalid balance, setting it to zero")
+						}
 						pn.node.balance = 0
 					} else {
 						pn.node.balance -= oldBalance

--- a/changelog/terence_fix-genesis-forkchoice-balance-warning.md
+++ b/changelog/terence_fix-genesis-forkchoice-balance-warning.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Demoted genesis node pending balance underflow warning to debug in forkchoice. The ePBS pending/full balance split causes a harmless accounting mismatch at genesis where there is no separate payload delivery.


### PR DESCRIPTION
  - Demotes the "node with invalid balance, setting it to zero" warning to DEBUG level for genesis nodes in forkchoice
  - Non-genesis block retain the WARN level since underflow there indicates a real bug
  - This is required for gloas e2e test because it plans to fail on any warning and error