### PR TITLE
Prevent expensive state replay when computing sync committees members for the current period

### DIFF
--- a/beacon-chain/rpc/core/duties.go
+++ b/beacon-chain/rpc/core/duties.go
@@ -138,24 +138,19 @@ func (s *Service) SyncCommitteeDuties(ctx context.Context, st state.BeaconState,
 	nextSyncCommitteeFirstEpoch := currentSyncCommitteeFirstEpoch + params.BeaconConfig().EpochsPerSyncCommitteePeriod
 	isCurrentCommittee := requestedEpoch < nextSyncCommitteeFirstEpoch
 
-	var committee [][]byte
+	syncCommitteeFunc := st.NextSyncCommittee
 	if isCurrentCommittee {
-		sc, err := st.CurrentSyncCommittee()
-		if err != nil {
-			return nil, &RpcError{Err: errors.Wrap(err, "could not get sync committee"), Reason: Internal}
-		}
-		committee = sc.Pubkeys
-	} else {
-		sc, err := st.NextSyncCommittee()
-		if err != nil {
-			return nil, &RpcError{Err: errors.Wrap(err, "could not get sync committee"), Reason: Internal}
-		}
-		committee = sc.Pubkeys
+		syncCommitteeFunc = st.CurrentSyncCommittee
+	}
+
+	sc, err := syncCommitteeFunc()
+	if err != nil {
+		return nil, &RpcError{Err: errors.Wrap(err, "could not get sync committee"), Reason: Internal}
 	}
 
 	// Build pubkey → positions map from committee pubkeys.
 	committeePubkeys := make(map[[fieldparams.BLSPubkeyLength]byte][]uint64)
-	for j, pk := range committee {
+	for j, pk := range sc.Pubkeys {
 		var pk48 [fieldparams.BLSPubkeyLength]byte
 		copy(pk48[:], pk)
 		committeePubkeys[pk48] = append(committeePubkeys[pk48], uint64(j))

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -1189,9 +1189,28 @@ func (s *Server) GetSyncCommitteeDuties(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	startingEpoch := min(requestedEpoch, currentEpoch)
+	currentCommitteeFirstEpoch, err := slots.SyncCommitteePeriodStartEpoch(currentEpoch)
+	if err != nil {
+		httputil.HandleError(w, "Could not get sync committee period start epoch: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-	st, err := s.Stater.StateByEpoch(ctx, startingEpoch)
+	requestedCommitteeFirstEpoch, err := slots.SyncCommitteePeriodStartEpoch(requestedEpoch)
+	if err != nil {
+		httputil.HandleError(w, "Could not get sync committee period start epoch: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Sync committee assignments are computed at the start of the sync committee period and don't change during the period.
+	// - For the current period we use the current epoch to avoid expensive state replays.
+	// - For the next period we also use the current epoch and later read NextSyncCommittee (known one period in advance) to avoid fetching a future state.
+	// - For a past period we fall back to the first epoch of that period.
+	targetEpoch := currentEpoch
+	if requestedCommitteeFirstEpoch < currentCommitteeFirstEpoch {
+		targetEpoch = requestedCommitteeFirstEpoch
+	}
+
+	st, err := s.Stater.StateByEpoch(ctx, targetEpoch)
 	if err != nil {
 		shared.WriteStateFetchError(w, err)
 		return

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -3062,6 +3062,93 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 		require.Equal(t, 1, len(duty.ValidatorSyncCommitteeIndices))
 		assert.Equal(t, "1", duty.ValidatorSyncCommitteeIndices[0])
 	})
+	t.Run("past sync committee period", func(t *testing.T) {
+		// Chain is two periods ahead, the request targets epoch 0 (a past period).
+		// The handler must load the state at the requested period's start epoch and
+		// use its CurrentSyncCommittee, NOT the current state's committee.
+		pastEpochStartSlot := primitives.Slot(0)
+		currentSlot := primitives.Slot(uint64(params.BeaconConfig().EpochsPerSyncCommitteePeriod) * 2 * uint64(params.BeaconConfig().SlotsPerEpoch))
+
+		pastSt, _ := util.DeterministicGenesisStateAltair(t, numVals)
+		require.NoError(t, pastSt.SetSlot(pastEpochStartSlot))
+		require.NoError(t, pastSt.SetGenesisTime(genesisTime))
+
+		pastVals := pastSt.Validators()
+		pastCommittee := &ethpbalpha.SyncCommittee{AggregatePubkey: make([]byte, 48)}
+
+		for i := range 5 {
+			pastCommittee.Pubkeys = append(pastCommittee.Pubkeys, pastVals[i].PublicKey)
+		}
+
+		require.NoError(t, pastSt.SetCurrentSyncCommittee(pastCommittee))
+
+		pastNextCommittee := &ethpbalpha.SyncCommittee{AggregatePubkey: make([]byte, 48)}
+		for i := 5; i < 10; i++ {
+			pastNextCommittee.Pubkeys = append(pastNextCommittee.Pubkeys, pastVals[i].PublicKey)
+		}
+
+		require.NoError(t, pastSt.SetNextSyncCommittee(pastNextCommittee))
+
+		// Current state has different sync committees so that if the handler used
+		// the current state instead of the past state, assertions below would fail.
+		currentSt, _ := util.DeterministicGenesisStateAltair(t, numVals)
+		require.NoError(t, currentSt.SetSlot(currentSlot))
+		require.NoError(t, currentSt.SetGenesisTime(genesisTime))
+
+		currentVals := currentSt.Validators()
+		currentCommittee := &ethpbalpha.SyncCommittee{AggregatePubkey: make([]byte, 48)}
+
+		for i := 5; i < 10; i++ {
+			currentCommittee.Pubkeys = append(currentCommittee.Pubkeys, currentVals[i].PublicKey)
+		}
+
+		require.NoError(t, currentSt.SetCurrentSyncCommittee(currentCommittee))
+
+		currentNextCommittee := &ethpbalpha.SyncCommittee{AggregatePubkey: make([]byte, 48)}
+		for i := range 5 {
+			currentNextCommittee.Pubkeys = append(currentNextCommittee.Pubkeys, currentVals[i].PublicKey)
+		}
+
+		require.NoError(t, currentSt.SetNextSyncCommittee(currentNextCommittee))
+
+		mockChainService := &mockChain.ChainService{Genesis: genesisTime, Slot: &currentSlot, State: currentSt}
+		s := &Server{
+			Stater: &testutil.MockStater{StatesByEpoch: map[primitives.Epoch]state.BeaconState{
+				0: pastSt,
+				primitives.Epoch(uint64(params.BeaconConfig().EpochsPerSyncCommitteePeriod) * 2): currentSt,
+			}},
+			SyncChecker:           &mockSync.Sync{IsSyncing: false},
+			TimeFetcher:           mockChainService,
+			HeadFetcher:           mockChainService,
+			OptimisticModeFetcher: mockChainService,
+		}
+
+		var body bytes.Buffer
+		_, err := body.WriteString("[\"1\"]")
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodGet, "http://www.example.com/eth/v1/validator/duties/sync/{epoch}", &body)
+		request.SetPathValue("epoch", "0")
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		s.GetSyncCommitteeDuties(writer, request)
+		require.Equal(t, http.StatusOK, writer.Code)
+
+		resp := &structs.GetSyncCommitteeDutiesResponse{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
+		require.Equal(t, 1, len(resp.Data))
+
+		duty := resp.Data[0]
+		// Validator 1 is in pastSt's CurrentSyncCommittee at index 1. If the handler
+		// had loaded currentSt instead, validator 1 would not appear in its
+		// CurrentSyncCommittee and no duty would be returned.
+		require.Equal(t, hexutil.Encode(pastVals[1].PublicKey), duty.Pubkey)
+		require.Equal(t, "1", duty.ValidatorIndex)
+		require.Equal(t, 1, len(duty.ValidatorSyncCommitteeIndices))
+		require.Equal(t, "1", duty.ValidatorSyncCommitteeIndices[0])
+	})
+
 	t.Run("epoch too far in the future", func(t *testing.T) {
 		var body bytes.Buffer
 		_, err := body.WriteString("[\"5\"]")

--- a/changelog/manu_sync_committee_duties_state_replay.md
+++ b/changelog/manu_sync_committee_duties_state_replay.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `GetSyncCommitteeDuties` now fetches the state at the current epoch for current and next-period requests to avoid expensive state replays.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD=256` epochs, `SYNC_COMMITTEE_SIZE=512` validators are randomly chosen to be part of the sync committee.

When calling the the [/eth/v1/validator/duties/sync/epoch](https://ethereum.github.io/beacon-APIs/#/Validator/getSyncCommitteeDuties) endpoint with `epoch` being set to the first epoch of the current period, the Prysm beacon node:
1. Finds the youngest state in the DB before this epoch
2. Replays (expensive) states up the requested epoch

While this is technically correct, the step `2.` is very resource consuming.

This pull request leverages the fact that the `current_sync_committee` and `next_sync_committee` fields do not change within a period.

==> If the requested epoch and the current epoch are within the same period, then we can fetch `current_sync_committee` and `next_sync_committee` from the state corresponding to the current epoch, which is way less expensive.

**Which issues(s) does this PR fix?**

Fixes:
- https://github.com/OffchainLabs/prysm/issues/16686

**Other notes for review**
Please read commit by commit.

With a Nimbus VC connected:
**Before this PR**
<img width="936" height="308" alt="image" src="https://github.com/user-attachments/assets/b76f588d-dc95-4916-af93-6ea80b092609" />

**After this PR**
<img width="941" height="305" alt="image" src="https://github.com/user-attachments/assets/65302c90-be33-4525-be5c-a13338335d39" />

**Test plan**
Read how to reproduce the issue in the linked issue, and check that the same reproduction steps do not reproduce the issue with this PR.

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
