### PR TITLE
state: add QueueBuilderPaymentForSlot and update stategen for deferred processing

### DIFF
--- a/beacon-chain/state/interfaces_gloas.go
+++ b/beacon-chain/state/interfaces_gloas.go
@@ -18,6 +18,7 @@ type writeOnlyGloasFields interface {
 	SetBuilderPendingPayment(index primitives.Slot, payment *ethpb.BuilderPendingPayment) error
 	ClearBuilderPendingPayment(index primitives.Slot) error
 	QueueBuilderPayment() error
+	QueueBuilderPaymentForSlot(parentSlot primitives.Slot) error
 	RotateBuilderPendingPayments() error
 	AppendBuilderPendingWithdrawals([]*ethpb.BuilderPendingWithdrawal) error
 

--- a/beacon-chain/state/state-native/setters_gloas.go
+++ b/beacon-chain/state/state-native/setters_gloas.go
@@ -91,18 +91,20 @@ func (b *BeaconState) SetExecutionPayloadBid(h interfaces.ROExecutionPayloadBid)
 	randao := h.PrevRandao()
 	blobKzgCommitments := h.BlobKzgCommitments()
 	feeRecipient := h.FeeRecipient()
+	executionRequestsRoot := h.ExecutionRequestsRoot()
 	b.latestExecutionPayloadBid = &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    parentBlockHash[:],
-		ParentBlockRoot:    parentBlockRoot[:],
-		BlockHash:          blockHash[:],
-		PrevRandao:         randao[:],
-		GasLimit:           h.GasLimit(),
-		BuilderIndex:       h.BuilderIndex(),
-		Slot:               h.Slot(),
-		Value:              h.Value(),
-		ExecutionPayment:   h.ExecutionPayment(),
-		BlobKzgCommitments: blobKzgCommitments,
-		FeeRecipient:       feeRecipient[:],
+		ParentBlockHash:       parentBlockHash[:],
+		ParentBlockRoot:       parentBlockRoot[:],
+		BlockHash:             blockHash[:],
+		PrevRandao:            randao[:],
+		GasLimit:              h.GasLimit(),
+		BuilderIndex:          h.BuilderIndex(),
+		Slot:                  h.Slot(),
+		Value:                 h.Value(),
+		ExecutionPayment:      h.ExecutionPayment(),
+		BlobKzgCommitments:    blobKzgCommitments,
+		FeeRecipient:          feeRecipient[:],
+		ExecutionRequestsRoot: executionRequestsRoot[:],
 	}
 	b.markFieldAsDirty(types.LatestExecutionPayloadBid)
 
@@ -141,13 +143,37 @@ func (b *BeaconState) QueueBuilderPayment() error {
 	if b.version < version.Gloas {
 		return errNotSupported("QueueBuilderPayment", b.version)
 	}
+	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
+	paymentIndex := slotsPerEpoch + (b.slot % slotsPerEpoch)
+	return b.queueBuilderPaymentAtIndex(paymentIndex)
+}
 
+// QueueBuilderPaymentForSlot queues the builder payment at the epoch-relative
+// index for the given slot. Used by process_parent_execution_payload to clear
+// the parent slot's payment entry.
+func (b *BeaconState) QueueBuilderPaymentForSlot(parentSlot primitives.Slot) error {
+	if b.version < version.Gloas {
+		return errNotSupported("QueueBuilderPaymentForSlot", b.version)
+	}
+	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
+	currentEpoch := slots.ToEpoch(b.slot)
+	parentEpoch := slots.ToEpoch(parentSlot)
+
+	var paymentIndex primitives.Slot
+	if parentEpoch == currentEpoch {
+		paymentIndex = slotsPerEpoch + (parentSlot % slotsPerEpoch)
+	} else if parentEpoch+1 == currentEpoch {
+		paymentIndex = parentSlot % slotsPerEpoch
+	} else {
+		return nil
+	}
+	return b.queueBuilderPaymentAtIndex(paymentIndex)
+}
+
+func (b *BeaconState) queueBuilderPaymentAtIndex(paymentIndex primitives.Slot) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	slot := b.slot
-	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
-	paymentIndex := slotsPerEpoch + (slot % slotsPerEpoch)
 	if uint64(paymentIndex) >= uint64(len(b.builderPendingPayments)) {
 		return fmt.Errorf("builder pending payments index %d out of range (len=%d)", paymentIndex, len(b.builderPendingPayments))
 	}

--- a/beacon-chain/state/state-native/setters_gloas_test.go
+++ b/beacon-chain/state/state-native/setters_gloas_test.go
@@ -49,8 +49,9 @@ func (t testExecutionPayloadBid) BlobKzgCommitments() [][]byte { return t.blobKz
 func (t testExecutionPayloadBid) BlobKzgCommitmentCount() uint64 {
 	return uint64(len(t.blobKzgCommitments))
 }
-func (t testExecutionPayloadBid) FeeRecipient() [20]byte { return t.feeRecipient }
-func (t testExecutionPayloadBid) IsNil() bool            { return false }
+func (t testExecutionPayloadBid) FeeRecipient() [20]byte          { return t.feeRecipient }
+func (t testExecutionPayloadBid) ExecutionRequestsRoot() [32]byte { return [32]byte{} }
+func (t testExecutionPayloadBid) IsNil() bool                     { return false }
 
 func TestSetExecutionPayloadBid(t *testing.T) {
 	t.Run("previous fork returns expected error", func(t *testing.T) {

--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
     importpath = "github.com/OffchainLabs/prysm/v7/beacon-chain/state/stategen",
     visibility = ["//visibility:public"],
     deps = [
-        "//beacon-chain/core/gloas:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/core/transition:go_default_library",

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -5,7 +5,6 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/helpers"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/time"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db"
@@ -239,21 +238,9 @@ func (s *State) loadStateByBlockHash(ctx context.Context, blockHash [32]byte, sl
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not load state by resolved beacon block root %#x for execution block hash %#x", blockRoot, blockHash)
 	}
-	blk, err := s.beaconDB.Block(ctx, blockRoot)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not load block by resolved beacon block root %#x for execution block hash %#x", blockRoot, blockHash)
-	}
-	signedEnvelope, err := s.beaconDB.ExecutionPayloadEnvelope(ctx, blockRoot)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not retrieve execution payload envelope for block with root %#x at slot %d", blockRoot, slot)
-	}
-	envelope, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(signedEnvelope.GetMessage())
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not wrap blinded execution payload envelope for block with root %#x at slot %d", blockRoot, slot)
-	}
-	if err := gloas.ProcessBlindedExecutionPayload(ctx, blockState, blk.Block().StateRoot(), envelope); err != nil {
-		return nil, errors.Wrapf(err, "could not apply execution payload envelope for block with root %#x at slot %d", blockRoot, slot)
-	}
+	// With deferred payload processing, state mutations from the execution
+	// payload are applied by ProcessParentExecutionPayload in the next block's
+	// state transition. No separate envelope processing needed here.
 	return blockState, nil
 }
 

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -1,12 +1,10 @@
 package stategen
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"time"
 
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/db/filters"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
@@ -14,7 +12,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
-	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -42,14 +39,7 @@ func (s *State) replayBlocks(
 	// For Gloas states: if the first replay block's bid parentBlockHash doesn't
 	// match the ancestor state's latestBlockHash, the ancestor block's execution
 	// payload was delivered but the state is post-CL (EL not yet applied). Apply
-	// the ancestor's envelope to bring the state to post-EL before replaying.
-	if len(signed) > 0 && state.Version() >= version.Gloas && signed[0].Block().Version() >= version.Gloas {
-		if err := s.maybeApplyAncestorEnvelope(ctx, state, signed[0]); err != nil {
-			return nil, errors.Wrap(err, "could not apply ancestor execution payload envelope")
-		}
-	}
-
-	for i, blk := range signed {
+	for _, blk := range signed {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
@@ -62,43 +52,9 @@ func (s *State) replayBlocks(
 			continue
 		}
 
-		var envelope *ethpb.SignedBlindedExecutionPayloadEnvelope
-		if i < len(signed)-1 && blk.Block().Version() >= version.Gloas {
-			bid, err := blk.Block().Body().SignedExecutionPayloadBid()
-			if err != nil {
-				return nil, errors.Wrapf(err, "could not get execution payload bid for block at slot %d", blk.Block().Slot())
-			}
-			if bid == nil || bid.Message == nil {
-				return nil, fmt.Errorf("missing execution payload bid for block at slot %d", blk.Block().Slot())
-			}
-			child := signed[i+1].Block()
-			childBid, err := child.Body().SignedExecutionPayloadBid()
-			if err != nil {
-				return nil, errors.Wrapf(err, "could not get execution payload bid for block at slot %d", child.Slot())
-			}
-			if childBid == nil || childBid.Message == nil {
-				return nil, fmt.Errorf("missing execution payload bid for block at slot %d", child.Slot())
-			}
-			if bytes.Equal(childBid.Message.ParentBlockHash, bid.Message.BlockHash) {
-				root := child.ParentRoot()
-				envelope, err = s.beaconDB.ExecutionPayloadEnvelope(ctx, root)
-				if err != nil {
-					return nil, errors.Wrapf(err, "could not retrieve execution payload envelope for block with root %#x at slot %d", root, slot)
-				}
-			}
-		}
 		state, err = executeStateTransitionStateGen(ctx, state, blk)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not execute state transition for block at slot %d", slot)
-		}
-		if envelope != nil && envelope.Message != nil {
-			wrappedEnvelope, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(envelope.Message)
-			if err != nil {
-				return nil, errors.Wrapf(err, "could not wrap blinded execution payload envelope for block at slot %d", slot)
-			}
-			if err := gloas.ProcessBlindedExecutionPayload(ctx, state, blk.Block().StateRoot(), wrappedEnvelope); err != nil {
-				return nil, errors.Wrapf(err, "could not apply execution payload envelope for block at slot %d", slot)
-			}
 		}
 	}
 
@@ -113,49 +69,6 @@ func (s *State) replayBlocks(
 }
 
 // maybeApplyAncestorEnvelope checks whether the ancestor state needs its
-// execution payload envelope applied before block replay can proceed. This is
-// needed when the ancestor state is post-CL (latestBlockHash not yet updated
-// with the delivered payload). The check compares the first replay block's bid
-// parentBlockHash with the state's latestBlockHash: a mismatch means the
-// ancestor's payload was delivered but the state doesn't reflect it.
-func (s *State) maybeApplyAncestorEnvelope(
-	ctx context.Context,
-	st state.BeaconState,
-	firstBlock interfaces.ReadOnlySignedBeaconBlock,
-) error {
-	firstBid, err := firstBlock.Block().Body().SignedExecutionPayloadBid()
-	if err != nil || firstBid == nil || firstBid.Message == nil {
-		return nil
-	}
-	latestHash, err := st.LatestBlockHash()
-	if err != nil {
-		return err
-	}
-	if bytes.Equal(firstBid.Message.ParentBlockHash, latestHash[:]) {
-		return nil
-	}
-	// The first block expects a different latestBlockHash than what the state
-	// has: the ancestor's execution payload was delivered but the state is
-	// post-CL. Apply the ancestor's envelope.
-	ancestorRoot := firstBlock.Block().ParentRoot()
-	envelope, err := s.beaconDB.ExecutionPayloadEnvelope(ctx, ancestorRoot)
-	if err != nil {
-		return errors.Wrapf(err, "could not retrieve execution payload envelope for ancestor root %#x", ancestorRoot)
-	}
-	if envelope == nil || envelope.Message == nil {
-		return errors.Errorf("Received nil execution payload envelope for ancestor root %#x", ancestorRoot)
-	}
-	ancestorBlock, err := s.beaconDB.Block(ctx, ancestorRoot)
-	if err != nil {
-		return errors.Wrapf(err, "could not retrieve ancestor block for root %#x", ancestorRoot)
-	}
-	wrappedEnvelope, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(envelope.Message)
-	if err != nil {
-		return errors.Wrap(err, "could not wrap ancestor blinded execution payload envelope")
-	}
-	return gloas.ProcessBlindedExecutionPayload(ctx, st, ancestorBlock.Block().StateRoot(), wrappedEnvelope)
-}
-
 // loadBlocks loads the blocks between start slot and end slot by recursively fetching from end block root.
 // The Blocks are returned in slot-descending order.
 func (s *State) loadBlocks(ctx context.Context, startSlot, endSlot primitives.Slot, endBlockRoot [32]byte) ([]interfaces.ReadOnlySignedBeaconBlock, error) {

--- a/beacon-chain/state/stategen/replayer.go
+++ b/beacon-chain/state/stategen/replayer.go
@@ -5,15 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/db"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
-	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
-	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -112,7 +108,7 @@ func (rs *stateReplayer) ReplayBlocks(ctx context.Context) (state.BeaconState, e
 		"diff":      diff,
 	}).Debug("Replaying canonical blocks from most recent state")
 
-	for i, b := range descendants {
+	for _, b := range descendants {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
@@ -122,29 +118,6 @@ func (rs *stateReplayer) ReplayBlocks(ctx context.Context) (state.BeaconState, e
 			return nil, errors.Wrap(err, "could not execute state transition")
 		}
 
-		// Apply the envelope for all blocks except the last one.
-		// The caller is responsible for applying the envelope on the last block if needed.
-		if i < len(descendants)-1 && b.Version() >= version.Gloas {
-			if p, ok := rs.chainer.(executionPayloadEnvelopeProvider); ok {
-				root, err := b.Block().HashTreeRoot()
-				if err != nil {
-					return nil, errors.Wrap(err, "could not compute block root for execution payload envelope lookup")
-				}
-				signedEnvelope, err := p.executionPayloadEnvelope(ctx, root)
-				if err != nil && !errors.Is(err, db.ErrNotFound) {
-					return nil, errors.Wrap(err, "could not retrieve execution payload envelope")
-				}
-				if signedEnvelope != nil && signedEnvelope.Message != nil {
-					envelope, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(signedEnvelope.Message)
-					if err != nil {
-						return nil, errors.Wrap(err, "could not wrap blinded execution payload envelope")
-					}
-					if err := gloas.ProcessBlindedExecutionPayload(ctx, s, b.Block().StateRoot(), envelope); err != nil {
-						return nil, errors.Wrap(err, "could not apply execution payload envelope")
-					}
-				}
-			}
-		}
 	}
 	if rs.target > s.Slot() {
 		s, err = ReplayProcessSlots(ctx, s, rs.target)


### PR DESCRIPTION
## Summary
Part 4/10 of deferred payload processing (consensus-specs#5094).

## Stack

1. # 
2. #16661 proto: add parent_block_hash and execution_requests_root to bid
3. #16662 consensus-types: add ParentBlockHash getter and ParentExecutionRequests interface
4. **#16663 state: add QueueBuilderPaymentForSlot and update stategen** ← you are here
5. #16664 core/transition: remove ProcessSlotsForBlock
6. #16665 core/gloas: add ProcessParentExecutionPayload
7. #16666 blockchain: update block processing and FCU for deferred payload
8. #16667 sync: update validation for deferred processing
9. #16668 rpc: update proposer for deferred payload processing
10. #16669 db/verification: cleanup for deferred processing