### PR TITLE
Use fork-aware deserialization for data columns from disk

### DIFF
--- a/beacon-chain/db/filesystem/data_column.go
+++ b/beacon-chain/db/filesystem/data_column.go
@@ -546,7 +546,7 @@ func (dcs *DataColumnStorage) Get(root [fieldparams.RootLength]byte, indices []u
 			return nil, errors.Wrap(err, "seek")
 		}
 
-		verifiedRODataColumn, err := verification.VerifiedRODataColumnFromDisk(file, root, metadata.sszEncodedDataColumnSidecarSize)
+		verifiedRODataColumn, err := verification.VerifiedRODataColumnFromDisk(file, root, metadata.sszEncodedDataColumnSidecarSize, summary.epoch)
 		if err != nil {
 			return nil, errors.Wrap(err, "verified RO data column from disk")
 		}

--- a/beacon-chain/verification/filesystem.go
+++ b/beacon-chain/verification/filesystem.go
@@ -2,7 +2,9 @@ package verification
 
 import (
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/pkg/errors"
 
@@ -28,8 +30,7 @@ func VerifiedROBlobFromDisk(fs afero.Fs, root [32]byte, path string) (blocks.Ver
 
 // VerifiedRODataColumnFromDisk creates a verified read-only data column sidecar from disk.
 // The file cursor must be positioned at the start of the data column sidecar SSZ data.
-func VerifiedRODataColumnFromDisk(file afero.File, root [fieldparams.RootLength]byte, sszEncodedDataColumnSidecarSize uint32) (blocks.VerifiedRODataColumn, error) {
-	// Read the ssz encoded data column sidecar from the file
+func VerifiedRODataColumnFromDisk(file afero.File, root [fieldparams.RootLength]byte, sszEncodedDataColumnSidecarSize uint32, epoch primitives.Epoch) (blocks.VerifiedRODataColumn, error) {
 	sszEncodedDataColumnSidecar := make([]byte, sszEncodedDataColumnSidecarSize)
 	count, err := file.Read(sszEncodedDataColumnSidecar)
 	if err != nil {
@@ -39,20 +40,23 @@ func VerifiedRODataColumnFromDisk(file afero.File, root [fieldparams.RootLength]
 		return VerifiedRODataColumnError(errors.Errorf("read %d bytes while expecting %d", count, sszEncodedDataColumnSidecarSize))
 	}
 
-	// Unmarshal the SSZ encoded data column sidecar.
-	dataColumnSidecar := &ethpb.DataColumnSidecar{}
-	if err := dataColumnSidecar.UnmarshalSSZ(sszEncodedDataColumnSidecar); err != nil {
-		return VerifiedRODataColumnError(err)
+	var roDataColumnSidecar blocks.RODataColumn
+	if epoch >= params.BeaconConfig().GloasForkEpoch {
+		dc := &ethpb.DataColumnSidecarGloas{}
+		if err := dc.UnmarshalSSZ(sszEncodedDataColumnSidecar); err != nil {
+			return VerifiedRODataColumnError(err)
+		}
+		roDataColumnSidecar, err = blocks.NewRODataColumnGloasWithRoot(dc, root)
+	} else {
+		dc := &ethpb.DataColumnSidecar{}
+		if err := dc.UnmarshalSSZ(sszEncodedDataColumnSidecar); err != nil {
+			return VerifiedRODataColumnError(err)
+		}
+		roDataColumnSidecar, err = blocks.NewRODataColumnWithRoot(dc, root)
 	}
-
-	// Create a RO data column.
-	roDataColumnSidecar, err := blocks.NewRODataColumnWithRoot(dataColumnSidecar, root)
 	if err != nil {
 		return VerifiedRODataColumnError(err)
 	}
 
-	// Create a verified RO data column.
-	verifiedRODataColumn := blocks.NewVerifiedRODataColumn(roDataColumnSidecar)
-
-	return verifiedRODataColumn, nil
+	return blocks.NewVerifiedRODataColumn(roDataColumnSidecar), nil
 }

--- a/beacon-chain/verification/filesystem_test.go
+++ b/beacon-chain/verification/filesystem_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/config/params"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	"github.com/spf13/afero"
@@ -23,7 +26,7 @@ func TestVerifiedROBlobFromDisk(t *testing.T) {
 
 	// Write test data to file..
 	filePath := "/test/blob.ssz"
-	err = afero.WriteFile(fs, filePath, sszData, 0644)
+	err = afero.WriteFile(fs, filePath, sszData, 0o644)
 	require.NoError(t, err)
 
 	// Test the function.
@@ -55,7 +58,7 @@ func TestVerifiedRODataColumnFromDisk(t *testing.T) {
 		// Write partial data.
 		filePath := "/test/partial.ssz"
 		partialData := sszData[:len(sszData)/2]
-		err := afero.WriteFile(fs, filePath, partialData, 0644)
+		err := afero.WriteFile(fs, filePath, partialData, 0o644)
 		require.NoError(t, err)
 
 		// Open file for reading.
@@ -63,7 +66,7 @@ func TestVerifiedRODataColumnFromDisk(t *testing.T) {
 		require.NoError(t, err)
 
 		// Test the function.
-		_, err = VerifiedRODataColumnFromDisk(file, blockRoot, sszSize)
+		_, err = VerifiedRODataColumnFromDisk(file, blockRoot, sszSize, 0)
 		require.NotNil(t, err)
 
 		err = file.Close()
@@ -76,7 +79,7 @@ func TestVerifiedRODataColumnFromDisk(t *testing.T) {
 
 		// Write test data to file.
 		filePath := "/test/datacolumn.ssz"
-		err := afero.WriteFile(fs, filePath, sszData, 0644)
+		err := afero.WriteFile(fs, filePath, sszData, 0o644)
 		require.NoError(t, err)
 
 		// Open file for reading.
@@ -84,7 +87,7 @@ func TestVerifiedRODataColumnFromDisk(t *testing.T) {
 		require.NoError(t, err)
 
 		// Test the function.
-		verifiedColumn, err := VerifiedRODataColumnFromDisk(file, blockRoot, sszSize)
+		verifiedColumn, err := VerifiedRODataColumnFromDisk(file, blockRoot, sszSize, 0)
 		require.NoError(t, err)
 
 		// Verify the result.
@@ -94,5 +97,62 @@ func TestVerifiedRODataColumnFromDisk(t *testing.T) {
 
 		err = file.Close()
 		require.NoError(t, err)
+	})
+
+	t.Run("gloas roundtrip", func(t *testing.T) {
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig().Copy()
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		blockRoot := [fieldparams.RootLength]byte{0xaa, 0xbb}
+		slot := primitives.Slot(5)
+		idx := uint64(42)
+
+		numCells := 3
+		column := make([][]byte, numCells)
+		kzgProofs := make([][]byte, numCells)
+		for i := range numCells {
+			cell := make([]byte, 2048)
+			cell[0] = byte(i + 1)
+			column[i] = cell
+			kzgProofs[i] = make([]byte, 48)
+		}
+
+		original := &ethpb.DataColumnSidecarGloas{
+			Index:           idx,
+			Slot:            slot,
+			BeaconBlockRoot: blockRoot[:],
+			Column:          column,
+			KzgProofs:       kzgProofs,
+		}
+
+		sszData, err := original.MarshalSSZ()
+		require.NoError(t, err)
+		sszSize := uint32(len(sszData))
+
+		fs := afero.NewMemMapFs()
+		filePath := "/test/gloas_column.ssz"
+		err = afero.WriteFile(fs, filePath, sszData, 0o644)
+		require.NoError(t, err)
+
+		file, err := fs.Open(filePath)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, file.Close()) }()
+
+		gloasEpoch := primitives.Epoch(0)
+		verifiedColumn, err := VerifiedRODataColumnFromDisk(file, blockRoot, sszSize, gloasEpoch)
+		require.NoError(t, err)
+
+		col := verifiedColumn.RODataColumn
+		require.Equal(t, true, col.IsGloas())
+		require.Equal(t, idx, col.Index())
+		require.Equal(t, slot, col.Slot())
+		require.Equal(t, blockRoot, col.BlockRoot())
+		require.Equal(t, numCells, len(col.Column()))
+		require.Equal(t, numCells, len(col.KzgProofs()))
+		require.Equal(t, byte(1), col.Column()[0][0])
+		require.Equal(t, byte(2), col.Column()[1][0])
+		require.Equal(t, byte(3), col.Column()[2][0])
 	})
 }

--- a/changelog/terence_gloas-disk-deserialization.md
+++ b/changelog/terence_gloas-disk-deserialization.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use fork-aware deserialization when reading data columns from disk, using the Gloas SSZ type for columns at or after the Gloas fork epoch.


### PR DESCRIPTION
- `VerifiedRODataColumnFromDisk` now takes an epoch parameter
- Columns at or after the Gloas fork epoch unmarshal as `DataColumnSidecarGloas`
- Earlier columns continue to unmarshal as `DataColumnSidecar` (Fulu)
- Previously all columns used the Fulu type, which fails for Gloas
