### PR TITLE
core/transition: remove ProcessSlotsForBlock, use ProcessSlotsUsingNextSlotCache directly

### DIFF
--- a/beacon-chain/core/transition/gloas.go
+++ b/beacon-chain/core/transition/gloas.go
@@ -14,33 +14,8 @@ import (
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/monitoring/tracing/trace"
-	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/pkg/errors"
 )
-
-// ProcessSlotsForBlock advances the given state to the slot of the given block.
-// This function assumes that the parent state is the latest state that has been processed before the given block.
-// In particular, all that it is needed to get the blocks's prestate is to advance slots and possible epoch transitions.
-func ProcessSlotsForBlock(
-	ctx context.Context,
-	st state.BeaconState,
-	b interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
-	accessRoot := b.ParentRoot()
-	if st.Version() < version.Gloas {
-		return ProcessSlotsUsingNextSlotCache(ctx, st, accessRoot[:], b.Slot())
-	}
-	full, err := st.IsParentBlockFull()
-	if err != nil {
-		return nil, errors.Wrap(err, "could not determine if parent block is full")
-	}
-	if full {
-		accessRoot, err = st.LatestBlockHash()
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get latest block hash")
-		}
-	}
-	return ProcessSlotsUsingNextSlotCache(ctx, st, accessRoot[:], b.Slot())
-}
 
 // ProcessOperations
 //

--- a/beacon-chain/core/transition/transition_gloas_test.go
+++ b/beacon-chain/core/transition/transition_gloas_test.go
@@ -10,9 +10,7 @@ import (
 	state_native "github.com/OffchainLabs/prysm/v7/beacon-chain/state/state-native"
 	fieldparams "github.com/OffchainLabs/prysm/v7/config/fieldparams"
 	"github.com/OffchainLabs/prysm/v7/config/params"
-	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
-	engine "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/stretchr/testify/require"
@@ -75,12 +73,13 @@ func newGloasState(t *testing.T, slot primitives.Slot, availability []byte) stat
 		ExecutionPayloadAvailability: availability,
 		BuilderPendingPayments:       make([]*ethpb.BuilderPendingPayment, int(cfg.SlotsPerEpoch*2)),
 		LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
-			ParentBlockHash:    make([]byte, 32),
-			ParentBlockRoot:    make([]byte, 32),
-			BlockHash:          make([]byte, 32),
-			PrevRandao:         make([]byte, 32),
-			FeeRecipient:       make([]byte, 20),
-			BlobKzgCommitments: [][]byte{make([]byte, 48)},
+			ParentBlockHash:       make([]byte, 32),
+			ParentBlockRoot:       make([]byte, 32),
+			BlockHash:             make([]byte, 32),
+			PrevRandao:            make([]byte, 32),
+			FeeRecipient:          make([]byte, 20),
+			BlobKzgCommitments:    [][]byte{make([]byte, 48)},
+			ExecutionRequestsRoot: make([]byte, 32),
 		},
 		Eth1Data: &ethpb.Eth1Data{
 			DepositRoot: make([]byte, 32),
@@ -142,216 +141,3 @@ func testBeaconBlockHeader() *ethpb.BeaconBlockHeader {
 	}
 }
 
-// newGloasForkBoundaryState returns a Gloas BeaconState where IsParentBlockFull()==true
-// because bid.BlockHash == latestBlockHash. The parentBlockRoot parameter controls
-// whether the bid looks like an upgrade-seed (all-zeros) or a real committed bid (non-zero).
-func newGloasForkBoundaryState(
-	t *testing.T,
-	slot primitives.Slot,
-	blockHash [32]byte,
-	parentBlockRoot [32]byte,
-) state.BeaconState {
-	t.Helper()
-	cfg := params.BeaconConfig()
-	availability := bytes.Repeat([]byte{0xFF}, int(cfg.SlotsPerHistoricalRoot/8))
-	protoState := &ethpb.BeaconStateGloas{
-		Slot:                         slot,
-		LatestBlockHeader:            testBeaconBlockHeader(),
-		BlockRoots:                   make([][]byte, cfg.SlotsPerHistoricalRoot),
-		StateRoots:                   make([][]byte, cfg.SlotsPerHistoricalRoot),
-		RandaoMixes:                  make([][]byte, fieldparams.RandaoMixesLength),
-		ExecutionPayloadAvailability: availability,
-		BuilderPendingPayments:       make([]*ethpb.BuilderPendingPayment, int(cfg.SlotsPerEpoch*2)),
-		// bid.BlockHash == LatestBlockHash so that IsParentBlockFull() returns true.
-		LatestBlockHash: blockHash[:],
-		LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
-			ParentBlockHash:    make([]byte, 32),
-			ParentBlockRoot:    parentBlockRoot[:],
-			BlockHash:          blockHash[:],
-			PrevRandao:         make([]byte, 32),
-			FeeRecipient:       make([]byte, 20),
-			BlobKzgCommitments: [][]byte{make([]byte, 48)},
-		},
-		Eth1Data: &ethpb.Eth1Data{
-			DepositRoot: make([]byte, 32),
-			BlockHash:   make([]byte, 32),
-		},
-		PreviousEpochParticipation:  []byte{},
-		CurrentEpochParticipation:   []byte{},
-		JustificationBits:           []byte{0},
-		PreviousJustifiedCheckpoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
-		CurrentJustifiedCheckpoint:  &ethpb.Checkpoint{Root: make([]byte, 32)},
-		FinalizedCheckpoint:         &ethpb.Checkpoint{Root: make([]byte, 32)},
-		PayloadExpectedWithdrawals:  make([]*engine.Withdrawal, 0),
-		ProposerLookahead:           make([]primitives.ValidatorIndex, 0),
-		Builders:                    make([]*ethpb.Builder, 0),
-	}
-	for i := range protoState.BlockRoots {
-		protoState.BlockRoots[i] = make([]byte, 32)
-	}
-	for i := range protoState.StateRoots {
-		protoState.StateRoots[i] = make([]byte, 32)
-	}
-	for i := range protoState.RandaoMixes {
-		protoState.RandaoMixes[i] = make([]byte, 32)
-	}
-	for i := range protoState.BuilderPendingPayments {
-		protoState.BuilderPendingPayments[i] = &ethpb.BuilderPendingPayment{
-			Withdrawal: &ethpb.BuilderPendingWithdrawal{FeeRecipient: make([]byte, 20)},
-		}
-	}
-	pubkeys := make([][]byte, cfg.SyncCommitteeSize)
-	for i := range pubkeys {
-		pubkeys[i] = make([]byte, fieldparams.BLSPubkeyLength)
-	}
-	aggPubkey := make([]byte, fieldparams.BLSPubkeyLength)
-	protoState.CurrentSyncCommittee = &ethpb.SyncCommittee{Pubkeys: pubkeys, AggregatePubkey: aggPubkey}
-	protoState.NextSyncCommittee = &ethpb.SyncCommittee{Pubkeys: pubkeys, AggregatePubkey: aggPubkey}
-	st, err := state_native.InitializeFromProtoGloas(protoState)
-	require.NoError(t, err)
-	return st
-}
-
-// newGloasTestBlock returns an ROBlock at the given slot with the given parentRoot.
-func newGloasTestBlock(t *testing.T, slot primitives.Slot, parentRoot [32]byte) consensusblocks.ROBlock {
-	t.Helper()
-	blkProto := &ethpb.SignedBeaconBlockGloas{
-		Block: &ethpb.BeaconBlockGloas{
-			Slot:       slot,
-			ParentRoot: parentRoot[:],
-			StateRoot:  make([]byte, 32),
-			Body: &ethpb.BeaconBlockBodyGloas{
-				RandaoReveal: make([]byte, fieldparams.BLSSignatureLength),
-				Graffiti:     make([]byte, 32),
-				Eth1Data:     &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)},
-				SyncAggregate: &ethpb.SyncAggregate{
-					SyncCommitteeBits:      make([]byte, fieldparams.SyncAggregateSyncCommitteeBytesLength),
-					SyncCommitteeSignature: make([]byte, fieldparams.BLSSignatureLength),
-				},
-				SignedExecutionPayloadBid: &ethpb.SignedExecutionPayloadBid{
-					Message: &ethpb.ExecutionPayloadBid{
-						Slot:               slot,
-						ParentBlockHash:    make([]byte, 32),
-						ParentBlockRoot:    make([]byte, 32),
-						BlockHash:          make([]byte, 32),
-						PrevRandao:         make([]byte, 32),
-						FeeRecipient:       make([]byte, 20),
-						BlobKzgCommitments: [][]byte{},
-					},
-					Signature: make([]byte, fieldparams.BLSSignatureLength),
-				},
-				PayloadAttestations: []*ethpb.PayloadAttestation{},
-			},
-		},
-		Signature: make([]byte, fieldparams.BLSSignatureLength),
-	}
-	wsb, err := consensusblocks.NewSignedBeaconBlock(blkProto)
-	require.NoError(t, err)
-	rob, err := consensusblocks.NewROBlock(wsb)
-	require.NoError(t, err)
-	return rob
-}
-
-// TestProcessSlotsForBlock_UpgradeSeededBid verifies that ProcessSlotsForBlock uses
-// b.ParentRoot() as the NSC access key when the state has an upgrade-seeded bid
-// (bid.ParentBlockRoot == zero). This guards against the Fulu->Gloas fork-boundary
-// false positive where UpgradeToGloas seeds bid.BlockHash == latestBlockHash while
-// leaving bid.ParentBlockRoot as all-zeros.
-func TestProcessSlotsForBlock_UpgradeSeededBid(t *testing.T) {
-	ctx := context.Background()
-	parentRoot := [32]byte{0x01, 0x02, 0x03}
-	blockHash := [32]byte{0xAA, 0xBB, 0xCC}
-	targetSlot := primitives.Slot(9)
-
-	// Build a Gloas state at slot 8 with IsParentBlockFull()==true but
-	// bid.ParentBlockRoot==zero (upgrade-seeded: not a real committed bid).
-	st := newGloasForkBoundaryState(t, targetSlot-1, blockHash, [32]byte{})
-	require.Equal(t, version.Gloas, st.Version())
-
-	// Verify preconditions.
-	full, err := st.IsParentBlockFull()
-	require.NoError(t, err)
-	require.True(t, full, "precondition: IsParentBlockFull must be true")
-
-	bid, err := st.LatestExecutionPayloadBid()
-	require.NoError(t, err)
-	require.Equal(t, [32]byte{}, bid.ParentBlockRoot(), "upgrade-seeded bid must have zero ParentBlockRoot")
-
-	// Prime NSC with parentRoot as the access key.
-	// With the guard in place (realBid==false), ProcessSlotsForBlock will use
-	// b.ParentRoot() as the NSC key and find this cached entry.
-	require.NoError(t, UpdateNextSlotCache(ctx, parentRoot[:], st))
-
-	blk := newGloasTestBlock(t, targetSlot, parentRoot)
-
-	out, err := ProcessSlotsForBlock(ctx, st, blk.Block())
-	require.NoError(t, err)
-	require.Equal(t, targetSlot, out.Slot())
-
-	// Verify that the NSC entry primed under parentRoot is still present,
-	// confirming it was used (read) rather than bypassed.
-	cached := NextSlotState(parentRoot[:], targetSlot)
-	require.NotNil(t, cached, "NSC entry under parentRoot should still be present after use")
-}
-
-// TestProcessSlotsForBlock_RealBid verifies that ProcessSlotsForBlock uses
-// LatestBlockHash as the NSC access key when the state has a real committed bid
-// (bid.ParentBlockRoot != zero). This is the normal post-fork case.
-func TestProcessSlotsForBlock_RealBid(t *testing.T) {
-	ctx := context.Background()
-	parentRoot := [32]byte{0x01, 0x02, 0x03}
-	blockHash := [32]byte{0xAA, 0xBB, 0xCC}
-	realParentBlockRoot := [32]byte{0xDE, 0xAD, 0xBE, 0xEF}
-	targetSlot := primitives.Slot(9)
-
-	// Build a Gloas state at slot 8 with IsParentBlockFull()==true and
-	// bid.ParentBlockRoot!=zero (a real committed bid).
-	st := newGloasForkBoundaryState(t, targetSlot-1, blockHash, realParentBlockRoot)
-	require.Equal(t, version.Gloas, st.Version())
-
-	// Verify preconditions.
-	full, err := st.IsParentBlockFull()
-	require.NoError(t, err)
-	require.True(t, full, "precondition: IsParentBlockFull must be true")
-
-	bid, err := st.LatestExecutionPayloadBid()
-	require.NoError(t, err)
-	require.NotEqual(t, [32]byte{}, bid.ParentBlockRoot(), "real bid must have non-zero ParentBlockRoot")
-
-	// Prime NSC with the EL block hash as access key.
-	// With the guard in place (realBid==true), ProcessSlotsForBlock will use
-	// LatestBlockHash as the NSC key and find this cached entry.
-	require.NoError(t, UpdateNextSlotCache(ctx, blockHash[:], st))
-
-	blk := newGloasTestBlock(t, targetSlot, parentRoot)
-
-	out, err := ProcessSlotsForBlock(ctx, st, blk.Block())
-	require.NoError(t, err)
-	require.Equal(t, targetSlot, out.Slot())
-
-	// Verify that the NSC entry primed under blockHash is still present,
-	// confirming it was used (read) rather than bypassed.
-	cached := NextSlotState(blockHash[:], targetSlot)
-	require.NotNil(t, cached, "NSC entry under blockHash should still be present after use")
-}
-
-// TestProcessSlotsForBlock_PreGloas verifies that ProcessSlotsForBlock uses
-// b.ParentRoot() as access key on pre-Gloas (Fulu) states, unchanged by the fix.
-func TestProcessSlotsForBlock_PreGloas(t *testing.T) {
-	ctx := context.Background()
-	parentRoot := [32]byte{0x01, 0x02, 0x03}
-	targetSlot := primitives.Slot(5)
-
-	// newGloasState creates a Gloas-versioned state; we need a Fulu/pre-Gloas state.
-	// Use newGloasState as a base and just verify the slot advancement works.
-	// Note: version.Gloas is the version created by newGloasState; for pre-Gloas
-	// the function takes the version < Gloas path. We build a minimal Gloas state
-	// to test, but note ProcessSlotsForBlock has an explicit version check at top.
-	st := newGloasState(t, targetSlot-1, bytes.Repeat([]byte{0}, int(params.BeaconConfig().SlotsPerHistoricalRoot/8)))
-
-	blk := newGloasTestBlock(t, targetSlot, parentRoot)
-
-	out, err := ProcessSlotsForBlock(ctx, st, blk.Block())
-	require.NoError(t, err)
-	require.Equal(t, targetSlot, out.Slot())
-}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -63,7 +63,8 @@ func ExecuteStateTransitionNoVerifyAnySig(
 	interop.WriteBlockToDisk(signed, false /* Has the block failed */)
 	interop.WriteStateToDisk(st)
 
-	st, err = ProcessSlotsForBlock(ctx, st, signed.Block())
+	parentRoot := signed.Block().ParentRoot()
+	st, err = ProcessSlotsUsingNextSlotCache(ctx, st, parentRoot[:], signed.Block().Slot())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "could not process slots")
 	}
@@ -134,7 +135,8 @@ func CalculateStateRoot(
 
 	// Execute per slots transition.
 	var err error
-	state, err = ProcessSlotsForBlock(ctx, state, signed.Block())
+	parentRoot := signed.Block().ParentRoot()
+	state, err = ProcessSlotsUsingNextSlotCache(ctx, state, parentRoot[:], signed.Block().Slot())
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not process slots")
 	}
@@ -396,6 +398,13 @@ func ProcessBlockForStateRoot(
 
 	blk := signed.Block()
 	body := blk.Body()
+
+	if state.Version() >= version.Gloas {
+		if err := gloas.ProcessParentExecutionPayload(ctx, state, blk); err != nil {
+			return nil, errors.Wrap(err, "could not process parent execution payload")
+		}
+	}
+
 	bodyRoot, err := body.HashTreeRoot()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not hash tree root beacon block body")
@@ -408,18 +417,14 @@ func ProcessBlockForStateRoot(
 	}
 
 	if state.Version() >= version.Gloas {
-		// <spec fn="process_block" fork="gloas" hash="cc0f05ee">
+		// <spec fn="process_block" fork="gloas" hash="defer_payload">
 		// def process_block(state: BeaconState, block: BeaconBlock) -> None:
-		//     process_block_header(state, block)
-		//     # [Modified in Gloas:EIP7732]
+		//     process_parent_execution_payload(state, block)  # already called above
+		//     process_block_header(state, block)              # already called above
 		//     process_withdrawals(state)
-		//     # [Modified in Gloas:EIP7732]
-		//     # Removed `process_execution_payload`
-		//     # [New in Gloas:EIP7732]
 		//     process_execution_payload_bid(state, block)
 		//     process_randao(state, block.body)
 		//     process_eth1_data(state, block.body)
-		//     # [Modified in Gloas:EIP7732]
 		//     process_operations(state, block.body)
 		//     process_sync_aggregate(state, block.body.sync_aggregate)
 		// </spec>


### PR DESCRIPTION
## Summary
Part 5/10 of deferred payload processing (consensus-specs#5094).

## Stack

1. # 
2. #16661 proto: add parent_block_hash and execution_requests_root to bid
3. #16662 consensus-types: add ParentBlockHash getter and ParentExecutionRequests interface
4. #16663 state: add QueueBuilderPaymentForSlot and update stategen
5. **#16664 core/transition: remove ProcessSlotsForBlock** ← you are here
6. #16665 core/gloas: add ProcessParentExecutionPayload
7. #16666 blockchain: update block processing and FCU for deferred payload
8. #16667 sync: update validation for deferred processing
9. #16668 rpc: update proposer for deferred payload processing
10. #16669 db/verification: cleanup for deferred processing