### PR TITLE
Fix initial sync envelope validation for genesis blocks

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
@@ -75,6 +75,7 @@ func (f *blocksFetcher) validatePayloadBlockConsistency(r *fetchRequestResponse)
 		f.downscorePeer(r.blocksFrom, r.err)
 		return
 	}
+
 	for i, b := range r.bwb[1:] {
 		nh, err := b.Block.ParentHash()
 		if err != nil {
@@ -83,6 +84,14 @@ func (f *blocksFetcher) validatePayloadBlockConsistency(r *fetchRequestResponse)
 			return
 		}
 		if nh == bh {
+			continue
+		}
+
+		// Genesis slot 0 has no execution payload envelope. When the batch starts
+		// from genesis the first parentHash transition (0x00→real hash) does
+		// not correspond to any envelope, so skip the match.
+		if bh == [32]byte{} && r.bwb[i].Block.Block().Slot() == 0 {
+			bh = nh
 			continue
 		}
 		if pidx >= len(r.envelopes) {

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_payload.go
@@ -87,10 +87,8 @@ func (f *blocksFetcher) validatePayloadBlockConsistency(r *fetchRequestResponse)
 			continue
 		}
 
-		// Genesis slot 0 has no execution payload envelope. When the batch starts
-		// from genesis the first parentHash transition (0x00→real hash) does
-		// not correspond to any envelope, so skip the match.
-		if bh == [32]byte{} && r.bwb[i].Block.Block().Slot() == 0 {
+		// Handle genesis case
+		if bh == [32]byte{} {
 			bh = nh
 			continue
 		}

--- a/changelog/terence_fix-initial-sync-genesis-envelope.md
+++ b/changelog/terence_fix-initial-sync-genesis-envelope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed initial sync failing on Gloas chains when syncing from genesis.


### PR DESCRIPTION
  - Fixes initial sync failing with envelope does not match block when syncing a Gloas chain from genesis
  - Genesis (slot 0) has no separate execution payload envelope, its execution block hash is embedded in the genesis state. The validation loop incorrectly tried to match this hash transition against an envelope, which always failed