### PR TITLE
Fix Gloas data column KZG commitments for operation feed

### DIFF
--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -76,6 +76,12 @@ func (s *Service) validateDataColumnGloas(
 		return blocks.VerifiedRODataColumn{}, ignoreValidation(err)
 	}
 
+	commitments, err := block.Block().Body().BlobKzgCommitments()
+	if err != nil {
+		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.Wrap(err, "get bid blob kzg commitments"))
+	}
+	verifiedRODataColumn.SetBidCommitments(commitments)
+
 	s.setSeenDataColumnRootIndex(verifiedRODataColumn.BlockRoot(), verifiedRODataColumn.Index(), verifiedRODataColumn.Slot())
 	return verifiedRODataColumn, nil
 }

--- a/changelog/terence_fix-gloas-data-column-commitments.md
+++ b/changelog/terence_fix-gloas-data-column-commitments.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed Gloas data column KZG commitments by sourcing them from the block's execution payload bid.

--- a/consensus-types/blocks/rodatacolumn.go
+++ b/consensus-types/blocks/rodatacolumn.go
@@ -17,9 +17,10 @@ var (
 // RODataColumn represents a read-only data column sidecar with its block root.
 // It supports both Fulu and Gloas fork variants. Only one of fulu/gloas is non-nil.
 type RODataColumn struct {
-	fulu  *ethpb.DataColumnSidecar
-	gloas *ethpb.DataColumnSidecarGloas
-	root  [fieldparams.RootLength]byte
+	fulu                *ethpb.DataColumnSidecar
+	gloas               *ethpb.DataColumnSidecarGloas
+	root                [fieldparams.RootLength]byte
+	bidCommitmentsGloas [][]byte // KZG commitments from the block's execution payload bid.
 }
 
 // NewRODataColumn creates a new RODataColumn from a Fulu DataColumnSidecar.
@@ -142,13 +143,22 @@ func (dc *RODataColumn) SignedBlockHeader() (*ethpb.SignedBeaconBlockHeader, err
 	return dc.fulu.SignedBlockHeader, nil
 }
 
-// KzgCommitments returns the KZG commitments. Returns an error for Gloas sidecars
-// (commitments come from the block's bid).
+// KzgCommitments returns the KZG commitments.
+// For Fulu these are in the sidecar. For Gloas these come from the block's bid
+// and must be set via SetBidCommitments.
 func (dc *RODataColumn) KzgCommitments() ([][]byte, error) {
 	if dc.gloas != nil {
-		return nil, errNotFuluDataColumn
+		if dc.bidCommitmentsGloas == nil {
+			return nil, errNotFuluDataColumn
+		}
+		return dc.bidCommitmentsGloas, nil
 	}
 	return dc.fulu.KzgCommitments, nil
+}
+
+// SetBidCommitments sets the KZG commitments from the block's bid to be used for gloas.
+func (dc *RODataColumn) SetBidCommitments(c [][]byte) {
+	dc.bidCommitmentsGloas = c
 }
 
 // KzgCommitmentsInclusionProof returns the inclusion proof. Returns an error for Gloas sidecars.


### PR DESCRIPTION
  - Fix `WARN sync: Failed to get KZG commitments for operation feed error=data column sidecar is not a fulu type` spam on Gloas devnet
  - Gloas data column sidecars don't carry KZG commitments, they live in the block's execution payload bid. Added `bidCommitmentsGloas` to `RODataColumn` and populate it in `validateDataColumnGloas` using the block already fetched from DB
  - We want two things 1.) No extra DB lookups 2.) no function signature changes