### PR TITLE
consensus-types: add ParentBlockHash getter and ParentExecutionRequests interface

### DIFF
--- a/consensus-types/blocks/execution_payload_envelope.go
+++ b/consensus-types/blocks/execution_payload_envelope.go
@@ -60,9 +60,6 @@ func (s signedExecutionPayloadEnvelope) IsNil() bool {
 	if len(s.s.Message.BeaconBlockRoot) != field_params.RootLength {
 		return true
 	}
-	if len(s.s.Message.StateRoot) != field_params.RootLength {
-		return true
-	}
 	if s.s.Message.ExecutionRequests == nil {
 		return true
 	}
@@ -127,11 +124,6 @@ func (p *executionPayloadEnvelope) Slot() primitives.Slot {
 	return p.p.Slot
 }
 
-// StateRoot returns the state root carried by the envelope.
-func (p *executionPayloadEnvelope) StateRoot() [field_params.RootLength]byte {
-	return [field_params.RootLength]byte(p.p.StateRoot)
-}
-
 // BlockHash returns the block hash from the execution payload.
 func (p *executionPayloadEnvelope) BlockHash() [field_params.RootLength]byte {
 	return [field_params.RootLength]byte(p.p.Payload.BlockHash)
@@ -181,10 +173,6 @@ func (p *blindedExecutionPayloadEnvelope) BeaconBlockRoot() [field_params.RootLe
 
 func (p *blindedExecutionPayloadEnvelope) Slot() primitives.Slot {
 	return p.p.Slot
-}
-
-func (p *blindedExecutionPayloadEnvelope) StateRoot() [field_params.RootLength]byte {
-	return [field_params.RootLength]byte(p.p.StateRoot)
 }
 
 func (p *blindedExecutionPayloadEnvelope) BlockHash() [field_params.RootLength]byte {

--- a/consensus-types/blocks/execution_payload_envelope_test.go
+++ b/consensus-types/blocks/execution_payload_envelope_test.go
@@ -48,7 +48,6 @@ func validExecutionPayloadEnvelope() *ethpb.ExecutionPayloadEnvelope {
 		BuilderIndex:    10,
 		BeaconBlockRoot: bytes.Repeat([]byte{0xAA}, 32),
 		Slot:            9,
-		StateRoot:       bytes.Repeat([]byte{0xBB}, 32),
 	}
 }
 
@@ -75,7 +74,6 @@ func TestWrappedROExecutionPayloadEnvelope(t *testing.T) {
 		require.Equal(t, primitives.BuilderIndex(10), wrapped.BuilderIndex())
 		require.Equal(t, primitives.Slot(9), wrapped.Slot())
 		assert.DeepEqual(t, [32]byte(bytes.Repeat([]byte{0xAA}, 32)), wrapped.BeaconBlockRoot())
-		assert.DeepEqual(t, [32]byte(bytes.Repeat([]byte{0xBB}, 32)), wrapped.StateRoot())
 
 		reqs := wrapped.ExecutionRequests()
 		require.NotNil(t, reqs)

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -1303,6 +1303,14 @@ func (b *BeaconBlockBody) SignedExecutionPayloadBid() (*eth.SignedExecutionPaylo
 	return nil, consensus_types.ErrNotSupported("SignedExecutionPayloadBid", b.version)
 }
 
+// ParentExecutionRequests returns the parent's deferred execution requests.
+func (b *BeaconBlockBody) ParentExecutionRequests() (*enginev1.ExecutionRequests, error) {
+	if b.version >= version.Gloas {
+		return b.parentExecutionRequests, nil
+	}
+	return nil, consensus_types.ErrNotSupported("ParentExecutionRequests", b.version)
+}
+
 // Version returns the version of the beacon block body
 func (b *BeaconBlockBody) Version() int {
 	return b.version

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -678,15 +678,17 @@ func hydrateBeaconBlockBodyGloas() *eth.BeaconBlockBodyGloas {
 		},
 		SignedExecutionPayloadBid: &eth.SignedExecutionPayloadBid{
 			Message: &eth.ExecutionPayloadBid{
-				ParentBlockHash:    make([]byte, fieldparams.RootLength),
-				ParentBlockRoot:    make([]byte, fieldparams.RootLength),
-				BlockHash:          make([]byte, fieldparams.RootLength),
-				PrevRandao:         make([]byte, fieldparams.RootLength),
-				FeeRecipient:       make([]byte, 20),
-				BlobKzgCommitments: [][]byte{make([]byte, fieldparams.BLSPubkeyLength)},
+				ParentBlockHash:       make([]byte, fieldparams.RootLength),
+				ParentBlockRoot:       make([]byte, fieldparams.RootLength),
+				BlockHash:             make([]byte, fieldparams.RootLength),
+				PrevRandao:            make([]byte, fieldparams.RootLength),
+				FeeRecipient:          make([]byte, 20),
+				BlobKzgCommitments:    [][]byte{make([]byte, fieldparams.BLSPubkeyLength)},
+				ExecutionRequestsRoot: make([]byte, fieldparams.RootLength),
 			},
 			Signature: make([]byte, fieldparams.BLSSignatureLength),
 		},
+		ParentExecutionRequests: &pb.ExecutionRequests{},
 		PayloadAttestations: []*eth.PayloadAttestation{
 			{
 				AggregationBits: bits,

--- a/consensus-types/blocks/proto.go
+++ b/consensus-types/blocks/proto.go
@@ -711,6 +711,7 @@ func (b *BeaconBlockBody) Proto() (proto.Message, error) {
 			BlsToExecutionChanges:     b.blsToExecutionChanges,
 			SignedExecutionPayloadBid: b.signedExecutionPayloadBid,
 			PayloadAttestations:       b.payloadAttestations,
+			ParentExecutionRequests:   b.parentExecutionRequests,
 		}, nil
 	default:
 		return nil, errors.New("unsupported beacon block body version")
@@ -1568,6 +1569,10 @@ func initBlockBodyFromProtoGloas(pb *eth.BeaconBlockBodyGloas) (*BeaconBlockBody
 		return nil, errNilBlockBody
 	}
 
+	per := pb.ParentExecutionRequests
+	if per == nil {
+		per = &enginev1.ExecutionRequests{}
+	}
 	b := &BeaconBlockBody{
 		version:                   version.Gloas,
 		randaoReveal:              bytesutil.ToBytes96(pb.RandaoReveal),
@@ -1582,6 +1587,7 @@ func initBlockBodyFromProtoGloas(pb *eth.BeaconBlockBodyGloas) (*BeaconBlockBody
 		blsToExecutionChanges:     pb.BlsToExecutionChanges,
 		signedExecutionPayloadBid: pb.SignedExecutionPayloadBid,
 		payloadAttestations:       pb.PayloadAttestations,
+		parentExecutionRequests:   per,
 	}
 	return b, nil
 }

--- a/consensus-types/blocks/setters.go
+++ b/consensus-types/blocks/setters.go
@@ -192,6 +192,15 @@ func (b *SignedBeaconBlock) SetPayloadAttestations(pa []*eth.PayloadAttestation)
 	return nil
 }
 
+// SetParentExecutionRequests sets the parent execution requests in the block.
+func (b *SignedBeaconBlock) SetParentExecutionRequests(r *enginev1.ExecutionRequests) error {
+	if b.version < version.Gloas {
+		return consensus_types.ErrNotSupported("SetParentExecutionRequests", b.version)
+	}
+	b.block.body.parentExecutionRequests = r
+	return nil
+}
+
 // SetSignedExecutionPayloadBid sets the signed execution payload header in the block.
 func (b *SignedBeaconBlock) SetSignedExecutionPayloadBid(header *eth.SignedExecutionPayloadBid) error {
 	if b.version < version.Gloas {

--- a/consensus-types/blocks/signed_execution_bid.go
+++ b/consensus-types/blocks/signed_execution_bid.go
@@ -151,3 +151,11 @@ func (h executionPayloadBidGloas) BlobKzgCommitmentCount() uint64 {
 func (h executionPayloadBidGloas) FeeRecipient() [20]byte {
 	return [20]byte(h.payload.FeeRecipient)
 }
+
+// ExecutionRequestsRoot returns the hash tree root of the execution requests.
+func (h executionPayloadBidGloas) ExecutionRequestsRoot() [32]byte {
+	if len(h.payload.ExecutionRequestsRoot) < 32 {
+		return [32]byte{}
+	}
+	return [32]byte(h.payload.ExecutionRequestsRoot)
+}

--- a/consensus-types/blocks/signed_execution_bid_test.go
+++ b/consensus-types/blocks/signed_execution_bid_test.go
@@ -15,17 +15,18 @@ import (
 
 func validExecutionPayloadBid() *ethpb.ExecutionPayloadBid {
 	return &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    bytes.Repeat([]byte{0x01}, 32),
-		ParentBlockRoot:    bytes.Repeat([]byte{0x02}, 32),
-		BlockHash:          bytes.Repeat([]byte{0x03}, 32),
-		PrevRandao:         bytes.Repeat([]byte{0x04}, 32),
-		GasLimit:           123,
-		BuilderIndex:       5,
-		Slot:               6,
-		Value:              7,
-		ExecutionPayment:   8,
-		BlobKzgCommitments: [][]byte{bytes.Repeat([]byte{0x05}, 48)},
-		FeeRecipient:       bytes.Repeat([]byte{0x06}, 20),
+		ParentBlockHash:       bytes.Repeat([]byte{0x01}, 32),
+		ParentBlockRoot:       bytes.Repeat([]byte{0x02}, 32),
+		BlockHash:             bytes.Repeat([]byte{0x03}, 32),
+		PrevRandao:            bytes.Repeat([]byte{0x04}, 32),
+		GasLimit:              123,
+		BuilderIndex:          5,
+		Slot:                  6,
+		Value:                 7,
+		ExecutionPayment:      8,
+		BlobKzgCommitments:    [][]byte{bytes.Repeat([]byte{0x05}, 48)},
+		FeeRecipient:          bytes.Repeat([]byte{0x06}, 20),
+		ExecutionRequestsRoot: bytes.Repeat([]byte{0x07}, 32),
 	}
 }
 

--- a/consensus-types/blocks/types.go
+++ b/consensus-types/blocks/types.go
@@ -59,6 +59,7 @@ type BeaconBlockBody struct {
 	executionRequests         *enginev1.ExecutionRequests
 	signedExecutionPayloadBid *eth.SignedExecutionPayloadBid
 	payloadAttestations       []*eth.PayloadAttestation
+	parentExecutionRequests   *enginev1.ExecutionRequests
 }
 
 var _ interfaces.ReadOnlyBeaconBlockBody = &BeaconBlockBody{}

--- a/consensus-types/interfaces/beacon_block.go
+++ b/consensus-types/interfaces/beacon_block.go
@@ -71,6 +71,7 @@ type ReadOnlyBeaconBlockBody interface {
 	ExecutionRequests() (*enginev1.ExecutionRequests, error)
 	PayloadAttestations() ([]*ethpb.PayloadAttestation, error)
 	SignedExecutionPayloadBid() (*ethpb.SignedExecutionPayloadBid, error)
+	ParentExecutionRequests() (*enginev1.ExecutionRequests, error)
 }
 
 type SignedBeaconBlock interface {
@@ -95,6 +96,7 @@ type SignedBeaconBlock interface {
 	SetExecutionRequests(er *enginev1.ExecutionRequests) error
 	SetPayloadAttestations(pa []*ethpb.PayloadAttestation) error
 	SetSignedExecutionPayloadBid(header *ethpb.SignedExecutionPayloadBid) error
+	SetParentExecutionRequests(r *enginev1.ExecutionRequests) error
 	Unblind(e ExecutionData) error
 }
 

--- a/consensus-types/interfaces/execution_payload_envelope.go
+++ b/consensus-types/interfaces/execution_payload_envelope.go
@@ -22,7 +22,6 @@ type ROBlindedExecutionPayloadEnvelope interface {
 	BuilderIndex() primitives.BuilderIndex
 	BeaconBlockRoot() [field_params.RootLength]byte
 	Slot() primitives.Slot
-	StateRoot() [field_params.RootLength]byte
 	BlockHash() [field_params.RootLength]byte
 	IsBlinded() bool
 	IsNil() bool

--- a/consensus-types/interfaces/signed_execution_payload_bid.go
+++ b/consensus-types/interfaces/signed_execution_payload_bid.go
@@ -25,5 +25,6 @@ type ROExecutionPayloadBid interface {
 	BlobKzgCommitments() [][]byte
 	BlobKzgCommitmentCount() uint64
 	FeeRecipient() [20]byte
+	ExecutionRequestsRoot() [32]byte
 	IsNil() bool
 }

--- a/consensus-types/mock/block.go
+++ b/consensus-types/mock/block.go
@@ -284,6 +284,10 @@ func (b *BeaconBlockBody) SignedExecutionPayloadBid() (*eth.SignedExecutionPaylo
 	panic("implement me")
 }
 
+func (b *BeaconBlockBody) ParentExecutionRequests() (*enginev1.ExecutionRequests, error) {
+	panic("implement me")
+}
+
 func (b *BeaconBlockBody) Attestations() []eth.Att {
 	panic("implement me")
 }


### PR DESCRIPTION
## Summary
Part 3/10 of deferred payload processing (consensus-specs#5094).

## Stack

1. # 
2. #16661 proto: add parent_block_hash and execution_requests_root to bid
3. **#16662 consensus-types: add ParentBlockHash getter and ParentExecutionRequests interface** ← you are here
4. #16663 state: add QueueBuilderPaymentForSlot and update stategen
5. #16664 core/transition: remove ProcessSlotsForBlock
6. #16665 core/gloas: add ProcessParentExecutionPayload
7. #16666 blockchain: update block processing and FCU for deferred payload
8. #16667 sync: update validation for deferred processing
9. #16668 rpc: update proposer for deferred payload processing
10. #16669 db/verification: cleanup for deferred processing