### PR TITLE
sync: update block and envelope validation for deferred processing

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -140,6 +140,7 @@ go_library(
         "//math:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
+        "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/prysm/v1alpha1/attestation:go_default_library",
         "//proto/prysm/v1alpha1/metadata:go_default_library",

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_payload_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_payload_test.go
@@ -34,7 +34,6 @@ func makeEnvelope(t *testing.T, slot primitives.Slot, blockHash [32]byte, parent
 		Message: &ethpb.ExecutionPayloadEnvelope{
 			Slot:              slot,
 			BeaconBlockRoot:   make([]byte, fieldparams.RootLength),
-			StateRoot:         make([]byte, fieldparams.RootLength),
 			ExecutionRequests: &enginev1.ExecutionRequests{},
 			Payload: &enginev1.ExecutionPayloadDeneb{
 				ParentHash:    parentHash[:],

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_range.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_range.go
@@ -206,7 +206,6 @@ func (s *Service) streamCanonicalEnvelopes(ctx context.Context, rp rangeParams, 
 				BuilderIndex:      c.env.Message.BuilderIndex,
 				BeaconBlockRoot:   c.env.Message.BeaconBlockRoot,
 				Slot:              c.env.Message.Slot,
-				StateRoot:         c.env.Message.StateRoot,
 			},
 			Signature: c.env.Signature,
 		}

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_range_test.go
@@ -47,7 +47,6 @@ func testSignedEnvelope(slot primitives.Slot, beaconBlockRoot []byte) *pb.Signed
 			},
 			ExecutionRequests: &engpb.ExecutionRequests{},
 			BeaconBlockRoot:   root,
-			StateRoot:         make([]byte, 32),
 			Slot:              slot,
 		},
 		Signature: make([]byte, 96),

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_root.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_root.go
@@ -158,7 +158,6 @@ func (s *Service) executionPayloadEnvelopesByRootRPCHandler(ctx context.Context,
 					BuilderIndex:      req.env.Message.BuilderIndex,
 					BeaconBlockRoot:   req.env.Message.BeaconBlockRoot,
 					Slot:              req.env.Message.Slot,
-					StateRoot:         req.env.Message.StateRoot,
 				},
 				Signature: req.env.Signature,
 			}

--- a/beacon-chain/sync/rpc_execution_payload_envelopes_by_root_test.go
+++ b/beacon-chain/sync/rpc_execution_payload_envelopes_by_root_test.go
@@ -52,7 +52,6 @@ func TestSendExecutionPayloadEnvelopesByRootRequest(t *testing.T) {
 				},
 				BeaconBlockRoot: root[:],
 				Slot:            slot,
-				StateRoot:       make([]byte, fieldparams.RootLength),
 			},
 			Signature: make([]byte, fieldparams.BLSSignatureLength),
 		}

--- a/beacon-chain/sync/validate_beacon_block_gloas.go
+++ b/beacon-chain/sync/validate_beacon_block_gloas.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/OffchainLabs/prysm/v7/beacon-chain/blockchain"
@@ -9,6 +10,8 @@ import (
 	consensusblocks "github.com/OffchainLabs/prysm/v7/consensus-types/blocks"
 	"github.com/OffchainLabs/prysm/v7/consensus-types/interfaces"
 	"github.com/OffchainLabs/prysm/v7/crypto/rand"
+	enginev1 "github.com/OffchainLabs/prysm/v7/proto/engine/v1"
+	ethpb "github.com/OffchainLabs/prysm/v7/proto/prysm/v1alpha1"
 	"github.com/OffchainLabs/prysm/v7/runtime/version"
 	"github.com/OffchainLabs/prysm/v7/time/slots"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -17,8 +20,9 @@ import (
 
 // validateExecutionPayloadBid validates execution payload bid gossip rules.
 // [REJECT] The bid's parent (defined by bid.parent_block_root) equals the block's parent (defined by block.parent_root).
-// [REJECT] The length of KZG commitments is less than or equal to the limitation defined in the consensus layer --
-// i.e. validate that len(bid.blob_kzg_commitments) <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+// [REJECT] The length of KZG commitments is less than or equal to the limitation defined in the consensus layer.
+// [REJECT] If parent was FULL, hash_tree_root(block.body.parent_execution_requests) == parent_bid.execution_requests_root.
+// [REJECT] If parent was EMPTY, block.body.parent_execution_requests == ExecutionRequests().
 func (s *Service) validateExecutionPayloadBid(ctx context.Context, blk interfaces.ReadOnlyBeaconBlock) (pubsub.ValidationResult, error) {
 	if blk.Version() < version.Gloas {
 		return pubsub.ValidationAccept, nil
@@ -43,6 +47,52 @@ func (s *Service) validateExecutionPayloadBid(ctx context.Context, blk interface
 	maxBlobsPerBlock := params.BeaconConfig().MaxBlobsPerBlockAtEpoch(slots.ToEpoch(blk.Slot()))
 	if bid.BlobKzgCommitmentCount() > uint64(maxBlobsPerBlock) {
 		return pubsub.ValidationReject, errors.Wrapf(errRejectCommitmentLen, "%d > %d", bid.BlobKzgCommitmentCount(), maxBlobsPerBlock)
+	}
+
+	return pubsub.ValidationAccept, nil
+}
+
+// validateParentExecutionRequests checks the REJECT conditions for parent_execution_requests.
+func (s *Service) validateParentExecutionRequests(ctx context.Context, blk interfaces.ReadOnlyBeaconBlock, bid *ethpb.SignedExecutionPayloadBid) (pubsub.ValidationResult, error) {
+	parentRoot := blk.ParentRoot()
+	parentBlock, err := s.cfg.beaconDB.Block(ctx, parentRoot)
+	if err != nil {
+		return pubsub.ValidationIgnore, errors.Wrap(err, "could not get parent block")
+	}
+	// Pre-Gloas parent: parent_execution_requests must be empty.
+	if parentBlock.Block().Version() < version.Gloas {
+		parentExecutionRequests, err := blk.Body().ParentExecutionRequests()
+		if err != nil {
+			return pubsub.ValidationIgnore, errors.Wrap(err, "could not get parent execution requests")
+		}
+		if !isEmptyExecutionRequests(parentExecutionRequests) {
+			return pubsub.ValidationReject, errors.New("pre-Gloas parent but parent_execution_requests is non-empty")
+		}
+		return pubsub.ValidationAccept, nil
+	}
+	parentSignedBid, err := parentBlock.Block().Body().SignedExecutionPayloadBid()
+	if err != nil {
+		return pubsub.ValidationIgnore, errors.Wrap(err, "could not get parent bid")
+	}
+
+	parentExecutionRequests, err := blk.Body().ParentExecutionRequests()
+	if err != nil {
+		return pubsub.ValidationIgnore, errors.Wrap(err, "could not get parent execution requests")
+	}
+
+	isParentFull := bytes.Equal(bid.Message.ParentBlockHash, parentSignedBid.Message.BlockHash)
+	if isParentFull {
+		root, err := parentExecutionRequests.HashTreeRoot()
+		if err != nil {
+			return pubsub.ValidationIgnore, errors.Wrap(err, "could not compute parent execution requests root")
+		}
+		if !bytes.Equal(root[:], parentSignedBid.Message.ExecutionRequestsRoot) {
+			return pubsub.ValidationReject, errors.New("parent execution requests root does not match parent bid commitment")
+		}
+	} else {
+		if !isEmptyExecutionRequests(parentExecutionRequests) {
+			return pubsub.ValidationReject, errors.New("parent was empty but parent_execution_requests is non-empty")
+		}
 	}
 	return pubsub.ValidationAccept, nil
 }
@@ -108,4 +158,11 @@ func (s *Service) requestPayloadEnvelope(root [32]byte) {
 			log.WithError(err).Debug("Could not process requested payload envelope")
 		}
 	}
+}
+
+func isEmptyExecutionRequests(r *enginev1.ExecutionRequests) bool {
+	if r == nil {
+		return true
+	}
+	return len(r.Deposits) == 0 && len(r.Withdrawals) == 0 && len(r.Consolidations) == 0
 }

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -231,6 +231,18 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		return res, err
 	}
 
+	if blk.Block().Version() >= version.Gloas {
+		signedBid, _ := blk.Block().Body().SignedExecutionPayloadBid()
+		if signedBid != nil {
+			if res, err := s.validateParentExecutionRequests(ctx, blk.Block(), signedBid); err != nil {
+				if res == pubsub.ValidationReject {
+					s.setBadBlock(ctx, blockRoot)
+				}
+				return res, err
+			}
+		}
+	}
+
 	err = s.validateBeaconBlock(ctx, blk, blockRoot)
 	if err != nil {
 		if s.hasBadBlock(blockRoot) {
@@ -370,7 +382,7 @@ func (s *Service) blockVerifyingState(ctx context.Context, blk interfaces.ReadOn
 		if err != nil {
 			return nil, err
 		}
-		return transition.ProcessSlotsForBlock(ctx, headState, blk.Block())
+		return transition.ProcessSlotsUsingNextSlotCache(ctx, headState, parentRoot[:], blk.Block().Slot())
 	}
 	// If head and block are in the same epoch and head is compatible with the parent's dependent root, then use head
 	if blockEpoch == headEpoch {
@@ -399,7 +411,7 @@ func (s *Service) blockVerifyingState(ctx context.Context, blk interfaces.ReadOn
 	if blockEpoch == parentEpoch {
 		return parentState, nil
 	}
-	return transition.ProcessSlotsForBlock(ctx, parentState, blk.Block())
+	return transition.ProcessSlotsUsingNextSlotCache(ctx, parentState, parentRoot[:], blk.Block().Slot())
 }
 
 func validateDenebBeaconBlock(blk interfaces.ReadOnlyBeaconBlock) error {

--- a/beacon-chain/sync/validate_execution_payload_envelope.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope.go
@@ -117,6 +117,10 @@ func (s *Service) validateExecutionPayloadEnvelope(ctx context.Context, pid peer
 	if err := v.VerifyPayloadHash(bid); err != nil {
 		return pubsub.ValidationReject, err
 	}
+	// [REJECT] hash_tree_root(envelope.execution_requests) == bid.execution_requests_root.
+	if err := v.VerifyExecutionRequestsRoot(bid); err != nil {
+		return pubsub.ValidationReject, err
+	}
 
 	// For self-build, the state is retrived via how we retrieve for beacon block optimization
 	// For builder index, the state is retrived via head state read only

--- a/beacon-chain/sync/validate_execution_payload_envelope_test.go
+++ b/beacon-chain/sync/validate_execution_payload_envelope_test.go
@@ -186,6 +186,10 @@ func (m *mockExecutionPayloadEnvelopeVerifier) VerifyPayloadHash(_ interfaces.RO
 	return m.errPayloadHash
 }
 
+func (m *mockExecutionPayloadEnvelopeVerifier) VerifyExecutionRequestsRoot(_ interfaces.ROExecutionPayloadBid) error {
+	return nil
+}
+
 func (m *mockExecutionPayloadEnvelopeVerifier) VerifySignature(_ state.ReadOnlyBeaconState) error {
 	return m.errSignature
 }
@@ -359,7 +363,6 @@ func testSignedExecutionPayloadEnvelope(t *testing.T, slot primitives.Slot, buil
 			BuilderIndex:    builderIdx,
 			BeaconBlockRoot: root[:],
 			Slot:            slot,
-			StateRoot:       bytes.Repeat([]byte{0xBB}, 32),
 		},
 		Signature: bytes.Repeat([]byte{0xAA}, 96),
 	}


### PR DESCRIPTION
## Summary
Part 8/10 of deferred payload processing (consensus-specs#5094).

## Stack

1. # 
2. #16661 proto: add parent_block_hash and execution_requests_root to bid
3. #16662 consensus-types: add ParentBlockHash getter and ParentExecutionRequests interface
4. #16663 state: add QueueBuilderPaymentForSlot and update stategen
5. #16664 core/transition: remove ProcessSlotsForBlock
6. #16665 core/gloas: add ProcessParentExecutionPayload
7. #16666 blockchain: update block processing and FCU for deferred payload
8. **#16667 sync: update validation for deferred processing** ← you are here
9. #16668 rpc: update proposer for deferred payload processing
10. #16669 db/verification: cleanup for deferred processing