### PR TITLE
core/gloas: add ProcessParentExecutionPayload for deferred processing

### DIFF
--- a/beacon-chain/core/gloas/BUILD.bazel
+++ b/beacon-chain/core/gloas/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "deposit_request.go",
         "log.go",
         "metrics.go",
+        "parent_payload.go",
         "payload.go",
         "payload_attestation.go",
         "pending_payment.go",

--- a/beacon-chain/core/gloas/bid_test.go
+++ b/beacon-chain/core/gloas/bid_test.go
@@ -53,6 +53,9 @@ func (s stubBlockBody) PayloadAttestations() ([]*ethpb.PayloadAttestation, error
 func (s stubBlockBody) SignedExecutionPayloadBid() (*ethpb.SignedExecutionPayloadBid, error) {
 	return s.signedBid, nil
 }
+func (s stubBlockBody) ParentExecutionRequests() (*enginev1.ExecutionRequests, error) {
+	return nil, nil
+}
 func (s stubBlockBody) MarshalSSZ() ([]byte, error)         { return nil, nil }
 func (s stubBlockBody) MarshalSSZTo([]byte) ([]byte, error) { return nil, nil }
 func (s stubBlockBody) UnmarshalSSZ([]byte) error           { return nil }
@@ -216,17 +219,18 @@ func TestProcessExecutionPayloadBid_SelfBuildSuccess(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, params.BeaconConfig().MinActivationBalance+1000, randao, latestHash, pubKey)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0xCC}, 32),
-		BlockHash:          bytes.Repeat([]byte{0xDD}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              0,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0xFF}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0xCC}, 32),
+		BlockHash:             bytes.Repeat([]byte{0xDD}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 0,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0xFF}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	signed := &ethpb.SignedExecutionPayloadBid{
 		Message:   bid,
@@ -258,16 +262,17 @@ func TestProcessExecutionPayloadBid_SelfBuildNonZeroAmountFails(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, params.BeaconConfig().MinActivationBalance+1000, randao, latestHash, [48]byte{})
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0xAA}, 32),
-		BlockHash:          bytes.Repeat([]byte{0xBB}, 32),
-		PrevRandao:         randao[:],
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              10,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0xDD}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0xAA}, 32),
+		BlockHash:             bytes.Repeat([]byte{0xBB}, 32),
+		PrevRandao:            randao[:],
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 10,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0xDD}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	signed := &ethpb.SignedExecutionPayloadBid{
 		Message:   bid,
@@ -302,17 +307,18 @@ func TestProcessExecutionPayloadBid_PendingPaymentAndCacheBid(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, balance, randao, latestHash, pubKey)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0xCC}, 32),
-		BlockHash:          bytes.Repeat([]byte{0xDD}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              500_000,
-		ExecutionPayment:   1,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0xFF}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0xCC}, 32),
+		BlockHash:             bytes.Repeat([]byte{0xDD}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 500_000,
+		ExecutionPayment:      1,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0xFF}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 
 	genesis := bytesutil.ToBytes32(state.GenesisValidatorsRoot())
@@ -363,17 +369,18 @@ func TestProcessExecutionPayloadBid_BuilderNotActive(t *testing.T) {
 	state = stateIface.(*state_native.BeaconState)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0x03}, 32),
-		BlockHash:          bytes.Repeat([]byte{0x04}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              10,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0x06}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0x03}, 32),
+		BlockHash:             bytes.Repeat([]byte{0x04}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 10,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0x06}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	genesis := bytesutil.ToBytes32(state.GenesisValidatorsRoot())
 	sig := signBid(t, sk, bid, state.Fork(), genesis)
@@ -416,17 +423,18 @@ func TestProcessExecutionPayloadBid_CannotCoverBid(t *testing.T) {
 	state = stateIface.(*state_native.BeaconState)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0xCC}, 32),
-		BlockHash:          bytes.Repeat([]byte{0xDD}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              25,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0xFF}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0xCC}, 32),
+		BlockHash:             bytes.Repeat([]byte{0xDD}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 25,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0xFF}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	genesis := bytesutil.ToBytes32(state.GenesisValidatorsRoot())
 	sig := signBid(t, sk, bid, state.Fork(), genesis)
@@ -458,17 +466,18 @@ func TestProcessExecutionPayloadBid_InvalidSignature(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, params.BeaconConfig().MinDepositAmount+1000, randao, latestHash, pubKey)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0xCC}, 32),
-		BlockHash:          bytes.Repeat([]byte{0xDD}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              10,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0xFF}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0xCC}, 32),
+		BlockHash:             bytes.Repeat([]byte{0xDD}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 10,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0xFF}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	// Use an invalid signature.
 	invalidSig := [96]byte{1}
@@ -495,14 +504,15 @@ func TestProcessExecutionPayloadBid_TooManyBlobCommitments(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, params.BeaconConfig().MinActivationBalance+1000, randao, latestHash, pubKey)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0xCC}, 32),
-		BlockHash:          bytes.Repeat([]byte{0xDD}, 32),
-		PrevRandao:         randao[:],
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		BlobKzgCommitments: tooManyBlobCommitmentsForSlot(slot),
-		FeeRecipient:       bytes.Repeat([]byte{0xFF}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0xCC}, 32),
+		BlockHash:             bytes.Repeat([]byte{0xDD}, 32),
+		PrevRandao:            randao[:],
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		BlobKzgCommitments:    tooManyBlobCommitmentsForSlot(slot),
+		FeeRecipient:          bytes.Repeat([]byte{0xFF}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	signed := &ethpb.SignedExecutionPayloadBid{
 		Message:   bid,
@@ -536,17 +546,18 @@ func TestProcessExecutionPayloadBid_SlotMismatch(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, params.BeaconConfig().MinDepositAmount+1000, randao, latestHash, pubKey)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0xAA}, 32),
-		BlockHash:          bytes.Repeat([]byte{0xBB}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot + 1, // mismatch
-		Value:              1,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0xDD}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0xAA}, 32),
+		BlockHash:             bytes.Repeat([]byte{0xBB}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot + 1, // mismatch
+		Value:                 1,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0xDD}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	genesis := bytesutil.ToBytes32(state.GenesisValidatorsRoot())
 	sig := signBid(t, sk, bid, state.Fork(), genesis)
@@ -578,17 +589,18 @@ func TestProcessExecutionPayloadBid_ParentHashMismatch(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, params.BeaconConfig().MinDepositAmount+1000, randao, latestHash, pubKey)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    bytes.Repeat([]byte{0x11}, 32), // mismatch
-		ParentBlockRoot:    bytes.Repeat([]byte{0x22}, 32),
-		BlockHash:          bytes.Repeat([]byte{0x33}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              1,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0x55}, 20),
+		ParentBlockHash:       bytes.Repeat([]byte{0x11}, 32), // mismatch
+		ParentBlockRoot:       bytes.Repeat([]byte{0x22}, 32),
+		BlockHash:             bytes.Repeat([]byte{0x33}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 1,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0x55}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	genesis := bytesutil.ToBytes32(state.GenesisValidatorsRoot())
 	sig := signBid(t, sk, bid, state.Fork(), genesis)
@@ -621,17 +633,18 @@ func TestProcessExecutionPayloadBid_ParentRootMismatch(t *testing.T) {
 
 	parentRoot := bytes.Repeat([]byte{0x22}, 32)
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    parentRoot,
-		BlockHash:          bytes.Repeat([]byte{0x33}, 32),
-		PrevRandao:         randao[:],
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              1,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0x55}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       parentRoot,
+		BlockHash:             bytes.Repeat([]byte{0x33}, 32),
+		PrevRandao:            randao[:],
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 1,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0x55}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	genesis := bytesutil.ToBytes32(state.GenesisValidatorsRoot())
 	sig := signBid(t, sk, bid, state.Fork(), genesis)
@@ -663,17 +676,18 @@ func TestProcessExecutionPayloadBid_PrevRandaoMismatch(t *testing.T) {
 	state := buildGloasState(t, slot, proposerIdx, builderIdx, params.BeaconConfig().MinDepositAmount+1000, randao, latestHash, pubKey)
 
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:    latestHash[:],
-		ParentBlockRoot:    bytes.Repeat([]byte{0x22}, 32),
-		BlockHash:          bytes.Repeat([]byte{0x33}, 32),
-		PrevRandao:         bytes.Repeat([]byte{0x01}, 32), // mismatch
-		GasLimit:           1,
-		BuilderIndex:       builderIdx,
-		Slot:               slot,
-		Value:              1,
-		ExecutionPayment:   0,
-		BlobKzgCommitments: blobCommitmentsForSlot(slot, 1),
-		FeeRecipient:       bytes.Repeat([]byte{0x55}, 20),
+		ParentBlockHash:       latestHash[:],
+		ParentBlockRoot:       bytes.Repeat([]byte{0x22}, 32),
+		BlockHash:             bytes.Repeat([]byte{0x33}, 32),
+		PrevRandao:            bytes.Repeat([]byte{0x01}, 32), // mismatch
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 1,
+		ExecutionPayment:      0,
+		BlobKzgCommitments:    blobCommitmentsForSlot(slot, 1),
+		FeeRecipient:          bytes.Repeat([]byte{0x55}, 20),
+		ExecutionRequestsRoot: make([]byte, 32),
 	}
 	genesis := bytesutil.ToBytes32(state.GenesisValidatorsRoot())
 	sig := signBid(t, sk, bid, state.Fork(), genesis)

--- a/beacon-chain/core/gloas/parent_payload.go
+++ b/beacon-chain/core/gloas/parent_payload.go
@@ -1,0 +1,134 @@
+package gloas
+
+import (
+	"bytes"
+	"context"
+
+	requests "github.com/OffchainLabs/prysm/v7/beacon-chain/core/requests"
+	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
+	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	"github.com/pkg/errors"
+)
+
+// ProcessParentExecutionPayload processes deferred effects from the parent's
+// execution payload. Must run first in process_block, before process_block_header,
+// because it reads state.latest_block_header.slot and state.latest_execution_payload_bid
+// which are overwritten by process_block_header and process_execution_payload_bid.
+//
+//	<spec fn="process_parent_execution_payload" fork="gloas" hash="defer_payload">
+//	def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> None:
+//	    bid = block.body.signed_execution_payload_bid.message
+//	    parent_bid = state.latest_execution_payload_bid
+//	    is_parent_full = bid.parent_block_hash == parent_bid.block_hash
+//	    if not is_parent_full:
+//	        assert block.body.parent_execution_requests == ExecutionRequests()
+//	        return
+//	    parent_slot = state.latest_block_header.slot
+//	    parent_epoch = compute_epoch_at_slot(parent_slot)
+//	    state.execution_payload_availability[parent_slot % SLOTS_PER_HISTORICAL_ROOT] = 0b1
+//	    requests = block.body.parent_execution_requests
+//	    assert hash_tree_root(requests) == parent_bid.execution_requests_root
+//	    for_ops(requests.deposits, process_deposit_request)
+//	    for_ops(requests.withdrawals, process_withdrawal_request)
+//	    for_ops(requests.consolidations, process_consolidation_request)
+//	    if parent_epoch == get_current_epoch(state):
+//	        payment_index = SLOTS_PER_EPOCH + parent_slot % SLOTS_PER_EPOCH
+//	    elif parent_epoch == get_previous_epoch(state):
+//	        payment_index = parent_slot % SLOTS_PER_EPOCH
+//	    else:
+//	        payment_index = None
+//	    if payment_index is not None:
+//	        payment = state.builder_pending_payments[payment_index]
+//	        if payment.withdrawal.amount > 0:
+//	            state.builder_pending_withdrawals.append(payment.withdrawal)
+//	        state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+//	    state.latest_block_hash = bid.parent_block_hash
+//	</spec>
+func ProcessParentExecutionPayload(ctx context.Context, st state.BeaconState, blk interfaces.ReadOnlyBeaconBlock) error {
+	body := blk.Body()
+	signedBid, err := body.SignedExecutionPayloadBid()
+	if err != nil {
+		return errors.Wrap(err, "could not get signed execution payload bid")
+	}
+	bid := signedBid.Message
+
+	parentBid, err := st.LatestExecutionPayloadBid()
+	if err != nil {
+		return errors.Wrap(err, "could not get parent execution payload bid")
+	}
+
+	parentExecutionRequests, err := body.ParentExecutionRequests()
+	if err != nil {
+		return errors.Wrap(err, "could not get parent execution requests")
+	}
+
+	// Determine parent payload status from block data.
+	parentBidBlockHash := parentBid.BlockHash()
+	isParentFull := bytes.Equal(bid.ParentBlockHash, parentBidBlockHash[:])
+
+	if !isParentFull {
+		// Parent was EMPTY — no execution requests expected.
+		if !isEmptyExecutionRequests(parentExecutionRequests) {
+			return errors.New("parent was empty but parent_execution_requests is non-empty")
+		}
+		return nil
+	}
+
+	// Parent was FULL.
+	parentSlot := st.LatestBlockHeader().Slot
+	if err := st.SetExecutionPayloadAvailability(parentSlot, true); err != nil {
+		return errors.Wrap(err, "could not set parent execution payload availability")
+	}
+
+	requestsRoot, err := parentExecutionRequests.HashTreeRoot()
+	if err != nil {
+		return errors.Wrap(err, "could not compute parent execution requests root")
+	}
+	parentBidRequestRoot := parentBid.ExecutionRequestsRoot()
+	if requestsRoot != parentBidRequestRoot {
+		return errors.Errorf("parent execution requests root mismatch: block=%#x, bid=%#x", requestsRoot, parentBidRequestRoot)
+	}
+
+	if err := processExecutionRequests(ctx, st, parentExecutionRequests); err != nil {
+		return errors.Wrap(err, "could not process parent execution requests")
+	}
+
+	if err := st.QueueBuilderPaymentForSlot(parentSlot); err != nil {
+		return errors.Wrap(err, "could not queue builder payment")
+	}
+
+	var parentBlockHash [32]byte
+	copy(parentBlockHash[:], bid.ParentBlockHash)
+	if err := st.SetLatestBlockHash(parentBlockHash); err != nil {
+		return errors.Wrap(err, "could not set latest block hash")
+	}
+
+	return nil
+}
+
+// isEmptyExecutionRequests returns true if the execution requests contain no entries.
+func isEmptyExecutionRequests(r *enginev1.ExecutionRequests) bool {
+	if r == nil {
+		return true
+	}
+	return len(r.Deposits) == 0 && len(r.Withdrawals) == 0 && len(r.Consolidations) == 0
+}
+
+// processExecutionRequests processes deposits, withdrawals, and consolidations from execution requests.
+func processExecutionRequests(ctx context.Context, st state.BeaconState, rqs *enginev1.ExecutionRequests) error {
+	if err := processDepositRequests(ctx, st, rqs.Deposits); err != nil {
+		return errors.Wrap(err, "could not process deposit requests")
+	}
+
+	var err error
+	st, err = requests.ProcessWithdrawalRequests(ctx, st, rqs.Withdrawals)
+	if err != nil {
+		return errors.Wrap(err, "could not process withdrawal requests")
+	}
+	err = requests.ProcessConsolidationRequests(ctx, st, rqs.Consolidations)
+	if err != nil {
+		return errors.Wrap(err, "could not process consolidation requests")
+	}
+	return nil
+}

--- a/beacon-chain/core/gloas/payload.go
+++ b/beacon-chain/core/gloas/payload.go
@@ -5,104 +5,49 @@ import (
 	"context"
 	"fmt"
 
-	requests "github.com/OffchainLabs/prysm/v7/beacon-chain/core/requests"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	"github.com/OffchainLabs/prysm/v7/crypto/bls"
-	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	"github.com/pkg/errors"
 )
 
-// ProcessExecutionPayload is the gossip entry point: verify signature, validate
-// consistency, apply state mutations, and verify the post-payload state root.
+// ProcessExecutionPayload is a verification function called by fork-choice when
+// importing a signed execution payload. It verifies the payload against the
+// execution engine without processing execution requests or updating state.
+// Actual state mutations are deferred to process_parent_execution_payload in
+// the next block.
 //
-//	<spec fn="process_execution_payload" fork="gloas" hash="36bd3af3">
-//	def process_execution_payload(
-//	    state: BeaconState,
-//	    # [Modified in Gloas:EIP7732]
-//	    # Removed `body`
-//	    # [New in Gloas:EIP7732]
-//	    signed_envelope: SignedExecutionPayloadEnvelope,
-//	    execution_engine: ExecutionEngine,
-//	    # [New in Gloas:EIP7732]
-//	    verify: bool = True,
-//	) -> None:
+//	<spec fn="process_execution_payload" fork="gloas" hash="defer_payload">
+//	def process_execution_payload(state, signed_envelope, execution_engine, verify=True):
 //	    envelope = signed_envelope.message
 //	    payload = envelope.payload
-//
-//	    # Verify signature
 //	    if verify:
 //	        assert verify_execution_payload_envelope_signature(state, signed_envelope)
-//
-//	    # Cache latest block header state root
-//	    previous_state_root = hash_tree_root(state)
-//	    if state.latest_block_header.state_root == Root():
-//	        state.latest_block_header.state_root = previous_state_root
-//
-//	    # Verify consistency with the beacon block
-//	    assert envelope.beacon_block_root == hash_tree_root(state.latest_block_header)
+//	    header = copy(state.latest_block_header)
+//	    header.state_root = hash_tree_root(state)
+//	    assert envelope.beacon_block_root == hash_tree_root(header)
 //	    assert envelope.slot == state.slot
-//
-//	    # Verify consistency with the committed bid
 //	    committed_bid = state.latest_execution_payload_bid
 //	    assert envelope.builder_index == committed_bid.builder_index
 //	    assert committed_bid.prev_randao == payload.prev_randao
-//
-//	    # Verify consistency with expected withdrawals
+//	    assert hash_tree_root(envelope.execution_requests) == committed_bid.execution_requests_root
 //	    assert hash_tree_root(payload.withdrawals) == hash_tree_root(state.payload_expected_withdrawals)
-//
-//	    # Verify the gas_limit
 //	    assert committed_bid.gas_limit == payload.gas_limit
-//	    # Verify the block hash
 //	    assert committed_bid.block_hash == payload.block_hash
-//	    # Verify consistency of the parent hash with respect to the previous execution payload
 //	    assert payload.parent_hash == state.latest_block_hash
-//	    # Verify timestamp
 //	    assert payload.timestamp == compute_time_at_slot(state, state.slot)
-//	    # Verify the execution payload is valid
-//	    versioned_hashes = [
-//	        kzg_commitment_to_versioned_hash(commitment)
-//	        # [Modified in Gloas:EIP7732]
-//	        for commitment in committed_bid.blob_kzg_commitments
-//	    ]
-//	    requests = envelope.execution_requests
 //	    assert execution_engine.verify_and_notify_new_payload(
 //	        NewPayloadRequest(
 //	            execution_payload=payload,
-//	            versioned_hashes=versioned_hashes,
+//	            versioned_hashes=[kzg_commitment_to_versioned_hash(c) for c in committed_bid.blob_kzg_commitments],
 //	            parent_beacon_block_root=state.latest_block_header.parent_root,
-//	            execution_requests=requests,
+//	            execution_requests=envelope.execution_requests,
 //	        )
 //	    )
-//
-//	    def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
-//	        for operation in operations:
-//	            fn(state, operation)
-//
-//	    for_ops(requests.deposits, process_deposit_request)
-//	    for_ops(requests.withdrawals, process_withdrawal_request)
-//	    for_ops(requests.consolidations, process_consolidation_request)
-//
-//	    # Queue the builder payment
-//	    payment = state.builder_pending_payments[SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH]
-//	    amount = payment.withdrawal.amount
-//	    if amount > 0:
-//	        state.builder_pending_withdrawals.append(payment.withdrawal)
-//	    state.builder_pending_payments[SLOTS_PER_EPOCH + state.slot % SLOTS_PER_EPOCH] = (
-//	        BuilderPendingPayment()
-//	    )
-//
-//	    # Cache the execution payload hash
-//	    state.execution_payload_availability[state.slot % SLOTS_PER_HISTORICAL_ROOT] = 0b1
-//	    state.latest_block_hash = payload.block_hash
-//
-//	    # Verify the state root
-//	    if verify:
-//	        assert envelope.state_root == hash_tree_root(state)
 //	</spec>
 func ProcessExecutionPayload(
 	ctx context.Context,
@@ -118,26 +63,15 @@ func ProcessExecutionPayload(
 		return errors.Wrap(err, "could not get envelope from signed envelope")
 	}
 
-	if err := cacheLatestBlockHeaderStateRoot(ctx, st); err != nil {
-		return err
-	}
-	if err := validatePayloadConsistency(st, envelope); err != nil {
-		return err
-	}
-	if err := applyExecutionPayloadStateMutations(ctx, st, envelope.ExecutionRequests(), envelope.BlockHash()); err != nil {
-		return err
-	}
-	return verifyPostStateRoot(ctx, st, envelope)
+	return validatePayloadConsistency(ctx, st, envelope)
 }
 
-// ProcessExecutionPayloadWithDeferredSig is the init-sync entry point: extract the
-// signature for deferred verification, validate consistency, apply state
-// mutations, and verify the post-payload state root. The caller provides the
-// previousStateRoot to avoid recomputing it.
+// ProcessExecutionPayloadWithDeferredSig is the init-sync entry point: extract
+// the signature for deferred batch verification and validate consistency.
+// No state mutations are performed.
 func ProcessExecutionPayloadWithDeferredSig(
 	ctx context.Context,
 	st state.BeaconState,
-	previousStateRoot [32]byte,
 	signedEnvelope interfaces.ROSignedExecutionPayloadEnvelope,
 ) (*bls.SignatureBatch, error) {
 	sigBatch, err := ExecutionPayloadEnvelopeSignatureBatch(st, signedEnvelope)
@@ -150,119 +84,25 @@ func ProcessExecutionPayloadWithDeferredSig(
 		return nil, errors.Wrap(err, "could not get envelope from signed envelope")
 	}
 
-	if err := setLatestBlockHeaderStateRoot(st, previousStateRoot); err != nil {
-		return nil, errors.Wrap(err, "could not set latest block header state root")
-	}
-
-	if err := validatePayloadConsistency(st, envelope); err != nil {
-		return nil, err
-	}
-	if err := applyExecutionPayloadStateMutations(ctx, st, envelope.ExecutionRequests(), envelope.BlockHash()); err != nil {
-		return nil, err
-	}
-	if err := verifyPostStateRoot(ctx, st, envelope); err != nil {
+	if err := validatePayloadConsistency(ctx, st, envelope); err != nil {
 		return nil, err
 	}
 	return sigBatch, nil
 }
 
-// ProcessBlindedExecutionPayload is the replay/stategen entry
-// point: patch the block header, do minimal bid consistency checks, and apply
-// state mutations. No payload data is available — only the blinded envelope.
-// A nil envelope is a no-op (the payload was not delivered for that slot).
-func ProcessBlindedExecutionPayload(
-	ctx context.Context,
-	st state.BeaconState,
-	previousStateRoot [32]byte,
-	envelope interfaces.ROBlindedExecutionPayloadEnvelope,
-) error {
-	if envelope == nil {
-		return nil
-	}
-
-	if err := setLatestBlockHeaderStateRoot(st, previousStateRoot); err != nil {
-		return errors.Wrap(err, "could not set latest block header state root")
-	}
-
-	if envelope.Slot() != st.Slot() {
-		return errors.Errorf("blinded envelope slot does not match state slot: envelope=%d, state=%d", envelope.Slot(), st.Slot())
-	}
-
-	latestBid, err := st.LatestExecutionPayloadBid()
-	if err != nil {
-		return errors.Wrap(err, "could not get latest execution payload bid")
-	}
-	if latestBid == nil {
-		return errors.New("latest execution payload bid is nil")
-	}
-	if envelope.BuilderIndex() != latestBid.BuilderIndex() {
-		return errors.Errorf(
-			"blinded envelope builder index does not match committed bid builder index: envelope=%d, bid=%d",
-			envelope.BuilderIndex(),
-			latestBid.BuilderIndex(),
-		)
-	}
-
-	bidBlockHash := latestBid.BlockHash()
-	envelopeBlockHash := envelope.BlockHash()
-	if bidBlockHash != envelopeBlockHash {
-		return errors.Errorf(
-			"blinded envelope block hash does not match committed bid block hash: envelope=%#x, bid=%#x",
-			envelopeBlockHash,
-			bidBlockHash,
-		)
-	}
-
-	return applyExecutionPayloadStateMutations(ctx, st, envelope.ExecutionRequests(), envelopeBlockHash)
-}
-
-// ApplyExecutionPayload patches the block header state root, validates
-// consistency, and applies state mutations. No signature or post-state-root
-// verification is performed. Used by the proposer path to compute the
-// post-payload state root for the envelope.
-func ApplyExecutionPayload(
-	ctx context.Context,
-	st state.BeaconState,
-	envelope interfaces.ROExecutionPayloadEnvelope,
-) error {
-	if err := cacheLatestBlockHeaderStateRoot(ctx, st); err != nil {
-		return err
-	}
-	if err := validatePayloadConsistency(st, envelope); err != nil {
-		return err
-	}
-	return applyExecutionPayloadStateMutations(ctx, st, envelope.ExecutionRequests(), envelope.BlockHash())
-}
-
-func setLatestBlockHeaderStateRoot(st state.BeaconState, root [32]byte) error {
-	latestHeader := st.LatestBlockHeader()
-	latestHeader.StateRoot = root[:]
-	return st.SetLatestBlockHeader(latestHeader)
-}
-
-// cacheLatestBlockHeaderStateRoot fills in the state root on the latest block
-// header if it hasn't been set yet (the spec's "cache latest block header
-// state root" step).
-func cacheLatestBlockHeaderStateRoot(ctx context.Context, st state.BeaconState) error {
-	latestHeader := st.LatestBlockHeader()
-	if len(latestHeader.StateRoot) == 0 || bytes.Equal(latestHeader.StateRoot, make([]byte, 32)) {
-		previousStateRoot, err := st.HashTreeRoot(ctx)
+// validatePayloadConsistency checks that the envelope and payload are consistent
+// with the beacon block header, the committed bid, and the current state.
+func validatePayloadConsistency(ctx context.Context, st state.BeaconState, envelope interfaces.ROExecutionPayloadEnvelope) error {
+	// Cache latest block header state root (local copy, no state mutation).
+	header := st.LatestBlockHeader()
+	if len(header.StateRoot) == 0 || bytes.Equal(header.StateRoot, make([]byte, 32)) {
+		stateRoot, err := st.HashTreeRoot(ctx)
 		if err != nil {
 			return errors.Wrap(err, "could not compute state root")
 		}
-		latestHeader.StateRoot = previousStateRoot[:]
-		if err := st.SetLatestBlockHeader(latestHeader); err != nil {
-			return errors.Wrap(err, "could not set latest block header")
-		}
+		header.StateRoot = stateRoot[:]
 	}
-	return nil
-}
-
-// validatePayloadConsistency checks that the envelope and payload are consistent
-// with the beacon block header, the committed bid, and the current state.
-func validatePayloadConsistency(st state.BeaconState, envelope interfaces.ROExecutionPayloadEnvelope) error {
-	latestHeader := st.LatestBlockHeader()
-	blockHeaderRoot, err := latestHeader.HashTreeRoot()
+	blockHeaderRoot, err := header.HashTreeRoot()
 	if err != nil {
 		return errors.Wrap(err, "could not compute block header root")
 	}
@@ -285,6 +125,16 @@ func validatePayloadConsistency(st state.BeaconState, envelope interfaces.ROExec
 	}
 	if envelope.BuilderIndex() != latestBid.BuilderIndex() {
 		return errors.Errorf("envelope builder index does not match committed bid builder index: envelope=%d, bid=%d", envelope.BuilderIndex(), latestBid.BuilderIndex())
+	}
+
+	// Verify execution_requests_root matches the bid commitment.
+	executionRequestsRoot, err := envelope.ExecutionRequests().HashTreeRoot()
+	if err != nil {
+		return errors.Wrap(err, "could not compute execution requests root")
+	}
+	bidExecutionRequestsRoot := latestBid.ExecutionRequestsRoot()
+	if executionRequestsRoot != bidExecutionRequestsRoot {
+		return errors.Errorf("execution requests root mismatch: envelope=%#x, bid=%#x", executionRequestsRoot, bidExecutionRequestsRoot)
 	}
 
 	payload, err := envelope.Execution()
@@ -332,47 +182,6 @@ func validatePayloadConsistency(st state.BeaconState, envelope interfaces.ROExec
 	}
 	if payload.Timestamp() != uint64(t.Unix()) {
 		return errors.Errorf("payload timestamp does not match expected timestamp: payload=%d, expected=%d", payload.Timestamp(), uint64(t.Unix()))
-	}
-
-	return nil
-}
-
-// verifyPostStateRoot checks that the post-payload state root matches the
-// envelope's declared state root.
-func verifyPostStateRoot(ctx context.Context, st state.BeaconState, envelope interfaces.ROExecutionPayloadEnvelope) error {
-	r, err := st.HashTreeRoot(ctx)
-	if err != nil {
-		return errors.Wrap(err, "could not compute post-envelope state root")
-	}
-	if r != envelope.StateRoot() {
-		return fmt.Errorf("state root mismatch: expected %#x, got %#x", envelope.StateRoot(), r)
-	}
-	return nil
-}
-
-// applyExecutionPayloadStateMutations applies the state-changing operations
-// from an execution payload: process execution requests, queue builder payment,
-// set execution payload availability, and update the latest block hash.
-func applyExecutionPayloadStateMutations(
-	ctx context.Context,
-	st state.BeaconState,
-	executionRequests *enginev1.ExecutionRequests,
-	blockHash [32]byte,
-) error {
-	if err := processExecutionRequests(ctx, st, executionRequests); err != nil {
-		return errors.Wrap(err, "could not process execution requests")
-	}
-
-	if err := st.QueueBuilderPayment(); err != nil {
-		return errors.Wrap(err, "could not queue builder payment")
-	}
-
-	if err := st.SetExecutionPayloadAvailability(st.Slot(), true); err != nil {
-		return errors.Wrap(err, "could not set execution payload availability")
-	}
-
-	if err := st.SetLatestBlockHash(blockHash); err != nil {
-		return errors.Wrap(err, "could not set latest block hash")
 	}
 
 	return nil
@@ -512,22 +321,4 @@ func builderPublicKey(st state.BeaconState, builderIdx primitives.BuilderIndex) 
 		return nil, fmt.Errorf("invalid builder public key: %w", err)
 	}
 	return publicKey, nil
-}
-
-// processExecutionRequests processes deposits, withdrawals, and consolidations from execution requests.
-func processExecutionRequests(ctx context.Context, st state.BeaconState, rqs *enginev1.ExecutionRequests) error {
-	if err := processDepositRequests(ctx, st, rqs.Deposits); err != nil {
-		return errors.Wrap(err, "could not process deposit requests")
-	}
-
-	var err error
-	st, err = requests.ProcessWithdrawalRequests(ctx, st, rqs.Withdrawals)
-	if err != nil {
-		return errors.Wrap(err, "could not process withdrawal requests")
-	}
-	err = requests.ProcessConsolidationRequests(ctx, st, rqs.Consolidations)
-	if err != nil {
-		return errors.Wrap(err, "could not process consolidation requests")
-	}
-	return nil
 }

--- a/beacon-chain/core/gloas/payload_test.go
+++ b/beacon-chain/core/gloas/payload_test.go
@@ -2,7 +2,6 @@ package gloas
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/signing"
@@ -68,17 +67,20 @@ func buildPayloadFixture(t *testing.T, mutate func(payload *enginev1.ExecutionPa
 		ExcessBlobGas: 0,
 	}
 
+	emptyRequestsRoot, err := (&enginev1.ExecutionRequests{}).HashTreeRoot()
+	require.NoError(t, err)
 	bid := &ethpb.ExecutionPayloadBid{
-		ParentBlockHash:  parentHash,
-		ParentBlockRoot:  bytes.Repeat([]byte{0xDD}, 32),
-		BlockHash:        blockHash,
-		PrevRandao:       randao,
-		GasLimit:         1,
-		BuilderIndex:     builderIdx,
-		Slot:             slot,
-		Value:            0,
-		ExecutionPayment: 0,
-		FeeRecipient:     bytes.Repeat([]byte{0xEE}, 20),
+		ParentBlockHash:       parentHash,
+		ParentBlockRoot:       bytes.Repeat([]byte{0xDD}, 32),
+		BlockHash:             blockHash,
+		PrevRandao:            randao,
+		GasLimit:              1,
+		BuilderIndex:          builderIdx,
+		Slot:                  slot,
+		Value:                 0,
+		ExecutionPayment:      0,
+		FeeRecipient:          bytes.Repeat([]byte{0xEE}, 20),
+		ExecutionRequestsRoot: emptyRequestsRoot[:],
 	}
 
 	header := &ethpb.BeaconBlockHeader{
@@ -187,18 +189,6 @@ func buildPayloadFixture(t *testing.T, mutate func(payload *enginev1.ExecutionPa
 	st, err := state_native.InitializeFromProtoGloas(stProto)
 	require.NoError(t, err)
 
-	expected := st.Copy()
-	ctx := context.Background()
-	require.NoError(t, processExecutionRequests(ctx, expected, envelope.ExecutionRequests))
-	require.NoError(t, expected.QueueBuilderPayment())
-	require.NoError(t, expected.SetExecutionPayloadAvailability(slot, true))
-	var blockHashArr [32]byte
-	copy(blockHashArr[:], payload.BlockHash)
-	require.NoError(t, expected.SetLatestBlockHash(blockHashArr))
-	expectedRoot, err := expected.HashTreeRoot(ctx)
-	require.NoError(t, err)
-	envelope.StateRoot = expectedRoot[:]
-
 	epoch := slots.ToEpoch(slot)
 	domain, err := signing.Domain(st.Fork(), epoch, cfg.DomainBeaconBuilder, st.GenesisValidatorsRoot())
 	require.NoError(t, err)
@@ -226,30 +216,12 @@ func buildPayloadFixture(t *testing.T, mutate func(payload *enginev1.ExecutionPa
 func TestProcessExecutionPayload_Success(t *testing.T) {
 	fixture := buildPayloadFixture(t, nil)
 	require.NoError(t, ProcessExecutionPayload(t.Context(), fixture.state, fixture.signed))
-
-	latestHash, err := fixture.state.LatestBlockHash()
-	require.NoError(t, err)
-	var expectedHash [32]byte
-	copy(expectedHash[:], fixture.payload.BlockHash)
-	require.Equal(t, expectedHash, latestHash)
-
-	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
-	paymentIndex := slotsPerEpoch + (fixture.slot % slotsPerEpoch)
-	payments, err := fixture.state.BuilderPendingPayments()
-	require.NoError(t, err)
-	payment := payments[paymentIndex]
-	require.NotNil(t, payment)
-	require.Equal(t, primitives.Gwei(0), payment.Withdrawal.Amount)
 }
 
 func TestProcessExecutionPayloadWithDeferredSig_Success(t *testing.T) {
 	fixture := buildPayloadFixture(t, nil)
 
-	header := fixture.state.LatestBlockHeader()
-	var previousStateRoot [32]byte
-	copy(previousStateRoot[:], header.StateRoot)
-
-	sigBatch, err := ProcessExecutionPayloadWithDeferredSig(t.Context(), fixture.state, previousStateRoot, fixture.signed)
+	sigBatch, err := ProcessExecutionPayloadWithDeferredSig(t.Context(), fixture.state, fixture.signed)
 	require.NoError(t, err)
 	require.NotNil(t, sigBatch)
 	require.Equal(t, 1, len(sigBatch.Signatures))
@@ -261,63 +233,6 @@ func TestProcessExecutionPayloadWithDeferredSig_Success(t *testing.T) {
 	valid, err := sigBatch.Verify()
 	require.NoError(t, err)
 	require.Equal(t, true, valid)
-
-	latestHash, err := fixture.state.LatestBlockHash()
-	require.NoError(t, err)
-	var expectedHash [32]byte
-	copy(expectedHash[:], fixture.payload.BlockHash)
-	require.Equal(t, expectedHash, latestHash)
-
-	available, err := fixture.state.ExecutionPayloadAvailability(fixture.slot)
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), available)
-
-	updatedHeader := fixture.state.LatestBlockHeader()
-	require.DeepEqual(t, previousStateRoot[:], updatedHeader.StateRoot)
-}
-
-func TestProcessExecutionPayloadWithDeferredSig_PreviousStateRootMismatch(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-
-	previousStateRoot := [32]byte{0x42}
-
-	_, err := ProcessExecutionPayloadWithDeferredSig(t.Context(), fixture.state, previousStateRoot, fixture.signed)
-	require.ErrorContains(t, "envelope beacon block root does not match state latest block header root", err)
-}
-
-func TestApplyExecutionPayload_Success(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-
-	envelope, err := fixture.signed.Envelope()
-	require.NoError(t, err)
-	require.NoError(t, ApplyExecutionPayload(t.Context(), fixture.state, envelope))
-
-	latestHash, err := fixture.state.LatestBlockHash()
-	require.NoError(t, err)
-	var expectedHash [32]byte
-	copy(expectedHash[:], fixture.payload.BlockHash)
-	require.Equal(t, expectedHash, latestHash)
-
-	available, err := fixture.state.ExecutionPayloadAvailability(fixture.slot)
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), available)
-}
-
-func TestApplyExecutionPayloadStateMutations_UpdatesAvailabilityAndLatestHash(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-
-	newHash := [32]byte{}
-	newHash[0] = 0x99
-
-	require.NoError(t, applyExecutionPayloadStateMutations(t.Context(), fixture.state, fixture.envelope.ExecutionRequests, newHash))
-
-	latestHash, err := fixture.state.LatestBlockHash()
-	require.NoError(t, err)
-	require.Equal(t, newHash, latestHash)
-
-	available, err := fixture.state.ExecutionPayloadAvailability(fixture.slot)
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), available)
 }
 
 func TestProcessExecutionPayload_PrevRandaoMismatch(t *testing.T) {
@@ -341,95 +256,6 @@ func TestQueueBuilderPayment_ZeroAmountClearsSlot(t *testing.T) {
 	payment := payments[paymentIndex]
 	require.NotNil(t, payment)
 	require.Equal(t, primitives.Gwei(0), payment.Withdrawal.Amount)
-}
-
-func TestProcessBlindedExecutionPayload_NilEnvelope(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-	require.NoError(t, ProcessBlindedExecutionPayload(t.Context(), fixture.state, [32]byte{}, nil))
-}
-
-func TestProcessBlindedExecutionPayload_Success(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-	st := fixture.state
-
-	blockHash := [32]byte(fixture.payload.BlockHash)
-	stateRoot := [32]byte{0xAA}
-	envelope := &ethpb.SignedBlindedExecutionPayloadEnvelope{
-		Message: &ethpb.BlindedExecutionPayloadEnvelope{
-			Slot:              fixture.slot,
-			BuilderIndex:      fixture.envelope.BuilderIndex,
-			BlockHash:         blockHash[:],
-			BeaconBlockRoot:   make([]byte, 32),
-			ExecutionRequests: fixture.envelope.ExecutionRequests,
-		},
-	}
-
-	wrappedEnv, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(envelope.Message)
-	require.NoError(t, err)
-	require.NoError(t, ProcessBlindedExecutionPayload(t.Context(), st, stateRoot, wrappedEnv))
-
-	latestHash, err := st.LatestBlockHash()
-	require.NoError(t, err)
-	require.Equal(t, blockHash, latestHash)
-
-	available, err := st.ExecutionPayloadAvailability(fixture.slot)
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), available)
-
-	header := st.LatestBlockHeader()
-	require.DeepEqual(t, stateRoot[:], header.StateRoot)
-}
-
-func TestProcessBlindedExecutionPayload_SlotMismatch(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-
-	envelope := &ethpb.SignedBlindedExecutionPayloadEnvelope{
-		Message: &ethpb.BlindedExecutionPayloadEnvelope{
-			Slot:            fixture.slot + 1,
-			BlockHash:       make([]byte, 32),
-			BeaconBlockRoot: make([]byte, 32),
-		},
-	}
-	wrappedEnv, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(envelope.Message)
-	require.NoError(t, err)
-	err = ProcessBlindedExecutionPayload(t.Context(), fixture.state, [32]byte{}, wrappedEnv)
-	require.ErrorContains(t, "blinded envelope slot does not match state slot", err)
-}
-
-func TestProcessBlindedExecutionPayload_BuilderIndexMismatch(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-
-	blockHash := [32]byte(fixture.payload.BlockHash)
-	envelope := &ethpb.SignedBlindedExecutionPayloadEnvelope{
-		Message: &ethpb.BlindedExecutionPayloadEnvelope{
-			Slot:            fixture.slot,
-			BuilderIndex:    999,
-			BlockHash:       blockHash[:],
-			BeaconBlockRoot: make([]byte, 32),
-		},
-	}
-	wrappedEnv, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(envelope.Message)
-	require.NoError(t, err)
-	err = ProcessBlindedExecutionPayload(t.Context(), fixture.state, [32]byte{}, wrappedEnv)
-	require.ErrorContains(t, "builder index does not match", err)
-}
-
-func TestProcessBlindedExecutionPayload_BlockHashMismatch(t *testing.T) {
-	fixture := buildPayloadFixture(t, nil)
-
-	wrongHash := bytes.Repeat([]byte{0xFF}, 32)
-	envelope := &ethpb.SignedBlindedExecutionPayloadEnvelope{
-		Message: &ethpb.BlindedExecutionPayloadEnvelope{
-			Slot:            fixture.slot,
-			BuilderIndex:    fixture.envelope.BuilderIndex,
-			BlockHash:       wrongHash,
-			BeaconBlockRoot: make([]byte, 32),
-		},
-	}
-	wrappedEnv, err := blocks.WrappedROBlindedExecutionPayloadEnvelope(envelope.Message)
-	require.NoError(t, err)
-	err = ProcessBlindedExecutionPayload(t.Context(), fixture.state, [32]byte{}, wrappedEnv)
-	require.ErrorContains(t, "block hash does not match", err)
 }
 
 func TestVerifyExecutionPayloadEnvelopeSignature(t *testing.T) {

--- a/beacon-chain/core/gloas/upgrade.go
+++ b/beacon-chain/core/gloas/upgrade.go
@@ -56,6 +56,7 @@ import (
 //	        # [New in Gloas:EIP7732]
 //	        latest_execution_payload_bid=ExecutionPayloadBid(
 //	            block_hash=pre.latest_execution_payload_header.block_hash,
+//	            execution_requests_root=hash_tree_root(ExecutionRequests()),
 //	        ),
 //	        next_withdrawal_index=pre.next_withdrawal_index,
 //	        next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
@@ -307,6 +308,11 @@ func upgradeToGloas(beaconState state.BeaconState) (state.BeaconState, error) {
 		}
 	}
 
+	emptyExecutionRequestsRoot, err := (&enginev1.ExecutionRequests{}).HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not compute empty execution requests root")
+	}
+
 	s := &ethpb.BeaconStateGloas{
 		GenesisTime:           uint64(beaconState.GenesisTime().Unix()),
 		GenesisValidatorsRoot: beaconState.GenesisValidatorsRoot(),
@@ -337,11 +343,12 @@ func upgradeToGloas(beaconState state.BeaconState) (state.BeaconState, error) {
 		CurrentSyncCommittee:        currentSyncCommittee,
 		NextSyncCommittee:           nextSyncCommittee,
 		LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
-			BlockHash:       payloadHeader.BlockHash(),
-			FeeRecipient:    make([]byte, fieldparams.FeeRecipientLength),
-			ParentBlockHash: make([]byte, fieldparams.RootLength),
-			ParentBlockRoot: make([]byte, fieldparams.RootLength),
-			PrevRandao:      make([]byte, fieldparams.RootLength),
+			BlockHash:             payloadHeader.BlockHash(),
+			FeeRecipient:          make([]byte, fieldparams.FeeRecipientLength),
+			ParentBlockHash:       make([]byte, fieldparams.RootLength),
+			ParentBlockRoot:       make([]byte, fieldparams.RootLength),
+			PrevRandao:            make([]byte, fieldparams.RootLength),
+			ExecutionRequestsRoot: emptyExecutionRequestsRoot[:],
 		},
 		NextWithdrawalIndex:           wi,
 		NextWithdrawalValidatorIndex:  vi,


### PR DESCRIPTION
## Summary
Part 6/10 of deferred payload processing (consensus-specs#5094).

## Stack

1. # 
2. #16661 proto: add parent_block_hash and execution_requests_root to bid
3. #16662 consensus-types: add ParentBlockHash getter and ParentExecutionRequests interface
4. #16663 state: add QueueBuilderPaymentForSlot and update stategen
5. #16664 core/transition: remove ProcessSlotsForBlock
6. **#16665 core/gloas: add ProcessParentExecutionPayload** ← you are here
7. #16666 blockchain: update block processing and FCU for deferred payload
8. #16667 sync: update validation for deferred processing
9. #16668 rpc: update proposer for deferred payload processing
10. #16669 db/verification: cleanup for deferred processing