### PR TITLE
Add missing fields to Gloas genesis block bid

### DIFF
--- a/beacon-chain/core/blocks/genesis.go
+++ b/beacon-chain/core/blocks/genesis.go
@@ -222,6 +222,8 @@ func gloasGenesisBlock(root [fieldparams.RootLength]byte) *ethpb.BeaconBlockGloa
 					ParentBlockHash:    make([]byte, 32),
 					ParentBlockRoot:    make([]byte, 32),
 					BlockHash:          make([]byte, 32),
+					PrevRandao:         make([]byte, 32),
+					FeeRecipient:       make([]byte, 20),
 					BlobKzgCommitments: make([][]byte, 0),
 				},
 				Signature: make([]byte, fieldparams.BLSSignatureLength),

--- a/changelog/terence_gloas-genesis-bid-fields.md
+++ b/changelog/terence_gloas-genesis-bid-fields.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Add missing `PrevRandao` and `FeeRecipient` fields to the Gloas genesis block's execution payload bid.


### PR DESCRIPTION
  - The Gloas genesis block's `SignedExecutionPayloadBid` was missing `PrevRandao` (32 bytes) and `FeeRecipient` (20 bytes)
  - This caused SSZ marshaling failures at genesis