### PR TITLE
Set bid KZG commitments on gloas's data columns

### DIFF
--- a/beacon-chain/sync/data_column_sidecars.go
+++ b/beacon-chain/sync/data_column_sidecars.go
@@ -79,6 +79,8 @@ func FetchDataColumnSidecars(
 	slotByRoot := make(map[[fieldparams.RootLength]byte]primitives.Slot, blockCount)
 	storedIndicesByRoot := make(map[[fieldparams.RootLength]byte]map[uint64]bool, blockCount)
 
+	commitmentsByRoot := make(map[[fieldparams.RootLength]byte][][]byte, blockCount)
+
 	for _, roBlock := range roBlocks {
 		block := roBlock.Block()
 
@@ -97,6 +99,7 @@ func FetchDataColumnSidecars(
 		incompleteRoots[root] = true
 		slotByRoot[root] = slot
 		slotsWithCommitments[slot] = true
+		commitmentsByRoot[root] = commitments
 
 		storedIndices := params.Storage.Summary(root).Stored()
 		if len(storedIndices) > 0 {
@@ -120,7 +123,7 @@ func FetchDataColumnSidecars(
 	}
 
 	// Request direct sidecars from peers.
-	directSidecarsByRoot, err := requestDirectSidecarsFromPeers(params, slotByRoot, requestedIndices, slotsWithCommitments, storedIndicesByRoot, incompleteRoots)
+	directSidecarsByRoot, err := requestDirectSidecarsFromPeers(params, slotByRoot, requestedIndices, slotsWithCommitments, storedIndicesByRoot, incompleteRoots, commitmentsByRoot)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "request direct sidecars from peers")
 	}
@@ -139,7 +142,7 @@ func FetchDataColumnSidecars(
 	}
 
 	// Request all possible indirect sidecars from peers which are neither stored nor in `directSidecarsByRoot`
-	indirectSidecarsByRoot, err := requestIndirectSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, storedIndicesByRoot, directSidecarsByRoot, requestedIndices, incompleteRoots)
+	indirectSidecarsByRoot, err := requestIndirectSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, storedIndicesByRoot, directSidecarsByRoot, requestedIndices, incompleteRoots, commitmentsByRoot)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "request all sidecars from peers")
 	}
@@ -230,6 +233,7 @@ func requestDirectSidecarsFromPeers(
 	slotsWithCommitments map[primitives.Slot]bool,
 	storedIndicesByRoot map[[fieldparams.RootLength]byte]map[uint64]bool,
 	incompleteRoots map[[fieldparams.RootLength]byte]bool,
+	commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte,
 ) (map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn, error) {
 	start := time.Now()
 
@@ -286,6 +290,9 @@ func requestDirectSidecarsFromPeers(
 		// Fetch the sidecars from the chosen peers.
 		roDataColumnsByPeer := fetchDataColumnSidecarsFromPeers(params, slotByRoot, slotsWithCommitments, indicesByRootByPeerToQuery)
 
+		// Set bid commitments on Gloas columns before verification.
+		setBidCommitments(commitmentsByRoot, roDataColumnsByPeer)
+
 		// Verify the received data column sidecars.
 		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(params.P2P, params.NewVerifier, roDataColumnsByPeer)
 		if err != nil {
@@ -336,6 +343,7 @@ func requestIndirectSidecarsFromPeers(
 	alreadyAvailableByRoot map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn,
 	requestedIndices map[uint64]bool,
 	roots map[[fieldparams.RootLength]byte]bool,
+	commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte,
 ) (map[[fieldparams.RootLength]byte][]blocks.VerifiedRODataColumn, error) {
 	start := time.Now()
 
@@ -403,6 +411,9 @@ func requestIndirectSidecarsFromPeers(
 
 		// Fetch the sidecars from the chosen peers.
 		roDataColumnsByPeer := fetchDataColumnSidecarsFromPeers(p, slotByRoot, slotsWithCommitments, indicesByRootByPeerToQuery)
+
+		// Set bid commitments on Gloas columns before verification.
+		setBidCommitments(commitmentsByRoot, roDataColumnsByPeer)
 
 		// Verify the received data column sidecars.
 		verifiedRoDataColumnSidecars, err := verifyDataColumnSidecarsByPeer(p.P2P, p.NewVerifier, roDataColumnsByPeer)
@@ -1012,6 +1023,23 @@ func verifyByRootDataColumnSidecars(newVerifier verification.NewDataColumnsVerif
 	}
 
 	return verifiedRoDataColumns, nil
+}
+
+// setBidCommitments sets bid KZG commitments on Gloas data columns so verification can proceed.
+func setBidCommitments(commitmentsByRoot map[[fieldparams.RootLength]byte][][]byte, columnsByPeer map[goPeer.ID][]blocks.RODataColumn) {
+	if len(commitmentsByRoot) == 0 {
+		return
+	}
+	for _, columns := range columnsByPeer {
+		for i := range columns {
+			if !columns[i].IsGloas() {
+				continue
+			}
+			if comms, ok := commitmentsByRoot[columns[i].BlockRoot()]; ok {
+				columns[i].SetBidCommitments(comms)
+			}
+		}
+	}
 }
 
 // computeIndicesByRootByPeer returns a peers->root->indices map only for

--- a/beacon-chain/sync/data_column_sidecars_test.go
+++ b/beacon-chain/sync/data_column_sidecars_test.go
@@ -1032,3 +1032,50 @@ func TestComputeTotalCount(t *testing.T) {
 	actual := computeTotalCount(input)
 	require.Equal(t, expected, actual)
 }
+
+func TestSetBidCommitments(t *testing.T) {
+	root := [fieldparams.RootLength]byte{1}
+	comms := [][]byte{{0xaa}, {0xbb}}
+
+	// Fulu column should be untouched.
+	fuluDC := &ethpb.DataColumnSidecar{
+		SignedBlockHeader: &ethpb.SignedBeaconBlockHeader{
+			Header: &ethpb.BeaconBlockHeader{
+				ParentRoot: make([]byte, 32),
+				StateRoot:  make([]byte, 32),
+				BodyRoot:   make([]byte, 32),
+			},
+			Signature: make([]byte, 96),
+		},
+	}
+	fuluCol := blocks.NewRODataColumnNoVerify(fuluDC)
+
+	// Gloas column should get commitments set.
+	gloasDC := &ethpb.DataColumnSidecarGloas{
+		Index:           5,
+		BeaconBlockRoot: root[:],
+		Column:          [][]byte{make([]byte, 2048)},
+		KzgProofs:       [][]byte{make([]byte, 48)},
+	}
+	gloasCol, err := blocks.NewRODataColumnGloasWithRoot(gloasDC, root)
+	require.NoError(t, err)
+
+	pid := peer.ID("test-peer")
+	columnsByPeer := map[peer.ID][]blocks.RODataColumn{
+		pid: {fuluCol, gloasCol},
+	}
+	commitmentsByRoot := map[[fieldparams.RootLength]byte][][]byte{
+		root: comms,
+	}
+
+	setBidCommitments(commitmentsByRoot, columnsByPeer)
+
+	// Fulu column should not have bid commitments.
+	_, err = columnsByPeer[pid][0].KzgCommitments()
+	require.NoError(t, err)
+
+	// Gloas column should now have bid commitments.
+	got, err := columnsByPeer[pid][1].KzgCommitments()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(got))
+}

--- a/changelog/terence_gloas-bid-commitments.md
+++ b/changelog/terence_gloas-bid-commitments.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Set bid KZG commitments on Gloas data columns during gossip validation and RPC fetch so that KZG proof verification can proceed.


### PR DESCRIPTION
  - Set bid commitments on verified columns during gossip validation (`validateDataColumnGloas`)
  - Add `setBidCommitments` helper for the RPC fetch path (`FetchDataColumnSidecars`)
  - Track `commitmentsByRoot` on `DataColumnSidecarsParams` so peer fetches can set commitments before verification