### PR TITLE
Add pending data column queue for Gloas deferred sidecar validation

### DIFF
--- a/beacon-chain/sync/pending_data_columns_queue.go
+++ b/beacon-chain/sync/pending_data_columns_queue.go
@@ -1,0 +1,154 @@
+package sync
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/sirupsen/logrus"
+)
+
+// pendingDataColumnExpSlots is the number of slots after which a queued data column
+// sidecar is considered stale and evicted.
+const pendingDataColumnExpSlots primitives.Slot = 4
+
+// pendingGloasDataColumnEntry holds a Gloas data column sidecar that arrived before
+// its block was seen, queued for deferred re-validation once the block arrives.
+type pendingGloasDataColumnEntry struct {
+	roDataColumn blocks.RODataColumn
+	// topic is preserved from the original gossip message for subnet re-validation.
+	topic string
+	// forwardingPeer is the peer that sent us this sidecar. Stored so we can
+	// downgrade it retroactively if re-validation later rejects the sidecar.
+	forwardingPeer peer.ID
+	arrivalSlot    primitives.Slot
+}
+
+// processPendingDataColumnsForRoot is called from beaconBlockSubscriber immediately
+// after a block is received and added to the DB. It does two things in one pass:
+//
+//  1. Evicts stale entries across all pending roots (sidecars whose block never
+//     arrived within pendingDataColumnExpSlots slots).
+//  2. Re-validates and processes all queued sidecars for the newly arrived root.
+//
+// On re-validation failure (REJECT): the forwarding peer is downscored.
+// On success: the sidecar is saved to the chain and re-broadcast to the network,
+// because the original gossip message was returned as ValidationIgnore.
+func (s *Service) processPendingDataColumnsForRoot(ctx context.Context, root [32]byte) {
+	const dataColumnSidecarSubTopic = "/data_column_sidecar_%d/"
+
+	currentSlot := s.cfg.clock.CurrentSlot()
+
+	// Evict stale entries and extract the entries for this root in a single lock window.
+	s.pendingDataColumnsLock.Lock()
+	for r, entries := range s.pendingDataColumnsByRoot {
+		var live []pendingGloasDataColumnEntry
+		for _, e := range entries {
+			if currentSlot > e.arrivalSlot+pendingDataColumnExpSlots {
+				delete(s.pendingDataColumnKeys, computeRootIndexCacheKey(e.roDataColumn.BlockRoot(), e.roDataColumn.Index))
+				continue
+			}
+			live = append(live, e)
+		}
+		if len(live) == 0 {
+			delete(s.pendingDataColumnsByRoot, r)
+		} else {
+			s.pendingDataColumnsByRoot[r] = live
+		}
+	}
+	entries, ok := s.pendingDataColumnsByRoot[root]
+	if ok {
+		delete(s.pendingDataColumnsByRoot, root)
+	}
+	s.pendingDataColumnsLock.Unlock()
+
+	if !ok {
+		return
+	}
+
+	for _, entry := range entries {
+		key := computeRootIndexCacheKey(entry.roDataColumn.BlockRoot(), entry.roDataColumn.Index)
+
+		// Re-run full Gloas validation now that the block is in the DB.
+		// We reconstruct a minimal pubsub.Message with only the topic field set;
+		// validateDataColumnGloas uses msg.Topic only for subnet validation.
+		topic := entry.topic
+		syntheticMsg := &pubsub.Message{Message: &pubsubpb.Message{Topic: &topic}}
+
+		verifiedRODataColumn, err := s.validateDataColumnGloas(ctx, syntheticMsg, entry.roDataColumn, dataColumnSidecarSubTopic)
+
+		s.pendingDataColumnsLock.Lock()
+		delete(s.pendingDataColumnKeys, key)
+		s.pendingDataColumnsLock.Unlock()
+
+		if err != nil {
+			// Distinguish REJECT from IGNORE.
+			// REJECT: sidecar is genuinely invalid — downgrade the forwarding peer.
+			// IGNORE: benign (already seen, etc.) — no penalty.
+			var vErr validationError
+			if stderrors.As(err, &vErr) && vErr.result == pubsub.ValidationReject {
+				if entry.forwardingPeer != "" {
+					newScore := s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(entry.forwardingPeer)
+					log.WithFields(logrus.Fields{
+						"peer":     entry.forwardingPeer,
+						"slot":     entry.roDataColumn.Slot(),
+						"index":    entry.roDataColumn.Index,
+						"newScore": newScore,
+					}).Debug("Downscored peer for deferred invalid Gloas data column sidecar")
+				}
+			}
+			continue
+		}
+
+		// Forward to the chain — same path as a sidecar arriving after its block normally.
+		if err := s.receiveDataColumnSidecar(ctx, verifiedRODataColumn); err != nil {
+			log.WithError(err).
+				WithField("slot", verifiedRODataColumn.Slot()).
+				Debug("Failed to receive deferred Gloas data column sidecar")
+			continue
+		}
+
+		// Re-broadcast: the original message was returned as ValidationIgnore so the
+		// network never propagated it. Now that it is confirmed valid, push it back out.
+		if err := s.cfg.p2p.BroadcastDataColumnSidecars(ctx, []blocks.VerifiedRODataColumn{verifiedRODataColumn}); err != nil {
+			log.WithError(err).
+				WithField("slot", verifiedRODataColumn.Slot()).
+				WithField("index", verifiedRODataColumn.Index).
+				Debug("Failed to re-broadcast deferred Gloas data column sidecar")
+		}
+	}
+}
+
+// addDataColumnToPendingQueue enqueues a Gloas data column sidecar for deferred
+// re-validation once its block becomes available. forwardingPeer is the peer that
+// sent us the sidecar; it will be downscored if re-validation rejects it.
+// Duplicate (blockRoot, columnIndex) pairs are silently ignored.
+func (s *Service) addDataColumnToPendingQueue(roDataColumn blocks.RODataColumn, topic string, forwardingPeer peer.ID) {
+	key := computeRootIndexCacheKey(roDataColumn.BlockRoot(), roDataColumn.Index)
+
+	s.pendingDataColumnsLock.Lock()
+	defer s.pendingDataColumnsLock.Unlock()
+
+	if s.pendingDataColumnsByRoot == nil || s.pendingDataColumnKeys == nil {
+		return
+	}
+	if s.pendingDataColumnKeys[key] {
+		return
+	}
+
+	blockRoot := roDataColumn.BlockRoot()
+	s.pendingDataColumnKeys[key] = true
+	s.pendingDataColumnsByRoot[blockRoot] = append(
+		s.pendingDataColumnsByRoot[blockRoot],
+		pendingGloasDataColumnEntry{
+			roDataColumn:   roDataColumn,
+			topic:          topic,
+			forwardingPeer: forwardingPeer,
+			arrivalSlot:    roDataColumn.Slot(),
+		},
+	)
+}

--- a/beacon-chain/sync/pending_data_columns_queue.go
+++ b/beacon-chain/sync/pending_data_columns_queue.go
@@ -49,7 +49,7 @@ func (s *Service) processPendingDataColumnsForRoot(ctx context.Context, root [32
 		var live []pendingGloasDataColumnEntry
 		for _, e := range entries {
 			if currentSlot > e.arrivalSlot+pendingDataColumnExpSlots {
-				delete(s.pendingDataColumnKeys, computeRootIndexCacheKey(e.roDataColumn.BlockRoot(), e.roDataColumn.Index))
+				delete(s.pendingDataColumnKeys, computeRootIndexCacheKey(e.roDataColumn.BlockRoot(), e.roDataColumn.Index()))
 				continue
 			}
 			live = append(live, e)
@@ -71,7 +71,7 @@ func (s *Service) processPendingDataColumnsForRoot(ctx context.Context, root [32
 	}
 
 	for _, entry := range entries {
-		key := computeRootIndexCacheKey(entry.roDataColumn.BlockRoot(), entry.roDataColumn.Index)
+		key := computeRootIndexCacheKey(entry.roDataColumn.BlockRoot(), entry.roDataColumn.Index())
 
 		// Re-run full Gloas validation now that the block is in the DB.
 		// We reconstruct a minimal pubsub.Message with only the topic field set;
@@ -128,7 +128,7 @@ func (s *Service) processPendingDataColumnsForRoot(ctx context.Context, root [32
 // sent us the sidecar; it will be downscored if re-validation rejects it.
 // Duplicate (blockRoot, columnIndex) pairs are silently ignored.
 func (s *Service) addDataColumnToPendingQueue(roDataColumn blocks.RODataColumn, topic string, forwardingPeer peer.ID) {
-	key := computeRootIndexCacheKey(roDataColumn.BlockRoot(), roDataColumn.Index)
+	key := computeRootIndexCacheKey(roDataColumn.BlockRoot(), roDataColumn.Index())
 
 	s.pendingDataColumnsLock.Lock()
 	defer s.pendingDataColumnsLock.Unlock()

--- a/beacon-chain/sync/pending_data_columns_queue_test.go
+++ b/beacon-chain/sync/pending_data_columns_queue_test.go
@@ -57,14 +57,25 @@ func buildGloasFixture(t *testing.T, svc *Service) (blocks.RODataColumn, interfa
 	require.Equal(t, true, len(roSidecars) > 0)
 	base := roSidecars[0]
 
+	kzgCommitments, err := base.KzgCommitments()
+	require.NoError(t, err)
+	kzgProofs := base.KzgProofs()
+	column := base.Column()
+	kzgCommitmentsInclusionProof, err := base.KzgCommitmentsInclusionProof()
+	require.NoError(t, err)
+	proposerIndex, err := base.ProposerIndex()
+	require.NoError(t, err)
+	signedBlockHeader, err := base.SignedBlockHeader()
+	require.NoError(t, err)
+
 	bid := util.GenerateTestSignedExecutionPayloadBid(base.Slot())
-	bid.Message.BlobKzgCommitments = bytesutil.SafeCopy2dBytes(base.KzgCommitments)
+	bid.Message.BlobKzgCommitments = bytesutil.SafeCopy2dBytes(kzgCommitments)
 
 	gloasProto := util.NewBeaconBlockGloas()
 	gloasProto.Block.Slot = base.Slot()
-	gloasProto.Block.ProposerIndex = base.ProposerIndex()
-	gloasProto.Block.ParentRoot = bytes.Clone(base.SignedBlockHeader.Header.ParentRoot)
-	gloasProto.Block.StateRoot = bytes.Clone(base.SignedBlockHeader.Header.StateRoot)
+	gloasProto.Block.ProposerIndex = proposerIndex
+	gloasProto.Block.ParentRoot = bytes.Clone(signedBlockHeader.Header.ParentRoot)
+	gloasProto.Block.StateRoot = bytes.Clone(signedBlockHeader.Header.StateRoot)
 	gloasProto.Block.Body.SignedExecutionPayloadBid = bid
 
 	signedBlock, err := blocks.NewSignedBeaconBlock(gloasProto)
@@ -75,12 +86,12 @@ func buildGloasFixture(t *testing.T, svc *Service) (blocks.RODataColumn, interfa
 	require.NoError(t, err)
 
 	sidecar := &ethpb.DataColumnSidecar{
-		Index:                        base.Index,
-		Column:                       bytesutil.SafeCopy2dBytes(base.Column),
-		KzgCommitments:               bytesutil.SafeCopy2dBytes(base.KzgCommitments),
-		KzgProofs:                    bytesutil.SafeCopy2dBytes(base.KzgProofs),
+		Index:                        base.Index(),
+		Column:                       bytesutil.SafeCopy2dBytes(column),
+		KzgCommitments:               bytesutil.SafeCopy2dBytes(kzgCommitments),
+		KzgProofs:                    bytesutil.SafeCopy2dBytes(kzgProofs),
 		SignedBlockHeader:            header,
-		KzgCommitmentsInclusionProof: bytesutil.SafeCopy2dBytes(base.KzgCommitmentsInclusionProof),
+		KzgCommitmentsInclusionProof: bytesutil.SafeCopy2dBytes(kzgCommitmentsInclusionProof),
 	}
 
 	rodc, err := blocks.NewRODataColumnWithRoot(sidecar, blockRoot)
@@ -137,7 +148,7 @@ func TestProcessPendingDataColumns_EvictsOldEntries(t *testing.T) {
 	require.Equal(t, true, len(roSidecars) > 0)
 	rodc := roSidecars[0]
 
-	key := computeRootIndexCacheKey(rodc.BlockRoot(), rodc.Index)
+	key := computeRootIndexCacheKey(rodc.BlockRoot(), rodc.Index())
 	root := rodc.BlockRoot()
 
 	// Insert with arrivalSlot=0 — stale relative to current slot.
@@ -189,11 +200,26 @@ func TestValidateDataColumnGloas_QueuesWhenBlockNotSeen(t *testing.T) {
 	genesisSec := time.Now().Unix() - int64(params.BeaconConfig().SecondsPerSlot)
 	chainService := &mock.ChainService{Genesis: time.Unix(genesisSec, 0)}
 	svc := buildGloasService(t, chainService)
-	rodc, _, topic := buildGloasFixture(t, svc)
 
-	// Encode into a pubsub message.
+	// Build a minimal DataColumnSidecarGloas. The block root is random and not in
+	// the DB, which is sufficient to trigger the block-not-seen path.
+	// Column and KzgProofs are empty (zero blobs) which is valid SSZ.
+	blockRoot := [32]byte{0xde, 0xad, 0xbe, 0xef}
+	gloasSidecar := &ethpb.DataColumnSidecarGloas{
+		Index:           0,
+		Column:          [][]byte{},
+		KzgProofs:       [][]byte{},
+		Slot:            1,
+		BeaconBlockRoot: blockRoot[:],
+	}
+
+	digest, err := svc.currentForkDigest()
+	require.NoError(t, err)
+	topicBase := p2p.GossipTypeMapping[reflect.TypeOf(gloasSidecar)]
+	topic := svc.addDigestAndIndexToTopic(topicBase, digest, uint64(0))
+
 	buf := new(bytes.Buffer)
-	_, err := svc.cfg.p2p.Encoding().EncodeGossip(buf, rodc.DataColumnSidecar)
+	_, err = svc.cfg.p2p.Encoding().EncodeGossip(buf, gloasSidecar)
 	require.NoError(t, err)
 	msg := &pubsub.Message{Message: &pb.Message{Data: buf.Bytes(), Topic: &topic}}
 
@@ -264,7 +290,7 @@ func TestProcessPendingDataColumns_MultipleEntriesSameRoot(t *testing.T) {
 	// Both sidecars must belong to the same block root.
 	require.Equal(t, rodc0.BlockRoot(), rodc1.BlockRoot())
 	// And have different column indices so both are accepted by the queue.
-	require.NotEqual(t, rodc0.Index, rodc1.Index)
+	require.NotEqual(t, rodc0.Index(), rodc1.Index())
 
 	root := rodc0.BlockRoot()
 	topic := "t"

--- a/beacon-chain/sync/pending_data_columns_queue_test.go
+++ b/beacon-chain/sync/pending_data_columns_queue_test.go
@@ -1,0 +1,283 @@
+package sync
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
+	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
+	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
+	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
+	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
+	"github.com/OffchainLabs/prysm/v7/testing/require"
+	"github.com/OffchainLabs/prysm/v7/testing/util"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+)
+
+// buildGloasService returns a Service with Gloas epoch = 0 and the given chain/db wired in.
+func buildGloasService(t *testing.T, chainService *mock.ChainService) *Service {
+	t.Helper()
+	p := p2ptest.NewTestP2P(t)
+	clock := startup.NewClock(chainService.Genesis, chainService.ValidatorsRoot)
+	return &Service{
+		cfg: &config{
+			p2p:                p,
+			initialSync:        &mockSync.Sync{},
+			clock:              clock,
+			chain:              chainService,
+			beaconDB:           chainService.DB,
+			operationNotifier:  chainService.OperationNotifier(),
+			batchVerifierLimit: 10,
+		},
+		ctx:                      t.Context(),
+		newColumnsVerifier:       testVerifierReturnsAll(&verification.MockDataColumnsVerifier{}),
+		seenDataColumnCache:      newSlotAwareCache(seenDataColumnSize),
+		pendingDataColumnsByRoot: make(map[[32]byte][]pendingGloasDataColumnEntry),
+		pendingDataColumnKeys:    make(map[string]bool),
+	}
+}
+
+// buildGloasFixture returns a sidecar + its Gloas block + an RODataColumn keyed by the block root.
+func buildGloasFixture(t *testing.T, svc *Service) (blocks.RODataColumn, interfaces.ReadOnlySignedBeaconBlock, string) {
+	t.Helper()
+	require.NoError(t, kzg.Start())
+
+	_, roSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, 1, util.WithSlot(1))
+	require.Equal(t, true, len(roSidecars) > 0)
+	base := roSidecars[0]
+
+	bid := util.GenerateTestSignedExecutionPayloadBid(base.Slot())
+	bid.Message.BlobKzgCommitments = bytesutil.SafeCopy2dBytes(base.KzgCommitments)
+
+	gloasProto := util.NewBeaconBlockGloas()
+	gloasProto.Block.Slot = base.Slot()
+	gloasProto.Block.ProposerIndex = base.ProposerIndex()
+	gloasProto.Block.ParentRoot = bytes.Clone(base.SignedBlockHeader.Header.ParentRoot)
+	gloasProto.Block.StateRoot = bytes.Clone(base.SignedBlockHeader.Header.StateRoot)
+	gloasProto.Block.Body.SignedExecutionPayloadBid = bid
+
+	signedBlock, err := blocks.NewSignedBeaconBlock(gloasProto)
+	require.NoError(t, err)
+	header, err := signedBlock.Header()
+	require.NoError(t, err)
+	blockRoot, err := signedBlock.Block().HashTreeRoot()
+	require.NoError(t, err)
+
+	sidecar := &ethpb.DataColumnSidecar{
+		Index:                        base.Index,
+		Column:                       bytesutil.SafeCopy2dBytes(base.Column),
+		KzgCommitments:               bytesutil.SafeCopy2dBytes(base.KzgCommitments),
+		KzgProofs:                    bytesutil.SafeCopy2dBytes(base.KzgProofs),
+		SignedBlockHeader:            header,
+		KzgCommitmentsInclusionProof: bytesutil.SafeCopy2dBytes(base.KzgCommitmentsInclusionProof),
+	}
+
+	rodc, err := blocks.NewRODataColumnWithRoot(sidecar, blockRoot)
+	require.NoError(t, err)
+
+	digest, err := svc.currentForkDigest()
+	require.NoError(t, err)
+	topicBase := p2p.GossipTypeMapping[reflect.TypeOf(sidecar)]
+	topic := svc.addDigestAndIndexToTopic(topicBase, digest, uint64(0))
+
+	return rodc, signedBlock, topic
+}
+
+// TestAddDataColumnToPendingQueue checks basic queue insertion and deduplication.
+func TestAddDataColumnToPendingQueue(t *testing.T) {
+	require.NoError(t, kzg.Start())
+	chainService := &mock.ChainService{Genesis: time.Now()}
+	svc := buildGloasService(t, chainService)
+
+	_, roSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, 1, util.WithSlot(1))
+	require.Equal(t, true, len(roSidecars) > 0)
+	rodc := roSidecars[0]
+
+	// First insertion.
+	svc.addDataColumnToPendingQueue(rodc, "test-topic", "")
+	root := rodc.BlockRoot()
+	require.Equal(t, 1, len(svc.pendingDataColumnsByRoot))
+	require.Equal(t, 1, len(svc.pendingDataColumnsByRoot[root]))
+	require.Equal(t, "test-topic", svc.pendingDataColumnsByRoot[root][0].topic)
+	require.Equal(t, rodc.Slot(), svc.pendingDataColumnsByRoot[root][0].arrivalSlot)
+	require.Equal(t, 1, len(svc.pendingDataColumnKeys))
+
+	// Duplicate arrival must not create a second entry.
+	svc.addDataColumnToPendingQueue(rodc, "test-topic", "")
+	require.Equal(t, 1, len(svc.pendingDataColumnsByRoot[root]))
+	require.Equal(t, 1, len(svc.pendingDataColumnKeys))
+}
+
+// TestProcessPendingDataColumns_EvictsOldEntries verifies stale entries are removed.
+// Eviction is triggered on each call to processPendingDataColumnsForRoot, which sweeps
+// all roots before processing the specific one. Calling it with a zero root that has no
+// queued entries exercises the eviction-only path.
+func TestProcessPendingDataColumns_EvictsOldEntries(t *testing.T) {
+	require.NoError(t, kzg.Start())
+
+	// Set genesis far enough in the past so current slot > pendingDataColumnExpSlots.
+	// With SecondsPerSlot=12 and expiry=4, we need current slot >= 5, so genesis must
+	// be at least 5 slots ago.
+	secsBack := int64(params.BeaconConfig().SecondsPerSlot) * (int64(pendingDataColumnExpSlots) + 2)
+	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-secsBack, 0)}
+	svc := buildGloasService(t, chainService)
+
+	_, roSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, 1, util.WithSlot(1))
+	require.Equal(t, true, len(roSidecars) > 0)
+	rodc := roSidecars[0]
+
+	key := computeRootIndexCacheKey(rodc.BlockRoot(), rodc.Index)
+	root := rodc.BlockRoot()
+
+	// Insert with arrivalSlot=0 — stale relative to current slot.
+	svc.pendingDataColumnsByRoot[root] = []pendingGloasDataColumnEntry{
+		{roDataColumn: rodc, topic: "t", arrivalSlot: 0},
+	}
+	svc.pendingDataColumnKeys[key] = true
+
+	// Trigger eviction by processing a non-existent root. The global eviction sweep
+	// runs at the start of every processPendingDataColumnsForRoot call regardless of root.
+	svc.processPendingDataColumnsForRoot(t.Context(), [32]byte{})
+
+	require.Equal(t, 0, len(svc.pendingDataColumnsByRoot))
+	require.Equal(t, 0, len(svc.pendingDataColumnKeys))
+}
+
+// TestProcessPendingDataColumns_UnrelatedRootDoesNotClear verifies that processing
+// a different block root leaves unrelated queued entries untouched.
+// With event-driven processing, processPendingDataColumnsForRoot is only called when
+// a specific block arrives; entries for other roots are unaffected.
+func TestProcessPendingDataColumns_UnrelatedRootDoesNotClear(t *testing.T) {
+	require.NoError(t, kzg.Start())
+	chainService := &mock.ChainService{Genesis: time.Now()}
+	svc := buildGloasService(t, chainService)
+
+	_, roSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, 1, util.WithSlot(1))
+	require.Equal(t, true, len(roSidecars) > 0)
+	rodc := roSidecars[0]
+
+	svc.addDataColumnToPendingQueue(rodc, "t", "")
+
+	// Fire with a completely different root — entry for rodc's root must survive.
+	svc.processPendingDataColumnsForRoot(t.Context(), [32]byte{0xff})
+	require.Equal(t, 1, len(svc.pendingDataColumnsByRoot))
+}
+
+// TestValidateDataColumnGloas_QueuesWhenBlockNotSeen verifies that validateDataColumn
+// returns ValidationIgnore and places the sidecar in the pending queue when the block
+// has not been seen.
+func TestValidateDataColumnGloas_QueuesWhenBlockNotSeen(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	ctx := t.Context()
+
+	// No DB → HasBlock returns false.
+	genesisSec := time.Now().Unix() - int64(params.BeaconConfig().SecondsPerSlot)
+	chainService := &mock.ChainService{Genesis: time.Unix(genesisSec, 0)}
+	svc := buildGloasService(t, chainService)
+	rodc, _, topic := buildGloasFixture(t, svc)
+
+	// Encode into a pubsub message.
+	buf := new(bytes.Buffer)
+	_, err := svc.cfg.p2p.Encoding().EncodeGossip(buf, rodc.DataColumnSidecar)
+	require.NoError(t, err)
+	msg := &pubsub.Message{Message: &pb.Message{Data: buf.Bytes(), Topic: &topic}}
+
+	result, err := svc.validateDataColumn(ctx, "peer1", msg)
+	require.ErrorContains(t, "gloas data column block not yet seen", err)
+	require.Equal(t, pubsub.ValidationIgnore, result)
+
+	// The sidecar must now be in the pending queue.
+	require.Equal(t, 1, len(svc.pendingDataColumnsByRoot))
+	require.Equal(t, 1, len(svc.pendingDataColumnKeys))
+}
+
+// TestProcessPendingDataColumns_ProcessesWhenBlockArrives is an end-to-end test:
+// sidecar is queued before its block, then processed once the block is saved.
+func TestProcessPendingDataColumns_ProcessesWhenBlockArrives(t *testing.T) {
+	require.NoError(t, kzg.Start())
+
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.GloasForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
+	ctx := t.Context()
+	db := dbtest.SetupDB(t)
+	genesisSec := time.Now().Unix() - int64(params.BeaconConfig().SecondsPerSlot)
+	chainService := &mock.ChainService{
+		Genesis: time.Unix(genesisSec, 0),
+		DB:      db,
+	}
+	svc := buildGloasService(t, chainService)
+	rodc, signedBlock, topic := buildGloasFixture(t, svc)
+
+	blockRoot, err := signedBlock.Block().HashTreeRoot()
+	require.NoError(t, err)
+
+	// Step 1: sidecar arrives before its block → queued.
+	svc.addDataColumnToPendingQueue(rodc, topic, "")
+	require.Equal(t, 1, len(svc.pendingDataColumnsByRoot))
+
+	// Step 2: block arrives and is saved to DB.
+	require.NoError(t, db.SaveBlock(ctx, signedBlock))
+
+	// Step 3: beaconBlockSubscriber fires processPendingDataColumnsForRoot → entry processed and queue cleared.
+	svc.processPendingDataColumnsForRoot(ctx, blockRoot)
+	require.Equal(t, 0, len(svc.pendingDataColumnsByRoot))
+	require.Equal(t, 0, len(svc.pendingDataColumnKeys))
+
+	// Chain must have received the validated sidecar.
+	require.Equal(t, 1, len(chainService.DataColumns))
+}
+
+// TestProcessPendingDataColumns_MultipleEntriesSameRoot verifies that the queue
+// correctly holds multiple sidecars under a single block root and clears them all
+// once the block is available (regardless of individual KZG validation outcomes).
+// Note: the Gloas validator creates a real verifier, so only sidecars whose KZG
+// data matches the block's bid commitments will actually reach the chain.
+func TestProcessPendingDataColumns_MultipleEntriesSameRoot(t *testing.T) {
+	require.NoError(t, kzg.Start())
+
+	chainService := &mock.ChainService{Genesis: time.Now()}
+	svc := buildGloasService(t, chainService)
+
+	_, roSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, 2, util.WithSlot(1))
+	require.Equal(t, true, len(roSidecars) >= 2)
+
+	rodc0 := roSidecars[0]
+	rodc1 := roSidecars[1]
+	// Both sidecars must belong to the same block root.
+	require.Equal(t, rodc0.BlockRoot(), rodc1.BlockRoot())
+	// And have different column indices so both are accepted by the queue.
+	require.NotEqual(t, rodc0.Index, rodc1.Index)
+
+	root := rodc0.BlockRoot()
+	topic := "t"
+
+	svc.addDataColumnToPendingQueue(rodc0, topic, "")
+	svc.addDataColumnToPendingQueue(rodc1, topic, "")
+
+	// Both should be queued under the same root.
+	require.Equal(t, 1, len(svc.pendingDataColumnsByRoot))
+	require.Equal(t, 2, len(svc.pendingDataColumnsByRoot[root]))
+	require.Equal(t, 2, len(svc.pendingDataColumnKeys))
+
+	// Verify dedup: adding either again is a no-op.
+	svc.addDataColumnToPendingQueue(rodc0, topic, "")
+	require.Equal(t, 2, len(svc.pendingDataColumnsByRoot[root]))
+}

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -206,6 +206,13 @@ type Service struct {
 	pendingPayloadEnvelopes              map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope
 	pendingEnvelopeLock                  sync.RWMutex
 	selfBuildSigFailures                 int
+	// pendingDataColumnsByRoot holds Gloas data column sidecars that arrived before
+	// their block was seen, keyed by block root.
+	pendingDataColumnsByRoot map[[32]byte][]pendingGloasDataColumnEntry
+	pendingDataColumnsLock   sync.RWMutex
+	// pendingDataColumnKeys tracks which (blockRoot, columnIndex) pairs are already
+	// queued to avoid duplicate entries.
+	pendingDataColumnKeys map[string]bool
 }
 
 // NewService initializes new regular sync service.
@@ -224,6 +231,8 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 		payloadAttestationCache:  &cache.PayloadAttestationCache{},
 		proposerPreferencesCache: cache.NewProposerPreferencesCache(),
 		pendingPayloadEnvelopes:  make(map[[32]byte]map[uint64]*ethpb.SignedExecutionPayloadEnvelope),
+		pendingDataColumnsByRoot: make(map[[32]byte][]pendingGloasDataColumnEntry),
+		pendingDataColumnKeys:    make(map[string]bool),
 	}
 
 	for _, opt := range opts {

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -82,6 +82,7 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 	}
 
 	go s.processPendingPayloadEnvelope(s.ctx, root)
+	go s.processPendingDataColumnsForRoot(s.ctx, root)
 
 	return nil
 }

--- a/beacon-chain/sync/validate_data_column.go
+++ b/beacon-chain/sync/validate_data_column.go
@@ -88,6 +88,12 @@ func (s *Service) validateDataColumn(ctx context.Context, pid peer.ID, msg *pubs
 	if slots.ToEpoch(roDataColumn.Slot()) >= params.BeaconConfig().GloasForkEpoch {
 		verifiedRODataColumn, err = s.validateDataColumnGloas(ctx, msg, roDataColumn, dataColumnSidecarSubTopic)
 		if err != nil {
+			// When the block hasn't been seen yet, queue the sidecar for deferred
+			// re-validation once the block arrives. The peer ID is stored so the
+			// forwarding peer can be downscored if re-validation later rejects it.
+			if stderrors.Is(err, errGloasBlockNotSeen) && msg != nil && msg.Topic != nil {
+				s.addDataColumnToPendingQueue(roDataColumn, *msg.Topic, pid)
+			}
 			return validationResultFromError(err), baseValidationErr(err)
 		}
 	} else {

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -13,6 +13,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// errGloasBlockNotSeen is the sentinel error returned by validateDataColumnGloas when
+// the sidecar's block has not yet been seen. The caller detects this with errors.Is
+// to queue the sidecar for deferred re-validation once the block arrives.
+var errGloasBlockNotSeen = errors.New("gloas data column block not yet seen")
+
 func (s *Service) validateDataColumnGloas(
 	ctx context.Context,
 	msg *pubsub.Message,
@@ -26,9 +31,7 @@ func (s *Service) validateDataColumnGloas(
 	// If not yet seen, a client MUST queue the sidecar for deferred validation and possible processing once
 	// the block is received or retrieved.
 	if s.cfg.chain == nil || !s.cfg.chain.HasBlock(ctx, roDataColumn.BlockRoot()) {
-		// TODO: Queue the sidecar for deferred validation and possible processing once the
-		// block is received or retrieved
-		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.New("gloas data column block not yet seen"))
+		return blocks.VerifiedRODataColumn{}, ignoreValidation(errGloasBlockNotSeen)
 	}
 
 	block, err := s.cfg.beaconDB.Block(ctx, roDataColumn.BlockRoot())

--- a/changelog/tushar994_queue-data-column.md
+++ b/changelog/tushar994_queue-data-column.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add pending data column queue for Gloas deferred sidecar validation


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

  Per the ePBS / Gloas spec, when a data column sidecar arrives via gossip before its beacon block has been seen, clients MUST queue it for deferred  
  validation rather than dropping it. Unlike Fulu sidecars (which are self-contained), Gloas sidecar validation requires the block's
  bid.blob_kzg_commitments, so validation cannot proceed without the block.                                                                           
                                                            
  Previously, sidecars in this situation were returned as ValidationIgnore and silently lost. This PR implements the pending queue:                   
  
  - When validateDataColumnGloas can't find the block, it returns a sentinel error (errGloasBlockNotSeen). The caller (validateDataColumn) detects    
  this and enqueues the sidecar along with the forwarding peer ID.
  - When a block arrives, beaconBlockSubscriber fires processPendingDataColumnsForRoot (in a goroutine) which re-runs full Gloas validation for all   
  queued sidecars under that root.                                                                                                                    
  - On re-validation success: the sidecar is saved to the chain and re-broadcast to the network (since the original message returned ValidationIgnore,
   the network never propagated it).                                                                                                                  
  - On re-validation REJECT: the forwarding peer is downscored via BadResponsesScorer.
  - Stale entries (block never arrived within 4 slots) are evicted on each processing pass.                                                           
  - Duplicate (blockRoot, columnIndex) pairs are suppressed via a dedup map.                                                                          


**Which issues(s) does this PR fix?**

Fixes #16621 

**Other notes for review**

  To run the new tests:                                                                                                                             
```                                                                                                                  
  go test -tags develop -run "TestAddDataColumnToPendingQueue|TestProcessPendingDataColumns|TestValidateDataColumnGloas_QueuesWhenBlockNotSeen" ./beacon-chain/sync/ -v
```
                                                                                                                        
  
  What each test covers:                                                                                                                              
  - TestAddDataColumnToPendingQueue — queue insertion and dedup (same sidecar twice = one entry)
  - TestProcessPendingDataColumns_EvictsOldEntries — sidecars whose block never arrived are cleaned up after 4 slots                                  
  - TestProcessPendingDataColumns_UnrelatedRootDoesNotClear — processing root A doesn't affect entries queued under root B
  - TestValidateDataColumnGloas_QueuesWhenBlockNotSeen — full gossip path: sidecar arriving before its block returns ValidationIgnore and lands in the
   queue                                                                                                                                              
  - TestProcessPendingDataColumns_ProcessesWhenBlockArrives — end-to-end: sidecar queued → block saved to DB → processPendingDataColumnsForRoot fires 
  → chain receives the sidecar → queue is empty                                                                                                       
  - TestProcessPendingDataColumns_MultipleEntriesSameRoot — two sidecars for the same block both queue correctly and dedup works per column index     
                                                            
  ---                                                                                                                                                 
  Regression: make sure nothing else broke                  
                                                                                                                                                      
  go test -tags develop -count=1 ./beacon-chain/sync/       
                                                                                                                                                      
  ---                                                                                                                                                 
  Build check
                                                                                                                                                      
  go build -tags develop ./beacon-chain/sync/...            

  ---


**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
