### PR TITLE
Decode Gloas data columns using correct protobuf type over RPC

### DIFF
--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -788,14 +788,20 @@ func readChunkedDataColumnSidecar(
 		)
 	}
 
-	// Decode the data column sidecar from the stream.
-	dataColumnSidecar := new(ethpb.DataColumnSidecar)
-	if err := p2pApi.Encoding().DecodeWithMaxLength(stream, dataColumnSidecar); err != nil {
-		return nil, errors.Wrap(err, "failed to decode the protobuf-encoded BlobSidecar message from RPC chunk stream")
+	var roDataColumn blocks.RODataColumn
+	if msgVersion >= version.Gloas {
+		dc := new(ethpb.DataColumnSidecarGloas)
+		if err := p2pApi.Encoding().DecodeWithMaxLength(stream, dc); err != nil {
+			return nil, errors.Wrap(err, "failed to decode Gloas DataColumnSidecar from RPC chunk stream")
+		}
+		roDataColumn, err = blocks.NewRODataColumnGloas(dc)
+	} else {
+		dc := new(ethpb.DataColumnSidecar)
+		if err := p2pApi.Encoding().DecodeWithMaxLength(stream, dc); err != nil {
+			return nil, errors.Wrap(err, "failed to decode Fulu DataColumnSidecar from RPC chunk stream")
+		}
+		roDataColumn, err = blocks.NewRODataColumn(dc)
 	}
-
-	// Create a read-only data column from the data column sidecar.
-	roDataColumn, err := blocks.NewRODataColumn(dataColumnSidecar)
 	if err != nil {
 		return nil, errors.Wrap(err, "new read only data column")
 	}

--- a/beacon-chain/sync/rpc_send_request_test.go
+++ b/beacon-chain/sync/rpc_send_request_test.go
@@ -1651,4 +1651,44 @@ func TestReadChunkedDataColumnSidecar(t *testing.T) {
 			t.Fatal("Did not receive stream within 1 sec")
 		}
 	})
+
+	t.Run("nominal gloas", func(t *testing.T) {
+		p1, p2 := p2ptest.NewTestP2P(t), p2ptest.NewTestP2P(t)
+
+		expected := &ethpb.DataColumnSidecarGloas{
+			Index:           7,
+			Column:          [][]byte{make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+			BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		p2.SetStreamHandler(p2p.RPCDataColumnSidecarsByRootTopicV1, func(stream network.Stream) {
+			defer wg.Done()
+
+			actual, err := readChunkedDataColumnSidecar(stream, p2, ContextByteVersions{[4]byte{1, 2, 3, 4}: version.Gloas})
+			require.NoError(t, err)
+			require.Equal(t, true, actual.IsGloas())
+			require.Equal(t, uint64(7), actual.Index())
+		})
+
+		p1.Connect(p2)
+
+		stream, err := p1.BHost.NewStream(t.Context(), p2.PeerID(), p2p.RPCDataColumnSidecarsByRootTopicV1)
+		require.NoError(t, err)
+
+		_, err = stream.Write([]byte{responseCodeSuccess})
+		require.NoError(t, err)
+
+		err = writeContextToStream([]byte{1, 2, 3, 4}, stream)
+		require.NoError(t, err)
+
+		_, err = p1.Encoding().EncodeWithMaxLength(stream, expected)
+		require.NoError(t, err)
+
+		if util.WaitTimeout(&wg, time.Minute) {
+			t.Fatal("Did not receive stream within 1 sec")
+		}
+	})
 }

--- a/changelog/terence_gloas-rpc-data-column-decode.md
+++ b/changelog/terence_gloas-rpc-data-column-decode.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Decode Gloas data column sidecars using the correct protobuf type when receiving them over RPC.


### PR DESCRIPTION
  - `readChunkedDataColumnSidecar` now branches on fork version
  - Gloas columns decode as `DataColumnSidecarGloas`, Fulu as `DataColumnSidecar`
  - Previously all RPC columns decoded as Fulu, causing failures when non-proposer nodes fetched Gloas columns from peers