### PR TITLE
Fix initial sync bid validation failure

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -198,46 +198,46 @@ func (s *Service) getBatchPrestate(ctx context.Context, b consensusblocks.ROBloc
 		}
 		return blockPreState, false, nil
 	}
+	parentRoot := b.Block().ParentRoot()
 	full, err := consensusblocks.BlockBuiltOnEnvelope(envelopes[0], b)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "could not check if block builds on envelope")
 	}
+	blockPreState, err := s.cfg.StateGen.StateByRootInitialSync(ctx, parentRoot)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "could not get block pre state")
+	}
 	if !full {
-		blockPreState, err := s.cfg.StateGen.StateByRootInitialSync(ctx, b.Block().ParentRoot())
-		if err != nil {
-			return nil, false, errors.Wrap(err, "could not get block pre state")
-		}
 		return blockPreState, false, nil
 	}
-	parentRoot := b.Block().ParentRoot()
+	parentBlock, err := s.cfg.BeaconDB.Block(ctx, parentRoot)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "could not get parent block")
+	}
 	if s.cfg.BeaconDB.HasExecutionPayloadEnvelope(ctx, parentRoot) {
-		// This path should have been filtered already in init sync.
-		log.Debugf("Ignoring already processed envelope for blockroot %#x", parentRoot)
-		env, err := envelopes[0].Envelope()
+		// The parent envelope was already saved by a previous batch but the
+		// replayed state may not include it (replay skips the last block's
+		// envelope). Load the blinded form from DB and apply it.
+		blindedEnv, err := s.cfg.BeaconDB.ExecutionPayloadEnvelope(ctx, parentRoot)
 		if err != nil {
-			return nil, false, err
+			return nil, false, errors.Wrap(err, "could not load parent blinded envelope from DB")
 		}
-		blockPreState, err := s.cfg.StateGen.StateByRootInitialSync(ctx, env.BlockHash())
+		wrappedEnv, err := consensusblocks.WrappedROBlindedExecutionPayloadEnvelope(blindedEnv.Message)
 		if err != nil {
-			return nil, false, err
+			return nil, false, errors.Wrap(err, "could not wrap blinded envelope")
 		}
-		return blockPreState, false, nil
+		if err := gloas.ProcessBlindedExecutionPayload(ctx, blockPreState, parentBlock.Block().StateRoot(), wrappedEnv); err != nil {
+			return nil, false, errors.Wrap(err, "could not apply parent blinded envelope from DB")
+		}
+		return blockPreState, true, nil
 	}
 	env, err := envelopes[0].Envelope()
 	if err != nil {
 		return nil, false, err
 	}
 	// notify the engine of the new envelope
-	blockPreState, err := s.cfg.StateGen.StateByRootInitialSync(ctx, b.Block().ParentRoot())
-	if err != nil {
-		return nil, false, errors.Wrap(err, "could not get block pre state")
-	}
 	if _, err := s.notifyNewEnvelope(ctx, blockPreState, env); err != nil {
 		return nil, false, err
-	}
-	parentBlock, err := s.cfg.BeaconDB.Block(ctx, parentRoot)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "could not get parent block")
 	}
 	if err := gloas.ProcessBlindedExecutionPayload(ctx, blockPreState, parentBlock.Block().StateRoot(), env); err != nil {
 		return nil, false, err

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -427,9 +427,6 @@ func envelopesForBlocks(
 		// Check if this envelope is the parent envelope for the first block.
 		builtOn, err := blocks.BlockBuiltOnEnvelope(e, bwb[0].Block)
 		if err == nil && builtOn {
-			if isPayloadProc(ctx, e) {
-				continue
-			}
 			return envelopes[i:]
 		}
 

--- a/changelog/potuz_init_sync_restart.md
+++ b/changelog/potuz_init_sync_restart.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix init sync on Gloas on restarts.


### PR DESCRIPTION

During initial sync, state replay skips the last block's execution payload envelope (no next block to verify delivery). When the parent envelope was already saved by a previous batch, envelopesForBlocks skipped it as "already processed", leaving getBatchPrestate unable to apply it. This caused LatestBlockHash to be stale, failing bid validation on the next block.

Two fixes:
- envelopesForBlocks: always include the parent envelope even if persisted
- getBatchPrestate: when parent envelope is in DB, load and apply the blinded form instead of the broken StateByRootInitialSync(env.BlockHash) call that passed an execution hash where a beacon block root was expected

