### PR TITLE
Queue Gloas data column sidecars arriving before their block

### DIFF
--- a/beacon-chain/sync/fuzz_exports.go
+++ b/beacon-chain/sync/fuzz_exports.go
@@ -22,6 +22,7 @@ func NewRegularSyncFuzz(opts ...Option) *Service {
 		slotToPendingBlocks:  gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:    make(map[[32]byte]bool),
 		blkRootToPendingAtts: make(map[[32]byte][]any),
+		pendingGloasColumns:  make(map[[32]byte]*pendingGloasEntry),
 	}
 	r.rateLimiter = newRateLimiter(r.cfg.p2p)
 

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -160,7 +160,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 
 			// Process synchronously because it's likely that the next pending block depends on it.
 			s.processPendingPayloadEnvelope(ctx, blkRoot)
-			s.processPendingGloasColumns(ctx, blkRoot, b)
+			s.processPendingGloasColumns(blkRoot, b)
 			blkRoots = append(blkRoots, blkRoot)
 
 			// Remove the processed block from the queue.

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -160,6 +160,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 
 			// Process synchronously because it's likely that the next pending block depends on it.
 			s.processPendingPayloadEnvelope(ctx, blkRoot)
+			s.processPendingGloasColumns(ctx, blkRoot, b)
 			blkRoots = append(blkRoots, blkRoot)
 
 			// Remove the processed block from the queue.

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -97,15 +97,9 @@ func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock)
 		return nil
 	}
 
-	filtered := make([]blocks.ROBlock, 0, len(blks))
+	// Process any gossip columns queued before the block arrived.
 	for _, blk := range blks {
-		if !s.hasPendingGloasColumns(blk.Root()) {
-			filtered = append(filtered, blk)
-		}
-	}
-	blks = filtered
-	if len(blks) == 0 {
-		return nil
+		s.processPendingGloasColumns(blk.Root(), blk)
 	}
 
 	samplesPerSlot := params.BeaconConfig().SamplesPerSlot

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -97,6 +97,17 @@ func (s *Service) requestAndSaveMissingDataColumnSidecars(blks []blocks.ROBlock)
 		return nil
 	}
 
+	filtered := make([]blocks.ROBlock, 0, len(blks))
+	for _, blk := range blks {
+		if !s.hasPendingGloasColumns(blk.Root()) {
+			filtered = append(filtered, blk)
+		}
+	}
+	blks = filtered
+	if len(blks) == 0 {
+		return nil
+	}
+
 	samplesPerSlot := params.BeaconConfig().SamplesPerSlot
 
 	custodyGroupCount, err := s.cfg.p2p.CustodyGroupCount(s.ctx)

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -160,6 +160,8 @@ type Service struct {
 	seenBlobLock                         sync.RWMutex
 	seenBlobCache                        *lru.Cache
 	seenDataColumnCache                  *slotAwareCache
+	pendingGloasColumnsLock              sync.RWMutex
+	pendingGloasColumns                  map[[32]byte]*pendingGloasEntry
 	seenAggregatedAttestationLock        sync.RWMutex
 	seenAggregatedAttestationCache       *lru.Cache
 	seenUnAggregatedAttestationLock      sync.RWMutex
@@ -219,6 +221,7 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 		slotToPendingBlocks:      gcache.New(pendingBlockExpTime /* exp time */, 0 /* disable janitor */),
 		seenPendingBlocks:        make(map[[32]byte]bool),
 		blkRootToPendingAtts:     make(map[[32]byte][]any),
+		pendingGloasColumns:      make(map[[32]byte]*pendingGloasEntry),
 		dataColumnLogCh:          make(chan dataColumnLogEntry, 1000),
 		reconstructionRandGen:    rand.NewGenerator(),
 		payloadAttestationCache:  &cache.PayloadAttestationCache{},
@@ -328,6 +331,8 @@ func (s *Service) Start() {
 
 	// Prune data column cache periodically on finalization.
 	async.RunEvery(s.ctx, 30*time.Second, s.pruneDataColumnCache)
+
+	go s.prunePendingGloasColumns()
 
 	if !params.FuluEnabled() {
 		return

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -81,9 +81,9 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 		return errors.Wrap(err, "process pending atts for block")
 	}
 
-	s.processPendingGloasColumns(ctx, root, signed)
-
 	go s.processPendingPayloadEnvelope(s.ctx, root)
+
+	s.processPendingGloasColumns(root, signed)
 
 	return nil
 }

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -81,6 +81,8 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 		return errors.Wrap(err, "process pending atts for block")
 	}
 
+	s.processPendingGloasColumns(ctx, root, signed)
+
 	go s.processPendingPayloadEnvelope(s.ctx, root)
 
 	return nil

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -22,6 +22,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// maxPendingGloasRoots caps the number of distinct block roots in the pending queue.
+const maxPendingGloasRoots = 8
+
 type pendingColumnEntry struct {
 	sidecar *ethpb.DataColumnSidecarGloas
 	peer    peer.ID
@@ -138,6 +141,9 @@ func (s *Service) queuePendingGloasColumn(roCol blocks.RODataColumn, pid peer.ID
 
 	entry := s.pendingGloasColumns[root]
 	if entry == nil {
+		if len(s.pendingGloasColumns) >= maxPendingGloasRoots {
+			return
+		}
 		entry = &pendingGloasEntry{slot: slot}
 		s.pendingGloasColumns[root] = entry
 	}
@@ -148,13 +154,17 @@ func (s *Service) queuePendingGloasColumn(roCol blocks.RODataColumn, pid peer.ID
 	entry.columns[idx] = &pendingColumnEntry{sidecar: dc, peer: pid}
 }
 
-func (s *Service) processPendingGloasColumns(_ context.Context, root [fieldparams.RootLength]byte, blk interfaces.ReadOnlySignedBeaconBlock) {
+func (s *Service) processPendingGloasColumns(root [fieldparams.RootLength]byte, blk interfaces.ReadOnlySignedBeaconBlock) {
+	if blk == nil || blk.IsNil() {
+		return
+	}
+
 	s.pendingGloasColumnsLock.Lock()
 	entry := s.pendingGloasColumns[root]
 	delete(s.pendingGloasColumns, root)
 	s.pendingGloasColumnsLock.Unlock()
 
-	if entry == nil || blk == nil || blk.IsNil() {
+	if entry == nil {
 		return
 	}
 
@@ -164,15 +174,24 @@ func (s *Service) processPendingGloasColumns(_ context.Context, root [fieldparam
 		return
 	}
 
-	var verified []blocks.VerifiedRODataColumn
+	// Count pending sidecars for pre-allocation.
+	count := 0
+	for _, pe := range entry.columns {
+		if pe != nil {
+			count++
+		}
+	}
+
+	verified := make([]blocks.VerifiedRODataColumn, 0, count)
 	var skipped int
-	var badPeers []peer.ID
+	badPeers := make(map[peer.ID]bool)
 	for _, pe := range entry.columns {
 		if pe == nil {
 			continue
 		}
 		roCol, err := blocks.NewRODataColumnGloasWithRoot(pe.sidecar, root)
 		if err != nil {
+			log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Error("Failed to wrap pending Gloas column")
 			skipped++
 			continue
 		}
@@ -182,29 +201,27 @@ func (s *Service) processPendingGloasColumns(_ context.Context, root [fieldparam
 			continue
 		}
 
-		verifier := verification.NewGloasDataColumnVerifier(roCol, blk.Block(), verification.GossipDataColumnSidecarRequirementsGloas)
-		verifier.SatisfyRequirement(verification.RequireBlockSeenGloas)
-		verifier.SatisfyRequirement(verification.RequireNotSeenGloas)
-		verifier.SatisfyRequirement(verification.RequireCorrectSubnet)
+		verifier := verification.NewGloasDataColumnVerifier(roCol, blk.Block(), verification.PendingGloasColumnRequirements)
 
 		if err := verifier.VerifyDataColumnSidecarSlotMatchesBlockGloas(); err != nil {
 			skipped++
-			badPeers = append(badPeers, pe.peer)
+			badPeers[pe.peer] = true
 			continue
 		}
 		if err := verifier.VerifyDataColumnSidecarGloas(); err != nil {
 			skipped++
-			badPeers = append(badPeers, pe.peer)
+			badPeers[pe.peer] = true
 			continue
 		}
 		if err := verifier.VerifyDataColumnSidecarKzgProofsGloas(); err != nil {
 			skipped++
-			badPeers = append(badPeers, pe.peer)
+			badPeers[pe.peer] = true
 			continue
 		}
 
 		v, err := verifier.VerifiedRODataColumn()
 		if err != nil {
+			log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Error("Failed to get verified pending Gloas column")
 			skipped++
 			continue
 		}
@@ -214,21 +231,22 @@ func (s *Service) processPendingGloasColumns(_ context.Context, root [fieldparam
 		verified = append(verified, v)
 	}
 
-	for _, pid := range badPeers {
+	for pid := range badPeers {
 		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pid)
 	}
 
 	if len(verified) > 0 {
 		if err := s.cfg.dataColumnStorage.Save(verified); err != nil {
 			log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Warn("Failed to save pending Gloas columns")
-		} else {
-			log.WithFields(logrus.Fields{
-				"root":    fmt.Sprintf("%#x", root),
-				"count":   len(verified),
-				"skipped": skipped,
-				"slot":    entry.slot,
-			}).Debug("Processed pending Gloas data columns")
+			return
 		}
+
+		log.WithFields(logrus.Fields{
+			"root":    fmt.Sprintf("%#x", root),
+			"count":   len(verified),
+			"skipped": skipped,
+			"slot":    entry.slot,
+		}).Debug("Processed pending Gloas data columns")
 	}
 }
 
@@ -248,7 +266,7 @@ func (s *Service) prunePendingGloasColumns() {
 		case currentSlot := <-slotTicker.C():
 			s.pendingGloasColumnsLock.Lock()
 			for r, e := range s.pendingGloasColumns {
-				if e.slot < currentSlot {
+				if e.slot+1 < currentSlot {
 					delete(s.pendingGloasColumns, r)
 				}
 			}

--- a/beacon-chain/sync/validate_data_column_gloas.go
+++ b/beacon-chain/sync/validate_data_column_gloas.go
@@ -2,16 +2,35 @@ package sync
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
+	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/encoding/bytesutil"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/logging"
+	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
+
+type pendingColumnEntry struct {
+	sidecar *ethpb.DataColumnSidecarGloas
+	peer    peer.ID
+}
+
+type pendingGloasEntry struct {
+	slot    primitives.Slot
+	columns [fieldparams.NumberOfColumns]*pendingColumnEntry
+}
 
 func (s *Service) validateDataColumnGloas(
 	ctx context.Context,
@@ -26,8 +45,12 @@ func (s *Service) validateDataColumnGloas(
 	// If not yet seen, a client MUST queue the sidecar for deferred validation and possible processing once
 	// the block is received or retrieved.
 	if s.cfg.chain == nil || !s.cfg.chain.HasBlock(ctx, roDataColumn.BlockRoot()) {
-		// TODO: Queue the sidecar for deferred validation and possible processing once the
-		// block is received or retrieved
+		actualSubnet := peerdas.ComputeSubnetForDataColumnSidecar(roDataColumn.Index())
+		expectedSubTopic := fmt.Sprintf(dataColumnSidecarSubTopic, actualSubnet)
+		if msg.Topic == nil || !strings.Contains(*msg.Topic+"/", expectedSubTopic) {
+			return blocks.VerifiedRODataColumn{}, errors.New("gloas data column on wrong subnet")
+		}
+		s.queuePendingGloasColumn(roDataColumn, peer.ID(msg.GetFrom()))
 		return blocks.VerifiedRODataColumn{}, ignoreValidation(errors.New("gloas data column block not yet seen"))
 	}
 
@@ -95,6 +118,145 @@ func (s *Service) hasSeenDataColumnRootIndex(root [fieldparams.RootLength]byte, 
 func (s *Service) setSeenDataColumnRootIndex(root [fieldparams.RootLength]byte, index uint64, slot primitives.Slot) {
 	key := computeRootIndexCacheKey(root, index)
 	s.seenDataColumnCache.Add(slot, key, true)
+}
+
+func (s *Service) queuePendingGloasColumn(roCol blocks.RODataColumn, pid peer.ID) {
+	dc := roCol.DataColumnSidecarGloas()
+	if dc == nil {
+		return
+	}
+	idx := roCol.Index()
+	if idx >= fieldparams.NumberOfColumns {
+		return
+	}
+
+	root := roCol.BlockRoot()
+	slot := roCol.Slot()
+
+	s.pendingGloasColumnsLock.Lock()
+	defer s.pendingGloasColumnsLock.Unlock()
+
+	entry := s.pendingGloasColumns[root]
+	if entry == nil {
+		entry = &pendingGloasEntry{slot: slot}
+		s.pendingGloasColumns[root] = entry
+	}
+
+	if entry.columns[idx] != nil {
+		return
+	}
+	entry.columns[idx] = &pendingColumnEntry{sidecar: dc, peer: pid}
+}
+
+func (s *Service) processPendingGloasColumns(_ context.Context, root [fieldparams.RootLength]byte, blk interfaces.ReadOnlySignedBeaconBlock) {
+	s.pendingGloasColumnsLock.Lock()
+	entry := s.pendingGloasColumns[root]
+	delete(s.pendingGloasColumns, root)
+	s.pendingGloasColumnsLock.Unlock()
+
+	if entry == nil || blk == nil || blk.IsNil() {
+		return
+	}
+
+	commitments, err := blk.Block().Body().BlobKzgCommitments()
+	if err != nil {
+		log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Warn("Failed to get bid commitments for pending Gloas columns")
+		return
+	}
+
+	var verified []blocks.VerifiedRODataColumn
+	var skipped int
+	var badPeers []peer.ID
+	for _, pe := range entry.columns {
+		if pe == nil {
+			continue
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(pe.sidecar, root)
+		if err != nil {
+			skipped++
+			continue
+		}
+		roCol.SetBidCommitments(commitments)
+
+		if s.hasSeenDataColumnRootIndex(root, roCol.Index()) {
+			continue
+		}
+
+		verifier := verification.NewGloasDataColumnVerifier(roCol, blk.Block(), verification.GossipDataColumnSidecarRequirementsGloas)
+		verifier.SatisfyRequirement(verification.RequireBlockSeenGloas)
+		verifier.SatisfyRequirement(verification.RequireNotSeenGloas)
+		verifier.SatisfyRequirement(verification.RequireCorrectSubnet)
+
+		if err := verifier.VerifyDataColumnSidecarSlotMatchesBlockGloas(); err != nil {
+			skipped++
+			badPeers = append(badPeers, pe.peer)
+			continue
+		}
+		if err := verifier.VerifyDataColumnSidecarGloas(); err != nil {
+			skipped++
+			badPeers = append(badPeers, pe.peer)
+			continue
+		}
+		if err := verifier.VerifyDataColumnSidecarKzgProofsGloas(); err != nil {
+			skipped++
+			badPeers = append(badPeers, pe.peer)
+			continue
+		}
+
+		v, err := verifier.VerifiedRODataColumn()
+		if err != nil {
+			skipped++
+			continue
+		}
+		v.SetBidCommitments(commitments)
+
+		s.setSeenDataColumnRootIndex(root, v.Index(), v.Slot())
+		verified = append(verified, v)
+	}
+
+	for _, pid := range badPeers {
+		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(pid)
+	}
+
+	if len(verified) > 0 {
+		if err := s.cfg.dataColumnStorage.Save(verified); err != nil {
+			log.WithError(err).WithField("root", fmt.Sprintf("%#x", root)).Warn("Failed to save pending Gloas columns")
+		} else {
+			log.WithFields(logrus.Fields{
+				"root":    fmt.Sprintf("%#x", root),
+				"count":   len(verified),
+				"skipped": skipped,
+				"slot":    entry.slot,
+			}).Debug("Processed pending Gloas data columns")
+		}
+	}
+}
+
+func (s *Service) hasPendingGloasColumns(root [fieldparams.RootLength]byte) bool {
+	s.pendingGloasColumnsLock.RLock()
+	defer s.pendingGloasColumnsLock.RUnlock()
+	_, ok := s.pendingGloasColumns[root]
+	return ok
+}
+
+// prunePendingGloasColumns removes stale entries every slot.
+func (s *Service) prunePendingGloasColumns() {
+	slotTicker := slots.NewSlotTicker(s.cfg.clock.GenesisTime(), params.BeaconConfig().SecondsPerSlot)
+	defer slotTicker.Done()
+	for {
+		select {
+		case currentSlot := <-slotTicker.C():
+			s.pendingGloasColumnsLock.Lock()
+			for r, e := range s.pendingGloasColumns {
+				if e.slot < currentSlot {
+					delete(s.pendingGloasColumns, r)
+				}
+			}
+			s.pendingGloasColumnsLock.Unlock()
+		case <-s.ctx.Done():
+			return
+		}
+	}
 }
 
 func computeRootIndexCacheKey(root [fieldparams.RootLength]byte, index uint64) string {

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/startup"
 	mockSync "github.com/OffchainLabs/prysm/v7/beacon-chain/sync/initial-sync/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/verification"
+	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
@@ -25,6 +26,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/testing/util"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
 	ssz "github.com/prysmaticlabs/fastssz"
 )
 
@@ -50,6 +52,7 @@ func TestValidateDataColumnGloas(t *testing.T) {
 			ctx:                 ctx,
 			newColumnsVerifier:  newDataColumnsVerifier,
 			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
 		}
 
 		buf := new(bytes.Buffer)
@@ -184,5 +187,91 @@ func TestValidateDataColumnGloas(t *testing.T) {
 
 		_, err = service.validateDataColumnGloas(ctx, msg, roDataColumn, "/data_column_sidecar_%d/")
 		require.ErrorContains(t, "slot does not match block slot", err)
+	})
+}
+
+func TestPendingGloasColumns(t *testing.T) {
+	clock := startup.NewClock(time.Now(), [32]byte{})
+
+	t.Run("queue and retrieve", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		root := [32]byte{0xaa}
+		dc := &ethpb.DataColumnSidecarGloas{
+			Index:           5,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: root[:],
+			Column:          [][]byte{make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+		require.NoError(t, err)
+
+		s.queuePendingGloasColumn(roCol, "peer1")
+		require.Equal(t, true, s.hasPendingGloasColumns(root))
+
+		entry := s.pendingGloasColumns[root]
+		require.NotNil(t, entry)
+		require.NotNil(t, entry.columns[5])
+		require.Equal(t, peer.ID("peer1"), entry.columns[5].peer)
+	})
+
+	t.Run("dedup by index", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		root := [32]byte{0xbb}
+		dc := &ethpb.DataColumnSidecarGloas{
+			Index:           10,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: root[:],
+			Column:          [][]byte{make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+		require.NoError(t, err)
+
+		s.queuePendingGloasColumn(roCol, "peer1")
+		s.queuePendingGloasColumn(roCol, "peer2")
+		require.Equal(t, peer.ID("peer1"), s.pendingGloasColumns[root].columns[10].peer)
+	})
+
+	t.Run("stale entries ignored on process", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		staleRoot := [32]byte{0xcc}
+		currentSlot := clock.CurrentSlot()
+		if currentSlot == 0 {
+			t.Skip("cannot test at slot 0")
+		}
+		s.pendingGloasColumns[staleRoot] = &pendingGloasEntry{slot: currentSlot - 1}
+
+		s.processPendingGloasColumns(t.Context(), staleRoot, nil)
+		require.Equal(t, false, s.hasPendingGloasColumns(staleRoot))
+	})
+
+	t.Run("index out of bounds rejected", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		root := [32]byte{0xee}
+		dc := &ethpb.DataColumnSidecarGloas{
+			Index:           fieldparams.NumberOfColumns + 1,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: root[:],
+			Column:          [][]byte{make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+		require.NoError(t, err)
+
+		s.queuePendingGloasColumn(roCol, "peer1")
+		require.Equal(t, false, s.hasPendingGloasColumns(root))
 	})
 }

--- a/beacon-chain/sync/validate_data_column_gloas_test.go
+++ b/beacon-chain/sync/validate_data_column_gloas_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/kzg"
 	mock "github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/peerdas"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filesystem"
 	dbtest "github.com/OffchainLabs/prysm/v7/beacon-chain/db/testing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/p2p"
 	p2ptest "github.com/OffchainLabs/prysm/v7/beacon-chain/p2p/testing"
@@ -29,6 +30,44 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	ssz "github.com/prysmaticlabs/fastssz"
 )
+
+func gloasFixture(t *testing.T) (*ethpb.DataColumnSidecarGloas, interfaces.ReadOnlySignedBeaconBlock) {
+	t.Helper()
+
+	roBlock, roSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, 1, util.WithSlot(1))
+	require.Equal(t, true, len(roSidecars) > 0)
+
+	base := roSidecars[0]
+	bid := util.GenerateTestSignedExecutionPayloadBid(base.Slot())
+	comms, err := roBlock.Block().Body().BlobKzgCommitments()
+	require.NoError(t, err)
+	bid.Message.BlobKzgCommitments = bytesutil.SafeCopy2dBytes(comms)
+
+	pb := util.NewBeaconBlockGloas()
+	pb.Block.Slot = base.Slot()
+	pb.Block.ProposerIndex = roBlock.Block().ProposerIndex()
+	parentRoot := roBlock.Block().ParentRoot()
+	pb.Block.ParentRoot = parentRoot[:]
+	stateRoot := roBlock.Block().StateRoot()
+	pb.Block.StateRoot = stateRoot[:]
+	pb.Block.Body.SignedExecutionPayloadBid = bid
+
+	signedBlock, err := blocks.NewSignedBeaconBlock(pb)
+	require.NoError(t, err)
+
+	blockRoot, err := signedBlock.Block().HashTreeRoot()
+	require.NoError(t, err)
+
+	sidecar := &ethpb.DataColumnSidecarGloas{
+		Index:           base.Index(),
+		Column:          bytesutil.SafeCopy2dBytes(base.Column()),
+		KzgProofs:       bytesutil.SafeCopy2dBytes(base.KzgProofs()),
+		Slot:            base.Slot(),
+		BeaconBlockRoot: blockRoot[:],
+	}
+
+	return sidecar, signedBlock
+}
 
 func TestValidateDataColumnGloas(t *testing.T) {
 	err := kzg.Start()
@@ -68,44 +107,6 @@ func TestValidateDataColumnGloas(t *testing.T) {
 
 		message := &pubsub.Message{Message: &pb.Message{Data: buf.Bytes(), Topic: &topic}}
 		return service, message
-	}
-
-	gloasFixture := func(t *testing.T) (*ethpb.DataColumnSidecarGloas, interfaces.ReadOnlySignedBeaconBlock) {
-		t.Helper()
-
-		roBlock, roSidecars, _ := util.GenerateTestFuluBlockWithSidecars(t, 1, util.WithSlot(1))
-		require.Equal(t, true, len(roSidecars) > 0)
-
-		base := roSidecars[0]
-		bid := util.GenerateTestSignedExecutionPayloadBid(base.Slot())
-		comms, err := roBlock.Block().Body().BlobKzgCommitments()
-		require.NoError(t, err)
-		bid.Message.BlobKzgCommitments = bytesutil.SafeCopy2dBytes(comms)
-
-		pb := util.NewBeaconBlockGloas()
-		pb.Block.Slot = base.Slot()
-		pb.Block.ProposerIndex = roBlock.Block().ProposerIndex()
-		parentRoot := roBlock.Block().ParentRoot()
-		pb.Block.ParentRoot = parentRoot[:]
-		stateRoot := roBlock.Block().StateRoot()
-		pb.Block.StateRoot = stateRoot[:]
-		pb.Block.Body.SignedExecutionPayloadBid = bid
-
-		signedBlock, err := blocks.NewSignedBeaconBlock(pb)
-		require.NoError(t, err)
-
-		blockRoot, err := signedBlock.Block().HashTreeRoot()
-		require.NoError(t, err)
-
-		sidecar := &ethpb.DataColumnSidecarGloas{
-			Index:           base.Index(),
-			Column:          bytesutil.SafeCopy2dBytes(base.Column()),
-			KzgProofs:       bytesutil.SafeCopy2dBytes(base.KzgProofs()),
-			Slot:            base.Slot(),
-			BeaconBlockRoot: blockRoot[:],
-		}
-
-		return sidecar, signedBlock
 	}
 
 	t.Run("ignores unseen block", func(t *testing.T) {
@@ -239,20 +240,17 @@ func TestPendingGloasColumns(t *testing.T) {
 		require.Equal(t, peer.ID("peer1"), s.pendingGloasColumns[root].columns[10].peer)
 	})
 
-	t.Run("stale entries ignored on process", func(t *testing.T) {
+	t.Run("nil block is no-op", func(t *testing.T) {
 		s := &Service{
 			cfg:                 &config{clock: clock},
 			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
 		}
-		staleRoot := [32]byte{0xcc}
-		currentSlot := clock.CurrentSlot()
-		if currentSlot == 0 {
-			t.Skip("cannot test at slot 0")
-		}
-		s.pendingGloasColumns[staleRoot] = &pendingGloasEntry{slot: currentSlot - 1}
+		root := [32]byte{0xcc}
+		s.pendingGloasColumns[root] = &pendingGloasEntry{slot: clock.CurrentSlot()}
 
-		s.processPendingGloasColumns(t.Context(), staleRoot, nil)
-		require.Equal(t, false, s.hasPendingGloasColumns(staleRoot))
+		s.processPendingGloasColumns(root, nil)
+		// Entry should remain because the block was nil.
+		require.Equal(t, true, s.hasPendingGloasColumns(root))
 	})
 
 	t.Run("index out of bounds rejected", func(t *testing.T) {
@@ -273,5 +271,187 @@ func TestPendingGloasColumns(t *testing.T) {
 
 		s.queuePendingGloasColumn(roCol, "peer1")
 		require.Equal(t, false, s.hasPendingGloasColumns(root))
+	})
+
+	t.Run("map capped at maxPendingGloasRoots", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		// Fill up to the cap.
+		for i := range maxPendingGloasRoots {
+			root := [32]byte{byte(i)}
+			dc := &ethpb.DataColumnSidecarGloas{
+				Index:           0,
+				Slot:            clock.CurrentSlot(),
+				BeaconBlockRoot: root[:],
+				Column:          [][]byte{make([]byte, 2048)},
+				KzgProofs:       [][]byte{make([]byte, 48)},
+			}
+			roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, root)
+			require.NoError(t, err)
+			s.queuePendingGloasColumn(roCol, "peer1")
+		}
+		require.Equal(t, maxPendingGloasRoots, len(s.pendingGloasColumns))
+
+		// One more should be dropped.
+		overflowRoot := [32]byte{0xff}
+		dc := &ethpb.DataColumnSidecarGloas{
+			Index:           0,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: overflowRoot[:],
+			Column:          [][]byte{make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+		}
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(dc, overflowRoot)
+		require.NoError(t, err)
+		s.queuePendingGloasColumn(roCol, "peer1")
+		require.Equal(t, false, s.hasPendingGloasColumns(overflowRoot))
+
+		// Adding to an existing root should still work.
+		existingRoot := [32]byte{0x00}
+		dc2 := &ethpb.DataColumnSidecarGloas{
+			Index:           1,
+			Slot:            clock.CurrentSlot(),
+			BeaconBlockRoot: existingRoot[:],
+			Column:          [][]byte{make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+		}
+		roCol2, err := blocks.NewRODataColumnGloasWithRoot(dc2, existingRoot)
+		require.NoError(t, err)
+		s.queuePendingGloasColumn(roCol2, "peer1")
+		require.NotNil(t, s.pendingGloasColumns[existingRoot].columns[1])
+	})
+
+	t.Run("process verifies and saves valid columns", func(t *testing.T) {
+		err := kzg.Start()
+		require.NoError(t, err)
+
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		p := p2ptest.NewTestP2P(t)
+		dcs := filesystem.NewEphemeralDataColumnStorage(t)
+
+		sidecar, signedBlock := gloasFixture(t)
+		blockRoot, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+
+		s := &Service{
+			cfg: &config{
+				p2p:               p,
+				clock:             clock,
+				dataColumnStorage: dcs,
+			},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+		}
+
+		// Queue the sidecar.
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+		require.NoError(t, err)
+		s.queuePendingGloasColumn(roCol, "peer1")
+		require.Equal(t, true, s.hasPendingGloasColumns(blockRoot))
+
+		// Process with the block.
+		s.processPendingGloasColumns(blockRoot, signedBlock)
+		require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
+
+		// Column should be marked as seen.
+		require.Equal(t, true, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+	})
+
+	t.Run("process downscores bad peer for slot mismatch", func(t *testing.T) {
+		err := kzg.Start()
+		require.NoError(t, err)
+
+		params.SetupTestConfigCleanup(t)
+		cfg := params.BeaconConfig()
+		cfg.FuluForkEpoch = 0
+		cfg.GloasForkEpoch = 0
+		params.OverrideBeaconConfig(cfg)
+
+		p := p2ptest.NewTestP2P(t)
+		dcs := filesystem.NewEphemeralDataColumnStorage(t)
+
+		sidecar, signedBlock := gloasFixture(t)
+		blockRoot, err := signedBlock.Block().HashTreeRoot()
+		require.NoError(t, err)
+
+		// Mismatch the slot.
+		sidecar.Slot = sidecar.Slot + 10
+
+		s := &Service{
+			cfg: &config{
+				p2p:               p,
+				clock:             clock,
+				dataColumnStorage: dcs,
+			},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+		}
+
+		roCol, err := blocks.NewRODataColumnGloasWithRoot(sidecar, blockRoot)
+		require.NoError(t, err)
+		s.queuePendingGloasColumn(roCol, "badpeer")
+
+		s.processPendingGloasColumns(blockRoot, signedBlock)
+		require.Equal(t, false, s.hasPendingGloasColumns(blockRoot))
+		// Column should NOT be marked as seen (it was invalid).
+		require.Equal(t, false, s.hasSeenDataColumnRootIndex(blockRoot, sidecar.Index))
+	})
+
+	t.Run("no entry is no-op", func(t *testing.T) {
+		p := p2ptest.NewTestP2P(t)
+		s := &Service{
+			cfg: &config{
+				p2p:   p,
+				clock: clock,
+			},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+			seenDataColumnCache: newSlotAwareCache(seenDataColumnSize),
+		}
+		root := [32]byte{0xdd}
+		pb := util.NewBeaconBlockGloas()
+		blk, err := blocks.NewSignedBeaconBlock(pb)
+		require.NoError(t, err)
+		// Should not panic.
+		s.processPendingGloasColumns(root, blk)
+	})
+
+	t.Run("prune keeps current and next slot", func(t *testing.T) {
+		s := &Service{
+			cfg:                 &config{clock: clock},
+			pendingGloasColumns: make(map[[32]byte]*pendingGloasEntry),
+		}
+		currentSlot := clock.CurrentSlot()
+		if currentSlot < 3 {
+			t.Skip("need slot >= 3")
+		}
+
+		staleRoot := [32]byte{0x01}
+		currentRoot := [32]byte{0x02}
+		prevRoot := [32]byte{0x03}
+
+		s.pendingGloasColumns[staleRoot] = &pendingGloasEntry{slot: currentSlot - 3}
+		s.pendingGloasColumns[currentRoot] = &pendingGloasEntry{slot: currentSlot}
+		s.pendingGloasColumns[prevRoot] = &pendingGloasEntry{slot: currentSlot - 1}
+
+		// Simulate what the ticker does.
+		s.pendingGloasColumnsLock.Lock()
+		for r, e := range s.pendingGloasColumns {
+			if e.slot+1 < currentSlot {
+				delete(s.pendingGloasColumns, r)
+			}
+		}
+		s.pendingGloasColumnsLock.Unlock()
+
+		// Stale should be pruned, current and prev should remain.
+		require.Equal(t, false, s.hasPendingGloasColumns(staleRoot))
+		require.Equal(t, true, s.hasPendingGloasColumns(currentRoot))
+		require.Equal(t, true, s.hasPendingGloasColumns(prevRoot))
 	})
 }

--- a/beacon-chain/verification/data_column_gloas.go
+++ b/beacon-chain/verification/data_column_gloas.go
@@ -21,6 +21,13 @@ var GossipDataColumnSidecarRequirementsGloas = []Requirement{
 	RequireNotSeenGloas,
 }
 
+// PendingGloasColumnRequirements defines the requirements for columns queued before their block arrived.
+var PendingGloasColumnRequirements = []Requirement{
+	RequireSlotMatchesBlockGloas,
+	RequireValidFieldsGloas,
+	RequireSidecarKzgProofVerifiedGloas,
+}
+
 type ROGloasDataColumnVerifier struct {
 	sidecar blocks.RODataColumn
 	block   interfaces.ReadOnlyBeaconBlock

--- a/changelog/terence_gloas-pending-columns-queue.md
+++ b/changelog/terence_gloas-pending-columns-queue.md
@@ -1,0 +1,3 @@
+### Added
+
+- Queue Gloas data column sidecars that arrive before their block for deferred validation, with per-index deduplication, slot-based pruning, and peer downscoring on verification failure.


### PR DESCRIPTION
In Gloas, data column sidecars can arrive via gossip before the block here is to queue instead of dropping and re-request later

### Design notes
  - Subnet is verified before queuing (reject bad subnet immediately)
  - Columns are stored in a fixed-size `[128]` array per block root, indexed by column index — duplicates for the same index are ignored
  - When the block arrives (via `beaconBlockSubscriber` or `processPendingBlocks`), queued columns are verified against the block's bid commitments and saved to storage
  - Peers that sent columns failing verification (slot mismatch, invalid sidecar, bad KZG proof) are downscored (PeerID is tracked)
  - A slot ticker prunes entries from past slots every slot boundary 
  - RPC column fetch is skipped for blocks that already have pending gossip columns
  - Each Gloas sidecar is ~44 KB at 21 max blobs (21 cells × 2048 bytes + proofs). 128 columns per block = ~5.5 MB per block root. The slot ticker ensures at most one slot's worth of pending roots exist at any time.
