### PR TITLE
fixing wrong path name in execution payload bid api

### DIFF
--- a/beacon-chain/rpc/endpoints.go
+++ b/beacon-chain/rpc/endpoints.go
@@ -940,7 +940,7 @@ func (s *Service) beaconEndpoints(
 			methods: []string{http.MethodPost},
 		},
 		{
-			template: "/eth/v2/beacon/execution_payload/bid",
+			template: "/eth/v1/beacon/execution_payload_bid",
 			name:     namespace + ".PublishSignedExecutionPayloadBid",
 			middleware: []middleware.Middleware{
 				middleware.ContentTypeHandler([]string{api.JsonMediaType, api.OctetStreamMediaType}),

--- a/beacon-chain/rpc/endpoints_test.go
+++ b/beacon-chain/rpc/endpoints_test.go
@@ -35,7 +35,7 @@ func Test_endpoints(t *testing.T) {
 		"/eth/v1/beacon/states/{state_id}/proposer_lookahead":          {http.MethodGet},
 		"/eth/v1/beacon/execution_payload_envelope/{block_id}":         {http.MethodGet},
 		"/eth/v1/beacon/execution_payload_envelope":                    {http.MethodPost},
-		"/eth/v2/beacon/execution_payload/bid":                         {http.MethodPost},
+		"/eth/v1/beacon/execution_payload_bid":                         {http.MethodPost},
 		"/eth/v1/beacon/headers":                                       {http.MethodGet},
 		"/eth/v1/beacon/headers/{block_id}":                            {http.MethodGet},
 		"/eth/v2/beacon/blinded_blocks":                                {http.MethodPost},

--- a/changelog/james-prysm_fix-payload-bid-path.md
+++ b/changelog/james-prysm_fix-payload-bid-path.md
@@ -1,0 +1,3 @@
+### Changed
+
+- changed POST incorrect endpoint /eth/v2/beacon/execution_payload/bid to /eth/v1/beacon/execution_payload_bid   


### PR DESCRIPTION

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

fixing wrong path name from /eth/v2/beacon/execution_payload/bid to /eth/v1/beacon/execution_payload_bid

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

**Acknowledgements**

- [x] I have read [CONTRIBUTING.md](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md).
- [x] I have included a uniquely named [changelog fragment file](https://github.com/prysmaticlabs/prysm/blob/develop/CONTRIBUTING.md#maintaining-changelogmd).
- [x] I have added a description with sufficient context for reviewers to understand this PR.
- [x] I have tested that my changes work as expected and I added a testing plan to the PR description (if applicable). 
