### PR TITLE
blockchain: update block processing and FCU for deferred payload

### DIFF
--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -18,18 +18,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (s *Service) isNewHead(r [32]byte, full bool) bool {
+func (s *Service) isNewHead(r [32]byte) bool {
 	s.headLock.RLock()
 	defer s.headLock.RUnlock()
 
 	currentHeadRoot := s.originBlockRoot
-	currentFull := false
 	if s.head != nil {
 		currentHeadRoot = s.headRoot()
-		currentFull = s.head.full
 	}
 
-	return r != currentHeadRoot || full != currentFull || r == [32]byte{}
+	return r != currentHeadRoot || r == [32]byte{}
 }
 
 func (s *Service) getStateAndBlock(ctx context.Context, r, h [32]byte) (state.BeaconState, interfaces.ReadOnlySignedBeaconBlock, error) {
@@ -72,7 +70,7 @@ func (s *Service) sendFCU(cfg *postBlockProcessConfig) {
 		return
 	}
 	// If head has not been updated and attributes are nil, we can skip the FCU.
-	if !s.isNewHead(cfg.headRoot, false) && (fcuArgs.attributes == nil || fcuArgs.attributes.IsEmpty()) {
+	if !s.isNewHead(cfg.headRoot) && (fcuArgs.attributes == nil || fcuArgs.attributes.IsEmpty()) {
 		return
 	}
 	// If we are proposing and we aim to reorg the block, we have already sent FCU with attributes on lateBlockTasks
@@ -83,7 +81,7 @@ func (s *Service) sendFCU(cfg *postBlockProcessConfig) {
 		go s.forkchoiceUpdateWithExecution(cfg.ctx, fcuArgs)
 	}
 
-	if s.isNewHead(fcuArgs.headRoot, false) {
+	if s.isNewHead(fcuArgs.headRoot) {
 		if err := s.saveHead(cfg.ctx, fcuArgs.headRoot, fcuArgs.headBlock, fcuArgs.headState); err != nil {
 			log.WithError(err).Error("Could not save head")
 		}

--- a/beacon-chain/blockchain/forkchoice_update_execution_test.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution_test.go
@@ -21,34 +21,20 @@ func TestService_isNewHead(t *testing.T) {
 	service := setupBeaconChain(t, beaconDB)
 
 	// Zero root is always a new head
-	require.Equal(t, true, service.isNewHead([32]byte{}, false))
-	require.Equal(t, true, service.isNewHead([32]byte{}, true))
+	require.Equal(t, true, service.isNewHead([32]byte{}))
 
 	// Different root is a new head
 	service.head = &head{root: [32]byte{1}}
-	require.Equal(t, true, service.isNewHead([32]byte{2}, false))
+	require.Equal(t, true, service.isNewHead([32]byte{2}))
 
-	// Same root and same full status is not a new head
-	require.Equal(t, false, service.isNewHead([32]byte{1}, false))
-
-	// Same root but different full status is a new head
-	require.Equal(t, true, service.isNewHead([32]byte{1}, true))
-
-	// Same root and both full is not a new head
-	service.head = &head{root: [32]byte{1}, full: true}
-	require.Equal(t, false, service.isNewHead([32]byte{1}, true))
-
-	// Same root, head is full but incoming is not full, is a new head
-	require.Equal(t, true, service.isNewHead([32]byte{1}, false))
+	// Same root is not a new head.
+	require.Equal(t, false, service.isNewHead([32]byte{1}))
 
 	// Nil head should use origin root
 	service.head = nil
 	service.originBlockRoot = [32]byte{3}
-	require.Equal(t, true, service.isNewHead([32]byte{2}, false))
-	require.Equal(t, false, service.isNewHead([32]byte{3}, false))
-
-	// Nil head with full=true is always a new head (originBlockRoot has full=false)
-	require.Equal(t, true, service.isNewHead([32]byte{3}, true))
+	require.Equal(t, true, service.isNewHead([32]byte{2}))
+	require.Equal(t, false, service.isNewHead([32]byte{3}))
 }
 
 func TestService_getHeadStateAndBlock(t *testing.T) {

--- a/beacon-chain/blockchain/gloas.go
+++ b/beacon-chain/blockchain/gloas.go
@@ -10,13 +10,11 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/config/params"
-	consensus_blocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	payloadattribute "github.com/OffchainLabs/prysm/v7/consensus-types/payload-attribute"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/primitives"
 	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
-	"github.com/pkg/errors"
 )
 
 func (s *Service) waitUntilEpoch(target primitives.Epoch, secondsPerSlot uint64) error {
@@ -35,42 +33,6 @@ func (s *Service) waitUntilEpoch(target primitives.Epoch, secondsPerSlot uint64)
 			return s.ctx.Err()
 		}
 	}
-}
-
-// getLookupParentRoot returns the root that serves as key to generate the parent state for the passed beacon block.
-// if it is based on empty or it is pre-Gloas, it is the parent root of the block, otherwise if it is based on full it is
-// the parent hash.
-// The caller of this function should not hold a lock on forkchoice.
-func (s *Service) getLookupParentRoot(b consensus_blocks.ROBlock) ([32]byte, error) {
-	bl := b.Block()
-	parentRoot := bl.ParentRoot()
-	if b.Version() < version.Gloas {
-		return parentRoot, nil
-	}
-	parentSlot, err := s.cfg.ForkChoiceStore.Slot(parentRoot)
-	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "failed to get slot for parent root")
-	}
-
-	if slots.ToEpoch(parentSlot) < params.BeaconConfig().GloasForkEpoch {
-		return parentRoot, nil
-	}
-	blockHash, err := s.cfg.ForkChoiceStore.BlockHash(parentRoot)
-	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "failed to get block hash for parent root")
-	}
-	bid, err := bl.Body().SignedExecutionPayloadBid()
-	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "failed to get signed execution payload bid from block body")
-	}
-	if bid == nil || bid.Message == nil || len(bid.Message.ParentBlockHash) != 32 {
-		return [32]byte{}, errors.New("invalid signed execution payload bid message")
-	}
-	parentHash := [32]byte(bid.Message.ParentBlockHash)
-	if blockHash == parentHash {
-		return parentHash, nil
-	}
-	return parentRoot, nil
 }
 
 func (s *Service) runLatePayloadTasks() {
@@ -193,9 +155,9 @@ func (s *Service) latePayloadTasks(ctx context.Context) {
 	}
 	beaconLatePayloadTaskTriggeredTotal.Inc()
 	// Head is the empty block.
-	bh, err := st.LatestBlockHash()
+	bh, err := s.BlockHash(hr)
 	if err != nil {
-		log.WithError(err).Error("Could not get latest block hash to notify engine")
+		log.WithError(err).Error("Could not get block hash from forkchoice to notify engine")
 		return
 	}
 	pid, err := s.notifyForkchoiceUpdateGloas(ctx, bh, attr)

--- a/beacon-chain/blockchain/gloas_test.go
+++ b/beacon-chain/blockchain/gloas_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/testing/require"
 	"github.com/OffchainLabs/prysm/v7/testing/util"
-	"github.com/OffchainLabs/prysm/v7/time/slots"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
@@ -63,12 +62,13 @@ func prepareGloasForkchoiceState(
 		FinalizedCheckpoint:        finalizedCheckpoint,
 		LatestBlockHeader:          blockHeader,
 		LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
-			BlockHash:          blockHash[:],
-			ParentBlockHash:    parentBlockHash[:],
-			ParentBlockRoot:    make([]byte, 32),
-			PrevRandao:         make([]byte, 32),
-			FeeRecipient:       make([]byte, 20),
-			BlobKzgCommitments: [][]byte{make([]byte, 48)},
+			BlockHash:             blockHash[:],
+			ParentBlockHash:       parentBlockHash[:],
+			ParentBlockRoot:       make([]byte, 32),
+			PrevRandao:            make([]byte, 32),
+			FeeRecipient:          make([]byte, 20),
+			BlobKzgCommitments:    [][]byte{make([]byte, 48)},
+			ExecutionRequestsRoot: make([]byte, 32),
 		},
 		Builders:                     make([]*ethpb.Builder, 0),
 		BuilderPendingPayments:       builderPendingPayments,
@@ -134,12 +134,13 @@ func testGloasState(t *testing.T, slot primitives.Slot, parentRoot [32]byte, blo
 			BlockHash:   make([]byte, 32),
 		},
 		LatestExecutionPayloadBid: &ethpb.ExecutionPayloadBid{
-			BlockHash:          blockHash[:],
-			ParentBlockHash:    make([]byte, 32),
-			ParentBlockRoot:    make([]byte, 32),
-			PrevRandao:         make([]byte, 32),
-			FeeRecipient:       make([]byte, 20),
-			BlobKzgCommitments: [][]byte{make([]byte, 48)},
+			BlockHash:             blockHash[:],
+			ParentBlockHash:       make([]byte, 32),
+			ParentBlockRoot:       make([]byte, 32),
+			PrevRandao:            make([]byte, 32),
+			FeeRecipient:          make([]byte, 20),
+			BlobKzgCommitments:    [][]byte{make([]byte, 48)},
+			ExecutionRequestsRoot: make([]byte, 32),
 		},
 		Builders:                     make([]*ethpb.Builder, 0),
 		BuilderPendingPayments:       builderPendingPayments,
@@ -186,7 +187,6 @@ func testSignedEnvelope(t *testing.T, blockRoot [32]byte, slot primitives.Slot, 
 			BuilderIndex:      0,
 			BeaconBlockRoot:   blockRoot[:],
 			Slot:              slot,
-			StateRoot:         make([]byte, 32),
 		},
 		Signature: make([]byte, 96),
 	}
@@ -423,7 +423,7 @@ func TestValidateExecutionOnEnvelope_Valid(t *testing.T) {
 	require.Equal(t, true, isValid)
 }
 
-func TestPostPayloadHeadUpdate_NotHead(t *testing.T) {
+func TestPostPayloadTasks_NotHead(t *testing.T) {
 	s, _ := setupGloasService(t, &mockExecution.EngineClient{})
 	ctx := t.Context()
 
@@ -443,10 +443,10 @@ func TestPostPayloadHeadUpdate_NotHead(t *testing.T) {
 	envelope, err := blocks.WrappedROExecutionPayloadEnvelope(env)
 	require.NoError(t, err)
 
-	require.NoError(t, s.postPayloadHeadUpdate(ctx, envelope, st, root, headRoot[:]))
+	require.NoError(t, s.postPayloadTasks(ctx, envelope, st, root, headRoot[:]))
 }
 
-func TestPostPayloadHeadUpdate_SetsHeadFull(t *testing.T) {
+func TestPostPayloadTasks_DoesNotMutateHead(t *testing.T) {
 	s, _ := setupGloasService(t, &mockExecution.EngineClient{})
 	ctx := t.Context()
 
@@ -456,11 +456,14 @@ func TestPostPayloadHeadUpdate_SetsHeadFull(t *testing.T) {
 	base, blk := testGloasState(t, 1, params.BeaconConfig().ZeroHash, blockHash)
 	st, err := state_native.InitializeFromProtoUnsafeGloas(base)
 	require.NoError(t, err)
+	oldBase, _ := testGloasState(t, 0, params.BeaconConfig().ZeroHash, blockHash)
+	oldSt, err := state_native.InitializeFromProtoUnsafeGloas(oldBase)
+	require.NoError(t, err)
 	signed, err := blocks.NewSignedBeaconBlock(blk)
 	require.NoError(t, err)
 
 	s.head = &head{root: root, block: signed, state: st, slot: 1}
-	require.Equal(t, false, s.head.full)
+	s.head.state = oldSt
 
 	env := &ethpb.ExecutionPayloadEnvelope{
 		BeaconBlockRoot: root[:],
@@ -470,181 +473,12 @@ func TestPostPayloadHeadUpdate_SetsHeadFull(t *testing.T) {
 	envelope, err := blocks.WrappedROExecutionPayloadEnvelope(env)
 	require.NoError(t, err)
 
-	require.NoError(t, s.postPayloadHeadUpdate(ctx, envelope, st, root, root[:]))
+	require.NoError(t, s.postPayloadTasks(ctx, envelope, st, root, root[:]))
 
 	s.headLock.RLock()
-	require.Equal(t, true, s.head.full)
+	require.Equal(t, root, s.head.root)
+	require.Equal(t, primitives.Slot(0), s.head.state.Slot())
 	s.headLock.RUnlock()
-}
-
-func TestGetLookupParentRoot_PreGloas(t *testing.T) {
-	service, _ := minimalTestService(t)
-
-	parentRoot := [32]byte{1}
-	blk := util.HydrateSignedBeaconBlockDeneb(&ethpb.SignedBeaconBlockDeneb{
-		Block: &ethpb.BeaconBlockDeneb{
-			ParentRoot: parentRoot[:],
-		},
-	})
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	roblock, err := blocks.NewROBlock(wsb)
-	require.NoError(t, err)
-
-	got, err := service.getLookupParentRoot(roblock)
-	require.NoError(t, err)
-	require.Equal(t, parentRoot, got)
-}
-
-func TestGetLookupParentRoot_GloasBuildsOnEmpty(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.GloasForkEpoch = 0
-	cfg.InitializeForkSchedule()
-	params.OverrideBeaconConfig(cfg)
-
-	service, req := minimalTestService(t)
-	ctx := t.Context()
-
-	parentRoot := [32]byte{1}
-	parentBlockHash := [32]byte{20}
-	parentNodeBlockHash := [32]byte{99} // Different from parentBlockHash => builds on empty
-
-	// Insert a Gloas node for the parent so BlockHash works.
-	st, parentROBlock, err := prepareGloasForkchoiceState(ctx, 1, parentRoot, params.BeaconConfig().ZeroHash, parentNodeBlockHash, params.BeaconConfig().ZeroHash, 0, 0)
-	require.NoError(t, err)
-	require.NoError(t, req.fcs.InsertNode(ctx, st, parentROBlock))
-
-	blockHash := [32]byte{10}
-	bid := util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
-		Message: &ethpb.ExecutionPayloadBid{
-			BlockHash:       blockHash[:],
-			ParentBlockHash: parentBlockHash[:],
-		},
-	})
-
-	blk := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{
-		Block: &ethpb.BeaconBlockGloas{
-			Slot:       2,
-			ParentRoot: parentRoot[:],
-			Body: &ethpb.BeaconBlockBodyGloas{
-				SignedExecutionPayloadBid: bid,
-			},
-		},
-	})
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	roblock, err := blocks.NewROBlock(wsb)
-	require.NoError(t, err)
-
-	got, err := service.getLookupParentRoot(roblock)
-	require.NoError(t, err)
-	// parentBlockHash != parentNodeBlockHash, so it builds on empty => returns parentRoot
-	require.Equal(t, parentRoot, got)
-}
-
-func TestGetLookupParentRoot_GloasBuildsOnFull(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.GloasForkEpoch = 0
-	cfg.InitializeForkSchedule()
-	params.OverrideBeaconConfig(cfg)
-
-	service, req := minimalTestService(t)
-	ctx := t.Context()
-
-	parentRoot := [32]byte{1}
-	parentNodeBlockHash := [32]byte{10}
-
-	// Insert a Gloas node for the parent so BlockHash works.
-	st, parentROBlock, err := prepareGloasForkchoiceState(ctx, 1, parentRoot, params.BeaconConfig().ZeroHash, parentNodeBlockHash, params.BeaconConfig().ZeroHash, 0, 0)
-	require.NoError(t, err)
-	require.NoError(t, req.fcs.InsertNode(ctx, st, parentROBlock))
-
-	// Set parentBlockHash in the bid to match the parent's blockHash.
-	blockHash := [32]byte{20}
-	bid := util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
-		Message: &ethpb.ExecutionPayloadBid{
-			BlockHash:       blockHash[:],
-			ParentBlockHash: parentNodeBlockHash[:],
-		},
-	})
-
-	blk := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{
-		Block: &ethpb.BeaconBlockGloas{
-			Slot:       2,
-			ParentRoot: parentRoot[:],
-			Body: &ethpb.BeaconBlockBodyGloas{
-				SignedExecutionPayloadBid: bid,
-			},
-		},
-	})
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	roblock, err := blocks.NewROBlock(wsb)
-	require.NoError(t, err)
-
-	got, err := service.getLookupParentRoot(roblock)
-	require.NoError(t, err)
-	// parentBlockHash == parentNodeBlockHash, so it builds on full => returns parentBlockHash
-	require.Equal(t, parentNodeBlockHash, got)
-}
-
-func TestGetLookupParentRoot_GloasParentPreForkEpoch(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.GloasForkEpoch = 2
-	cfg.InitializeForkSchedule()
-	params.OverrideBeaconConfig(cfg)
-
-	service, req := minimalTestService(t)
-	ctx := t.Context()
-
-	parentRoot := [32]byte{1}
-	parentNodeBlockHash := [32]byte{10}
-	parentSlot, err := slots.EpochStart(params.BeaconConfig().GloasForkEpoch)
-	require.NoError(t, err)
-	parentSlot = parentSlot - 1
-
-	st, parentROBlock, err := prepareGloasForkchoiceState(
-		ctx,
-		parentSlot,
-		parentRoot,
-		params.BeaconConfig().ZeroHash,
-		parentNodeBlockHash,
-		params.BeaconConfig().ZeroHash,
-		0,
-		0,
-	)
-	require.NoError(t, err)
-	require.NoError(t, req.fcs.InsertNode(ctx, st, parentROBlock))
-
-	blockHash := [32]byte{20}
-	bid := util.HydrateSignedExecutionPayloadBid(&ethpb.SignedExecutionPayloadBid{
-		Message: &ethpb.ExecutionPayloadBid{
-			BlockHash:       blockHash[:],
-			ParentBlockHash: parentNodeBlockHash[:],
-		},
-	})
-
-	blk := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{
-		Block: &ethpb.BeaconBlockGloas{
-			Slot:       parentSlot + 1,
-			ParentRoot: parentRoot[:],
-			Body: &ethpb.BeaconBlockBodyGloas{
-				SignedExecutionPayloadBid: bid,
-			},
-		},
-	})
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	roblock, err := blocks.NewROBlock(wsb)
-	require.NoError(t, err)
-
-	got, err := service.getLookupParentRoot(roblock)
-	require.NoError(t, err)
-	// Parent slot is pre-fork, so always return parentRoot.
-	require.Equal(t, parentRoot, got)
 }
 
 func TestLatePayloadTasks_ReturnsEarlyWhenBlockLate(t *testing.T) {
@@ -746,170 +580,6 @@ func TestLateBlockTasks_GloasFCU(t *testing.T) {
 	cachedPid, has := service.cfg.PayloadIDCache.PayloadID(service.CurrentSlot()+1, headRoot)
 	require.Equal(t, true, has)
 	require.Equal(t, primitives.PayloadID(pid[:]), cachedPid)
-}
-
-// TestSaveHead_GloasForkBoundary_PreforkBidForcesEmptyHead verifies that saveHead does not
-// treat the head as "full" when the latest execution payload bid was issued in a pre-fork epoch.
-// This guards against the Fulu->Gloas upgrade-seeded bid (bid.BlockHash == latestBlockHash,
-// bid.Slot == 0) causing a spurious full=true head before any real Gloas bid has been processed.
-func TestSaveHead_GloasForkBoundary_PreforkBidForcesEmptyHead(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.GloasForkEpoch = 1
-	cfg.InitializeForkSchedule()
-	params.OverrideBeaconConfig(cfg)
-
-	service, _ := setupGloasService(t, &mockExecution.EngineClient{})
-	ctx := t.Context()
-
-	blockRoot := bytesutil.ToBytes32([]byte("root1"))
-	parentRoot := params.BeaconConfig().ZeroHash
-	blockHash := bytesutil.ToBytes32([]byte("hash1"))
-
-	// Create a Gloas state where IsParentBlockFull()==true (bid.BlockHash == LatestBlockHash)
-	// but bid.Slot is 0 (epoch 0, pre-fork). This mimics the upgrade-seeded state.
-	base, blk := testGloasState(t, 1, parentRoot, blockHash)
-	base.LatestBlockHash = blockHash[:]
-	// bid.Slot defaults to 0, which is before GloasForkEpoch=1.
-
-	// Set a valid initial head so saveHead's headBlock() call does not panic.
-	// We do NOT insert the old block into forkchoice because insertGloasBlock
-	// would claim the tree root slot; the target block (parentRoot=ZeroHash) must
-	// be the first node inserted so it can become the tree root.
-	oldBlk := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{})
-	oldSigned, err2 := blocks.NewSignedBeaconBlock(oldBlk)
-	require.NoError(t, err2)
-	oldSt, err2 := state_native.InitializeFromProtoUnsafeGloas(&ethpb.BeaconStateGloas{
-		Slot:                       0,
-		RandaoMixes:                make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
-		CurrentJustifiedCheckpoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
-		FinalizedCheckpoint:        &ethpb.Checkpoint{Root: make([]byte, 32)},
-		LatestBlockHeader:          &ethpb.BeaconBlockHeader{ParentRoot: make([]byte, 32), StateRoot: make([]byte, 32), BodyRoot: make([]byte, 32)},
-		Eth1Data:                   &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)},
-		LatestExecutionPayloadBid:  &ethpb.ExecutionPayloadBid{BlockHash: make([]byte, 32), ParentBlockHash: make([]byte, 32), ParentBlockRoot: make([]byte, 32), PrevRandao: make([]byte, 32), FeeRecipient: make([]byte, 20), BlobKzgCommitments: [][]byte{make([]byte, 48)}},
-		BuilderPendingPayments: func() []*ethpb.BuilderPendingPayment {
-			pp := make([]*ethpb.BuilderPendingPayment, 64)
-			for i := range pp {
-				pp[i] = &ethpb.BuilderPendingPayment{Withdrawal: &ethpb.BuilderPendingWithdrawal{FeeRecipient: make([]byte, 20)}}
-			}
-			return pp
-		}(),
-		ExecutionPayloadAvailability: make([]byte, 1024),
-		LatestBlockHash:              make([]byte, 32),
-		PayloadExpectedWithdrawals:   make([]*enginev1.Withdrawal, 0),
-		ProposerLookahead:            make([]primitives.ValidatorIndex, 64),
-	})
-	require.NoError(t, err2)
-	oldRoot := bytesutil.ToBytes32([]byte("oldroot1"))
-	service.head = &head{root: oldRoot, block: oldSigned, state: oldSt, slot: 0}
-
-	insertGloasBlock(t, service, base, blk, blockRoot)
-
-	st, err := state_native.InitializeFromProtoUnsafeGloas(base)
-	require.NoError(t, err)
-
-	// Verify precondition: IsParentBlockFull() is true.
-	full, err := st.IsParentBlockFull()
-	require.NoError(t, err)
-	require.Equal(t, true, full, "precondition: IsParentBlockFull must be true")
-
-	// Verify guard precondition: bid.Slot is pre-fork.
-	bid, err := st.LatestExecutionPayloadBid()
-	require.NoError(t, err)
-	isPrefork := slots.ToEpoch(bid.Slot()) < params.BeaconConfig().GloasForkEpoch
-	require.Equal(t, true, isPrefork, "precondition: bid.Slot must be pre-fork")
-
-	ssigned, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-
-	// saveHead should NOT mark the head as full because bid.Slot < GloasForkEpoch.
-	require.NoError(t, service.saveHead(ctx, blockRoot, ssigned, st))
-
-	service.headLock.RLock()
-	headFull := service.head.full
-	service.headLock.RUnlock()
-	require.Equal(t, false, headFull, "head must not be full for upgrade-seeded bid")
-}
-
-// TestSaveHead_GloasForkBoundary_PostforkBidSetsFullHead verifies that saveHead correctly
-// marks the head as full when the latest bid is from a post-fork epoch.
-func TestSaveHead_GloasForkBoundary_PostforkBidSetsFullHead(t *testing.T) {
-	params.SetupTestConfigCleanup(t)
-	cfg := params.BeaconConfig().Copy()
-	cfg.GloasForkEpoch = 1
-	cfg.InitializeForkSchedule()
-	params.OverrideBeaconConfig(cfg)
-
-	service, _ := setupGloasService(t, &mockExecution.EngineClient{})
-	ctx := t.Context()
-
-	forkSlot, err := slots.EpochStart(params.BeaconConfig().GloasForkEpoch)
-	require.NoError(t, err)
-
-	blockRoot := bytesutil.ToBytes32([]byte("root1"))
-	parentRoot := params.BeaconConfig().ZeroHash
-	blockHash := bytesutil.ToBytes32([]byte("hash1"))
-
-	// Set a valid initial head so saveHead's headBlock() call does not panic.
-	// Do NOT use insertGloasBlock for the old block — the target block must be
-	// the first node inserted so it can claim the tree root (parentRoot=ZeroHash).
-	oldBlk2 := util.HydrateSignedBeaconBlockGloas(&ethpb.SignedBeaconBlockGloas{})
-	oldSigned2, err2 := blocks.NewSignedBeaconBlock(oldBlk2)
-	require.NoError(t, err2)
-	oldSt2, err2 := state_native.InitializeFromProtoUnsafeGloas(&ethpb.BeaconStateGloas{
-		Slot:                       0,
-		RandaoMixes:                make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
-		CurrentJustifiedCheckpoint: &ethpb.Checkpoint{Root: make([]byte, 32)},
-		FinalizedCheckpoint:        &ethpb.Checkpoint{Root: make([]byte, 32)},
-		LatestBlockHeader:          &ethpb.BeaconBlockHeader{ParentRoot: make([]byte, 32), StateRoot: make([]byte, 32), BodyRoot: make([]byte, 32)},
-		Eth1Data:                   &ethpb.Eth1Data{DepositRoot: make([]byte, 32), BlockHash: make([]byte, 32)},
-		LatestExecutionPayloadBid:  &ethpb.ExecutionPayloadBid{BlockHash: make([]byte, 32), ParentBlockHash: make([]byte, 32), ParentBlockRoot: make([]byte, 32), PrevRandao: make([]byte, 32), FeeRecipient: make([]byte, 20), BlobKzgCommitments: [][]byte{make([]byte, 48)}},
-		BuilderPendingPayments: func() []*ethpb.BuilderPendingPayment {
-			pp := make([]*ethpb.BuilderPendingPayment, 64)
-			for i := range pp {
-				pp[i] = &ethpb.BuilderPendingPayment{Withdrawal: &ethpb.BuilderPendingWithdrawal{FeeRecipient: make([]byte, 20)}}
-			}
-			return pp
-		}(),
-		ExecutionPayloadAvailability: make([]byte, 1024),
-		LatestBlockHash:              make([]byte, 32),
-		PayloadExpectedWithdrawals:   make([]*enginev1.Withdrawal, 0),
-		ProposerLookahead:            make([]primitives.ValidatorIndex, 64),
-	})
-	require.NoError(t, err2)
-	oldRoot2 := bytesutil.ToBytes32([]byte("oldroot2"))
-	service.head = &head{root: oldRoot2, block: oldSigned2, state: oldSt2, slot: 0}
-
-	base, blk := testGloasState(t, forkSlot+1, parentRoot, blockHash)
-	base.LatestBlockHash = blockHash[:]
-	// Set bid.Slot to a post-fork epoch slot.
-	base.LatestExecutionPayloadBid.Slot = forkSlot + 1
-
-	insertGloasBlock(t, service, base, blk, blockRoot)
-
-	st, err := state_native.InitializeFromProtoUnsafeGloas(base)
-	require.NoError(t, err)
-
-	// Verify preconditions.
-	full, err := st.IsParentBlockFull()
-	require.NoError(t, err)
-	require.Equal(t, true, full, "precondition: IsParentBlockFull must be true")
-
-	bid, err := st.LatestExecutionPayloadBid()
-	require.NoError(t, err)
-	isPostfork := slots.ToEpoch(bid.Slot()) >= params.BeaconConfig().GloasForkEpoch
-	require.Equal(t, true, isPostfork, "precondition: bid.Slot must be post-fork")
-
-	ssigned, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-
-	// saveHead SHOULD mark the head as full because bid.Slot >= GloasForkEpoch.
-	require.NoError(t, service.saveHead(ctx, blockRoot, ssigned, st))
-
-	service.headLock.RLock()
-	headFull := service.head.full
-	service.headLock.RUnlock()
-	require.Equal(t, true, headFull, "head must be full for real post-fork bid")
 }
 
 // TestLateBlockTasks_GloasForkBoundary_PreforkBidUsesHeadRoot verifies that lateBlockTasks

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -50,7 +50,6 @@ type head struct {
 	block      interfaces.ReadOnlySignedBeaconBlock // current head block.
 	state      state.BeaconState                    // current head state.
 	slot       primitives.Slot                      // the head block slot number
-	full       bool                                 // whether the head is post-CL or post-EL after Gloas
 	optimistic bool                                 // optimistic status when saved head
 }
 
@@ -61,24 +60,8 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 	ctx, span := trace.StartSpan(ctx, "blockChain.saveHead")
 	defer span.End()
 
-	// Pre-Gloas we use empty for head because we still key states by blockroot
-	var full bool
-	var err error
-	if headState.Version() >= version.Gloas {
-		gloasFirstSlot, err := slots.EpochStart(params.BeaconConfig().GloasForkEpoch)
-		if err != nil {
-			return errors.Wrap(err, "could not compute gloas first slot")
-		}
-		if headState.Slot() > gloasFirstSlot {
-			full, err = headState.IsParentBlockFull()
-			if err != nil {
-				return errors.Wrap(err, "could not determine if head is full or not")
-			}
-		}
-	}
-
 	// Do nothing if head hasn't changed.
-	if !s.isNewHead(newHeadRoot, full) {
+	if !s.isNewHead(newHeadRoot) {
 		return nil
 	}
 
@@ -174,7 +157,6 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 		state:      headState,
 		optimistic: isOptimistic,
 		slot:       headBlock.Block().Slot(),
-		full:       full,
 	}
 	if err := s.setHead(newHead); err != nil {
 		return errors.Wrap(err, "could not set head")
@@ -235,7 +217,6 @@ func (s *Service) setHead(newHead *head) error {
 		root:       newHead.root,
 		block:      bCp,
 		state:      newHead.state.Copy(),
-		full:       newHead.full,
 		optimistic: newHead.optimistic,
 		slot:       newHead.slot,
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -108,7 +108,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 	}
 	if cfg.roblock.Version() < version.Gloas {
 		s.sendFCU(cfg)
-	} else if s.isNewHead(cfg.headRoot, false) { // We reach this only when the incoming block is head.
+	} else if s.isNewHead(cfg.headRoot) { // We reach this only when the incoming block is head.
 		if err := s.saveHead(ctx, cfg.headRoot, cfg.roblock, cfg.postState); err != nil {
 			log.WithError(err).Error("Could not save head")
 		}
@@ -145,50 +145,6 @@ func getStateVersionAndPayload(st state.BeaconState) (int, interfaces.ExecutionD
 	return preStateVersion, preStateHeader, nil
 }
 
-// applyPayloadIfNeeded applies the parent block's execution payload envelope to
-// preState when the current block's bid indicates it built on a full parent.
-func (s *Service) applyPayloadIfNeeded(ctx context.Context, b interfaces.ReadOnlyBeaconBlock, parentRoot [32]byte, preState state.BeaconState) error {
-	if b.Version() < version.Gloas || parentRoot == [32]byte{} {
-		return nil
-	}
-	parentBlock, err := s.cfg.BeaconDB.Block(ctx, parentRoot)
-	if err != nil {
-		return errors.Wrapf(err, "could not get parent block with root %#x", parentRoot)
-	}
-	if parentBlock.Version() < version.Gloas {
-		return nil
-	}
-	sb, err := b.Body().SignedExecutionPayloadBid()
-	if err != nil {
-		return errors.Wrap(err, "could not get execution payload bid for block")
-	}
-	if sb == nil || sb.Message == nil {
-		return fmt.Errorf("missing execution payload bid for block at slot %d", b.Slot())
-	}
-	parentBid, err := parentBlock.Block().Body().SignedExecutionPayloadBid()
-	if err != nil {
-		return errors.Wrapf(err, "could not get execution payload bid for parent block with root %#x", parentRoot)
-	}
-	if parentBid == nil || parentBid.Message == nil {
-		return fmt.Errorf("missing execution payload bid for parent block with root %#x", parentRoot)
-	}
-	if !bytes.Equal(sb.Message.ParentBlockHash, parentBid.Message.BlockHash) {
-		return nil
-	}
-	signedEnvelope, err := s.cfg.BeaconDB.ExecutionPayloadEnvelope(ctx, parentRoot)
-	if err != nil {
-		return errors.Wrapf(err, "could not get execution payload envelope for parent block with root %#x", parentRoot)
-	}
-	if signedEnvelope == nil || signedEnvelope.Message == nil {
-		return nil
-	}
-	envelope, err := consensusblocks.WrappedROBlindedExecutionPayloadEnvelope(signedEnvelope.Message)
-	if err != nil {
-		return errors.Wrapf(err, "could not wrap blinded execution payload envelope for parent block with root %#x", parentRoot)
-	}
-	return gloas.ProcessBlindedExecutionPayload(ctx, preState, parentBlock.Block().StateRoot(), envelope)
-}
-
 // getBatchPrestate returns the pre-state to apply to the first beacon block in the batch and returns true if it applied the first envelope before
 func (s *Service) getBatchPrestate(ctx context.Context, b consensusblocks.ROBlock, envelopes []interfaces.ROSignedExecutionPayloadEnvelope) (state.BeaconState, bool, error) {
 	if len(envelopes) == 0 || b.Version() < version.Gloas {
@@ -210,37 +166,17 @@ func (s *Service) getBatchPrestate(ctx context.Context, b consensusblocks.ROBloc
 	if !full {
 		return blockPreState, false, nil
 	}
-	parentBlock, err := s.cfg.BeaconDB.Block(ctx, parentRoot)
-	if err != nil {
-		return nil, false, errors.Wrap(err, "could not get parent block")
-	}
-	if s.cfg.BeaconDB.HasExecutionPayloadEnvelope(ctx, parentRoot) {
-		// The parent envelope was already saved by a previous batch but the
-		// replayed state may not include it (replay skips the last block's
-		// envelope). Load the blinded form from DB and apply it.
-		blindedEnv, err := s.cfg.BeaconDB.ExecutionPayloadEnvelope(ctx, parentRoot)
+	// With deferred payload processing, state mutations from the parent's
+	// execution payload are applied by ProcessParentExecutionPayload inside
+	// the normal state transition. We still need to notify the engine.
+	if !s.cfg.BeaconDB.HasExecutionPayloadEnvelope(ctx, parentRoot) {
+		env, err := envelopes[0].Envelope()
 		if err != nil {
-			return nil, false, errors.Wrap(err, "could not load parent blinded envelope from DB")
+			return nil, false, err
 		}
-		wrappedEnv, err := consensusblocks.WrappedROBlindedExecutionPayloadEnvelope(blindedEnv.Message)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "could not wrap blinded envelope")
+		if _, err := s.notifyNewEnvelope(ctx, blockPreState, env); err != nil {
+			return nil, false, err
 		}
-		if err := gloas.ProcessBlindedExecutionPayload(ctx, blockPreState, parentBlock.Block().StateRoot(), wrappedEnv); err != nil {
-			return nil, false, errors.Wrap(err, "could not apply parent blinded envelope from DB")
-		}
-		return blockPreState, true, nil
-	}
-	env, err := envelopes[0].Envelope()
-	if err != nil {
-		return nil, false, err
-	}
-	// notify the engine of the new envelope
-	if _, err := s.notifyNewEnvelope(ctx, blockPreState, env); err != nil {
-		return nil, false, err
-	}
-	if err := gloas.ProcessBlindedExecutionPayload(ctx, blockPreState, parentBlock.Block().StateRoot(), env); err != nil {
-		return nil, false, err
 	}
 	return blockPreState, true, nil
 }
@@ -323,7 +259,7 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []consensusblocks.ROBlo
 			return invalidBlock{error: err}
 		}
 		if b.Root() == br && eidx < len(envelopes) {
-			envSigSet, err := gloas.ProcessExecutionPayloadWithDeferredSig(ctx, preState, b.Block().StateRoot(), envelopes[eidx])
+			envSigSet, err := gloas.ProcessExecutionPayloadWithDeferredSig(ctx, preState, envelopes[eidx])
 			if err != nil {
 				return err
 			}
@@ -1217,19 +1153,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	headState := s.headState(ctx)
 	s.headLock.RUnlock()
 
-	var accessRoot [32]byte
-	isFull, err := headState.IsParentBlockFull()
-	gloasFirstSlot, _ := slots.EpochStart(params.BeaconConfig().GloasForkEpoch)
-	if err != nil || !isFull || headState.Slot() <= gloasFirstSlot {
-		accessRoot = headRoot
-	} else {
-		accessRoot, err = headState.LatestBlockHash()
-		if err != nil {
-			log.WithError(err).Debug("could not perform late block tasks: failed to retrieve latest block hash, using head root as access root")
-			accessRoot = headRoot
-		}
-	}
-	s.refreshCaches(ctx, currentSlot, headRoot, headState, accessRoot)
+	s.refreshCaches(ctx, currentSlot, headRoot, headState, headRoot)
 	// return early if we already started building a block for the current
 	// head root
 	_, has := s.cfg.PayloadIDCache.PayloadID(s.CurrentSlot()+1, headRoot)
@@ -1237,16 +1161,16 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		return
 	}
 
-	attribute := s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:], accessRoot[:])
+	attribute := s.getPayloadAttribute(ctx, headState, s.CurrentSlot()+1, headRoot[:], headRoot[:])
 	// return early if we are not proposing next slot
 	if attribute.IsEmpty() {
 		return
 	}
 
 	if headState.Version() >= version.Gloas {
-		bh, err := headState.LatestBlockHash()
+		bh, err := s.BlockHash(headRoot)
 		if err != nil {
-			log.WithError(err).Debug("could not perform late block tasks: failed to retrieve latest block hash")
+			log.WithError(err).Debug("could not perform late block tasks: failed to retrieve block hash from forkchoice")
 			return
 		}
 		id, err := s.notifyForkchoiceUpdateGloas(ctx, bh, attribute)

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -195,25 +195,14 @@ func (s *Service) updateCachesPostBlockProcessing(cfg *postBlockProcessConfig) {
 	}
 }
 
-// reportProcessingTime reports the metric of how long it took to process the
-// current block
-func reportProcessingTime(startTime time.Time) {
-	onBlockProcessingTime.Observe(float64(time.Since(startTime).Milliseconds()))
-}
-
 // GetPrestateToPropose returns the pre-state for a proposer to base its block on.
-// It is similar to GetBlockPreState but it lacks unnecessary verifications.
 func (s *Service) GetPrestateToPropose(ctx context.Context, b consensus_blocks.ROBlock) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "blockChain.GetPreStateToPropose")
 	defer span.End()
 
-	accessRoot, err := s.getLookupParentRoot(b)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get lookup parent root")
-	}
-
+	parentRoot := b.Block().ParentRoot()
 	bl := b.Block()
-	preState, err := s.cfg.StateGen.StateByRoot(ctx, accessRoot)
+	preState, err := s.cfg.StateGen.StateByRoot(ctx, parentRoot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get pre state for slot %d", bl.Slot())
 	}
@@ -223,6 +212,12 @@ func (s *Service) GetPrestateToPropose(ctx context.Context, b consensus_blocks.R
 	return preState, nil
 }
 
+// reportProcessingTime reports the metric of how long it took to process the
+// current block
+func reportProcessingTime(startTime time.Time) {
+	onBlockProcessingTime.Observe(float64(time.Since(startTime).Milliseconds()))
+}
+
 // GetBlockPreState returns the pre state of an incoming block. It uses the parent root of the block
 // to retrieve the state in DB. It verifies the pre state's validity and the incoming block
 // is in the correct time window.
@@ -230,17 +225,14 @@ func (s *Service) GetBlockPreState(ctx context.Context, b consensus_blocks.ROBlo
 	ctx, span := trace.StartSpan(ctx, "blockChain.getBlockPreState")
 	defer span.End()
 
-	accessRoot, err := s.getLookupParentRoot(b)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get lookup parent root")
-	}
+	parentRoot := b.Block().ParentRoot()
 	// Verify incoming block has a valid pre state.
-	if err := s.verifyBlkPreState(ctx, accessRoot); err != nil {
+	if err := s.verifyBlkPreState(ctx, parentRoot); err != nil {
 		return nil, err
 	}
 
 	bl := b.Block()
-	preState, err := s.cfg.StateGen.StateByRoot(ctx, accessRoot)
+	preState, err := s.cfg.StateGen.StateByRoot(ctx, parentRoot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get pre state for slot %d", bl.Slot())
 	}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -134,49 +134,48 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 
 	start = time.Now()
 	// return early if we haven't changed head
-	newHeadRoot, newHeadBlockHash, full, err := s.cfg.ForkChoiceStore.FullHead(ctx)
+	newHeadRoot, _, _, err := s.cfg.ForkChoiceStore.FullHead(ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not compute head from new attestations")
 		return
 	}
-	if !s.isNewHead(newHeadRoot, full) {
+	if !s.isNewHead(newHeadRoot) {
 		return
 	}
 	log.WithField("newHeadRoot", fmt.Sprintf("%#x", newHeadRoot)).Debug("Head changed due to attestations")
-	var accessRoot [32]byte
-	postGloas := slots.ToEpoch(proposingSlot) >= params.BeaconConfig().GloasForkEpoch
-	if full && postGloas {
-		accessRoot = newHeadBlockHash
-	} else {
-		accessRoot = newHeadRoot
-	}
-	headState, headBlock, err := s.getStateAndBlock(ctx, newHeadRoot, accessRoot)
+	headState, headBlock, err := s.getStateAndBlock(ctx, newHeadRoot, newHeadRoot)
 	if err != nil {
 		log.WithError(err).Error("Could not get head block and state")
 		return
 	}
 	newAttHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 	if s.inRegularSync() {
-		attr := s.getPayloadAttribute(ctx, headState, proposingSlot, newHeadRoot[:], accessRoot[:])
+		attr := s.getPayloadAttribute(ctx, headState, proposingSlot, newHeadRoot[:], newHeadRoot[:])
 		if attr != nil && s.shouldOverrideFCU(newHeadRoot, proposingSlot) {
 			return
 		}
+		postGloas := slots.ToEpoch(proposingSlot) >= params.BeaconConfig().GloasForkEpoch
 		if postGloas {
-			go func() {
-				pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, newHeadBlockHash, attr)
-				if err != nil {
-					log.WithError(err).Error("Could not update forkchoice with engine")
-				}
-				if pid == nil {
-					if attr != nil {
-						log.Warn("Engine did not return a payload ID for the fork choice update with attributes")
+			blockHash, hashErr := s.cfg.ForkChoiceStore.BlockHash(newHeadRoot)
+			if hashErr != nil {
+				log.WithError(hashErr).Error("Could not get block hash from forkchoice for FCU")
+			} else {
+				go func() {
+					pid, err := s.notifyForkchoiceUpdateGloas(s.ctx, blockHash, attr)
+					if err != nil {
+						log.WithError(err).Error("Could not update forkchoice with engine")
 					}
-					return
-				}
-				var pId [8]byte
-				copy(pId[:], pid[:])
-				s.cfg.PayloadIDCache.Set(proposingSlot, newHeadRoot, pId)
-			}()
+					if pid == nil {
+						if attr != nil {
+							log.Warn("Engine did not return a payload ID for the fork choice update with attributes")
+						}
+						return
+					}
+					var pId [8]byte
+					copy(pId[:], pid[:])
+					s.cfg.PayloadIDCache.Set(proposingSlot, newHeadRoot, pId)
+				}()
+			}
 		} else {
 			fcuArgs := &fcuConfig{
 				headState:     headState,

--- a/beacon-chain/blockchain/receive_execution_payload_envelope.go
+++ b/beacon-chain/blockchain/receive_execution_payload_envelope.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed"
 	statefeed "github.com/OffchainLabs/prysm/v7/beacon-chain/core/feed/state"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/gloas"
-	"github.com/OffchainLabs/prysm/v7/beacon-chain/core/transition"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/execution"
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/state"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
@@ -111,7 +110,7 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 		log.WithError(err).Error("Could not get head root")
 		return nil
 	}
-	if err := s.postPayloadHeadUpdate(ctx, envelope, preState, root, headRoot); err != nil {
+	if err := s.postPayloadTasks(ctx, envelope, preState, root, headRoot); err != nil {
 		return err
 	}
 
@@ -138,7 +137,7 @@ func (s *Service) ReceiveExecutionPayloadEnvelope(ctx context.Context, signed in
 	return nil
 }
 
-func (s *Service) postPayloadHeadUpdate(ctx context.Context, envelope interfaces.ROExecutionPayloadEnvelope, st state.BeaconState, root [32]byte, headRoot []byte) error {
+func (s *Service) postPayloadTasks(ctx context.Context, envelope interfaces.ROExecutionPayloadEnvelope, st state.BeaconState, root [32]byte, headRoot []byte) error {
 	if !bytes.Equal(headRoot, root[:]) {
 		return nil
 	}
@@ -148,17 +147,9 @@ func (s *Service) postPayloadHeadUpdate(ctx context.Context, envelope interfaces
 	}
 	blockHash := bytesutil.ToBytes32(payload.BlockHash())
 
-	s.headLock.Lock()
-	s.head.state = st
-	s.head.full = true
-	s.headLock.Unlock()
-
 	go func() {
 		ctx, cancel := context.WithTimeout(s.ctx, slotDeadline)
 		defer cancel()
-		if err := transition.UpdateNextSlotCache(ctx, blockHash[:], st); err != nil {
-			log.WithError(err).Error("Could not update next slot cache")
-		}
 		if err := s.handleEpochBoundary(ctx, envelope.Slot(), st, blockHash[:]); err != nil {
 			log.WithError(err).Error("Could not handle epoch boundary")
 		}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -345,7 +345,7 @@ func (s *Service) initializeHead(ctx context.Context, st state.BeaconState) erro
 			return errors.Wrap(err, "could not get head state")
 		}
 	}
-	if err := s.setHead(&head{root, blk, st, blk.Block().Slot(), false, false}); err != nil {
+	if err := s.setHead(&head{root: root, block: blk, state: st, slot: blk.Block().Slot(), optimistic: false}); err != nil {
 		return errors.Wrap(err, "could not set head")
 	}
 	log.WithFields(logrus.Fields{
@@ -429,12 +429,11 @@ func (s *Service) saveGenesisData(ctx context.Context, genesisState state.Beacon
 	s.cfg.ForkChoiceStore.SetGenesisTime(s.genesisTime)
 
 	if err := s.setHead(&head{
-		genesisBlkRoot,
-		genesisBlk,
-		genesisState,
-		genesisBlk.Block().Slot(),
-		false,
-		false,
+		root:       genesisBlkRoot,
+		block:      genesisBlk,
+		state:      genesisState,
+		slot:       genesisBlk.Block().Slot(),
+		optimistic: false,
 	}); err != nil {
 		log.WithError(err).Fatal("Could not set head")
 	}

--- a/beacon-chain/cache/highest_execution_payload_bid_test.go
+++ b/beacon-chain/cache/highest_execution_payload_bid_test.go
@@ -89,16 +89,17 @@ func testSignedExecutionPayloadBid(
 ) *ethpb.SignedExecutionPayloadBid {
 	return &ethpb.SignedExecutionPayloadBid{
 		Message: &ethpb.ExecutionPayloadBid{
-			Slot:             slot,
-			ParentBlockHash:  bytes.Clone(parentHash[:]),
-			ParentBlockRoot:  bytes.Clone(parentRoot[:]),
-			BlockHash:        bytes.Repeat([]byte{0x03}, 32),
-			PrevRandao:       bytes.Repeat([]byte{0x04}, 32),
-			FeeRecipient:     bytes.Repeat([]byte{0x05}, 20),
-			GasLimit:         30_000_000,
-			BuilderIndex:     1,
-			Value:            primitives.Gwei(value),
-			ExecutionPayment: 10,
+			Slot:                  slot,
+			ParentBlockHash:       bytes.Clone(parentHash[:]),
+			ParentBlockRoot:       bytes.Clone(parentRoot[:]),
+			BlockHash:             bytes.Repeat([]byte{0x03}, 32),
+			PrevRandao:            bytes.Repeat([]byte{0x04}, 32),
+			FeeRecipient:          bytes.Repeat([]byte{0x05}, 20),
+			GasLimit:              30_000_000,
+			BuilderIndex:          1,
+			Value:                 primitives.Gwei(value),
+			ExecutionPayment:      10,
+			ExecutionRequestsRoot: make([]byte, 32),
 		},
 		Signature: bytes.Repeat([]byte{0x06}, 96),
 	}


### PR DESCRIPTION
## Summary
Part 7/10 of deferred payload processing (consensus-specs#5094).

## Stack

1. # 
2. #16661 proto: add parent_block_hash and execution_requests_root to bid
3. #16662 consensus-types: add ParentBlockHash getter and ParentExecutionRequests interface
4. #16663 state: add QueueBuilderPaymentForSlot and update stategen
5. #16664 core/transition: remove ProcessSlotsForBlock
6. #16665 core/gloas: add ProcessParentExecutionPayload
7. **#16666 blockchain: update block processing and FCU for deferred payload** ← you are here
8. #16667 sync: update validation for deferred processing
9. #16668 rpc: update proposer for deferred payload processing
10. #16669 db/verification: cleanup for deferred processing