### PR TITLE
Fix finalized and justified state endpoint to not advance the slot

### DIFF
--- a/beacon-chain/rpc/lookup/stater.go
+++ b/beacon-chain/rpc/lookup/stater.go
@@ -140,29 +140,13 @@ func (p *BeaconDbStater) State(ctx context.Context, stateId []byte) (state.Beaco
 		}
 	case "finalized":
 		checkpoint := p.ChainInfoFetcher.FinalizedCheckpt()
-		targetSlot, err := slots.EpochStart(checkpoint.Epoch)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get start slot")
-		}
-		// We use the stategen replayer to fetch the finalized state and then
-		// replay it to the start slot of our checkpoint's epoch. The replayer
-		// only ever accesses our canonical history, so the state retrieved will
-		// always be the finalized state at that epoch.
-		s, err = p.ReplayerBuilder.ReplayerForSlot(targetSlot).ReplayToSlot(ctx, targetSlot)
+		s, err = p.StateGenService.StateByRoot(ctx, bytesutil.ToBytes32(checkpoint.Root))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get finalized state")
 		}
 	case "justified":
 		checkpoint := p.ChainInfoFetcher.CurrentJustifiedCheckpt()
-		targetSlot, err := slots.EpochStart(checkpoint.Epoch)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get start slot")
-		}
-		// We use the stategen replayer to fetch the justified state and then
-		// replay it to the start slot of our checkpoint's epoch. The replayer
-		// only ever accesses our canonical history, so the state retrieved will
-		// always be the justified state at that epoch.
-		s, err = p.ReplayerBuilder.ReplayerForSlot(targetSlot).ReplayToSlot(ctx, targetSlot)
+		s, err = p.StateGenService.StateByRoot(ctx, bytesutil.ToBytes32(checkpoint.Root))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get justified state")
 		}

--- a/beacon-chain/rpc/lookup/stater_test.go
+++ b/beacon-chain/rpc/lookup/stater_test.go
@@ -91,20 +91,20 @@ func TestGetState(t *testing.T) {
 	})
 
 	t.Run("finalized", func(t *testing.T) {
+		// Use a block root distinct from the state root to verify
+		// we look up by checkpoint root, not by state root.
+		blockRoot := bytesutil.ToBytes32([]byte("finalized-block-root"))
 		stateGen := mockstategen.NewService()
-		replayer := mockstategen.NewReplayerBuilder()
-		replayer.SetMockStateForSlot(newBeaconState, params.BeaconConfig().SlotsPerEpoch*10)
-		stateGen.StatesByRoot[stateRoot] = newBeaconState
+		stateGen.StatesByRoot[blockRoot] = newBeaconState
 
 		p := BeaconDbStater{
 			ChainInfoFetcher: &chainMock.ChainService{
 				FinalizedCheckPoint: &ethpb.Checkpoint{
-					Root:  stateRoot[:],
+					Root:  blockRoot[:],
 					Epoch: 10,
 				},
 			},
 			StateGenService: stateGen,
-			ReplayerBuilder: replayer,
 		}
 
 		s, err := p.State(ctx, []byte("finalized"))
@@ -115,20 +115,18 @@ func TestGetState(t *testing.T) {
 	})
 
 	t.Run("justified", func(t *testing.T) {
+		blockRoot := bytesutil.ToBytes32([]byte("justified-block-root"))
 		stateGen := mockstategen.NewService()
-		replayer := mockstategen.NewReplayerBuilder()
-		replayer.SetMockStateForSlot(newBeaconState, params.BeaconConfig().SlotsPerEpoch*10)
-		stateGen.StatesByRoot[stateRoot] = newBeaconState
+		stateGen.StatesByRoot[blockRoot] = newBeaconState
 
 		p := BeaconDbStater{
 			ChainInfoFetcher: &chainMock.ChainService{
 				CurrentJustifiedCheckPoint: &ethpb.Checkpoint{
-					Root:  stateRoot[:],
+					Root:  blockRoot[:],
 					Epoch: 10,
 				},
 			},
 			StateGenService: stateGen,
-			ReplayerBuilder: replayer,
 		}
 
 		s, err := p.State(ctx, []byte("justified"))

--- a/changelog/potuz_finalized_state_endpoint.md
+++ b/changelog/potuz_finalized_state_endpoint.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed finalized and justified state endpoint to not advance the slot.


### PR DESCRIPTION
Use StateByRoot with the checkpoint root instead of replaying to the epoch start slot. The previous approach incorrectly advanced the state beyond the checkpoint block's post-state.