### PR TITLE
Fix blob index bounds check

### DIFF
--- a/beacon-chain/sync/verify/BUILD.bazel
+++ b/beacon-chain/sync/verify/BUILD.bazel
@@ -16,9 +16,9 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["blob_test.go"],
     embed = [":go_default_library"],
-    size = "small",
     deps = [
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/sync/verify/BUILD.bazel
+++ b/beacon-chain/sync/verify/BUILD.bazel
@@ -18,10 +18,13 @@ go_test(
     name = "go_default_test",
     srcs = ["blob_test.go"],
     embed = [":go_default_library"],
+    size = "small",
     deps = [
+        "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
     ],

--- a/beacon-chain/sync/verify/blob.go
+++ b/beacon-chain/sync/verify/blob.go
@@ -38,6 +38,9 @@ func BlobAlignsWithBlock(blob blocks.ROBlob, block blocks.ROBlock) error {
 	if err != nil {
 		return err
 	}
+	if blob.Index >= uint64(len(commits)) {
+		return errors.Wrapf(ErrIncorrectBlobIndex, "index %d out of range for %d commitments", blob.Index, len(commits))
+	}
 	blockCommitment := bytesutil.ToBytes48(commits[blob.Index])
 	blobCommitment := bytesutil.ToBytes48(blob.KzgCommitment)
 	if blobCommitment != blockCommitment {

--- a/beacon-chain/sync/verify/blob_test.go
+++ b/beacon-chain/sync/verify/blob_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 )
@@ -73,5 +75,77 @@ func TestBlobAlignsWithBlock(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestBlobAlignsWithBlock_OOBIndexReturnsError(t *testing.T) {
+	ds := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)
+	nCommitments := 3
+
+	roBlock, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, ds, nCommitments)
+	blockRoot := roBlock.Root()
+
+	// Sanity: valid blob (index=0) works fine.
+	require.NoError(t, BlobAlignsWithBlock(blobs[0], roBlock))
+
+	// OOB index: 3 is past the 3 commitments but within MaxBlobsPerBlock (6 for Deneb).
+	maxBlobs := params.BeaconConfig().MaxBlobsPerBlock(ds)
+	oobIndex := uint64(nCommitments)
+	require.Equal(t, true, oobIndex < uint64(maxBlobs),
+		"precondition: OOB index must be < MaxBlobsPerBlock for this test")
+
+	oobSidecar := &ethpb.BlobSidecar{
+		SignedBlockHeader:        blobs[0].SignedBlockHeader,
+		Index:                    oobIndex,
+		Blob:                     make([]byte, fieldparams.BlobSize),
+		KzgCommitment:            make([]byte, 48),
+		KzgProof:                 make([]byte, 48),
+		CommitmentInclusionProof: blobs[0].CommitmentInclusionProof,
+	}
+	oobBlob, err := blocks.NewROBlobWithRoot(oobSidecar, blockRoot)
+	require.NoError(t, err)
+
+	// Must return ErrIncorrectBlobIndex, not panic.
+	err = BlobAlignsWithBlock(oobBlob, roBlock)
+	require.ErrorIs(t, err, ErrIncorrectBlobIndex)
+}
+
+func TestBlobAlignsWithBlock_MaxIndexEdge(t *testing.T) {
+	ds := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)
+	nCommitments := 3
+
+	roBlock, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, ds, nCommitments)
+	blockRoot := roBlock.Root()
+
+	// index = nCommitments-1 (last valid): must not error.
+	require.NoError(t, BlobAlignsWithBlock(blobs[nCommitments-1], roBlock))
+
+	// index = nCommitments (first OOB): must return ErrIncorrectBlobIndex.
+	oobSidecar := &ethpb.BlobSidecar{
+		SignedBlockHeader:        blobs[0].SignedBlockHeader,
+		Index:                    uint64(nCommitments),
+		Blob:                     make([]byte, fieldparams.BlobSize),
+		KzgCommitment:            make([]byte, 48),
+		KzgProof:                 make([]byte, 48),
+		CommitmentInclusionProof: blobs[0].CommitmentInclusionProof,
+	}
+	oobBlob, err := blocks.NewROBlobWithRoot(oobSidecar, blockRoot)
+	require.NoError(t, err)
+
+	err = BlobAlignsWithBlock(oobBlob, roBlock)
+	require.ErrorIs(t, err, ErrIncorrectBlobIndex)
+}
+
+func TestBlobAlignsWithBlock_AllValidIndicesSucceed(t *testing.T) {
+	ds := util.SlotAtEpoch(t, params.BeaconConfig().DenebForkEpoch)
+	nCommitments := 4
+
+	roBlock, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, ds, nCommitments)
+
+	for i := 0; i < nCommitments; i++ {
+		i := i
+		t.Run(fmt.Sprintf("index_%d", i), func(t *testing.T) {
+			require.NoError(t, BlobAlignsWithBlock(blobs[i], roBlock))
+		})
 	}
 }

--- a/beacon-chain/sync/verify/blob_test.go
+++ b/beacon-chain/sync/verify/blob_test.go
@@ -142,8 +142,7 @@ func TestBlobAlignsWithBlock_AllValidIndicesSucceed(t *testing.T) {
 
 	roBlock, blobs := util.GenerateTestDenebBlockWithSidecar(t, [32]byte{}, ds, nCommitments)
 
-	for i := 0; i < nCommitments; i++ {
-		i := i
+	for i := range nCommitments {
 		t.Run(fmt.Sprintf("index_%d", i), func(t *testing.T) {
 			require.NoError(t, BlobAlignsWithBlock(blobs[i], roBlock))
 		})

--- a/changelog/alleysira_fix-blob-index-bounds-check.md
+++ b/changelog/alleysira_fix-blob-index-bounds-check.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Add bounds check for blob index to prevent out-of-range access and return `ErrIncorrectBlobIndex` instead of panic.

--- a/config/fieldparams/BUILD.bazel
+++ b/config/fieldparams/BUILD.bazel
@@ -2,6 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
+    # keep
     srcs = select({
         "//config:mainnet": ["mainnet.go"],
         "//config:minimal": ["minimal.go"],


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**

This PR addresses a runtime panic caused by a missing bounds check on blob indices. I've implemented a fix and would like to hear from you. Thanks!

##### What does this PR do?
- Add a bound check for `blob.Index`.
- Add 3 tests to show that without the fix prysm will panic.

##### Why is it needed?

`BlobAlignsWithBlock` accesses `commits[blob.Index]` without checking that `blob.Index < len(commits)`.  It only checks `blob.Index < MaxBlobsPerBlock` (the spec-wide maximum, e.g. 6 for Deneb). If a blob has an index that passes the spec max check but exceeds the actual number of commitments in the block, the code panics with an index-out-of-range runtime error. The added tests confirmed this.                                                                                   
                                                                                                                       
Fortunately, I think this is unreachable because all callers validate blob indices upstream:                                    
- `blobValidatorFromRootReq` rejects blobs whose index wasn't in the request                                           
- `newSequentialBlobValidator` enforces strictly sequential indices (0, 1, 2, ...)                                     
- `requestsForMissingIndices` only generates indices 0..len(commits)-1                                                 
                                                                      
The fix adds an explicit bounds check as defense-in-depth, so that if a future caller bypasses upstream validation, the function returns ErrIncorrectBlobIndex instead of panicking.

Three test functions are added to `blob_test.go`:                                                                      
  - `TestBlobAlignsWithBlock_OOBIndexReturnsError`: blob with `index >= len(commits)` but `< MaxBlobsPerBlock` returns ErrIncorrectBlobIndex. Without this fix, this test panics.                                         
  - `TestBlobAlignsWithBlock_MaxIndexEdge`: boundary test confirming the last valid index succeeds and the first OOB index errors.
  - `TestBlobAlignsWithBlock_AllValidIndicesSucceed`: all indices in 0..nCommitments-1 succeed without error or panic.

Without the fix:
```bash
$ go test ./beacon-chain/sync/verify/ -v -count=1
=== RUN   TestBlobAlignsWithBlock
=== RUN   TestBlobAlignsWithBlock/happy_path_blob_0
=== RUN   TestBlobAlignsWithBlock/mismatched_roots_blob_0
=== RUN   TestBlobAlignsWithBlock/mismatched_roots_-_fake_blob_0
=== RUN   TestBlobAlignsWithBlock/before_deneb_blob_0
--- PASS: TestBlobAlignsWithBlock (0.00s)
    --- PASS: TestBlobAlignsWithBlock/happy_path_blob_0 (0.00s)
    --- PASS: TestBlobAlignsWithBlock/mismatched_roots_blob_0 (0.00s)
    --- PASS: TestBlobAlignsWithBlock/mismatched_roots_-_fake_blob_0 (0.00s)
    --- PASS: TestBlobAlignsWithBlock/before_deneb_blob_0 (0.00s)
=== RUN   TestBlobAlignsWithBlock_OOBIndexReturnsError
--- FAIL: TestBlobAlignsWithBlock_OOBIndexReturnsError (0.00s)
panic: runtime error: index out of range [3] with length 3 [recovered, repanicked]

goroutine 116 [running]:
testing.tRunner.func1.2({0x12d1aa0, 0xc000363818})
        /home/alleysira/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-amd64/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
        /home/alleysira/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-amd64/src/testing/testing.go:1875 +0x35b
panic({0x12d1aa0?, 0xc000363818?})
        /home/alleysira/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-amd64/src/runtime/panic.go:783 +0x132
github.com/OffchainLabs/prysm/v7/beacon-chain/sync/verify.BlobAlignsWithBlock({0xc00030de60, {0xf, 0x74, 0x6b, 0x28, 0xa, 0x5a, 0x94, 0xdd, 0x55, ...}}, ...)
        /home/alleysira/pr/prysm/beacon-chain/sync/verify/blob.go:44 +0x5b0
github.com/OffchainLabs/prysm/v7/beacon-chain/sync/verify.TestBlobAlignsWithBlock_OOBIndexReturnsError(0xc0003a2540)
        /home/alleysira/pr/prysm/beacon-chain/sync/verify/blob_test.go:109 +0x557
testing.tRunner(0xc0003a2540, 0x14b91f8)
        /home/alleysira/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-amd64/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
        /home/alleysira/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.linux-amd64/src/testing/testing.go:1997 +0x465
FAIL    github.com/OffchainLabs/prysm/v7/beacon-chain/sync/verify       0.016s
FAIL
```
With the fix the test pass:
```shell
go test ./beacon-chain/sync/verify/ -v -count=1
=== RUN   TestBlobAlignsWithBlock
=== RUN   TestBlobAlignsWithBlock/happy_path_blob_0
=== RUN   TestBlobAlignsWithBlock/mismatched_roots_blob_0
=== RUN   TestBlobAlignsWithBlock/mismatched_roots_-_fake_blob_0
=== RUN   TestBlobAlignsWithBlock/before_deneb_blob_0
--- PASS: TestBlobAlignsWithBlock (0.00s)
    --- PASS: TestBlobAlignsWithBlock/happy_path_blob_0 (0.00s)
    --- PASS: TestBlobAlignsWithBlock/mismatched_roots_blob_0 (0.00s)
    --- PASS: TestBlobAlignsWithBlock/mismatched_roots_-_fake_blob_0 (0.00s)
    --- PASS: TestBlobAlignsWithBlock/before_deneb_blob_0 (0.00s)
=== RUN   TestBlobAlignsWithBlock_OOBIndexReturnsError
--- PASS: TestBlobAlignsWithBlock_OOBIndexReturnsError (0.00s)
=== RUN   TestBlobAlignsWithBlock_MaxIndexEdge
--- PASS: TestBlobAlignsWithBlock_MaxIndexEdge (0.00s)
=== RUN   TestBlobAlignsWithBlock_AllValidIndicesSucceed
=== RUN   TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_0
=== RUN   TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_1
=== RUN   TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_2
=== RUN   TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_3
--- PASS: TestBlobAlignsWithBlock_AllValidIndicesSucceed (0.00s)
    --- PASS: TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_0 (0.00s)
    --- PASS: TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_1 (0.00s)
    --- PASS: TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_2 (0.00s)
    --- PASS: TestBlobAlignsWithBlock_AllValidIndicesSucceed/index_3 (0.00s)
PASS
ok      github.com/OffchainLabs/prysm/v7/beacon-chain/sync/verify       0.017s
```

**Which issues(s) does this PR fix?**

None.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
