### PR TITLE
Fix event subscription timeout handling

### DIFF
--- a/api/server/httprest/server.go
+++ b/api/server/httprest/server.go
@@ -29,6 +29,8 @@ type Server struct {
 	startFailure error
 }
 
+const eventStreamPath = "/eth/v1/events"
+
 // New returns a new instance of the Server.
 func New(ctx context.Context, opts ...Option) (*Server, error) {
 	g := &Server{
@@ -48,7 +50,17 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 	handler = middleware.MiddlewareChain(g.cfg.router, g.cfg.middlewares)
 	if g.cfg.timeout > 0*time.Second {
 		defaultReadHeaderTimeout = g.cfg.timeout
-		handler = http.TimeoutHandler(handler, g.cfg.timeout, "request timed out")
+		baseHandler := handler
+		timeoutHandler := http.TimeoutHandler(baseHandler, g.cfg.timeout, "request timed out")
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// SSE streams stay open indefinitely, so the global timeout wrapper must not
+			// cancel `/eth/v1/events` before the handler starts streaming responses.
+			if r.URL != nil && r.URL.Path == eventStreamPath {
+				baseHandler.ServeHTTP(w, r)
+				return
+			}
+			timeoutHandler.ServeHTTP(w, r)
+		})
 	}
 	g.server = &http.Server{
 		Addr:              g.cfg.httpAddr,

--- a/api/server/httprest/server_test.go
+++ b/api/server/httprest/server_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/OffchainLabs/prysm/v7/cmd/beacon-chain/flags"
 	"github.com/OffchainLabs/prysm/v7/testing/assert"
@@ -37,10 +39,18 @@ func TestServer_StartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	g.Start()
-	go func() {
-		require.LogsContain(t, hook, "Starting HTTP server")
-		require.LogsDoNotContain(t, hook, "Starting API middleware")
-	}()
+	require.Eventually(t, func() bool {
+		foundStart := false
+		for _, entry := range hook.AllEntries() {
+			if strings.Contains(entry.Message, "Starting HTTP server") {
+				foundStart = true
+			}
+			if strings.Contains(entry.Message, "Starting API middleware") {
+				return false
+			}
+		}
+		return foundStart
+	}, time.Second, 10*time.Millisecond)
 	err = g.Stop()
 	require.NoError(t, err)
 }
@@ -67,4 +77,52 @@ func TestServer_NilHandler_NotFoundHandlerRegistered(t *testing.T) {
 	writer := httptest.NewRecorder()
 	g.cfg.router.ServeHTTP(writer, &http.Request{Method: "GET", Host: "localhost", URL: &url.URL{Path: "/foo"}})
 	assert.Equal(t, http.StatusNotFound, writer.Code)
+}
+
+func TestServer_TimeoutHandlerBypassesSSE(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc(eventStreamPath, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(20 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("stream-open"))
+		require.NoError(t, err)
+	})
+
+	g, err := New(t.Context(),
+		WithHTTPAddr("127.0.0.1:0"),
+		WithRouter(handler),
+		WithTimeout(5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, eventStreamPath, nil)
+	writer := httptest.NewRecorder()
+	g.server.Handler.ServeHTTP(writer, req)
+
+	assert.Equal(t, http.StatusOK, writer.Code)
+	assert.Equal(t, "stream-open", writer.Body.String())
+}
+
+func TestServer_TimeoutHandlerStillAppliesToNonSSE(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/foo", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(20 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("ok"))
+		require.NoError(t, err)
+	})
+
+	g, err := New(t.Context(),
+		WithHTTPAddr("127.0.0.1:0"),
+		WithRouter(handler),
+		WithTimeout(5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+	writer := httptest.NewRecorder()
+	g.server.Handler.ServeHTTP(writer, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
+	assert.Equal(t, true, strings.Contains(writer.Body.String(), "request timed out"))
 }

--- a/changelog/alizfara112_fix-event-subscription-timeout.md
+++ b/changelog/alizfara112_fix-event-subscription-timeout.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prevent `/eth/v1/events` subscriptions from timing out under the global HTTP timeout handler.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This excludes `/eth/v1/events` from the global `http.TimeoutHandler` while keeping the timeout behavior for other HTTP routes unchanged.

When `--api-timeout` is set, the timeout wrapper is incompatible with Prysm's SSE event stream handling and can return `200 OK` with an empty response body instead of keeping the stream open.

**Which issues(s) does this PR fix?**

Fixes #15710

**Other notes for review**

- Adds focused coverage for the SSE bypass and the unchanged timeout behavior for non-SSE routes.
- Stabilizes `TestServer_StartStop` by replacing a goroutine log assertion with `require.Eventually`.
- Validation used during review:
  `go test ./api/server/httprest -run 'TestServer_TimeoutHandler' -count=1 -v`

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable).