### PR TITLE
Skip inclusion proof verification for Gloas data columns

### DIFF
--- a/beacon-chain/core/peerdas/p2p_interface.go
+++ b/beacon-chain/core/peerdas/p2p_interface.go
@@ -158,6 +158,9 @@ func verifyDataColumnsSidecarKZGProofs(sidecars []blocks.RODataColumn, commitmen
 // VerifyDataColumnSidecarInclusionProof verifies if the given KZG commitments included in the given beacon block.
 // https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md#verify_data_column_sidecar_inclusion_proof
 func VerifyDataColumnSidecarInclusionProof(sidecar blocks.RODataColumn) error {
+	if sidecar.IsGloas() {
+		return nil
+	}
 	signedBlockHeader, err := sidecar.SignedBlockHeader()
 	if err != nil {
 		return errors.Wrap(err, "signed block header")

--- a/beacon-chain/core/peerdas/p2p_interface_test.go
+++ b/beacon-chain/core/peerdas/p2p_interface_test.go
@@ -215,6 +215,13 @@ func Test_VerifyKZGInclusionProofColumn(t *testing.T) {
 	}
 }
 
+func TestVerifyDataColumnSidecarInclusionProof_SkipsGloas(t *testing.T) {
+	dc := &ethpb.DataColumnSidecarGloas{Index: 0, Column: [][]byte{{0x01}}, KzgProofs: [][]byte{make([]byte, 48)}}
+	roCol, err := blocks.NewRODataColumnGloas(dc)
+	require.NoError(t, err)
+	require.NoError(t, peerdas.VerifyDataColumnSidecarInclusionProof(roCol))
+}
+
 func TestComputeSubnetForDataColumnSidecar(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	config := params.BeaconConfig()

--- a/beacon-chain/verification/data_column.go
+++ b/beacon-chain/verification/data_column.go
@@ -456,6 +456,9 @@ func (dv *RODataColumnsVerifier) SidecarInclusionProven() (err error) {
 	startTime := time.Now()
 
 	for _, dataColumn := range dv.dataColumns {
+		if dataColumn.IsGloas() {
+			continue
+		}
 		k, keyErr := inclusionProofKey(dataColumn)
 		if keyErr == nil {
 			if _, ok := dv.ic.Get(k); ok {

--- a/changelog/terence_gloas-skip-inclusion-proof.md
+++ b/changelog/terence_gloas-skip-inclusion-proof.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Skip data column inclusion proof verification for Gloas sidecars, which do not carry block headers or inclusion proofs.


### PR DESCRIPTION
  - Gloas data column sidecars don't carry block headers or inclusion proofs
  - Skip `VerifyDataColumnSidecarInclusionProof` for Gloas sidecars
  - Skip Gloas columns in the batch verifier `SidecarInclusionProven` loop